### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENV GOMEMLIMIT=10000MiB
 EXPOSE 8080
-ENTRYPOINT [ "/go/src/app/khi" ]
-CMD ["--host=0.0.0.0","--temporary-folder=/","--data-destination-folder=/","--frontend-asset-folder=/go/src/app/web"]
+ENTRYPOINT ["/go/src/app/khi","--temporary-folder=/","--data-destination-folder=/","--frontend-asset-folder=/go/src/app/web"]
+CMD ["--host=0.0.0.0"]


### PR DESCRIPTION
```
docker run -p 8080:8080 ghcr.io/googlecloudplatform/khi:latest -host 0.0.0.0 -access-token=`gcloud auth print-access-token` 
```
will override `CMD` argument, this causes temp folder error when I launched on not Cloud Shell.

error message
```
docker run -p 8080:8080 ghcr.io/googlecloudplatform/khi:latest -host 0.0.0.0 -access-token=`gcloud auth print-access-token` 
...
(Kick Inspect)
global > WARN task OiQKVLYwHFPuGPah was finished with an error
failed to run a task graph.
 definition ID=cloud.google.com/feature/gke-audit-parser got an error. 
 ERROR:
open /tmp/khi-2098919656: no such file or directory
```