### PR TITLE
Add a flag to skip tests using Cloud Logging API

### DIFF
--- a/internal/testflags/testflags.go
+++ b/internal/testflags/testflags.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testflags
 
 import "flag"

--- a/internal/testflags/testflags.go
+++ b/internal/testflags/testflags.go
@@ -2,4 +2,5 @@ package testflags
 
 import "flag"
 
+// SkipCloudLogging is a flag of program arguments on testing.  Unit tests using Cloud Logging APIs are skipped with this flag.
 var SkipCloudLogging = flag.Bool("skip-cloud-logging", false, "skip tests that require cloud logging")

--- a/internal/testflags/testflags.go
+++ b/internal/testflags/testflags.go
@@ -1,0 +1,5 @@
+package testflags
+
+import "flag"
+
+var SkipCloudLogging = flag.Bool("skip-cloud-logging", false, "skip tests that require cloud logging")

--- a/pkg/common/cache/cache_test.go
+++ b/pkg/common/cache/cache_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type testOnMemoryCacheItemStorageProvider struct {

--- a/pkg/common/cache/gzip_test.go
+++ b/pkg/common/cache/gzip_test.go
@@ -17,6 +17,8 @@ package cache
 import (
 	"crypto/rand"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGZipCacheItemStorageProvider(t *testing.T) {

--- a/pkg/common/cache/lru_test.go
+++ b/pkg/common/cache/lru_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestTouchKeyAndGetRemoved(t *testing.T) {

--- a/pkg/common/collection_test.go
+++ b/pkg/common/collection_test.go
@@ -20,6 +20,8 @@ import (
 	"sort" // Import the sort package
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestDedupStringArray(t *testing.T) {

--- a/pkg/common/concurrent_counter_test.go
+++ b/pkg/common/concurrent_counter_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestConcurrentCounter(t *testing.T) {

--- a/pkg/common/errorreport/reporter_test.go
+++ b/pkg/common/errorreport/reporter_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestCloudErrorReportWriterKeepWorkingWhenReporterFailsToWrite(t *testing.T) {

--- a/pkg/common/flag/flag_test.go
+++ b/pkg/common/flag/flag_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func setCommandlineArguments(t *testing.T, arguments []string) {

--- a/pkg/common/grouper/basic_test.go
+++ b/pkg/common/grouper/basic_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestBasicGrouper(t *testing.T) {

--- a/pkg/common/httpclient/basic_http_client_test.go
+++ b/pkg/common/httpclient/basic_http_client_test.go
@@ -21,6 +21,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type mockHeaderProvider struct {

--- a/pkg/common/httpclient/json_response_client_test.go
+++ b/pkg/common/httpclient/json_response_client_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type mockHttpClient struct {

--- a/pkg/common/httpclient/retry_client_test.go
+++ b/pkg/common/httpclient/retry_client_test.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/token"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type mockFailClient struct {

--- a/pkg/common/id_test.go
+++ b/pkg/common/id_test.go
@@ -14,7 +14,11 @@
 
 package common
 
-import "testing"
+import (
+	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
+)
 
 func TestNewUUID(t *testing.T) {
 	uuid1 := NewUUID()

--- a/pkg/common/parserutil/converter_test.go
+++ b/pkg/common/parserutil/converter_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestStripSpecialSequences(t *testing.T) {

--- a/pkg/common/sharding_map_test.go
+++ b/pkg/common/sharding_map_test.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 const keyLetters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/pkg/common/time_test.go
+++ b/pkg/common/time_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseTime(t *testing.T) {

--- a/pkg/common/token/multi_resolver_test.go
+++ b/pkg/common/token/multi_resolver_test.go
@@ -17,6 +17,8 @@ package token
 import (
 	"context"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestMultiTokenResolver_Resolve(t *testing.T) {

--- a/pkg/common/token/store_test.go
+++ b/pkg/common/token/store_test.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestBasicTokenStore_GetType(t *testing.T) {

--- a/pkg/common/token/token_refresher_test.go
+++ b/pkg/common/token/token_refresher_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestNewMultiTokenStoreRefresher(t *testing.T) {

--- a/pkg/common/token/token_test.go
+++ b/pkg/common/token/token_test.go
@@ -17,6 +17,8 @@ package token
 import (
 	"testing"
 	"time"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/inspection/common/task_registrer_test.go
+++ b/pkg/inspection/common/task_registrer_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection"
 	inspection_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/inspection"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestInspectionTasksAreResolvable(t *testing.T) {

--- a/pkg/inspection/form/textform_test.go
+++ b/pkg/inspection/form/textform_test.go
@@ -24,6 +24,8 @@ import (
 	common_task "github.com/GoogleCloudPlatform/khi/pkg/task"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func generateFakeVariableSet(taskId string, value string) *common_task.VariableSet {

--- a/pkg/inspection/inspectiondata/result_repository_test.go
+++ b/pkg/inspection/inspectiondata/result_repository_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestFileSystemResultRepository(t *testing.T) {

--- a/pkg/inspection/ioconfig/ioconfig_test.go
+++ b/pkg/inspection/ioconfig/ioconfig_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	task_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/task"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestTestIOConfigCanFindTheRoot(t *testing.T) {

--- a/pkg/inspection/logger/logger_test.go
+++ b/pkg/inspection/logger/logger_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGlobalLoggerHandlerWithChildLogger(t *testing.T) {

--- a/pkg/inspection/metadata/error/conformance_test.go
+++ b/pkg/inspection/metadata/error/conformance_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	metadata_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/metadata"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestProgressConformance(t *testing.T) {

--- a/pkg/inspection/metadata/form/conformance_test.go
+++ b/pkg/inspection/metadata/form/conformance_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
 	metadata_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/metadata"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func newFormFieldsForConformanceTest() metadata.Metadata {

--- a/pkg/inspection/metadata/form/form_test.go
+++ b/pkg/inspection/metadata/form/form_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func fieldWithIdAndPriorityForTest(id string, priority int) FormField {

--- a/pkg/inspection/metadata/header/conformance_test.go
+++ b/pkg/inspection/metadata/header/conformance_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	metadata_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/metadata"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestConformance(t *testing.T) {

--- a/pkg/inspection/metadata/logger/logger_test.go
+++ b/pkg/inspection/metadata/logger/logger_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/logger"
 	"github.com/GoogleCloudPlatform/khi/pkg/task/taskid"
 	metadata_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/metadata"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestConformance(t *testing.T) {

--- a/pkg/inspection/metadata/logger/throttle_test.go
+++ b/pkg/inspection/metadata/logger/throttle_test.go
@@ -16,6 +16,8 @@ package logger
 
 import (
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestConstantLogThrottle(t *testing.T) {

--- a/pkg/inspection/metadata/metadata_test.go
+++ b/pkg/inspection/metadata/metadata_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/task"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 // Metadata test utility used from tests in another package

--- a/pkg/inspection/metadata/plan/plan_test.go
+++ b/pkg/inspection/metadata/plan/plan_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	metadata_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/metadata"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestConformance(t *testing.T) {

--- a/pkg/inspection/metadata/progress/conformance_test.go
+++ b/pkg/inspection/metadata/progress/conformance_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
 	metadata_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/metadata"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func newProgressforConformanceTest() metadata.Metadata {

--- a/pkg/inspection/metadata/progress/indeterminate_updator_test.go
+++ b/pkg/inspection/metadata/progress/indeterminate_updator_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestIndeterminateUpdator(t *testing.T) {

--- a/pkg/inspection/metadata/progress/progress_test.go
+++ b/pkg/inspection/metadata/progress/progress_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGetTaskProgress(t *testing.T) {

--- a/pkg/inspection/metadata/query/query_test.go
+++ b/pkg/inspection/metadata/query/query_test.go
@@ -19,6 +19,8 @@ import (
 
 	metadata_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/metadata"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestQueryConformance(t *testing.T) {

--- a/pkg/log/cached_log_field_extractor_test.go
+++ b/pkg/log/cached_log_field_extractor_test.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type commonLogFieldExtractorStub struct {

--- a/pkg/log/log_entity_test.go
+++ b/pkg/log/log_entity_test.go
@@ -13,3 +13,7 @@
 // limitations under the License.
 
 package log
+
+import (
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
+)

--- a/pkg/log/structure/adapter/any_test.go
+++ b/pkg/log/structure/adapter/any_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredatastore"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestAnyAdapter(t *testing.T) {

--- a/pkg/log/structure/adapter/direct_test.go
+++ b/pkg/log/structure/adapter/direct_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredata"
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredatastore"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestDirectAdapter(t *testing.T) {

--- a/pkg/log/structure/adapter/merge_yaml_test.go
+++ b/pkg/log/structure/adapter/merge_yaml_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/merger"
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredatastore"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestYamlMergeAdapterTest(t *testing.T) {

--- a/pkg/log/structure/adapter/yaml_test.go
+++ b/pkg/log/structure/adapter/yaml_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredatastore"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestYamlAdapter(t *testing.T) {

--- a/pkg/log/structure/merger/keydiff_test.go
+++ b/pkg/log/structure/merger/keydiff_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestKeyDiff(t *testing.T) {

--- a/pkg/log/structure/merger/mergeconfigresolver_test.go
+++ b/pkg/log/structure/merger/mergeconfigresolver_test.go
@@ -14,7 +14,11 @@
 
 package merger
 
-import "testing"
+import (
+	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
+)
 
 func TestMergeConfigResolverWithoutParent(t *testing.T) {
 	type resolverTestCase struct {

--- a/pkg/log/structure/merger/merged_test.go
+++ b/pkg/log/structure/merger/merged_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredata"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 var emptyMergeKeyResolver = &MergeConfigResolver{
@@ -253,7 +255,7 @@ qux: 13
 		},
 		{
 			name: "merge map with $patch=replace",
-			prev: `foo: 
+			prev: `foo:
   bar: 10
   qux: 12
 `,
@@ -493,7 +495,7 @@ qux:
     - c`,
 			patch: `foo:
   bar: abcdefg
-qux: 
+qux:
   hoge: null
   fuga: null`,
 			expected: `foo:
@@ -570,7 +572,7 @@ qux:
   bar: 10
 `,
 			patch: `foo:
-  $retainKeys: 
+  $retainKeys:
     - qux
   qux: 11
 `,
@@ -584,7 +586,7 @@ qux:
   bar: 10
 `,
 			patch: `foo:
-  $retainKeys: 
+  $retainKeys:
     - bar
     - qux
   qux: 11
@@ -911,7 +913,7 @@ bar:
 		{
 			name: "mix $deleteFromPrimitiveList and $setElementOrder",
 			prev: `foo:
-  bar: 
+  bar:
     baz1: hello
     baz2: true
   qux:
@@ -921,7 +923,7 @@ bar:
       - grape
 `,
 			patch: `foo:
-  bar: 
+  bar:
     baz2: false
     baz1: hello2
   qux:
@@ -950,7 +952,7 @@ bar:
 		{
 			name: "mix $patch=delete and $setElementOrder",
 			prev: `foo:
-  bar: 
+  bar:
     baz1: hello
     baz2: true
   qux:
@@ -966,7 +968,7 @@ bar:
         value2: 30
 `,
 			patch: `foo:
-  bar: 
+  bar:
     baz2: false
     baz1: hello2
   qux:
@@ -996,7 +998,7 @@ bar:
       value2: 30
     - name: lemon
       value: 4
-      value2: 40  
+      value2: 40
 `,
 			keyResolver: keyResolverFromMap(map[string]string{
 				".foo.qux.quux": "name",

--- a/pkg/log/structure/reader_test.go
+++ b/pkg/log/structure/reader_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredata"
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredatastore"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 // testYamlAdapter is the copy of YamlAdapter in adapter package just for generating test structuredata from yaml string in test.
@@ -118,7 +120,7 @@ func TestReader(t *testing.T) {
 		{
 			Input: `foo:
 - bar: 1
-  qux: 
+  qux:
   - apple
   - banana
 - bar: 2

--- a/pkg/log/structure/structuredata/equal_test.go
+++ b/pkg/log/structure/structuredata/equal_test.go
@@ -14,7 +14,11 @@
 
 package structuredata
 
-import "testing"
+import (
+	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
+)
 
 func TestEqualStructureData(t *testing.T) {
 	testCases := []struct {
@@ -89,12 +93,12 @@ func TestEqualStructureData(t *testing.T) {
 			name: "deeper map",
 			a: `foo:
   bar:
-    qux: 
+    qux:
       quux: 10
 `,
 			b: `foo:
   bar:
-    qux: 
+    qux:
       quux: 10
 `, expected: true,
 		},
@@ -102,12 +106,12 @@ func TestEqualStructureData(t *testing.T) {
 			name: "deeper map with different value",
 			a: `foo:
   bar:
-    qux: 
+    qux:
       quux: 10
 `,
 			b: `foo:
   bar:
-    qux: 
+    qux:
       quux: 11
 `, expected: false,
 		}, {

--- a/pkg/log/structure/structuredata/reflect_test.go
+++ b/pkg/log/structure/structuredata/reflect_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestReadPodManifest(t *testing.T) {

--- a/pkg/log/structure/structuredata/serializer_test.go
+++ b/pkg/log/structure/structuredata/serializer_test.go
@@ -17,6 +17,8 @@ package structuredata
 import (
 	"fmt"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestYamlString(t *testing.T) {
@@ -31,7 +33,7 @@ func TestYamlString(t *testing.T) {
 `,
 		},
 		{
-			input: `foo: 
+			input: `foo:
   bar:
    - apple
    - banana
@@ -156,7 +158,7 @@ func TestJsonString(t *testing.T) {
 			wantValue: `{"data":"hello world"}`,
 		},
 		{
-			input: `foo: 
+			input: `foo:
   bar:
    - apple
    - banana

--- a/pkg/log/structure/structuredata/sortedmap_test.go
+++ b/pkg/log/structure/structuredata/sortedmap_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func shufleFields(fields []string) []string {

--- a/pkg/log/structure/structuredata/structure_test.go
+++ b/pkg/log/structure/structuredata/structure_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestYamlNodeStructuredData(t *testing.T) {

--- a/pkg/log/structure/structuredatastore/lru_test.go
+++ b/pkg/log/structure/structuredatastore/lru_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredata"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestLRUStructureDataStoreFactory(t *testing.T) {

--- a/pkg/model/binarychunk/builder_test.go
+++ b/pkg/model/binarychunk/builder_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/progress"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type testCompressorWaitForSecond struct {

--- a/pkg/model/binarychunk/compressor_test.go
+++ b/pkg/model/binarychunk/compressor_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestFileSystemGzipCompressor(t *testing.T) {

--- a/pkg/model/binarychunk/writer_test.go
+++ b/pkg/model/binarychunk/writer_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestFileSystemBinaryWriter(t *testing.T) {

--- a/pkg/model/enum/log_type_test.go
+++ b/pkg/model/enum/log_type_test.go
@@ -17,6 +17,8 @@ package enum
 import (
 	"fmt"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestLogTypeMetadataIsFilled(t *testing.T) {

--- a/pkg/model/enum/parent_relationship_test.go
+++ b/pkg/model/enum/parent_relationship_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParentRelationshipMetadataIsFilled(t *testing.T) {

--- a/pkg/model/enum/revision_state_test.go
+++ b/pkg/model/enum/revision_state_test.go
@@ -17,6 +17,8 @@ package enum
 import (
 	"fmt"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestRevisionStatesIsFilled(t *testing.T) {

--- a/pkg/model/enum/severity_test.go
+++ b/pkg/model/enum/severity_test.go
@@ -17,6 +17,8 @@ package enum
 import (
 	"fmt"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestSeverityMetadataIsFilled(t *testing.T) {

--- a/pkg/model/enum/verb_test.go
+++ b/pkg/model/enum/verb_test.go
@@ -17,6 +17,8 @@ package enum
 import (
 	"fmt"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestRevisionVerbIsFilled(t *testing.T) {

--- a/pkg/model/history/builder_test.go
+++ b/pkg/model/history/builder_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestHistoryEnsureResourceHistory(t *testing.T) {

--- a/pkg/model/history/changeset_test.go
+++ b/pkg/model/history/changeset_test.go
@@ -28,6 +28,8 @@ import (
 	log_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testlog"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestRecordLogSummary(t *testing.T) {

--- a/pkg/model/history/grouper/basic_groupers_test.go
+++ b/pkg/model/history/grouper/basic_groupers_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	log_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/log"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestAllDependentLogGrouper(t *testing.T) {

--- a/pkg/model/history/resourceinfo/cluster_test.go
+++ b/pkg/model/history/resourceinfo/cluster_test.go
@@ -13,3 +13,7 @@
 // limitations under the License.
 
 package resourceinfo
+
+import (
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
+)

--- a/pkg/model/history/resourceinfo/noderesource/logbinder_test.go
+++ b/pkg/model/history/resourceinfo/noderesource/logbinder_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type testResourceBinding struct {

--- a/pkg/model/history/resourceinfo/noderesource/resourcebinding_test.go
+++ b/pkg/model/history/resourceinfo/noderesource/resourcebinding_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestPodResourceBinding_GetResourcePath(t *testing.T) {

--- a/pkg/model/history/resourceinfo/resourcelease/history_test.go
+++ b/pkg/model/history/resourceinfo/resourcelease/history_test.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type testLeaseHolder struct {

--- a/pkg/model/history/resourcepath/cloudcomposer_test.go
+++ b/pkg/model/history/resourcepath/cloudcomposer_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestComposerTaskInstance(t *testing.T) {

--- a/pkg/model/history/resourcepath/controlplane_test.go
+++ b/pkg/model/history/resourcepath/controlplane_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestControlplaneComponent(t *testing.T) {

--- a/pkg/model/history/resourcepath/gcp_test.go
+++ b/pkg/model/history/resourcepath/gcp_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestNetworkEndpointGroup(t *testing.T) {

--- a/pkg/model/history/resourcepath/general_test.go
+++ b/pkg/model/history/resourcepath/general_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestAPIVersionLayerGeneralItem(t *testing.T) {

--- a/pkg/model/history/resourcepath/pseudo_test.go
+++ b/pkg/model/history/resourcepath/pseudo_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestCluster(t *testing.T) {

--- a/pkg/model/history/resourcepath/resource_test.go
+++ b/pkg/model/history/resourcepath/resource_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestContainer(t *testing.T) {

--- a/pkg/model/history/sorter_impl_test.go
+++ b/pkg/model/history/sorter_impl_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type resourceChunkSortStrategyTestCase struct {

--- a/pkg/model/history/sorter_test.go
+++ b/pkg/model/history/sorter_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type TestResourceChunkSortStrategy struct {

--- a/pkg/model/k8s/configsource/reflect_test.go
+++ b/pkg/model/k8s/configsource/reflect_test.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/merger"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestFromResourceTypeReflection(t *testing.T) {

--- a/pkg/model/k8s/default_merge_config_test.go
+++ b/pkg/model/k8s/default_merge_config_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGenerateDefaultMergeConfig(t *testing.T) {

--- a/pkg/model/k8s_operation_test.go
+++ b/pkg/model/k8s_operation_test.go
@@ -17,6 +17,8 @@ package model
 import (
 	"fmt"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestToSingularKindName(t *testing.T) {

--- a/pkg/parameters/auth_test.go
+++ b/pkg/parameters/auth_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestAuthParameters(t *testing.T) {

--- a/pkg/parameters/common_test.go
+++ b/pkg/parameters/common_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestCommonParameters(t *testing.T) {

--- a/pkg/parameters/debug_test.go
+++ b/pkg/parameters/debug_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestDebugParameters(t *testing.T) {

--- a/pkg/parameters/job_test.go
+++ b/pkg/parameters/job_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestJobParameters(t *testing.T) {

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	khiflag "github.com/GoogleCloudPlatform/khi/pkg/common/flag"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func prepareFlagParsingTest(t *testing.T) {

--- a/pkg/parameters/server_test.go
+++ b/pkg/parameters/server_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestServerParameters(t *testing.T) {

--- a/pkg/parser/k8s/klog_test.go
+++ b/pkg/parser/k8s/klog_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseKLogHeader(t *testing.T) {

--- a/pkg/parser/yaml/yamlutil/node_util_test.go
+++ b/pkg/parser/yaml/yamlutil/node_util_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/yaml.v3"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestNewEmptyNode(t *testing.T) {

--- a/pkg/popup/popup_test.go
+++ b/pkg/popup/popup_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type testPopupForm struct{}

--- a/pkg/rawlogs/repository_test.go
+++ b/pkg/rawlogs/repository_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestFilesystemRepository(t *testing.T) {

--- a/pkg/server/config/type_test.go
+++ b/pkg/server/config/type_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/parameters"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestNewGetConfigResponseFromParameters(t *testing.T) {

--- a/pkg/server/index/basetag_test.go
+++ b/pkg/server/index/basetag_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/parameters"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestBaseTagGenerator(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -43,6 +43,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/task"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type testPopupForm struct{}

--- a/pkg/source/gcp/api/accesstoken/header_provider_test.go
+++ b/pkg/source/gcp/api/accesstoken/header_provider_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/token"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGCPAccessTokenHeaderProvider(t *testing.T) {

--- a/pkg/source/gcp/api/accesstoken/mds_test.go
+++ b/pkg/source/gcp/api/accesstoken/mds_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/httpclient"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type mockMDSResponseHttpClient struct {

--- a/pkg/source/gcp/api/pageclient_test.go
+++ b/pkg/source/gcp/api/pageclient_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/httpclient"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type mockHttpClientForPageClient struct {

--- a/pkg/source/gcp/api/quotaproject/header_provider_test.go
+++ b/pkg/source/gcp/api/quotaproject/header_provider_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGCPQuotaProjectHeaderProvider(t *testing.T) {

--- a/pkg/source/gcp/k8s/k8s_test.go
+++ b/pkg/source/gcp/k8s/k8s_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseKubernetesOperation(t *testing.T) {

--- a/pkg/source/gcp/k8s/setup_test.go
+++ b/pkg/source/gcp/k8s/setup_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/source/gcp/log/log_extractor_test.go
+++ b/pkg/source/gcp/log/log_extractor_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure"
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/adapter"
 	"github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredatastore"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func logFromYaml(yaml string) (*log.LogEntity, error) {

--- a/pkg/source/gcp/query/queryutil/common_test.go
+++ b/pkg/source/gcp/query/queryutil/common_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestTimeRangeQuerySection(t *testing.T) {

--- a/pkg/source/gcp/query/queryutil/parallel_test.go
+++ b/pkg/source/gcp/query/queryutil/parallel_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestDivideTimeSegments(t *testing.T) {

--- a/pkg/source/gcp/query/queryutil/set_filter_test.go
+++ b/pkg/source/gcp/query/queryutil/set_filter_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseSetFilter(t *testing.T) {

--- a/pkg/source/gcp/task/cloud-composer/paeser_test.go
+++ b/pkg/source/gcp/task/cloud-composer/paeser_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
 	log_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/log"
 	"github.com/stretchr/testify/assert"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestAirflowSchedulerParser(t *testing.T) {

--- a/pkg/source/gcp/task/form_test.go
+++ b/pkg/source/gcp/task/form_test.go
@@ -31,6 +31,8 @@ import (
 	form_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/form"
 	task_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testtask"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 var testClusterNamePrefix = task_test.MockProcessorTaskFromTaskID(ClusterNamePrefixTaskID, "")

--- a/pkg/source/gcp/task/gke/autoscaler/query_test.go
+++ b/pkg/source/gcp/task/gke/autoscaler/query_test.go
@@ -17,7 +17,6 @@ package autoscaler
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -79,9 +78,6 @@ func TestGeneratedAutoscalerQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateAutoscalerQuery(tc.ProjectId, tc.ClusterName, tc.ExcludeStatus)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/autoscaler/query_test.go
+++ b/pkg/source/gcp/task/gke/autoscaler/query_test.go
@@ -17,6 +17,7 @@ package autoscaler
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -78,6 +79,9 @@ func TestGeneratedAutoscalerQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateAutoscalerQuery(tc.ProjectId, tc.ClusterName, tc.ExcludeStatus)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/autoscaler/query_test.go
+++ b/pkg/source/gcp/task/gke/autoscaler/query_test.go
@@ -17,7 +17,6 @@ package autoscaler
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -79,12 +78,9 @@ func TestGeneratedAutoscalerQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateAutoscalerQuery(tc.ProjectId, tc.ClusterName, tc.ExcludeStatus)
-			err := gcp_test.IsValidLogQuery(query)
+			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/pkg/source/gcp/task/gke/autoscaler/types_test.go
+++ b/pkg/source/gcp/task/gke/autoscaler/types_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestAutoscalerDecisionLogTypesToMatchLogString(t *testing.T) {
@@ -206,7 +208,7 @@ func TestAutoscalerDecisionLogTypesToMatchLogString(t *testing.T) {
 		},
 		{
 			Name: "Node Pool Deletion",
-			InputJSON: `{ 
+			InputJSON: `{
 				"decideTime": "1585830461",
 				"eventId": "68b0d1c7-b684-4542-bc19-f030922fb820",
 				"nodePoolDeleted": {

--- a/pkg/source/gcp/task/gke/compute_api/parser_test.go
+++ b/pkg/source/gcp/task/gke/compute_api/parser_test.go
@@ -24,6 +24,8 @@ import (
 	parser_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/parser"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestComputeApiParser_Parse_OperationFirstLog(t *testing.T) {

--- a/pkg/source/gcp/task/gke/gke_audit/parser_test.go
+++ b/pkg/source/gcp/task/gke/gke_audit/parser_test.go
@@ -24,6 +24,8 @@ import (
 	parser_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/parser"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGkeAuditLogParser_ClusterCreationStartLog(t *testing.T) {

--- a/pkg/source/gcp/task/gke/gke_audit/query_test.go
+++ b/pkg/source/gcp/task/gke/gke_audit/query_test.go
@@ -17,7 +17,6 @@ package gke_audit
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -57,12 +56,9 @@ func TestGeneratedGKEAuditQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateGKEAuditQuery(tc.ProjectId, tc.ClusterName)
-			err := gcp_test.IsValidLogQuery(query)
+			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/pkg/source/gcp/task/gke/gke_audit/query_test.go
+++ b/pkg/source/gcp/task/gke/gke_audit/query_test.go
@@ -17,6 +17,7 @@ package gke_audit
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -56,6 +57,9 @@ func TestGeneratedGKEAuditQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateGKEAuditQuery(tc.ProjectId, tc.ClusterName)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/gke_audit/query_test.go
+++ b/pkg/source/gcp/task/gke/gke_audit/query_test.go
@@ -17,7 +17,6 @@ package gke_audit
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -57,9 +56,6 @@ func TestGeneratedGKEAuditQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateGKEAuditQuery(tc.ProjectId, tc.ClusterName)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_audit/manifestutil/manifestutil_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/manifestutil/manifestutil_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testlog"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseDeletionStatus(t *testing.T) {

--- a/pkg/source/gcp/task/gke/k8s_audit/query/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/query/query_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -107,9 +106,6 @@ func TestGenerateK8sAuditQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sAuditQuery(tc.ClusterName, tc.KindFilter, tc.NamespaceFilter)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_audit/query/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/query/query_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -107,12 +106,9 @@ func TestGenerateK8sAuditQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sAuditQuery(tc.ClusterName, tc.KindFilter, tc.NamespaceFilter)
-			err := gcp_test.IsValidLogQuery(query)
+			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/pkg/source/gcp/task/gke/k8s_audit/query/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/query/query_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -106,6 +107,9 @@ func TestGenerateK8sAuditQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sAuditQuery(tc.ClusterName, tc.KindFilter, tc.NamespaceFilter)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_audit/recorder/containerstatusrecorder/recorder_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/recorder/containerstatusrecorder/recorder_test.go
@@ -30,6 +30,8 @@ import (
 	log_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 	corev1 "k8s.io/api/core/v1"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestRecordChangeSetForLog(t *testing.T) {

--- a/pkg/source/gcp/task/gke/k8s_audit/recorder/endpointslicerecorder/recorder_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/recorder/endpointslicerecorder/recorder_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	goyaml "gopkg.in/yaml.v3"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseSingleEndpoint(t *testing.T) {

--- a/pkg/source/gcp/task/gke/k8s_audit/rtype/rtype_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/rtype/rtype_test.go
@@ -17,6 +17,8 @@ package rtype
 import (
 	"fmt"
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestTypesAreFilled(t *testing.T) {

--- a/pkg/source/gcp/task/gke/k8s_audit/v2commonlogparse/task_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/v2commonlogparse/task_test.go
@@ -28,12 +28,14 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testtask"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseResourceSpecificParserInput(t *testing.T) {
 	baseLog := `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   resourceName: core/v1/namespaces/default/pods/my-pod
@@ -114,7 +116,7 @@ timestamp: 2024-01-01T00:00:00+09:00`
 func TestPrestepParseTaskFinishWithSuccess(t *testing.T) {
 	baseLog := `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   resourceName: core/v1/namespaces/default/pods/my-pod
@@ -159,7 +161,7 @@ timestamp: 2024-01-01T00:00:00+09:00`
 func TestPrestepParseIgnoreErrornousLogs(t *testing.T) {
 	baseLog := `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   resourceName: core/v1/namespaces/default/pods/my-pod
   status:

--- a/pkg/source/gcp/task/gke/k8s_audit/v2logconvert/task_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/v2logconvert/task_test.go
@@ -25,12 +25,14 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/k8saudittask"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testlog"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testtask"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestLogFillerTask(t *testing.T) {
 	builder := history.NewBuilder(&ioconfig.IOConfig{})
 	baseLog := `protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   resourceName: core/v1/namespaces/default/pods/my-pod

--- a/pkg/source/gcp/task/gke/k8s_audit/v2manifestgenerate/task_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/v2manifestgenerate/task_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testlog"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testtask"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestBodyMergerTask(t *testing.T) {
@@ -45,7 +47,7 @@ func TestBodyMergerTask(t *testing.T) {
 		Name: "Standard non patching merge",
 		baseLog: `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   resourceName: core/v1/namespaces/default/pods/my-pod
@@ -76,7 +78,7 @@ timestamp: 2024-01-01T00:00:00+09:00`,
 		Name: "Standard patching merge",
 		baseLog: `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   resourceName: core/v1/namespaces/default/pods/my-pod
@@ -107,7 +109,7 @@ qux: qux1`,
 		Name: "Standard patching merge with middle ignored failed patch request",
 		baseLog: `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   resourceName: core/v1/namespaces/default/pods/my-pod
@@ -138,7 +140,7 @@ qux: qux1
 		Name: "response field should be ignored when it was deleteoption",
 		baseLog: `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   resourceName: core/v1/namespaces/default/pods/my-pod
@@ -168,7 +170,7 @@ qux: qux1
 		Name: "Metadata level audit logs",
 		baseLog: `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   resourceName: core/v1/namespaces/default/pods/my-pod

--- a/pkg/source/gcp/task/gke/k8s_audit/v2timelinegrouping/task_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/v2timelinegrouping/task_test.go
@@ -26,6 +26,8 @@ import (
 	base_task "github.com/GoogleCloudPlatform/khi/pkg/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testlog"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testtask"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGroupByTimelineTask(t *testing.T) {
@@ -44,7 +46,7 @@ func TestGroupByTimelineTask(t *testing.T) {
 	t.Run("it grups logs by timleines", func(t *testing.T) {
 		baseLog := `insertId: foo
 protoPayload:
-  authenticationInfo: 
+  authenticationInfo:
     principalEmail: user@example.com
   methodName: io.k8s.core.v1.pods.create
   status:

--- a/pkg/source/gcp/task/gke/k8s_container/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_container/query_test.go
@@ -17,7 +17,6 @@ package k8s_container
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -61,9 +60,6 @@ func TestGenerateK8sContainerQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sContainerQuery(tc.ClusterName, tc.PodNameFilter, tc.NamespaceFilter)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_container/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_container/query_test.go
@@ -17,6 +17,7 @@ package k8s_container
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -60,6 +61,9 @@ func TestGenerateK8sContainerQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sContainerQuery(tc.ClusterName, tc.PodNameFilter, tc.NamespaceFilter)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_container/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_container/query_test.go
@@ -17,7 +17,6 @@ package k8s_container
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -61,12 +60,9 @@ func TestGenerateK8sContainerQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sContainerQuery(tc.ClusterName, tc.PodNameFilter, tc.NamespaceFilter)
-			err := gcp_test.IsValidLogQuery(query)
+			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/pkg/source/gcp/task/gke/k8s_container/severity_parser_test.go
+++ b/pkg/source/gcp/task/gke/k8s_container/severity_parser_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestMetricsLogType(t *testing.T) {

--- a/pkg/source/gcp/task/gke/k8s_control_plane_component/componentparser/controllermanager_test.go
+++ b/pkg/source/gcp/task/gke/k8s_control_plane_component/componentparser/controllermanager_test.go
@@ -21,6 +21,8 @@ import (
 
 	log_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/log"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func getControlPlaneComponentLogForTesting(message string) string {

--- a/pkg/source/gcp/task/gke/k8s_control_plane_component/componentparser/scheduler_test.go
+++ b/pkg/source/gcp/task/gke/k8s_control_plane_component/componentparser/scheduler_test.go
@@ -20,6 +20,8 @@ import (
 
 	log_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/log"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestPodRelatedLogsToResourcePath(t *testing.T) {

--- a/pkg/source/gcp/task/gke/k8s_control_plane_component/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_control_plane_component/query_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -82,6 +83,9 @@ resource.labels.project_id="foo-project"
 	}
 
 	for i, testCase := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(fmt.Sprintf("testcase-%d-%s", i, testCase.ExpectedQuery), func(t *testing.T) {
 			result := GenerateK8sControlPlaneQuery(testCase.InputClusterName, testCase.InputProjectName, testCase.InputControlplaneComponentNameFilter)
 			if result != testCase.ExpectedQuery {

--- a/pkg/source/gcp/task/gke/k8s_control_plane_component/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_control_plane_component/query_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -83,9 +82,6 @@ resource.labels.project_id="foo-project"
 	}
 
 	for i, testCase := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(fmt.Sprintf("testcase-%d-%s", i, testCase.ExpectedQuery), func(t *testing.T) {
 			result := GenerateK8sControlPlaneQuery(testCase.InputClusterName, testCase.InputProjectName, testCase.InputControlplaneComponentNameFilter)
 			if result != testCase.ExpectedQuery {

--- a/pkg/source/gcp/task/gke/k8s_control_plane_component/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_control_plane_component/query_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -83,16 +82,13 @@ resource.labels.project_id="foo-project"
 	}
 
 	for i, testCase := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(fmt.Sprintf("testcase-%d-%s", i, testCase.ExpectedQuery), func(t *testing.T) {
 			result := GenerateK8sControlPlaneQuery(testCase.InputClusterName, testCase.InputProjectName, testCase.InputControlplaneComponentNameFilter)
 			if result != testCase.ExpectedQuery {
 				t.Errorf("the result query is not valid:\nInput:\n%v\nActual:\n%s\nExpected:\n%s", testCase, result, testCase.ExpectedQuery)
 			}
 			t.Run("generated query must be valid in Cloud Logging", func(t *testing.T) {
-				err := gcp_test.IsValidLogQuery(result)
+				err := gcp_test.IsValidLogQuery(t, result)
 				if err != nil {
 					t.Errorf(err.Error())
 				}

--- a/pkg/source/gcp/task/gke/k8s_event/parser_test.go
+++ b/pkg/source/gcp/task/gke/k8s_event/parser_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	parser_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/parser"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestK8sEventParser_ParseSampleLog(t *testing.T) {

--- a/pkg/source/gcp/task/gke/k8s_event/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_event/query_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -101,6 +102,9 @@ func TestGenerateK8sEventQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sEventQuery(tc.ClusterName, tc.ProjectName, tc.NamespaceFilter)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_event/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_event/query_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -102,9 +101,6 @@ func TestGenerateK8sEventQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sEventQuery(tc.ClusterName, tc.ProjectName, tc.NamespaceFilter)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_event/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_event/query_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
@@ -102,12 +101,9 @@ func TestGenerateK8sEventQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sEventQuery(tc.ClusterName, tc.ProjectName, tc.NamespaceFilter)
-			err := gcp_test.IsValidLogQuery(query)
+			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/pkg/source/gcp/task/gke/k8s_node/parser_test.go
+++ b/pkg/source/gcp/task/gke/k8s_node/parser_test.go
@@ -25,6 +25,8 @@ import (
 	parser_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/parser"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseSummary(t *testing.T) {

--- a/pkg/source/gcp/task/gke/k8s_node/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_node/query_test.go
@@ -17,6 +17,7 @@ package k8s_node
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -48,6 +49,9 @@ func TestGenerateK8sNodeQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sNodeLogQuery(tc.ProjectName, tc.ClusterName, tc.NodeNameSubstrings)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_node/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_node/query_test.go
@@ -17,7 +17,6 @@ package k8s_node
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -49,9 +48,6 @@ func TestGenerateK8sNodeQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sNodeLogQuery(tc.ProjectName, tc.ClusterName, tc.NodeNameSubstrings)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/gke/k8s_node/query_test.go
+++ b/pkg/source/gcp/task/gke/k8s_node/query_test.go
@@ -17,7 +17,6 @@ package k8s_node
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -49,12 +48,9 @@ func TestGenerateK8sNodeQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sNodeLogQuery(tc.ProjectName, tc.ClusterName, tc.NodeNameSubstrings)
-			err := gcp_test.IsValidLogQuery(query)
+			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/pkg/source/gcp/task/gke/network_api/query_test.go
+++ b/pkg/source/gcp/task/gke/network_api/query_test.go
@@ -17,7 +17,6 @@ package network_api
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -33,12 +32,9 @@ func TestGenerateGenerateGCPNetworkAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateGCPNetworkAPIQuery(0, tc.NEGs)
-			err := gcp_test.IsValidLogQuery(query[0])
+			err := gcp_test.IsValidLogQuery(t, query[0])
 			if err != nil {
 				t.Errorf("Query is not valid: %v", err)
 			}

--- a/pkg/source/gcp/task/gke/network_api/query_test.go
+++ b/pkg/source/gcp/task/gke/network_api/query_test.go
@@ -17,6 +17,7 @@ package network_api
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -32,6 +33,9 @@ func TestGenerateGenerateGCPNetworkAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateGCPNetworkAPIQuery(0, tc.NEGs)
 			err := gcp_test.IsValidLogQuery(query[0])

--- a/pkg/source/gcp/task/gke/network_api/query_test.go
+++ b/pkg/source/gcp/task/gke/network_api/query_test.go
@@ -17,7 +17,6 @@ package network_api
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 )
 
@@ -33,9 +32,6 @@ func TestGenerateGenerateGCPNetworkAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateGCPNetworkAPIQuery(0, tc.NEGs)
 			err := gcp_test.IsValidLogQuery(query[0])

--- a/pkg/source/gcp/task/gke/serialport/parser_test.go
+++ b/pkg/source/gcp/task/gke/serialport/parser_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	parser_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/parser"
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestSerialPortLogParser_ParseBasicSerialPortLog(t *testing.T) {

--- a/pkg/source/gcp/task/gke/serialport/query_test.go
+++ b/pkg/source/gcp/task/gke/serialport/query_test.go
@@ -19,7 +19,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	inspection_task "github.com/GoogleCloudPlatform/khi/pkg/inspection/task"
 
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
@@ -93,15 +92,12 @@ labels."compute.googleapis.com/resource_name":("node-1")`,
 	}
 
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.name, func(t *testing.T) {
 			query := GenerateSerialPortQuery(tc.taskMode, tc.nodeNames, tc.nodeNameSubstrings)
 			if diff := cmp.Diff(tc.wantQuery, query[0]); diff != "" {
 				t.Errorf("the generated query is not matching with the expected query\n%s", diff)
 			}
-			err := gcp_test.IsValidLogQuery(query[0])
+			err := gcp_test.IsValidLogQuery(t, query[0])
 			if err != nil {
 				t.Errorf("the generated query is invalid. error:%v", err)
 			}
@@ -110,9 +106,6 @@ labels."compute.googleapis.com/resource_name":("node-1")`,
 }
 
 func TestMaximumNodeCountNotHittingQueryLengthLimit(t *testing.T) {
-	if *testflags.SkipCloudLogging {
-		t.Skip("cloud logging tests are skipped")
-	}
 	nodeNames := []string{}
 	for i := 0; i < MaxNodesPerQuery*2+1; i++ { // This query must be splitted with 3 sub groups.
 		nodeNames = append(nodeNames, fmt.Sprintf(`gke-%s-%s-%s`, randomString(46), randomString(8), randomString(4)))
@@ -122,7 +115,7 @@ func TestMaximumNodeCountNotHittingQueryLengthLimit(t *testing.T) {
 		t.Errorf("len(GenerateSerialPortQuery())=%d, want %d", len(query), 3)
 	}
 	for _, subquery := range query {
-		err := gcp_test.IsValidLogQuery(subquery)
+		err := gcp_test.IsValidLogQuery(t, subquery)
 		if err != nil {
 			t.Errorf("the generated query is invalid. error:%v", err)
 		}

--- a/pkg/source/gcp/task/gke/serialport/query_test.go
+++ b/pkg/source/gcp/task/gke/serialport/query_test.go
@@ -19,7 +19,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	inspection_task "github.com/GoogleCloudPlatform/khi/pkg/inspection/task"
 
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
@@ -93,9 +92,6 @@ labels."compute.googleapis.com/resource_name":("node-1")`,
 	}
 
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.name, func(t *testing.T) {
 			query := GenerateSerialPortQuery(tc.taskMode, tc.nodeNames, tc.nodeNameSubstrings)
 			if diff := cmp.Diff(tc.wantQuery, query[0]); diff != "" {
@@ -110,9 +106,6 @@ labels."compute.googleapis.com/resource_name":("node-1")`,
 }
 
 func TestMaximumNodeCountNotHittingQueryLengthLimit(t *testing.T) {
-	if *testflags.SkipCloudLogging {
-		t.Skip("cloud logging tests are skipped")
-	}
 	nodeNames := []string{}
 	for i := 0; i < MaxNodesPerQuery*2+1; i++ { // This query must be splitted with 3 sub groups.
 		nodeNames = append(nodeNames, fmt.Sprintf(`gke-%s-%s-%s`, randomString(46), randomString(8), randomString(4)))

--- a/pkg/source/gcp/task/gke/serialport/query_test.go
+++ b/pkg/source/gcp/task/gke/serialport/query_test.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	inspection_task "github.com/GoogleCloudPlatform/khi/pkg/inspection/task"
 
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
@@ -92,6 +93,9 @@ labels."compute.googleapis.com/resource_name":("node-1")`,
 	}
 
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.name, func(t *testing.T) {
 			query := GenerateSerialPortQuery(tc.taskMode, tc.nodeNames, tc.nodeNameSubstrings)
 			if diff := cmp.Diff(tc.wantQuery, query[0]); diff != "" {
@@ -106,6 +110,9 @@ labels."compute.googleapis.com/resource_name":("node-1")`,
 }
 
 func TestMaximumNodeCountNotHittingQueryLengthLimit(t *testing.T) {
+	if *testflags.SkipCloudLogging {
+		t.Skip("cloud logging tests are skipped")
+	}
 	nodeNames := []string{}
 	for i := 0; i < MaxNodesPerQuery*2+1; i++ { // This query must be splitted with 3 sub groups.
 		nodeNames = append(nodeNames, fmt.Sprintf(`gke-%s-%s-%s`, randomString(46), randomString(8), randomString(4)))

--- a/pkg/source/gcp/task/multicloud_api/parser_test.go
+++ b/pkg/source/gcp/task/multicloud_api/parser_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseResourceNameOfMulticloudAPI(t *testing.T) {

--- a/pkg/source/gcp/task/multicloud_api/query_test.go
+++ b/pkg/source/gcp/task/multicloud_api/query_test.go
@@ -17,7 +17,6 @@ package multicloud_api
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -58,12 +57,9 @@ func TestGenerateMultiCloudAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateMultiCloudAPIQuery(tc.ClusterName)
-			err := gcp_test.IsValidLogQuery(query)
+			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/pkg/source/gcp/task/multicloud_api/query_test.go
+++ b/pkg/source/gcp/task/multicloud_api/query_test.go
@@ -17,6 +17,7 @@ package multicloud_api
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -57,6 +58,9 @@ func TestGenerateMultiCloudAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateMultiCloudAPIQuery(tc.ClusterName)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/multicloud_api/query_test.go
+++ b/pkg/source/gcp/task/multicloud_api/query_test.go
@@ -17,7 +17,6 @@ package multicloud_api
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -58,9 +57,6 @@ func TestGenerateMultiCloudAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateMultiCloudAPIQuery(tc.ClusterName)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/onprem_api/parser_test.go
+++ b/pkg/source/gcp/task/onprem_api/parser_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestParseResourceNameOfOnPremAPI(t *testing.T) {

--- a/pkg/source/gcp/task/onprem_api/query_test.go
+++ b/pkg/source/gcp/task/onprem_api/query_test.go
@@ -17,7 +17,6 @@ package onprem_api
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -58,12 +57,9 @@ func TestGenerateOnPremAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateOnPremAPIQuery(tc.ClusterName)
-			err := gcp_test.IsValidLogQuery(query)
+			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf(err.Error())
 			}

--- a/pkg/source/gcp/task/onprem_api/query_test.go
+++ b/pkg/source/gcp/task/onprem_api/query_test.go
@@ -17,7 +17,6 @@ package onprem_api
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -58,9 +57,6 @@ func TestGenerateOnPremAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if *testflags.SkipCloudLogging {
-			t.Skip("cloud logging tests are skipped")
-		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateOnPremAPIQuery(tc.ClusterName)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task/onprem_api/query_test.go
+++ b/pkg/source/gcp/task/onprem_api/query_test.go
@@ -17,6 +17,7 @@ package onprem_api
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -57,6 +58,9 @@ func TestGenerateOnPremAPIQueryIsValid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		if *testflags.SkipCloudLogging {
+			t.Skip("cloud logging tests are skipped")
+		}
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateOnPremAPIQuery(tc.ClusterName)
 			err := gcp_test.IsValidLogQuery(query)

--- a/pkg/source/gcp/task_registrer_test.go
+++ b/pkg/source/gcp/task_registrer_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/common"
 	inspection_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/inspection"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func testPrepareInspectionServer(inspectionServer *inspection.InspectionTaskServer) error {

--- a/pkg/task/cached_processor_test.go
+++ b/pkg/task/cached_processor_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type cachableData struct{}

--- a/pkg/task/definition_set_test.go
+++ b/pkg/task/definition_set_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/exp/slices"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type testTaskDefinition struct {

--- a/pkg/task/label_test.go
+++ b/pkg/task/label_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestNewLabelSet(t *testing.T) {

--- a/pkg/task/processor_test.go
+++ b/pkg/task/processor_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestProcessorTaskWithSuccessResult(t *testing.T) {

--- a/pkg/task/runner_test.go
+++ b/pkg/task/runner_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 type debugRunnable struct {

--- a/pkg/task/taskid/taskid_test.go
+++ b/pkg/task/taskid/taskid_test.go
@@ -16,6 +16,8 @@ package taskid
 
 import (
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestNewTaskReference(t *testing.T) {

--- a/pkg/task/variable_test.go
+++ b/pkg/task/variable_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestVariableSetToBeReleasedWhenItWasSet(t *testing.T) {

--- a/pkg/testutil/gcp/log.go
+++ b/pkg/testutil/gcp/log.go
@@ -18,12 +18,19 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
 	"github.com/GoogleCloudPlatform/khi/pkg/parameters"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/api"
 )
 
-func IsValidLogQuery(query string) error {
+func IsValidLogQuery(t *testing.T, query string) error {
+	t.Helper()
+
+	if *testflags.SkipCloudLogging {
+		t.Skip("cloud logging tests are skipped")
+	}
 	accessToken, found := os.LookupEnv("GCP_ACCESS_TOKEN")
 	if found {
 		parameters.Auth.AccessToken = &accessToken

--- a/pkg/testutil/gcp/log_test.go
+++ b/pkg/testutil/gcp/log_test.go
@@ -16,6 +16,8 @@ package gcp_test
 
 import (
 	"testing"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestIsValidLogQuery(t *testing.T) {

--- a/pkg/testutil/gcp/log_test.go
+++ b/pkg/testutil/gcp/log_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIsValidLogQuery(t *testing.T) {
-	err := IsValidLogQuery("\"")
+	err := IsValidLogQuery(t, "\"")
 	if err == nil {
 		t.Errorf("got nil, want invalid query error")
 	}

--- a/pkg/testutil/log/log_test.go
+++ b/pkg/testutil/log/log_test.go
@@ -13,3 +13,7 @@
 // limitations under the License.
 
 package log_test
+
+import (
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
+)

--- a/pkg/testutil/testlog/base_test.go
+++ b/pkg/testutil/testlog/base_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestBaseYamlTestLogOpt(t *testing.T) {

--- a/pkg/testutil/testlog/field_test.go
+++ b/pkg/testutil/testlog/field_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestStringField(t *testing.T) {

--- a/pkg/testutil/testlog/testlog_test.go
+++ b/pkg/testutil/testlog/testlog_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestTestLogWith(t *testing.T) {

--- a/pkg/testutil/util_test.go
+++ b/pkg/testutil/util_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestRemoveSlogTimestampFromLine(t *testing.T) {


### PR DESCRIPTION
close #57 

## Background

Currently, some tests that make API requests to Google Cloud resources cannot be executed, which prevents running Go unit tests in development environments and CI. 
Therefore, we want to implement a flag to skip tests that requests to Google Cloud resources

## What

- Implement a flag (`skip-cloud-logging`) to skip tests that send API requests to Cloud Logging.
  - The flag is implemented in `internal/testflags` and is (blank-)imported in each test file.
  - Note: Since Go tests generate a binary for each package, be aware that without the blank import, running `go test ./... -args -skip-cloud-logging=true` will not work.

## Usage

```console
$ go test ./...  -args -skip-cloud-logging=true
```

## Result

One of the tests is failing, but this error existed before working on this PR.

```console
$ go test ./...  -args -skip-cloud-logging=true
```

<details><summary>result</summary>

```console        
?       github.com/GoogleCloudPlatform/khi/cmd/kubernetes-history-inspector     [no test files]
?       github.com/GoogleCloudPlatform/khi/internal/testflags   [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/common/constants [no test files]
ok      github.com/GoogleCloudPlatform/khi/pkg/common   0.201s
?       github.com/GoogleCloudPlatform/khi/pkg/common/worker    [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/inspection       [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/inspection/env   [no test files]
ok      github.com/GoogleCloudPlatform/khi/pkg/common/cache     1.126s
ok      github.com/GoogleCloudPlatform/khi/pkg/common/errorreport       0.848s
ok      github.com/GoogleCloudPlatform/khi/pkg/common/flag      0.500s
ok      github.com/GoogleCloudPlatform/khi/pkg/common/grouper   0.671s
ok      github.com/GoogleCloudPlatform/khi/pkg/common/httpclient        0.914s
ok      github.com/GoogleCloudPlatform/khi/pkg/common/parserutil        1.215s
?       github.com/GoogleCloudPlatform/khi/pkg/inspection/task  [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/inspection/task/serializer       [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/lifecycle        [no test files]
ok      github.com/GoogleCloudPlatform/khi/pkg/common/token     3.178s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/common        0.969s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/form  0.906s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/inspectiondata        0.658s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/ioconfig      0.998s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/logger        1.164s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata      1.275s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/error        1.161s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/form 1.118s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/header       1.126s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/logger       0.995s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/plan 1.036s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/progress     3.525s
ok      github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/query        1.032s
ok      github.com/GoogleCloudPlatform/khi/pkg/log      0.990s
ok      github.com/GoogleCloudPlatform/khi/pkg/log/structure    0.998s
ok      github.com/GoogleCloudPlatform/khi/pkg/log/structure/adapter    1.028s
ok      github.com/GoogleCloudPlatform/khi/pkg/log/structure/merger     0.999s
ok      github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredata      1.212s
?       github.com/GoogleCloudPlatform/khi/pkg/parser   [no test files]
ok      github.com/GoogleCloudPlatform/khi/pkg/log/structure/structuredatastore 3.027s
ok      github.com/GoogleCloudPlatform/khi/pkg/model    1.280s
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gdcv-for-baremetal       [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gdcv-for-vmware  [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke      [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit    [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/k8saudittask       [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder   [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder/bindingrecorder   [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder/commonrecorder    [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder/noderecorder      [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder/ownerreferencerecorder    [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder/snegrecorder      [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder/statusrecorder    [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/types      [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke-on-aws       [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke-on-azure     [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/form    [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp/api [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp/api/httpclient      [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/inspection      [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/inspection/env  [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/metadata        [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/parser  [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/task    [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset   [no test files]
?       github.com/GoogleCloudPlatform/khi/pkg/testutil/testtask        [no test files]
?       github.com/GoogleCloudPlatform/khi/scripts/frontend-codegen     [no test files]
ok      github.com/GoogleCloudPlatform/khi/pkg/model/binarychunk        34.106s
ok      github.com/GoogleCloudPlatform/khi/pkg/model/enum       1.266s
ok      github.com/GoogleCloudPlatform/khi/pkg/model/history    2.577s
ok      github.com/GoogleCloudPlatform/khi/pkg/model/history/grouper    0.895s
ok      github.com/GoogleCloudPlatform/khi/pkg/model/history/resourceinfo       1.018s [no tests to run]
ok      github.com/GoogleCloudPlatform/khi/pkg/model/history/resourceinfo/noderesource  1.125s
ok      github.com/GoogleCloudPlatform/khi/pkg/model/history/resourceinfo/resourcelease 0.974s
ok      github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath       0.956s
ok      github.com/GoogleCloudPlatform/khi/pkg/model/k8s        0.505s
ok      github.com/GoogleCloudPlatform/khi/pkg/model/k8s/configsource   0.626s
ok      github.com/GoogleCloudPlatform/khi/pkg/parameters       0.748s
ok      github.com/GoogleCloudPlatform/khi/pkg/parser/k8s       0.797s
ok      github.com/GoogleCloudPlatform/khi/pkg/parser/yaml/yamlutil     0.908s
ok      github.com/GoogleCloudPlatform/khi/pkg/popup    5.058s
ok      github.com/GoogleCloudPlatform/khi/pkg/rawlogs  13.493s
global > WARN task VfdcFIqoMyQAzUWE was finished with an error
context canceled
errorend > ERROR test error
global > WARN task RFBGeLizvhiXeIBD was finished with an error
failed to run a task graph.
 definition ID=errorend got an error. 
 ERROR:
test error
--- FAIL: TestKHIServer_EndpointExistsWithConfigs (0.00s)
    --- FAIL: TestKHIServer_EndpointExistsWithConfigs/custom_server_base_path_on_non-viewer_mode (0.00s)
panic: open ../../dist/test.html: no such file or directory [recovered]
        panic: open ../../dist/test.html: no such file or directory

goroutine 192 [running]:
testing.tRunner.func1.2({0x1037520e0, 0x140004dfce0})
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/testing/testing.go:1632 +0x1bc
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/testing/testing.go:1635 +0x334
panic({0x1037520e0?, 0x140004dfce0?})
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/runtime/panic.go:785 +0x124
github.com/GoogleCloudPlatform/khi/pkg/testutil.MustPlaceTemporalFile({0x1033d0fb1, 0x14}, {0x0, 0x0})
        /Users/junyaokabe/src/github.com/Okabe-Junya/khi/pkg/testutil/io.go:75 +0xec
github.com/GoogleCloudPlatform/khi/pkg/server.TestKHIServer_EndpointExistsWithConfigs.func1(0x140001b36c0)
        /Users/junyaokabe/src/github.com/Okabe-Junya/khi/pkg/server/server_test.go:775 +0x90
testing.tRunner(0x140001b36c0, 0x140000a2540)
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/testing/testing.go:1690 +0xe4
created by testing.(*T).Run in goroutine 191
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/testing/testing.go:1743 +0x314
FAIL    github.com/GoogleCloudPlatform/khi/pkg/server   5.692s
ok      github.com/GoogleCloudPlatform/khi/pkg/server/config    0.309s
ok      github.com/GoogleCloudPlatform/khi/pkg/server/index     0.866s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp       0.933s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/api   1.110s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/api/accesstoken       1.051s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/api/quotaproject      0.795s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/k8s   0.599s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/log   0.743s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil       0.823s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task  0.388s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/cloud-composer   0.529s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/autoscaler   0.397s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/compute_api  0.561s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/gke_audit    0.910s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/manifestutil       0.827s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/query      0.698s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder/containerstatusrecorder   0.412s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/recorder/endpointslicerecorder     0.766s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/rtype      0.821s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/v2commonlogparse   0.426s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/v2logconvert       0.777s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/v2manifestgenerate 1.222s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/v2timelinegrouping 1.435s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_container        1.502s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_control_plane_component  1.779s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_control_plane_component/componentparser  1.888s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_event    1.512s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_node     1.355s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/network_api  1.425s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/serialport   1.489s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/multicloud_api   1.104s
ok      github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/onprem_api       1.558s
ok      github.com/GoogleCloudPlatform/khi/pkg/task     5.485s
ok      github.com/GoogleCloudPlatform/khi/pkg/task/taskid      1.737s
ok      github.com/GoogleCloudPlatform/khi/pkg/testutil 1.495s
ok      github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp     2.926s
ok      github.com/GoogleCloudPlatform/khi/pkg/testutil/log     1.137s [no tests to run]
ok      github.com/GoogleCloudPlatform/khi/pkg/testutil/testlog 0.812s
FAIL
```

</details>

## Next Steps

I will:

- [ ] Update the Makefile and CI so that tests with the flag enabled can be easily executed
- [ ] Update the developer documentation