### PR TITLE
Add security policy to KHI.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+To report a security issue, please use [https://g.co/vulnz](https://g.co/vulnz).
+We use g.co/vulnz for our intake, and do coordination and disclosure here on
+GitHub (including using GitHub Security Advisory). The Google Security Team will
+respond within 5 working days of your report on g.co/vulnz.


### PR DESCRIPTION
After consideration within Google, we have decided to use g.co/vulnz for our intake, and coordination and disclosure here on GitHub.

See b/393470821 for details.