### PR TITLE
Adding types to store uploaded files

### DIFF
--- a/pkg/server/upload/store.go
+++ b/pkg/server/upload/store.go
@@ -1,0 +1,162 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// UploadStatus represents the status of an upload (Waiting or Completed).
+type UploadStatus int
+
+const (
+	// UploadStatusWaiting indicates this file is not yet uploaded or in progress of upload.
+	UploadStatusWaiting UploadStatus = 0
+
+	// UploadStatusUploading indicates this file is being uploaded.
+	UploadStatusUploading UploadStatus = 1
+
+	// UploadStatusVerifying indicates the file was uploaded but this is under verifying.
+	UploadStatusVerifying UploadStatus = 2
+
+	// UploadStatusComplete indicates the file has uploaded successfully.
+	UploadStatusCompleted UploadStatus = 3
+)
+
+// UploadResult holds the result of an upload operation.
+type UploadResult struct {
+	StoreProvider UploadFileStoreProvider
+	// Status is the current state of the upload.
+	Status UploadStatus
+	// UploadError contains any error that occurred during the upload process itself
+	UploadError error
+	// VerificationError contains any error returned by the UploadFileVerifier.
+	VerificationError error
+	// VerificationCount is the attempt count of the verification logic. This value is preventing the race condition in verification steps.
+	VerificationCount int
+}
+
+// UploadFileStore manages file uploads.
+type UploadFileStore struct {
+	StoreProvider UploadFileStoreProvider
+	resultLock    sync.RWMutex
+	results       map[string]UploadResult
+	verifierLock  sync.RWMutex
+	verifiers     map[string]UploadFileVerifier
+}
+
+// GetUploadToken returns the token to upload it from frontend.
+func (s *UploadFileStore) GetUploadToken(id string, verifier UploadFileVerifier) UploadToken {
+	s.resultLock.Lock()
+	s.verifierLock.Lock()
+	defer s.resultLock.Unlock()
+	defer s.verifierLock.Unlock()
+	token := s.StoreProvider.GetUploadToken(id)
+	_, ok := s.results[token.GetID()]
+	if !ok {
+		s.results[token.GetID()] = UploadResult{
+			Status: UploadStatusWaiting,
+		}
+	}
+	s.verifiers[token.GetID()] = verifier
+	return token
+}
+
+// GetResult returns the result of the upload with given token.
+func (s *UploadFileStore) GetResult(token UploadToken) (UploadResult, error) {
+	s.resultLock.RLock()
+	result, ok := s.results[token.GetID()]
+	s.resultLock.RUnlock()
+	if ok {
+		return result, nil
+	}
+	return UploadResult{}, fmt.Errorf("upload result not found for token %s", token.GetID())
+}
+
+// SetResultOnStartingUpload sets the upload status to Uploading.  It returns an error if the token is not found.
+func (s *UploadFileStore) SetResultOnStartingUpload(token UploadToken) error {
+	s.resultLock.Lock()
+	defer s.resultLock.Unlock()
+	_, ok := s.results[token.GetID()]
+	if !ok {
+		return fmt.Errorf("upload result not found for token %s", token.GetID())
+	}
+	s.results[token.GetID()] = UploadResult{
+		StoreProvider: s.StoreProvider,
+		Status:        UploadStatusUploading,
+	}
+	return nil
+}
+
+// SetResultOnCompletedUpload notify the file upload is completed and start verifier.
+func (s *UploadFileStore) SetResultOnCompletedUpload(token UploadToken, uploadError error) error {
+	s.resultLock.Lock()
+	defer s.resultLock.Unlock()
+	prev, ok := s.results[token.GetID()]
+	if !ok {
+		return fmt.Errorf("upload result not found for token %s", token.GetID())
+	}
+	nextVerificationIndex := prev.VerificationCount + 1
+	if uploadError == nil {
+		s.results[token.GetID()] = UploadResult{
+			StoreProvider:     s.StoreProvider,
+			Status:            UploadStatusVerifying,
+			UploadError:       uploadError,
+			VerificationCount: nextVerificationIndex,
+		}
+	} else {
+		s.results[token.GetID()] = UploadResult{
+			StoreProvider:     s.StoreProvider,
+			Status:            UploadStatusWaiting,
+			UploadError:       uploadError,
+			VerificationCount: prev.VerificationCount,
+		}
+	}
+	if uploadError == nil {
+		go func() {
+			err := s.verifiers[token.GetID()].Verify(s.StoreProvider, token)
+			s.resultLock.Lock()
+			defer s.resultLock.Unlock()
+			current, ok := s.results[token.GetID()]
+			if !ok {
+				slog.Error(fmt.Sprintf("upload result not found for token %s", token.GetID()))
+				return
+			}
+			if current.VerificationCount != nextVerificationIndex {
+				// user maybe uploaded file twice and the verification result for previous upload is ignored
+				return
+			}
+			s.results[token.GetID()] = UploadResult{
+				StoreProvider:     s.StoreProvider,
+				Status:            UploadStatusCompleted,
+				UploadError:       current.UploadError,
+				VerificationError: err,
+				VerificationCount: nextVerificationIndex,
+			}
+		}()
+	}
+	return nil
+}
+
+// NewUploadFileStore creates a new UploadFileStore.
+func NewUploadFileStore(storeProvider UploadFileStoreProvider) *UploadFileStore {
+	return &UploadFileStore{
+		StoreProvider: storeProvider,
+		results:       make(map[string]UploadResult),
+		verifiers:     make(map[string]UploadFileVerifier),
+	}
+}

--- a/pkg/server/upload/store_test.go
+++ b/pkg/server/upload/store_test.go
@@ -111,8 +111,8 @@ func TestUploadFileStore(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "not found") {
-			t.Errorf("Expected error message to contain 'not found', got '%v'", err)
+		if !strings.Contains(err.Error(), "unknown upload token specifed") {
+			t.Errorf("Expected error message to contain 'unknown upload token specifed', got '%v'", err)
 		}
 	})
 
@@ -123,8 +123,8 @@ func TestUploadFileStore(t *testing.T) {
 		if err == nil {
 			t.Error("Expected an error for nonexistent token")
 		}
-		if !strings.Contains(err.Error(), "not found") {
-			t.Errorf("Expected 'not found' in error, got: %v", err)
+		if !strings.Contains(err.Error(), "unknown upload token specifed") {
+			t.Errorf("Expected 'unknown upload token specifed' in error, got: %v", err)
 		}
 	})
 

--- a/pkg/server/upload/store_test.go
+++ b/pkg/server/upload/store_test.go
@@ -1,0 +1,263 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Mock UploadFileVerifier for testing.
+type MockUploadFileVerifier struct {
+	VerifyFunc func(storeProvider UploadFileStoreProvider, token UploadToken) error
+}
+
+func (m *MockUploadFileVerifier) Verify(storeProvider UploadFileStoreProvider, token UploadToken) error {
+	if m.VerifyFunc != nil {
+		return m.VerifyFunc(storeProvider, token)
+	}
+	return nil
+}
+
+func TestUploadFileStore(t *testing.T) {
+	// Create a temporary directory for testing.
+	tempDir, err := os.MkdirTemp("", "uploadtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up after the test.
+
+	// Create a new LocalUploadFileStore.
+	provider, err := NewLocalUploadFileStoreProvider(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Run("GetUploadToken_NewToken", func(t *testing.T) {
+		store := NewUploadFileStore(provider)
+		verifier := &MockUploadFileVerifier{}
+
+		token := store.GetUploadToken("test-id-1", verifier)
+
+		result, err := store.GetResult(token)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if result.Status != UploadStatusWaiting {
+			t.Errorf("Expected status 'Waiting', got '%v'", result.Status)
+		}
+	})
+
+	t.Run("GetResult_WithSuccessfulUploadScenario", func(t *testing.T) {
+		store := NewUploadFileStore(provider)
+		verifier := &MockUploadFileVerifier{}
+
+		token := store.GetUploadToken("test-id-2", verifier)
+
+		err := store.SetResultOnStartingUpload(token)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		result, err := store.GetResult(token)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if result.Status != UploadStatusUploading {
+			t.Errorf("Expected status 'Uploading', got '%v'", result.Status)
+		}
+
+		err = store.SetResultOnCompletedUpload(token, nil)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		result, err = store.GetResult(token)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if result.Status != UploadStatusVerifying {
+			t.Errorf("Expected status 'Verifying', got '%v'", result.Status)
+		}
+
+		<-time.After(100 * time.Microsecond)
+		result, err = store.GetResult(token)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if result.Status != UploadStatusCompleted {
+			t.Errorf("Expected status 'Completed', got '%v'", result.Status)
+		}
+	})
+
+	t.Run("SetResultOnStartingUpload_NotFound", func(t *testing.T) {
+		store := NewUploadFileStore(provider)
+
+		err := store.SetResultOnStartingUpload(&DirectUploadToken{ID: "non-existing-token"})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("Expected error message to contain 'not found', got '%v'", err)
+		}
+	})
+
+	t.Run("SetResultOnCompletedUpload_NotFound", func(t *testing.T) {
+		store := NewUploadFileStore(provider)
+
+		err := store.SetResultOnCompletedUpload(&DirectUploadToken{ID: "non-existing-token"}, nil)
+		if err == nil {
+			t.Error("Expected an error for nonexistent token")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("Expected 'not found' in error, got: %v", err)
+		}
+	})
+
+	t.Run("SetResultOnCompletedUpload_WithUploadError", func(t *testing.T) {
+		store := NewUploadFileStore(provider)
+
+		verifier := &MockUploadFileVerifier{
+			VerifyFunc: func(storeProvider UploadFileStoreProvider, token UploadToken) error {
+				t.Errorf("verify function shouldn't be called on upload fail")
+				return nil // Simulate successful verification (should be ignored due to upload error).
+			},
+		}
+
+		token := store.GetUploadToken("uploaderror-id", verifier)
+
+		err := store.SetResultOnStartingUpload(token) // Set initial status
+		if err != nil {
+			t.Fatalf("Unexpected error on SetResultOnStartingUpload: %v", err)
+		}
+
+		uploadErr := errors.New("simulated upload error")
+		err = store.SetResultOnCompletedUpload(token, uploadErr)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+
+		result, err := store.GetResult(token)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if result.Status != UploadStatusWaiting {
+			t.Errorf("Expected status 'Waiting', got '%v'", result.Status)
+		}
+		if result.UploadError != uploadErr {
+			t.Errorf("Expected UploadError to be '%v', got '%v'", uploadErr, result.UploadError)
+		}
+		if result.VerificationError != nil {
+			t.Errorf("Expected VerificationError to be nil, got '%v'", result.VerificationError) // Should be nil
+		}
+	})
+
+	t.Run("SetResultOnCompletedUpload_WithVerificationError", func(t *testing.T) {
+		store := NewUploadFileStore(provider)
+
+		verificationErr := errors.New("simulated verification error")
+		verifier := &MockUploadFileVerifier{
+			VerifyFunc: func(storeProvider UploadFileStoreProvider, token UploadToken) error {
+				return verificationErr
+			},
+		}
+
+		token := store.GetUploadToken("verifyerror-id", verifier)
+		err := store.SetResultOnStartingUpload(token)
+		if err != nil {
+			t.Fatalf("Unexpected error on SetResultOnStartingUpload: %v", err)
+		}
+
+		err = store.SetResultOnCompletedUpload(token, nil) // No upload error.
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // Allow verification goroutine to run.
+
+		result, err := store.GetResult(token)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if result.Status != UploadStatusCompleted {
+			t.Errorf("Expected status 'Completed', got '%v'", result.Status)
+		}
+		if result.UploadError != nil {
+			t.Errorf("Expected UploadError to be nil, got '%v'", result.UploadError)
+		}
+		if result.VerificationError != verificationErr {
+			t.Errorf("Expected VerificationError to be '%v', got '%v'", verificationErr, result.VerificationError)
+		}
+	})
+	t.Run("SetResultOnCompletedUpload_RaceVerifications", func(t *testing.T) {
+		store := NewUploadFileStore(provider)
+
+		verifier := &MockUploadFileVerifier{
+			VerifyFunc: func(storeProvider UploadFileStoreProvider, token UploadToken) error {
+				<-time.After(100 * time.Millisecond) // Lazy verification function
+				return nil
+			},
+		}
+
+		token := store.GetUploadToken("test-id-4", verifier)
+
+		err := store.SetResultOnStartingUpload(token)
+		if err != nil {
+			t.Fatalf("SetResultOnStartingUpload 1 error: %v", err)
+		}
+
+		err = store.SetResultOnCompletedUpload(token, nil)
+		if err != nil {
+			t.Fatalf("SetResultOnCompletedUpload 1 error: %v", err)
+		}
+
+		<-time.After(50 * time.Millisecond) // Start a new upload before the verification completes
+
+		err = store.SetResultOnStartingUpload(token)
+		if err != nil {
+			t.Fatalf("SetResultOnStartingUpload 2 error: %v", err)
+		}
+
+		// Verification for the first upload should be done before here, but new upload is already started
+		<-time.After(70 * time.Millisecond)
+
+		err = store.SetResultOnCompletedUpload(token, nil)
+		if err != nil {
+			t.Fatalf("SetResultOnCompletedUpload 2 error: %v", err)
+		}
+
+		result1, err := store.GetResult(token)
+		if err != nil {
+			t.Fatalf("GetResult returns error: %v", err)
+		}
+		if result1.Status != UploadStatusVerifying {
+			t.Errorf("Want Uploading status, got %v", result1.Status)
+		}
+
+		<-time.After(500 * time.Millisecond)
+
+		result2, err := store.GetResult(token)
+		if err != nil {
+			t.Fatalf("GetResult returns error: %v", err)
+		}
+		if result2.Status != UploadStatusCompleted {
+			t.Errorf("Want Completed status, got %v", result2.Status)
+		}
+	})
+}

--- a/pkg/server/upload/storeprovider.go
+++ b/pkg/server/upload/storeprovider.go
@@ -41,16 +41,7 @@ type LocalUploadFileStoreProvider struct {
 }
 
 // NewLocalUploadFileStoreProvider creates a new LocalUploadFileStore.
-// It takes the directory path as an argument and creates the directory
-// if it does not exist.  It returns an error if the directory
-// cannot be created (and does not already exist).
 func NewLocalUploadFileStoreProvider(directoryPath string) (*LocalUploadFileStoreProvider, error) {
-	// Create the directory (and any parent directories) if it doesn't exist.
-	// os.MkdirAll will not return an error if the directory already exists.
-	err := os.MkdirAll(directoryPath, 0755)
-	if err != nil {
-		return nil, err // Return the error if directory creation fails.
-	}
 	return &LocalUploadFileStoreProvider{directoryPath: directoryPath}, nil
 }
 
@@ -72,8 +63,11 @@ func (l *LocalUploadFileStoreProvider) Read(token UploadToken) (io.ReadCloser, e
 }
 
 func (l *LocalUploadFileStoreProvider) Write(token UploadToken, reader io.Reader) error {
+	err := l.ensureFolderExists()
+	if err != nil {
+		return err
+	}
 	filePath := filepath.Join(l.directoryPath, token.GetID())
-
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err
@@ -87,6 +81,12 @@ func (l *LocalUploadFileStoreProvider) Write(token UploadToken, reader io.Reader
 	}
 
 	return nil
+}
+
+func (l *LocalUploadFileStoreProvider) ensureFolderExists() error {
+	// Create the directory (and any parent directories) if it doesn't exist.
+	// os.MkdirAll will not return an error if the directory already exists.
+	return os.MkdirAll(l.directoryPath, 0700)
 }
 
 var _ UploadFileStoreProvider = &LocalUploadFileStoreProvider{}

--- a/pkg/server/upload/storeprovider.go
+++ b/pkg/server/upload/storeprovider.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type UploadFileStoreProvider interface {
+	// Generate a UploadToken for frontend
+	GetUploadToken(id string) UploadToken
+	// Read returns the io.ReadCloser interface to read the file with the given ID.
+	// The caller MUST close the returned ReadCloser.
+	Read(token UploadToken) (io.ReadCloser, error)
+}
+
+type DirectWritableUploadFileStoreProvider interface {
+	// Write writes file with given io.Writer interaface to the file with the given ID.
+	Write(token UploadToken, reader io.Reader) error
+}
+
+// LocalUploadFileStoreProvider is an implementation of UploadFileStore that stores files
+// in the local file system.
+type LocalUploadFileStoreProvider struct {
+	// directoryPath is the folder name where uploaded files are stored.
+	directoryPath string
+}
+
+// NewLocalUploadFileStoreProvider creates a new LocalUploadFileStore.
+// It takes the directory path as an argument and creates the directory
+// if it does not exist.  It returns an error if the directory
+// cannot be created (and does not already exist).
+func NewLocalUploadFileStoreProvider(directoryPath string) (*LocalUploadFileStoreProvider, error) {
+	// Create the directory (and any parent directories) if it doesn't exist.
+	// os.MkdirAll will not return an error if the directory already exists.
+	err := os.MkdirAll(directoryPath, 0755)
+	if err != nil {
+		return nil, err // Return the error if directory creation fails.
+	}
+	return &LocalUploadFileStoreProvider{directoryPath: directoryPath}, nil
+}
+
+// GetUploadToken implements UploadFileStoreProvider.
+func (l *LocalUploadFileStoreProvider) GetUploadToken(id string) UploadToken {
+	return &DirectUploadToken{ID: id}
+}
+
+func (l *LocalUploadFileStoreProvider) Read(token UploadToken) (io.ReadCloser, error) {
+	filePath := filepath.Join(l.directoryPath, token.GetID())
+	file, err := os.Open(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, os.ErrNotExist
+		}
+		return nil, err
+	}
+	return file, nil // os.File implements io.ReadCloser
+}
+
+func (l *LocalUploadFileStoreProvider) Write(token UploadToken, reader io.Reader) error {
+	filePath := filepath.Join(l.directoryPath, token.GetID())
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, reader)
+	if err != nil {
+		_ = os.Remove(filePath)
+		return err
+	}
+
+	return nil
+}
+
+var _ UploadFileStoreProvider = &LocalUploadFileStoreProvider{}
+var _ DirectWritableUploadFileStoreProvider = &LocalUploadFileStoreProvider{}

--- a/pkg/server/upload/storeprovider_test.go
+++ b/pkg/server/upload/storeprovider_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// MockLocalUploadFileStoreProvider is a mock implementation of LocalUploadFileStoreProvider for testing purposes.
+type MockLocalUploadFileStoreProvider struct {
+	Data string
+}
+
+func (t *MockLocalUploadFileStoreProvider) Read(token UploadToken) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(t.Data)), nil
+}
+
+func (t *MockLocalUploadFileStoreProvider) GetUploadToken(id string) UploadToken {
+	return &DirectUploadToken{ID: id}
+}
+
+var _ UploadFileStoreProvider = &MockLocalUploadFileStoreProvider{}
+
+func TestLocalUploadFileStoreProvider_Essential(t *testing.T) {
+	// Create a temporary directory for testing.
+	tempDir, err := os.MkdirTemp("", "uploadtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up after the test.
+
+	// Create a new LocalUploadFileStore.
+	store, err := NewLocalUploadFileStoreProvider(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("WriteAndRead_Basic", func(t *testing.T) {
+		token := store.GetUploadToken("test-token")
+		content := "This is some test content."
+		reader := strings.NewReader(content)
+
+		// Write the file.
+		err = store.Write(token, reader)
+		if err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+
+		// Read the file.
+		readCloser, err := store.Read(token)
+		if err != nil {
+			t.Fatalf("Read failed: %v", err)
+		}
+		defer readCloser.Close()
+
+		// Read the content and verify.
+		readContent, err := io.ReadAll(readCloser)
+		if err != nil {
+			t.Fatalf("ReadAll failed: %v", err)
+		}
+		if string(readContent) != content {
+			t.Errorf("Expected content: %q, got: %q", content, string(readContent))
+		}
+	})
+
+	t.Run("Read_NonExistentFile", func(t *testing.T) {
+		token := store.GetUploadToken("not-uploaded")
+		_, err := store.Read(token)
+		if !os.IsNotExist(err) {
+			t.Errorf("Expected os.ErrNotExist, got: %v", err)
+		}
+	})
+
+	t.Run("WriteAndRead_Overwrite", func(t *testing.T) {
+		token := store.GetUploadToken("test-token")
+		content1 := "Initial content"
+		content2 := "Overwritten content"
+
+		// Write initial content.
+		if err := store.Write(token, strings.NewReader(content1)); err != nil {
+			t.Fatalf("Initial write failed: %v", err)
+		}
+
+		// Overwrite the file.
+		if err := store.Write(token, strings.NewReader(content2)); err != nil {
+			t.Fatalf("Overwrite write failed: %v", err)
+		}
+
+		// Read and verify overwritten content.
+		readCloser, err := store.Read(token)
+		if err != nil {
+			t.Fatalf("Read after overwrite failed: %v", err)
+		}
+		defer readCloser.Close()
+
+		readContent, err := io.ReadAll(readCloser)
+		if err != nil {
+			t.Fatalf("ReadAll after overwrite failed: %v", err)
+		}
+		if string(readContent) != content2 {
+			t.Errorf("Expected content: %q, got: %q", content2, string(readContent))
+		}
+	})
+}

--- a/pkg/server/upload/uploadtoken.go
+++ b/pkg/server/upload/uploadtoken.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+// UploadToken is the type given to the frontend to receive the file.
+// This currently exects files are uploaded to API directly, but in future this may support the upload using signed URLs as well.
+// All token implements this type must be serializable as JSON.
+type UploadToken interface {
+	// GetType returns the type of token specifying the methods to upload the file.
+	GetType() string
+	// GetID returns the unique identifier of upload files.
+	GetID() string
+}
+
+// DirectUploadToken is a UploadToken for uploading the target file to API directly.
+type DirectUploadToken struct {
+	// ID identiies the file location uploade to this server directly.
+	ID string `json:"id"`
+}
+
+// GetID implements UploadToken.
+func (d *DirectUploadToken) GetID() string {
+	return d.ID
+}
+
+// GetType implements UploadToken.
+func (d *DirectUploadToken) GetType() string {
+	return "direct"
+}
+
+var _ UploadToken = &DirectUploadToken{}

--- a/pkg/server/upload/uploadtoken.go
+++ b/pkg/server/upload/uploadtoken.go
@@ -22,12 +22,20 @@ type UploadToken interface {
 	GetType() string
 	// GetID returns the unique identifier of upload files.
 	GetID() string
+	// GetHash returns a unique string calculated from all the field of the implementation.
+	// This must be calculated from ALL the field because this is for checking if 2 instances are identical.
+	GetHash() string
 }
 
 // DirectUploadToken is a UploadToken for uploading the target file to API directly.
 type DirectUploadToken struct {
 	// ID identiies the file location uploade to this server directly.
 	ID string `json:"id"`
+}
+
+// GetHash implements UploadToken.
+func (d *DirectUploadToken) GetHash() string {
+	return d.ID
 }
 
 // GetID implements UploadToken.

--- a/pkg/server/upload/verifier.go
+++ b/pkg/server/upload/verifier.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// UploadFileVerifier verifies uploaded files (e.g., file type checks).
+type UploadFileVerifier interface {
+	// Verify checks the file. This returns an error if invalid.
+	Verify(storeProvider UploadFileStoreProvider, token UploadToken) error
+}
+
+type NopUploadFileVerifier struct{}
+
+// Verify implements UploadFileVerifier.
+func (n *NopUploadFileVerifier) Verify(storeProvider UploadFileStoreProvider, token UploadToken) error {
+	return nil
+}
+
+var _ UploadFileVerifier = &NopUploadFileVerifier{}
+
+type JSONLineUploadFileVerifier struct {
+	MaxLineSizeInBytes int
+}
+
+// Verify implements UploadFileVerifier.
+func (j *JSONLineUploadFileVerifier) Verify(storeProvider UploadFileStoreProvider, token UploadToken) error {
+	reader, err := storeProvider.Read(token)
+	if err != nil {
+		return fmt.Errorf("failed to read the uploded file")
+	}
+	defer reader.Close()
+
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, j.MaxLineSizeInBytes), j.MaxLineSizeInBytes)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := scanner.Bytes()
+
+		// Check if the line is empty or just whitespace. Skip empty lines.
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		var data interface{}
+		if err := json.Unmarshal(line, &data); err != nil {
+			return fmt.Errorf("invalid JSON on line %d: %w", lineNumber, err)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading file: %w", err)
+	}
+
+	return nil
+}
+
+var _ UploadFileVerifier = &JSONLineUploadFileVerifier{}

--- a/pkg/server/upload/verifier.go
+++ b/pkg/server/upload/verifier.go
@@ -60,9 +60,15 @@ func (j *JSONLineUploadFileVerifier) Verify(storeProvider UploadFileStoreProvide
 			continue
 		}
 
-		var data interface{}
-		if err := json.Unmarshal(line, &data); err != nil {
-			return fmt.Errorf("invalid JSON on line %d: %w", lineNumber, err)
+		if !json.Valid(line) {
+			// json.Valid only returns valid or not, gets the error message with deserializing it.
+			var data interface{}
+			if err := json.Unmarshal(line, &data); err != nil {
+				return fmt.Errorf("invalid JSON on line %d: %w", lineNumber, err)
+			} else {
+				// The JSON is not valid but deserialized.
+				return fmt.Errorf("unreachable")
+			}
 		}
 	}
 

--- a/pkg/server/upload/verifier_test.go
+++ b/pkg/server/upload/verifier_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestJSONLineUploadFileVerifier(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        string
+		expectedErr string
+	}{
+		{
+			name: "Valid JSON Lines",
+			data: `{"name": "Alice", "age": 30}
+{"name": "Bob", "age": 25}
+{"name": "Charlie", "age": 40}`,
+			expectedErr: "",
+		},
+		{
+			name:        "Empty File",
+			data:        "",
+			expectedErr: "",
+		},
+		{
+			name:        "Single Valid Line",
+			data:        `{"name": "David", "age": 50}`,
+			expectedErr: "",
+		},
+		{
+			name: "Invalid JSON",
+			data: `{"name": "Eve", "age": 35}
+{invalid json}
+{"name": "Frank", "age": 45}`,
+			expectedErr: "invalid JSON on line 2: invalid character 'i' looking for beginning of object key string",
+		},
+		{
+			name: "Empty Lines and Whitespace",
+			data: `{"name": "Grace", "age": 55}
+
+{"name": "Hank", "age": 60}
+   `, expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verifier := &JSONLineUploadFileVerifier{MaxLineSizeInBytes: 1024 * 1024}
+			provider := &MockLocalUploadFileStoreProvider{Data: tt.data}
+			err := verifier.Verify(provider, &DirectUploadToken{ID: "test"})
+
+			if tt.expectedErr == "" {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error, but got nil")
+				} else if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Errorf("Expected error to contain: %q, but got: %v", tt.expectedErr, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a new type to manage uploaded files in an extensible way, laying the groundwork for supporting log input via file uploads in the future.

**Summary of Changes:**

We've created an `UploadFileStore` type to manage uploaded files, designed to be extensible for supporting file upload based inspection.

The upcoming file upload form element will utilize `UploadFileStore.GetUploadToken` to obtain a unique ID representing the uploaded file, based on specific parameters. This token will then be passed to the frontend.

The frontend will handle file uploads using the provided `UploadToken`.  This PR implements `LocalUploadFileStoreProvider`, which stores uploaded files in a specific directory on the server. The server should implement this upload mechanism in the later commit.  The design allows for future extensions, such as importing files uploaded to cloud storage services like GCS.

Once a file is uploaded, it's checked by the `UploadFileVerifier` specified during the upload process. This verifier confirms that the file meets the expected criteria.  For example, the included `JSONLineUploadFileVerifier` checks if the uploaded file is in valid JSON Lines format.

Throughout this upload and verification process, the `UploadFileStore` provides a way to retrieve the status associated with a token in a JSON-serializable format.  This enables these errors to be included in the form metadata to show them on frontend.