### PR TITLE
Feature: Introduce golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,44 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  backend-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        with:
+          version: v1.64
+          # TODO: Remove the `--issues-exit-code=0` flag once all issues are resolved
+          args: --config=.golangci.yaml --issues-exit-code=0

--- a/.github/workflows/pr-request.yaml
+++ b/.github/workflows/pr-request.yaml
@@ -34,6 +34,11 @@ jobs:
       with:
         go-version-file: './go.mod'
 
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+      with:
+        version: v1.64
+
     # TODO: Configure Github Action after getting the Workload Identity Pool for this project
     # https://github.com/GoogleCloudPlatform/khi/issues/29
     # - name: Authenticate to Google Cloud
@@ -61,7 +66,6 @@ jobs:
     - name: Backend Format and Lint Check
       run: |
         make check-format-go
-        make lint-go
 
   frontend-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-request.yaml
+++ b/.github/workflows/pr-request.yaml
@@ -34,11 +34,6 @@ jobs:
       with:
         go-version-file: './go.mod'
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
-      with:
-        version: v1.64
-
     # TODO: Configure Github Action after getting the Workload Identity Pool for this project
     # https://github.com/GoogleCloudPlatform/khi/issues/29
     # - name: Authenticate to Google Cloud
@@ -66,6 +61,7 @@ jobs:
     - name: Backend Format and Lint Check
       run: |
         make check-format-go
+        make lint-go
 
   frontend-tests:
     runs-on: ubuntu-latest
@@ -139,7 +135,7 @@ jobs:
     - name: Build web
       working-directory: ./web
       run: npx ng build --configuration ${{ matrix.configuration }}
-  
+
   license-header-check:
     runs-on: ubuntu-latest
     permissions:
@@ -147,15 +143,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: './go.mod'
-      
+
       - name: Install addlicense package
         run: go install github.com/google/addlicense@latest
-      
+
       - name: Run addlicense
         id: license_header_check
         run: addlicense  -c "Google LLC" -l apache -v -check .

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,31 @@
+run:
+  timeout: "30m"
+  allow-parallel-runners: true
+  go: "1.23"
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    # - errcheck
+    - gocritic
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - noctx
+    - staticcheck
+    - unused
+
+linters-settings:
+  govet:
+    enable-all: true
+  staticcheck:
+    # SA1006 is disabled
+    # See https://staticcheck.dev/docs/checks#SA1006 for more information
+    checks: ["-SA1006"]
+issues:
+  exclude-use-default: true
+
+output:
+  print-linter-name: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 run:
   timeout: "30m"
   allow-parallel-runners: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,9 @@ linters:
 linters-settings:
   govet:
     enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
   staticcheck:
     # SA1006 is disabled
     # See https://staticcheck.dev/docs/checks#SA1006 for more information

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,6 +39,12 @@ linters-settings:
     checks: ["-SA1006"]
 issues:
   exclude-use-default: true
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - noctx
+        - govet
 
 output:
   print-linter-name: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    # - errcheck
     - gocritic
     - goimports
     - gosimple

--- a/pkg/common/collection.go
+++ b/pkg/common/collection.go
@@ -29,7 +29,7 @@ func DedupStringArray(arr []string) []string {
 	for v := range arrByMap {
 		deduped = append(deduped, v)
 	}
-	slices.SortFunc(deduped, func(a, b string) int { return strings.Compare(a, b) })
+	slices.SortFunc(deduped, strings.Compare)
 	return deduped
 }
 

--- a/pkg/common/httpclient/basic_http_client_test.go
+++ b/pkg/common/httpclient/basic_http_client_test.go
@@ -104,10 +104,13 @@ func TestBasicHttpClient_DoWithContext(t *testing.T) {
 		client := NewBasicHttpClient()
 		req, _ := http.NewRequest("GET", "http://localhost:12345", nil)
 
-		_, err := client.DoWithContext(context.Background(), req)
+		resp, err := client.DoWithContext(context.Background(), req)
 
 		if err == nil {
 			t.Error("got nil, want error")
+		}
+		if resp != nil {
+			defer resp.Body.Close()
 		}
 	})
 
@@ -123,10 +126,13 @@ func TestBasicHttpClient_DoWithContext(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		_, err := client.DoWithContext(ctx, req)
+		resp, err := client.DoWithContext(ctx, req)
 
 		if err == nil {
 			t.Error("got nil, want error")
+		}
+		if resp != nil {
+			defer resp.Body.Close()
 		}
 		if !errors.Is(err, context.Canceled) {
 			t.Errorf("got %v, want context.Canceled", err)

--- a/pkg/common/httpclient/basic_http_client_test.go
+++ b/pkg/common/httpclient/basic_http_client_test.go
@@ -55,6 +55,7 @@ func TestBasicHttpClient_DoWithContext(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected no error, but got %v", err)
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("got status code %d, want %d", http.StatusOK, resp.StatusCode)
 		}
@@ -93,6 +94,7 @@ func TestBasicHttpClient_DoWithContext(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected no error, but got %v", err)
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("got status code %d, want %d", http.StatusOK, resp.StatusCode)
 		}

--- a/pkg/common/httpclient/json_response_client_test.go
+++ b/pkg/common/httpclient/json_response_client_test.go
@@ -55,10 +55,11 @@ func TestDoWithContext(t *testing.T) {
 }`)),
 		},
 	})
-	result, _, err := jsonClient.DoWithContext(context.Background(), &http.Request{})
+	result, resp, err := jsonClient.DoWithContext(context.Background(), &http.Request{})
 	if err != nil {
 		t.Errorf("unexpected err:%s", err.Error())
 	}
+	defer resp.Body.Close()
 	if diff := cmp.Diff(&testJsonType{
 		Foo: "foo-val",
 		Bar: "bar-val",

--- a/pkg/common/httpclient/retry_client_test.go
+++ b/pkg/common/httpclient/retry_client_test.go
@@ -227,6 +227,7 @@ func TestRetryBehavior(t *testing.T) {
 			for _, respCode := range tc.ResponseCodes {
 				responses = append(responses, &http.Response{
 					StatusCode: respCode,
+					Body:       io.NopCloser(bytes.NewBufferString("")),
 				})
 			}
 			baseClient := mockFailClient{
@@ -247,6 +248,8 @@ func TestRetryBehavior(t *testing.T) {
 			if tc.ExpectedError == "" {
 				if response == nil {
 					t.Error("got nil, want response")
+				} else {
+					defer response.Body.Close()
 				}
 				if err != nil {
 					t.Errorf("got error %v, want nil", err)

--- a/pkg/inspection/logger/format.go
+++ b/pkg/inspection/logger/format.go
@@ -102,16 +102,16 @@ func (lh *KHILogFormatHandler) wrapColorByLevel(level slog.Level, msg string) st
 	}
 	var colorBegin string
 	if level.Level() == slog.LevelDebug {
-		colorBegin = "\033[90m" //bright black
+		colorBegin = "\033[90m" // bright black
 	}
 	if level.Level() == slog.LevelInfo {
-		colorBegin = "\033[96m" //bright cyan
+		colorBegin = "\033[96m" // bright cyan
 	}
 	if level.Level() == slog.LevelWarn {
-		colorBegin = "\033[93m" //bright yellow
+		colorBegin = "\033[93m" // bright yellow
 	}
 	if level.Level() == slog.LevelError {
-		colorBegin = "\033[97;101m" //bright yellow
+		colorBegin = "\033[97;101m" // bright yellow
 	}
 	return fmt.Sprintf("%s%s%s", colorBegin, msg, reset)
 }

--- a/pkg/inspection/metadata/logger/throttle.go
+++ b/pkg/inspection/metadata/logger/throttle.go
@@ -48,11 +48,12 @@ func (c ConstantLogThrottle) ThrottleStatus(logKind string) LogThrottleStatus {
 		return StatusNoThrottle
 	}
 	cnt := c.counter.Incr(logKind)
-	if cnt == c.MaxCountPerKind {
+	switch {
+	case cnt == c.MaxCountPerKind:
 		return StatusJustBeforeThrottle
-	} else if cnt > c.MaxCountPerKind {
+	case cnt > c.MaxCountPerKind:
 		return StatusThrottled
-	} else {
+	default:
 		return StatusNoThrottle
 	}
 }

--- a/pkg/inspection/server.go
+++ b/pkg/inspection/server.go
@@ -84,11 +84,10 @@ func (s *InspectionTaskServer) AddInspectionType(newInspectionType InspectionTyp
 	if _, exist := idMap[newInspectionType.Id]; exist {
 		return fmt.Errorf("inspection type id:%s is duplicated. InspectionType ID must be unique", newInspectionType.Id)
 	}
-	inspectionTypesCandidate := append(s.inspectionTypes, &newInspectionType)
-	slices.SortFunc(inspectionTypesCandidate, func(a *InspectionType, b *InspectionType) int {
+	s.inspectionTypes = append(s.inspectionTypes, &newInspectionType)
+	slices.SortFunc(s.inspectionTypes, func(a *InspectionType, b *InspectionType) int {
 		return b.Priority - a.Priority
 	})
-	s.inspectionTypes = inspectionTypesCandidate
 	return nil
 }
 

--- a/pkg/log/structure/merger/merged.go
+++ b/pkg/log/structure/merger/merged.go
@@ -649,7 +649,7 @@ func reorderArrayKeysForMerge(prev []string, patch []string, setElementOrderDire
 		if _, found := patchMap[directiveElem]; !found {
 			if _, found := prevMap[directiveElem]; !found {
 				// Assume the item was existing from the past
-				liveOnlyList = append(liveOnlyList, directiveElem)
+				liveList = append(liveOnlyList, directiveElem)
 			}
 		}
 	}

--- a/pkg/log/structure/merger/merged.go
+++ b/pkg/log/structure/merger/merged.go
@@ -147,14 +147,16 @@ func (d *StrategicMergedStructureData) Value(fieldName string) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ty == structuredata.StructuredTypeScalar {
+
+	switch ty {
+	case structuredata.StructuredTypeScalar:
 		patchPolicy, err := d.readScalarAsString(d.patch, "$patch")
 		if err == nil && patchPolicy == "delete" {
 			return nil, nil
 		}
 		return d.patch.Value(fieldName)
-	}
-	if ty == structuredata.StructuredTypeMap {
+
+	case structuredata.StructuredTypeMap:
 		if fieldName == "" {
 			return d, nil
 		}
@@ -214,7 +216,9 @@ func (d *StrategicMergedStructureData) Value(fieldName string) (any, error) {
 				prevFound = true
 			}
 		}
-		if prevFound && patchFound {
+
+		switch {
+		case prevFound && patchFound:
 			result := NewStrategicMergedStructureData(fmt.Sprintf("%s.%s", d.path, fieldName), prevValueStructure, patchValueStructure, d.mergeKeyResolver)
 			deleteFromPrimitiveList, err := d.readArray(d.patch, fmt.Sprintf("$deleteFromPrimitiveList/%s", fieldName))
 			if err == nil {
@@ -229,7 +233,7 @@ func (d *StrategicMergedStructureData) Value(fieldName string) (any, error) {
 				}
 			}
 			return result, nil
-		} else if prevFound {
+		case prevFound:
 			result := NewStrategicMergedStructureData(fmt.Sprintf("%s.%s", d.path, fieldName), prevValueStructure, prevValueStructure, d.mergeKeyResolver)
 			deleteFromPrimitiveList, err := d.readArray(d.patch, fmt.Sprintf("$deleteFromPrimitiveList/%s", fieldName))
 			if err == nil {
@@ -244,7 +248,7 @@ func (d *StrategicMergedStructureData) Value(fieldName string) (any, error) {
 				}
 			}
 			return result, nil
-		} else if patchFound {
+		case patchFound:
 			result := NewStrategicMergedStructureData(fmt.Sprintf("%s.%s", d.path, fieldName), patchValueStructure, patchValueStructure, d.mergeKeyResolver)
 			deleteFromPrimitiveList, err := d.readArray(d.patch, fmt.Sprintf("$deleteFromPrimitiveList/%s", fieldName))
 			if err == nil {
@@ -259,11 +263,11 @@ func (d *StrategicMergedStructureData) Value(fieldName string) (any, error) {
 				}
 			}
 			return result, nil
-		} else {
+		default:
 			return nil, fmt.Errorf("field not found:%s", fieldName)
 		}
-	}
-	if ty == structuredata.StructuredTypeArray {
+
+	case structuredata.StructuredTypeArray:
 		if fieldName == "" {
 			return d, nil
 		}
@@ -285,8 +289,10 @@ func (d *StrategicMergedStructureData) Value(fieldName string) (any, error) {
 			return ref.From, nil
 		}
 		return ref.From.Value(ref.Index)
+
+	default:
+		return nil, fmt.Errorf("unsupported type to merge")
 	}
-	return nil, fmt.Errorf("unsupported type to merge")
 }
 
 func (d *StrategicMergedStructureData) buildArrayMergeResultSourceCache() error {
@@ -643,7 +649,7 @@ func reorderArrayKeysForMerge(prev []string, patch []string, setElementOrderDire
 		if _, found := patchMap[directiveElem]; !found {
 			if _, found := prevMap[directiveElem]; !found {
 				// Assume the item was existing from the past
-				liveList = append(liveOnlyList, directiveElem)
+				liveOnlyList = append(liveOnlyList, directiveElem)
 			}
 		}
 	}

--- a/pkg/log/structure/merger/merged.go
+++ b/pkg/log/structure/merger/merged.go
@@ -92,7 +92,8 @@ func (d *StrategicMergedStructureData) Keys() ([]string, error) {
 		return []string{""}, nil
 	}
 
-	if ty == structuredata.StructuredTypeMap {
+	switch ty {
+	case structuredata.StructuredTypeMap:
 		keydiff := NewKeyDiff(prevKeys, patchKeys)
 		strategicPatchKeys := splitPatchKeysByFieldsOrMergeAttributes(keydiff.OnlyInPatch)
 		if err == nil {
@@ -118,7 +119,7 @@ func (d *StrategicMergedStructureData) Keys() ([]string, error) {
 			return retainResult, nil
 		}
 		return result, nil
-	} else if ty == structuredata.StructuredTypeArray {
+	case structuredata.StructuredTypeArray:
 		if d.arrayMergeResultSourceCache == nil {
 			err := d.buildArrayMergeResultSourceCache()
 			if err != nil {
@@ -126,8 +127,7 @@ func (d *StrategicMergedStructureData) Keys() ([]string, error) {
 			}
 		}
 		return stringSequence(len(d.arrayMergeResultSourceCache.References)), nil
-
-	} else {
+	default:
 		return []string{""}, nil
 	}
 }

--- a/pkg/log/structure/reader_test.go
+++ b/pkg/log/structure/reader_test.go
@@ -180,11 +180,8 @@ func TestReader(t *testing.T) {
 							return
 						}
 						t.Fatal("no error returned")
-					} else {
-						if len(readers) != ctc.resultCount {
-							t.Errorf("the result is not matching with the expected count: expected:%d,actual:%d\n \nvalues:%v", ctc.resultCount, len(readers), readers)
-
-						}
+					} else if len(readers) != ctc.resultCount {
+						t.Errorf("the result is not matching with the expected count: expected:%d,actual:%d\n \nvalues:%v", ctc.resultCount, len(readers), readers)
 					}
 				})
 			}

--- a/pkg/model/binarychunk/builder_test.go
+++ b/pkg/model/binarychunk/builder_test.go
@@ -85,6 +85,9 @@ func TestBuilder(t *testing.T) {
 		var result bytes.Buffer
 
 		_, err := b.Build(context.Background(), &result, progress.NewTaskProgress("foo"))
+		if err != nil {
+			t.Errorf("err was not nil:%v", err)
+		}
 		bufferCount := 0
 		for {
 			_, err = result.Read(sizeReadBuffer)
@@ -104,9 +107,12 @@ func TestBuilder(t *testing.T) {
 
 			gzipReader, err := gzip.NewReader(bytes.NewBuffer(compressedBuffer))
 			if err != nil {
-				t.Errorf("err was not a nil:%v", err)
+				t.Errorf("err was not nil:%v", err)
 			}
 			decompressed, err := io.ReadAll(gzipReader)
+			if err != nil {
+				t.Errorf("err was not nil:%v", err)
+			}
 
 			if len(decompressed) != 1024*1024*50 {
 				t.Errorf("decompressed buffer size is not matching the source buffer size: %d != %d", len(decompressed), 1024*1024*50)

--- a/pkg/model/history/history.go
+++ b/pkg/model/history/history.go
@@ -52,7 +52,7 @@ type ResourceRevision struct {
 	ChangeTime time.Time                    `json:"changeTime"`
 	State      enum.RevisionState           `json:"state"`
 
-	// DEPRECATED: This field is no longer used. Will be removed in near future.
+	// Deprecated: This field is no longer used. Will be removed in near future.
 	Partial bool `json:"partial"`
 }
 

--- a/pkg/model/history/resourceinfo/endpoint_slices.go
+++ b/pkg/model/history/resourceinfo/endpoint_slices.go
@@ -101,7 +101,7 @@ func (e *EndpointSliceInfo) GetLastDiffs(uid string) ([]*EndpointSliceEndpointDi
 	}
 	result := []*EndpointSliceEndpointDiff{}
 	if previous == nil {
-		if current.Endpoints == nil || len(current.Endpoints) == 0 {
+		if len(current.Endpoints) == 0 {
 			return []*EndpointSliceEndpointDiff{}, nil
 		}
 		for _, endpoint := range current.Endpoints {

--- a/pkg/model/history/resourceinfo/endpoint_slices.go
+++ b/pkg/model/history/resourceinfo/endpoint_slices.go
@@ -100,7 +100,9 @@ func (e *EndpointSliceInfo) GetLastDiffs(uid string) ([]*EndpointSliceEndpointDi
 		return nil, err
 	}
 	result := []*EndpointSliceEndpointDiff{}
-	if previous == nil {
+
+	switch {
+	case previous == nil:
 		if len(current.Endpoints) == 0 {
 			return []*EndpointSliceEndpointDiff{}, nil
 		}
@@ -112,7 +114,7 @@ func (e *EndpointSliceInfo) GetLastDiffs(uid string) ([]*EndpointSliceEndpointDi
 				TargetRef: endpoint.TargetRef,
 			})
 		}
-	} else if current == nil {
+	case current == nil:
 		for _, endpoint := range previous.Endpoints {
 			result = append(result, &EndpointSliceEndpointDiff{
 				Operation: DiffDeleted,
@@ -121,7 +123,7 @@ func (e *EndpointSliceInfo) GetLastDiffs(uid string) ([]*EndpointSliceEndpointDi
 				TargetRef: endpoint.TargetRef,
 			})
 		}
-	} else {
+	default:
 		previousEndpointsMap := map[string]*model.EndpointSliceEndpoint{}
 		currentEndpointsMap := map[string]*model.EndpointSliceEndpoint{}
 		if previous.Endpoints != nil {
@@ -160,15 +162,13 @@ func (e *EndpointSliceInfo) GetLastDiffs(uid string) ([]*EndpointSliceEndpointDi
 					Current:   current,
 					TargetRef: current.TargetRef,
 				})
-			} else {
-				if !previous.Conditions.SameWith(current.Conditions) {
-					result = append(result, &EndpointSliceEndpointDiff{
-						Operation: DiffChanged,
-						Previous:  previous,
-						Current:   current,
-						TargetRef: current.TargetRef,
-					})
-				}
+			} else if !previous.Conditions.SameWith(current.Conditions) {
+				result = append(result, &EndpointSliceEndpointDiff{
+					Operation: DiffChanged,
+					Previous:  previous,
+					Current:   current,
+					TargetRef: current.TargetRef,
+				})
 			}
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -159,7 +159,7 @@ func CreateKHIServer(inspectionServer *inspection.InspectionTaskServer, serverCo
 			}
 			ctx.String(http.StatusAccepted, "ok")
 		})
-		//GET /api/v2/inspection/tasks/<task-id>/features
+		// GET /api/v2/inspection/tasks/<task-id>/features
 		router.GET("/api/v2/inspection/tasks/:taskId/features", func(ctx *gin.Context) {
 			taskId := ctx.Param("taskId")
 			task := inspectionServer.GetTask(taskId)

--- a/pkg/source/gcp/api/accesstoken/mds.go
+++ b/pkg/source/gcp/api/accesstoken/mds.go
@@ -42,7 +42,7 @@ func NewMetadataServerAccessTokenResolver(client *httpclient.JSONReponseHttpClie
 
 // Resolve implements token.TokenResolver.
 func (m *MDSTokenResolver) Resolve(ctx context.Context) (*token.Token, error) {
-	req, err := http.NewRequest("GET", metadataServerAddress, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", metadataServerAddress, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/source/gcp/api/accesstoken/mds.go
+++ b/pkg/source/gcp/api/accesstoken/mds.go
@@ -47,10 +47,13 @@ func (m *MDSTokenResolver) Resolve(ctx context.Context) (*token.Token, error) {
 		return nil, err
 	}
 	req.Header.Add("Metadata-Flavor", "Google")
-	response, _, err := m.client.DoWithContext(ctx, req)
+	response, httpResp, err := m.client.DoWithContext(ctx, req)
 	if err != nil {
 		slog.InfoContext(ctx, fmt.Sprintf("failed to get access token from metadata server\n%s", err.Error()))
 		return nil, err
+	}
+	if httpResp != nil && httpResp.Body != nil {
+		defer httpResp.Body.Close()
 	}
 	if response.AccessToken != "" {
 		return token.NewWithExpiry(response.AccessToken, time.Now().Add(time.Duration(response.ExpiresIn-1)*time.Second)), nil

--- a/pkg/source/gcp/api/gcp_client.go
+++ b/pkg/source/gcp/api/gcp_client.go
@@ -146,7 +146,7 @@ func NewGCPClient(refresher token.TokenRefresher, headerProviders []httpclient.H
 }
 
 func (c *GCPClientImpl) CreateGCPHttpRequest(ctx context.Context, method string, url string, body io.Reader) (*http.Request, error) {
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/source/gcp/api/gcp_client.go
+++ b/pkg/source/gcp/api/gcp_client.go
@@ -518,7 +518,10 @@ func (c *GCPClientImpl) GetComposerEnvironmentNames(ctx context.Context, project
 			}
 
 			client := httpclient.NewJsonResponseHttpClient[environmentListResponse](c.BaseClient)
-			response, _, err := client.DoWithContext(ctx, req)
+			response, httpResponse, err := client.DoWithContext(ctx, req)
+			if httpResponse != nil && httpResponse.Body != nil {
+				defer httpResponse.Body.Close()
+			}
 			if err != nil {
 				return nil, fmt.Errorf("failed to get JSON response: %w", err)
 			}
@@ -586,6 +589,9 @@ func (c *GCPClientImpl) ListLogEntries(ctx context.Context, projectId string, fi
 			}
 			client := httpclient.NewJsonResponseHttpClient[logEntriesListResponse](c.BaseClient)
 			response, httpResponse, err := client.DoWithContext(ctx, req)
+			if httpResponse != nil && httpResponse.Body != nil {
+				defer httpResponse.Body.Close()
+			}
 			if err != nil {
 				if httpResponse != nil {
 					slog.ErrorContext(ctx, fmt.Sprintf("Unretriable error found: %d:%s", httpResponse.StatusCode, httpResponse.Status))

--- a/pkg/source/gcp/api/pageclient.go
+++ b/pkg/source/gcp/api/pageclient.go
@@ -46,9 +46,12 @@ func (p *PageClient[T]) GetAll(ctx context.Context, requestGenerator RequestGene
 				return nil, err
 			}
 			client := httpclient.NewJsonResponseHttpClient[T](p.client)
-			typedResponse, _, err := client.DoWithContext(ctx, request)
+			typedResponse, resp, err := client.DoWithContext(ctx, request)
 			if err != nil {
 				return nil, err
+			}
+			if resp != nil && resp.Body != nil {
+				defer resp.Body.Close()
 			}
 			result = append(result, typedResponse)
 			nextPageToken = nextPageTokenMapper(typedResponse)

--- a/pkg/source/gcp/api/pageclient_test.go
+++ b/pkg/source/gcp/api/pageclient_test.go
@@ -48,20 +48,36 @@ func TestPageClient(t *testing.T) {
 		Value         string `json:"value"`
 		NextPageToken string `json:"nextPageToken"`
 	}
+
+	responseCleanup := func(responses []*http.Response) {
+		for _, resp := range responses {
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+		}
+	}
+
 	mc := &mockHttpClientForPageClient{}
 	pc := NewPageClient[TestResponseType](mc)
-	mc.Response = append(mc.Response, &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader("{\"value\": \"v1\", \"nextPageToken\": \"t1\"}")),
-	})
-	mc.Response = append(mc.Response, &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader("{\"value\": \"v2\", \"nextPageToken\": \"t2\"}")),
-	})
-	mc.Response = append(mc.Response, &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader("{\"value\": \"v3\"}")),
-	})
+
+	responses := []*http.Response{
+		{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("{\"value\": \"v1\", \"nextPageToken\": \"t1\"}")),
+		},
+		{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("{\"value\": \"v2\", \"nextPageToken\": \"t2\"}")),
+		},
+		{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("{\"value\": \"v3\"}")),
+		},
+	}
+
+	mc.Response = responses
+
+	defer responseCleanup(responses)
 
 	r, err := pc.GetAll(context.Background(), func(hasToken bool, pageToken string) (*http.Request, error) {
 		if !hasToken {

--- a/pkg/source/gcp/k8s/k8s.go
+++ b/pkg/source/gcp/k8s/k8s.go
@@ -24,11 +24,11 @@ import (
 func ParseKubernetesOperation(resourceName string, methodName string) *model.KubernetesObjectOperation {
 	resourceNameFragments := strings.Split(resourceName, "/")
 	methodNameFragments := strings.Split(methodName, ".")
-	pluralKind := ""
-	namespace := ""
-	name := "unknown"
-	subResourceName := ""
-	if methodNameFragments[4] == "namespaces" {
+	var pluralKind, namespace, name, subResourceName string
+	name = "unknown"
+
+	switch {
+	case methodNameFragments[4] == "namespaces":
 		// Branch for namespace resource
 		namespace = "Cluster-Scope"
 		name = resourceNameFragments[3]
@@ -36,7 +36,7 @@ func ParseKubernetesOperation(resourceName string, methodName string) *model.Kub
 		if len(resourceNameFragments) > 4 {
 			subResourceName = resourceNameFragments[4]
 		}
-	} else if resourceNameFragments[2] == "namespaces" && len(resourceNameFragments) >= 5 {
+	case resourceNameFragments[2] == "namespaces" && len(resourceNameFragments) >= 5:
 		namespace = resourceNameFragments[3]
 		pluralKind = resourceNameFragments[4]
 		if len(resourceNameFragments) > 5 {
@@ -45,7 +45,7 @@ func ParseKubernetesOperation(resourceName string, methodName string) *model.Kub
 		if len(resourceNameFragments) > 6 {
 			subResourceName = resourceNameFragments[6]
 		}
-	} else if len(resourceNameFragments) >= 3 {
+	case len(resourceNameFragments) >= 3:
 		namespace = "Cluster-Scope"
 		if len(resourceNameFragments) > 3 {
 			name = resourceNameFragments[3]

--- a/pkg/source/gcp/query/query.go
+++ b/pkg/source/gcp/query/query.go
@@ -94,23 +94,23 @@ func NewQueryGeneratorTask(taskId string, readableQueryName string, logType enum
 			// Run query only when thetask mode is for running
 			if taskMode == inspection_task.TaskModeRun {
 				worker := queryutil.NewParallelQueryWorker(queryThreadPool, client, queryString, startTime, endTime, 5)
-				logs, err := worker.Query(ctx, readerFactory, projectId, progress)
-				if err != nil {
-					if strings.HasPrefix(err.Error(), "401:") {
+				queryLogs, queryErr := worker.Query(ctx, readerFactory, projectId, progress)
+				if queryErr != nil {
+					if strings.HasPrefix(queryErr.Error(), "401:") {
 						errors := metadata.LoadOrStore(error_metadata.ErrorMessageSetMetadataKey, &error_metadata.ErrorMessageSetFactory{}).(*error_metadata.ErrorMessageSet)
 						errors.AddErrorMessage(error_metadata.NewUnauthorizedErrorMessage())
 					}
-					if strings.HasPrefix(err.Error(), "403:") {
+					if strings.HasPrefix(queryErr.Error(), "403:") {
 						errors := metadata.LoadOrStore(error_metadata.ErrorMessageSetMetadataKey, &error_metadata.ErrorMessageSetFactory{}).(*error_metadata.ErrorMessageSet)
 						errors.AddErrorMessage(error_metadata.NewPermissionErrorMessage(projectId))
 					}
-					if strings.HasPrefix(err.Error(), "404:") {
+					if strings.HasPrefix(queryErr.Error(), "404:") {
 						errors := metadata.LoadOrStore(error_metadata.ErrorMessageSetMetadataKey, &error_metadata.ErrorMessageSetFactory{}).(*error_metadata.ErrorMessageSet)
 						errors.AddErrorMessage(error_metadata.NewNotFoundErrorMessage(projectId))
 					}
-					return nil, err
+					return nil, queryErr
 				}
-				allLogs = append(allLogs, logs...)
+				allLogs = append(allLogs, queryLogs...)
 			}
 		}
 		if taskMode == inspection_task.TaskModeRun {

--- a/pkg/source/gcp/query/queryutil/parallel.go
+++ b/pkg/source/gcp/query/queryutil/parallel.go
@@ -89,6 +89,8 @@ func (p *ParallelQueryWorker) Query(ctx context.Context, readerFactory *structur
 	}()
 
 	cancellableCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.New("query completed"))
+
 	for i := 0; i < len(timeSegments)-1; i++ {
 		workerIndex := i
 		begin := timeSegments[i]
@@ -136,7 +138,7 @@ func (p *ParallelQueryWorker) Query(ctx context.Context, readerFactory *structur
 	wg.Wait()
 	close(logSink)
 	err := context.Cause(cancellableCtx)
-	if err != nil {
+	if err != nil && !errors.Is(err, errors.New("query completed")) {
 		return nil, err
 	}
 	return logEntries, nil

--- a/pkg/source/gcp/query/queryutil/set_filter.go
+++ b/pkg/source/gcp/query/queryutil/set_filter.go
@@ -127,8 +127,8 @@ func ParseSetFilter(filter string, aliases SetFilterAliasToItemsMap, allowAny bo
 			result.Additives = append(result.Additives, add)
 		}
 	}
-	slices.SortFunc(result.Additives, func(a, b string) int { return strings.Compare(a, b) })
-	slices.SortFunc(result.Subtractives, func(a, b string) int { return strings.Compare(a, b) })
+	slices.SortFunc(result.Additives, strings.Compare)
+	slices.SortFunc(result.Subtractives, strings.Compare)
 	if convertToLowerCase {
 		result.Additives = ToLowerForStringArray(result.Additives)
 		result.Subtractives = ToLowerForStringArray(result.Subtractives)

--- a/pkg/source/gcp/task/gke/compute_api/parser.go
+++ b/pkg/source/gcp/task/gke/compute_api/parser.go
@@ -91,11 +91,12 @@ func (*computeAPIParser) Parse(ctx context.Context, l *log.LogEntity, cs *histor
 	}
 	cs.RecordEvent(nodeResourcePath)
 
-	if isFirst && !isLast {
+	switch {
+	case isFirst && !isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Started", methodName))
-	} else if !isFirst && isLast {
+	case !isFirst && isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Finished", methodName))
-	} else {
+	default:
 		cs.RecordLogSummary(methodName)
 	}
 

--- a/pkg/source/gcp/task/gke/gke_audit/parser.go
+++ b/pkg/source/gcp/task/gke/gke_audit/parser.go
@@ -170,11 +170,12 @@ func (p *gkeAuditLogParser) Parse(ctx context.Context, l *log.LogEntity, cs *his
 		})
 	}
 
-	if isFirst && !isLast {
+	switch {
+	case isFirst && !isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Started", methodName))
-	} else if !isFirst && isLast {
+	case !isFirst && isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Finished", methodName))
-	} else {
+	default:
 		cs.RecordLogSummary(methodName)
 	}
 	return nil

--- a/pkg/source/gcp/task/gke/k8s_audit/recorder/containerstatusrecorder/recorder.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/recorder/containerstatusrecorder/recorder.go
@@ -73,8 +73,9 @@ func recordChangeSetForLog(ctx context.Context, resourcePath string, log *types.
 		tb := builder.GetTimelineBuilder(cpath.Path)
 		last := tb.GetLatestRevision()
 		if changed {
-			// Current container is running
-			if status.State.Running != nil {
+			switch {
+			case status.State.Running != nil:
+				// Current container is running
 				running := status.State.Running
 				time := running.StartedAt.Time
 				if last != nil && time.Sub(last.ChangeTime) > 0 && log.Log.Timestamp().Sub(time) > 0 && status.Ready {
@@ -111,7 +112,8 @@ func recordChangeSetForLog(ctx context.Context, resourcePath string, log *types.
 					})
 
 				}
-			} else if status.State.Terminated != nil { // Current container is terminated
+			case status.State.Terminated != nil:
+				// Current container is terminated
 				terminated := status.State.Terminated
 				if terminated.FinishedAt.Time.Unix() == errorTimestampInUnix {
 					// Pod termination status can have errornous timestamp when it can't be determined.
@@ -136,7 +138,8 @@ func recordChangeSetForLog(ctx context.Context, resourcePath string, log *types.
 					})
 				}
 
-			} else if status.State.Waiting != nil { // Current container is waiting
+			case status.State.Waiting != nil:
+				// Current container is waiting
 				cs.RecordRevision(cpath, &history.StagingResourceRevision{
 					Verb:       enum.RevisionVerbContainerWaiting,
 					Body:       string(statusYaml),

--- a/pkg/source/gcp/task/gke/k8s_audit/recorder/endpointslicerecorder/recorder.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/recorder/endpointslicerecorder/recorder.go
@@ -158,13 +158,14 @@ func parseSingleEndpoint(ctx context.Context, endpoint *model.EndpointSliceEndpo
 	isEndpointForPod := endpoint.TargetRef != nil && endpoint.TargetRef.Kind == "Pod"                                    // target of this endpoint is a Pod.
 	hasConditionChanged := endpoint.Conditions != nil && (prev == nil || !endpoint.Conditions.SameWith(prev.Conditions)) // the condition state is changed.
 	if hasConditionChanged {
-		if endpoint.Conditions.Ready {
+		switch {
+		case endpoint.Conditions.Ready:
 			state = enum.RevisionStateEndpointReady
 			verb = enum.RevisionVerbReady
-		} else if endpoint.Conditions.Terminating {
+		case endpoint.Conditions.Terminating:
 			state = enum.RevisionStateEndpointTerminating
 			verb = enum.RevisionVerbTerminating
-		} else {
+		default:
 			state = enum.RevisionStateEndpointUnready
 			verb = enum.RevisionVerbNonReady
 		}

--- a/pkg/source/gcp/task/gke/k8s_audit/v2timelinegrouping/task_test.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/v2timelinegrouping/task_test.go
@@ -82,10 +82,8 @@ timestamp: 2024-01-01T00:00:00+09:00`
 		for _, result := range result {
 			if count, found := expectedLogCounts[result.TimelineResourcePath]; !found {
 				t.Errorf("unexpected timeline %s not found", result.TimelineResourcePath)
-			} else {
-				if count != len(result.PreParsedLogs) {
-					t.Errorf("expected log count is not matching in a timeline:%s", result.TimelineResourcePath)
-				}
+			} else if count != len(result.PreParsedLogs) {
+				t.Errorf("expected log count is not matching in a timeline:%s", result.TimelineResourcePath)
 			}
 		}
 	})

--- a/pkg/source/gcp/task/gke/k8s_container/severity_parser.go
+++ b/pkg/source/gcp/task/gke/k8s_container/severity_parser.go
@@ -54,13 +54,14 @@ func (m *MetricsContainerLogSeverityParser) TryParse(message string) enum.Severi
 		return enum.SeverityUnknown
 	}
 	severityStr := fragments[1]
-	if severityStr == "info" {
+	switch severityStr {
+	case "info":
 		return enum.SeverityInfo
-	} else if severityStr == "warn" {
+	case "warn":
 		return enum.SeverityWarning
-	} else if severityStr == "error" {
+	case "error":
 		return enum.SeverityError
-	} else {
+	default:
 		return enum.SeverityUnknown
 	}
 }

--- a/pkg/source/gcp/task/gke/k8s_event/parser.go
+++ b/pkg/source/gcp/task/gke/k8s_event/parser.go
@@ -67,10 +67,8 @@ func (*k8sEventParser) Parse(ctx context.Context, l *log.LogEntity, cs *history.
 			return nil
 		}
 		return err
-	} else {
-		if kind != "Event" {
-			return fmt.Errorf("skipping kind:%s", kind)
-		}
+	} else if kind != "Event" {
+		return fmt.Errorf("skipping kind:%s", kind)
 	}
 	apiVersion := l.GetStringOrDefault("jsonPayload.involvedObject.apiVersion", "v1")
 

--- a/pkg/source/gcp/task/gke/network_api/parser.go
+++ b/pkg/source/gcp/task/gke/network_api/parser.go
@@ -78,7 +78,9 @@ func (*gceNetworkParser) Parse(ctx context.Context, l *log.LogEntity, cs *histor
 	} else {
 		negResourcePath = resourcepath.NetworkEndpointGroup("unknown", negName)
 	}
-	if !(isLast && isFirst) && (isLast || isFirst) {
+
+	switch {
+	case !(isLast && isFirst) && (isLast || isFirst):
 		state := enum.RevisionStateOperationStarted
 		if isLast {
 			state = enum.RevisionStateOperationFinished
@@ -91,7 +93,7 @@ func (*gceNetworkParser) Parse(ctx context.Context, l *log.LogEntity, cs *histor
 			ChangeTime: l.Timestamp(),
 			Partial:    false,
 		})
-	} else {
+	default:
 		cs.RecordEvent(negResourcePath)
 	}
 	if isFirst {
@@ -134,11 +136,12 @@ func (*gceNetworkParser) Parse(ctx context.Context, l *log.LogEntity, cs *histor
 			}
 		}
 	}
-	if isFirst && !isLast {
+	switch {
+	case isFirst && !isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Started", methodName))
-	} else if !isFirst && isLast {
+	case !isFirst && isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Finished", methodName))
-	} else {
+	default:
 		cs.RecordLogSummary(methodName)
 	}
 

--- a/pkg/source/gcp/task/multicloud_api/parser.go
+++ b/pkg/source/gcp/task/multicloud_api/parser.go
@@ -71,7 +71,9 @@ func (*multiCloudAuditLogParser) Parse(ctx context.Context, l *log.LogEntity, cs
 	principal := l.GetStringOrDefault("protoPayload.authenticationInfo.principalEmail", "unknown")
 	code := l.GetStringOrDefault("protoPayload.status.code", "0")
 	isSucceedRequest := code == "0"
-	operationResourcePath := resourcepath.ResourcePath{}
+
+	var operationResourcePath resourcepath.ResourcePath
+
 	if resource.NodepoolName == "" {
 		// assume this is a cluster operation
 		clusterResourcePath := resourcepath.Cluster(resource.ClusterName)
@@ -154,11 +156,12 @@ func (*multiCloudAuditLogParser) Parse(ctx context.Context, l *log.LogEntity, cs
 		})
 	}
 
-	if isFirst && !isLast {
+	switch {
+	case isFirst && !isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Started", methodName))
-	} else if !isFirst && isLast {
+	case !isFirst && isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Finished", methodName))
-	} else {
+	default:
 		cs.RecordLogSummary(methodName)
 	}
 	return nil

--- a/pkg/source/gcp/task/onprem_api/parser.go
+++ b/pkg/source/gcp/task/onprem_api/parser.go
@@ -179,11 +179,12 @@ func (*onpremCloudAuditLogParser) Parse(ctx context.Context, l *log.LogEntity, c
 		})
 	}
 
-	if isFirst && !isLast {
+	switch {
+	case isFirst && !isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Started", methodName))
-	} else if !isFirst && isLast {
+	case !isFirst && isLast:
 		cs.RecordLogSummary(fmt.Sprintf("%s Finished", methodName))
-	} else {
+	default:
 		cs.RecordLogSummary(methodName)
 	}
 	return nil

--- a/pkg/task/definition_set.go
+++ b/pkg/task/definition_set.go
@@ -97,10 +97,8 @@ func (s *DefinitionSet) FilteredSubset(key string, predicate LabelPredicate, inc
 			if predicate(labelValue) {
 				filteredTasks = append(filteredTasks, task)
 			}
-		} else {
-			if includeUndefined {
-				filteredTasks = append(filteredTasks, task)
-			}
+		} else if includeUndefined {
+			filteredTasks = append(filteredTasks, task)
 		}
 	}
 	return &DefinitionSet{

--- a/pkg/task/definition_set.go
+++ b/pkg/task/definition_set.go
@@ -193,10 +193,8 @@ func (s *DefinitionSet) sortTaskGraph() *SortTaskGraphResult {
 				if !isThreadUnsafe {
 					nextResolveTaskId = taskId
 					break
-				} else {
-					if nextResolvedTaskIdThreadUnsafeCandidate == "N/A" {
-						nextResolvedTaskIdThreadUnsafeCandidate = taskId
-					}
+				} else if nextResolvedTaskIdThreadUnsafeCandidate == "N/A" {
+					nextResolvedTaskIdThreadUnsafeCandidate = taskId
 				}
 			}
 		}
@@ -356,7 +354,7 @@ func sortedMapKeys[T any](inputMap map[string]T) []string {
 	for key := range inputMap {
 		result = append(result, key)
 	}
-	slices.SortFunc(result, func(a, b string) int { return strings.Compare(a, b) })
+	slices.SortFunc(result, strings.Compare)
 	return result
 }
 

--- a/pkg/testutil/log/log.go
+++ b/pkg/testutil/log/log.go
@@ -85,8 +85,5 @@ func MockLogWithId(id string) *log.LogEntity {
 		id:          id,
 		mainMessage: fmt.Sprintf("# mock log for %s", id),
 	})
-	if err != nil {
-		panic(err)
-	}
 	return yaml
 }

--- a/pkg/testutil/task/util.go
+++ b/pkg/testutil/task/util.go
@@ -20,14 +20,14 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/task"
 )
 
-// Deprecated. Use testtask package instead.
+// Deprecated: Use testtask package instead.
 func MockProcessorTaskFromTaskID(taskId string, value any) task.Definition {
 	return task.NewProcessorTask(taskId, []string{}, func(ctx context.Context, taskMode int, v *task.VariableSet) (any, error) {
 		return value, nil
 	})
 }
 
-// Deprecated. Use testtask package instead.
+// Deprecated: Use testtask package instead.
 // RunTaskGraph executes the task graph just with provided dependency tasks
 func RunTaskGraph(target task.Definition, mode int, initialParameters map[string]any, dependencies ...task.Definition) (*task.VariableSet, error) {
 	sourceDs, err := task.NewSet([]task.Definition{target})

--- a/pkg/testutil/util_test.go
+++ b/pkg/testutil/util_test.go
@@ -78,6 +78,7 @@ func TestResponseFromString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ResponseFromString(tt.args.code, tt.args.response)
+			defer got.Body.Close()
 			if got.StatusCode != tt.wantCode {
 				t.Errorf("ResponseFromString() = %v, want %v", got.StatusCode, tt.wantCode)
 			}

--- a/scripts/frontend-codegen/main.go
+++ b/scripts/frontend-codegen/main.go
@@ -49,7 +49,7 @@ type templateInput struct {
 }
 
 func main() {
-	var templateInput templateInput = templateInput{
+	var input templateInput = templateInput{
 		RevisionStates:          enum.RevisionStates,
 		ParentRelationships:     enum.ParentRelationships,
 		Severities:              enum.Severities,
@@ -69,7 +69,7 @@ func main() {
 		if l == 0.0 { // only applicable for #000
 			dl = 0.8
 		}
-		templateInput.LogTypeDarkColors[logType.Label] = fmt.Sprintf("hsl(%fdeg %f%% %f%%)", h, s*100, dl*100)
+		input.LogTypeDarkColors[logType.Label] = fmt.Sprintf("hsl(%fdeg %f%% %f%%)", h, s*100, dl*100)
 	}
 
 	for _, revisonState := range enum.RevisionStates {
@@ -79,12 +79,12 @@ func main() {
 		}
 		h, s, l := colorconv.ColorToHSL(color)
 		dl := l * 0.8
-		templateInput.RevisionStateDarkColors[revisonState.CSSSelector] = fmt.Sprintf("hsl(%fdeg %f%% %f%%)", h, s*100, dl*100)
+		input.RevisionStateDarkColors[revisonState.CSSSelector] = fmt.Sprintf("hsl(%fdeg %f%% %f%%)", h, s*100, dl*100)
 	}
 
 	sassTemplate := loadTemplate("color-sass", SASS_TEMPLATE)
 	var sassTemplateResult bytes.Buffer
-	err := sassTemplate.Execute(&sassTemplateResult, templateInput)
+	err := sassTemplate.Execute(&sassTemplateResult, input)
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +92,7 @@ func main() {
 
 	var legendTemplateResult bytes.Buffer
 	legendTemplate := loadTemplate("logtypes-ts", GENERATED_TS_TEMPLATE)
-	err = legendTemplate.Execute(&legendTemplateResult, templateInput)
+	err = legendTemplate.Execute(&legendTemplateResult, input)
 	if err != nil {
 		panic(err)
 	}

--- a/scripts/make/lint.mk
+++ b/scripts/make/lint.mk
@@ -4,8 +4,7 @@ lint-web: prepare-frontend
 
 .PHONY=lint-go
 lint-go:
-	go vet ./...
-
+	golangci-lint run
 .PHONY=format-go
 format-go:
 	gofmt -s -w .

--- a/scripts/make/lint.mk
+++ b/scripts/make/lint.mk
@@ -4,7 +4,7 @@ lint-web: prepare-frontend
 
 .PHONY=lint-go
 lint-go:
-	golangci-lint run
+	go vet ./...
 .PHONY=format-go
 format-go:
 	gofmt -s -w .

--- a/web/src/app/services/popup/mock.ts
+++ b/web/src/app/services/popup/mock.ts
@@ -54,20 +54,10 @@ export class MockPopupManager implements PopupManager {
   requests(): Observable<PopupFormRequestWithClient> {
     return of({
       id: 'test',
-      title: 'Google Admin inspection token',
+      title: 'Additional input required',
       type: 'text',
-      description:
-        'Google Admin token seems to be expired. Please copy the KHI command again from Google Admin and paste it here.',
-      placeholder: `gcloud auth configure-docker --quiet
-docker run --rm --pull always -p 8080:8080 -it -e KHI_FIXED_PROJECT_ID="XXXXXXXXX" -e GCP_DEFAULT_PROJECT="XXXXXXXXX" -e GCP_ACCESS_TOKEN=\`gcloud auth print-access-token\` -e KHI_GA_LABELS="justification=vector/123456,user=XXXXXXXXX" -e IAM_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" gcr.io/kubernetes-history-inspector/standalone:latest`,
+      description: 'Please input the additional input requested',
+      placeholder: `This is the placeholder`,
       client: new MockPopupClient(),
       options: {},
     });


### PR DESCRIPTION
## What

- Introduce [golangci-lint](https://golangci-lint.run/)
  - Add a configuration to start small and simple
- Fix golangci-lint errors
- Run the linter in CI

## Background

When hacking on this codebase, I noticed that the (Go) linter run by pre-commit was failing like this:

```
$ go vet ./...                   
# github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil
# [github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query/queryutil]
pkg/source/gcp/query/queryutil/parallel.go:91:2: the cancel function is not used on all paths (possible context leak)
pkg/source/gcp/query/queryutil/parallel.go:140:3: this return statement may be reached without using the cancel var defined on line 91
```

In addition, to detect several potential bugs in the codebase, I want to introduce a more comprehensive linter (or linter runner), such as golangci-lint.

## Results

```console
$ make lint-go
golangci-lint run
```

<details><summary>execution result</summary>

```console
pkg/common/errorreport/reporter.go:37:15: fieldalignment: struct with 48 pointer bytes could be 24 (govet)
type Reporter struct {
              ^
pkg/common/errorreport/reporter_test.go:35:17: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
        testCases := []struct {
                       ^
pkg/inspection/inspectiondata/result_repository.go:36:22: fieldalignment: struct with 32 pointer bytes could be 16 (govet)
type FileSystemStore struct {
                     ^
pkg/source/gcp/task/gke/gke_audit/parser.go:173:2: ifElseChain: rewrite if-else to switch statement (gocritic)
        if isFirst && !isLast {
        ^
pkg/testutil/log/log.go:29:28: fieldalignment: struct with 64 pointer bytes could be 48 (govet)
type mockLogFieldExtractor struct {
                           ^
pkg/testutil/log/log.go:88:9: nilness: impossible condition: nil != nil (govet)
        if err != nil {
               ^
pkg/common/collection.go:32:27: unlambda: replace `func(a, b string) int { return strings.Compare(a, b) }` with `strings.Compare` (gocritic)
        slices.SortFunc(deduped, func(a, b string) int { return strings.Compare(a, b) })
                                 ^
pkg/common/time_test.go:25:17: fieldalignment: struct with 40 pointer bytes could be 32 (govet)
        testCases := []struct {
                       ^
pkg/common/collection.go:54:4: shadow: declaration of "m" shadows declaration at line 37 (govet)
                        m := min(d[i-1][j]+1, d[i][j-1]+1)
                        ^
pkg/inspection/logger/format.go:105:27: commentFormatting: put a space between `//` and comment text (gocritic)
                colorBegin = "\033[90m" //bright black
                                        ^
pkg/inspection/logger/format.go:108:27: commentFormatting: put a space between `//` and comment text (gocritic)
                colorBegin = "\033[96m" //bright cyan
                                        ^
pkg/inspection/logger/format.go:111:27: commentFormatting: put a space between `//` and comment text (gocritic)
                colorBegin = "\033[93m" //bright yellow
                                        ^
pkg/inspection/logger/format.go:42:26: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type KHILogFormatHandler struct {
                         ^
pkg/inspection/logger/logger.go:32:26: fieldalignment: struct with 64 pointer bytes could be 56 (govet)
type globalLoggerHandler struct {
                         ^
pkg/source/gcp/task/cloud-composer/paeser_test.go:26:17: fieldalignment: struct with 40 pointer bytes could be 32 (govet)
        testCases := []struct {
                       ^
pkg/source/gcp/task/cloud-composer/paeser_test.go:122:17: fieldalignment: struct with 40 pointer bytes could be 32 (govet)
        testCases := []struct {
                       ^
pkg/testutil/util_test.go:78:29: response body must be closed (bodyclose)
                        got := ResponseFromString(tt.args.code, tt.args.response)
                                                 ^
pkg/testutil/util_test.go:56:12: fieldalignment: struct with 16 pointer bytes could be 8 (govet)
        type args struct {
                  ^
pkg/testutil/io.go:34:9: shadow: declaration of "err" shadows declaration at line 30 (govet)
                if _, err := os.Stat(filepath.Join(cwd, ROOT_INDICATOR_FILE)); err == nil {
                      ^
scripts/frontend-codegen/main.go:52:6: shadow: declaration of "templateInput" shadows declaration at line 41 (govet)
        var templateInput templateInput = templateInput{
            ^
pkg/log/cached_log_field_extractor.go:26:30: fieldalignment: struct with 112 pointer bytes could be 96 (govet)
type CachedLogFieldExtractor struct {
                             ^
pkg/log/cached_log_field_extractor_test.go:24:34: fieldalignment: struct with 80 pointer bytes could be 64 (govet)
type commonLogFieldExtractorStub struct {
                                 ^
pkg/task/definition_set.go:198:12: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
                                } else {
                                       ^
pkg/task/definition_set.go:361:26: unlambda: replace `func(a, b string) int { return strings.Compare(a, b) }` with `strings.Compare` (gocritic)
        slices.SortFunc(result, func(a, b string) int { return strings.Compare(a, b) })
                                ^
pkg/task/definition.go:78:29: fieldalignment: struct with 72 pointer bytes could be 56 (govet)
type ConstantDefinitionImpl struct {
                            ^
pkg/task/label.go:56:17: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type labelAdder struct {
                ^
pkg/task/label.go:98:23: fieldalignment: struct with 40 pointer bytes could be 24 (govet)
type equalLabelFilter struct {
                      ^
pkg/task/runner.go:36:18: fieldalignment: struct with 88 pointer bytes could be 64 (govet)
type LocalRunner struct {
                 ^
pkg/task/runner.go:47:26: fieldalignment: struct with 80 pointer bytes could be 72 (govet)
type LocalRunnerTaskStat struct {
                         ^
pkg/task/cached_processor_test.go:42:18: fieldalignment: struct with 16 pointer bytes could be 8 (govet)
        taskSeries := []struct {
                        ^
pkg/task/definition_set_test.go:28:25: fieldalignment: struct with 80 pointer bytes could be 64 (govet)
type testTaskDefinition struct {
                        ^
pkg/task/processor_test.go:85:17: fieldalignment: struct with 48 pointer bytes could be 32 (govet)
        cmpValues := []struct {
                       ^
pkg/task/runner_test.go:27:20: fieldalignment: struct with 24 pointer bytes could be 8 (govet)
type debugRunnable struct {
                   ^
pkg/inspection/metadata/form/form.go:35:16: fieldalignment: struct with 160 pointer bytes could be 136 (govet)
type FormField struct {
               ^
pkg/inspection/metadata/form/form.go:50:19: fieldalignment: struct with 32 pointer bytes could be 8 (govet)
type FormFieldSet struct {
                  ^
pkg/inspection/metadata/header/header.go:27:13: fieldalignment: struct with 64 pointer bytes could be 40 (govet)
type Header struct {
            ^
pkg/log/structure/merger/merged.go:646:16: appendAssign: append result not assigned to the same slice (gocritic)
                                liveList = append(liveOnlyList, directiveElem)
                                           ^
pkg/log/structure/merger/merged.go:95:2: ifElseChain: rewrite if-else to switch statement (gocritic)
        if ty == structuredata.StructuredTypeMap {
        ^
pkg/log/structure/merger/merged.go:217:3: ifElseChain: rewrite if-else to switch statement (gocritic)
                if prevFound && patchFound {
                ^
pkg/log/structure/merger/merged.go:54:35: fieldalignment: struct with 80 pointer bytes could be 72 (govet)
type StrategicMergedStructureData struct {
                                  ^
pkg/log/structure/merger/keydiff_test.go:24:16: fieldalignment: struct with 72 pointer bytes could be 56 (govet)
        testCase := []struct {
                      ^
pkg/log/structure/merger/merged_test.go:112:17: fieldalignment: struct with 96 pointer bytes could be 80 (govet)
        testCases := []struct {
                       ^
pkg/log/structure/merger/merged_test.go:458:17: fieldalignment: struct with 72 pointer bytes could be 64 (govet)
        testCases := []struct {
                       ^
pkg/log/structure/merger/merged_test.go:1110:17: fieldalignment: struct with 48 pointer bytes could be 32 (govet)
        testCases := []struct {
                       ^
pkg/log/structure/merger/merged.go:335:11: shadow: declaration of "err" shadows declaration at line 309 (govet)
                                vany, err := d.prev.Value(key)
                                      ^
pkg/log/structure/merger/merged.go:349:14: shadow: declaration of "err" shadows declaration at line 309 (govet)
                        keyValue, err := d.readScalar(field, mergeKey)
                                  ^
pkg/log/structure/merger/merged.go:363:14: shadow: declaration of "err" shadows declaration at line 309 (govet)
                        keyValue, err := d.readScalar(field, mergeKey)
                                  ^
pkg/log/structure/merger/merged_test.go:436:12: shadow: declaration of "err" shadows declaration at line 422 (govet)
                                child, err := merged.Value(tc.childField)
                                       ^
pkg/source/gcp/task/gke/k8s_event/parser.go:70:9: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
        } else {
               ^
pkg/source/gcp/task/gke/k8s_event/query_test.go:27:17: fieldalignment: struct with 104 pointer bytes could be 96 (govet)
        testCases := []struct {
                       ^
pkg/source/gcp/task/gke/k8s_event/query_test.go:60:17: fieldalignment: struct with 56 pointer bytes could be 48 (govet)
        testCases := []struct {
                       ^
pkg/source/gcp/task/gke/k8s_event/parser.go:63:19: shadow: declaration of "err" shadows declaration at line 61 (govet)
                if textPayload, err := l.GetString("textPayload"); err == nil {
                                ^
pkg/model/k8s.go:83:28: fieldalignment: struct with 64 pointer bytes could be 56 (govet)
type EndpointSliceEndpoint struct {
                           ^
pkg/model/k8s.go:91:20: fieldalignment: struct with 32 pointer bytes could be 16 (govet)
type EndpointSlice struct {
                   ^
pkg/model/enum/parent_relationship.go:36:41: fieldalignment: struct with 80 pointer bytes could be 72 (govet)
type ParentRelationshipFrontendMetadata struct {
                                        ^
pkg/source/gcp/task/gke/k8s_audit/recorder/endpointslicerecorder/recorder.go:36:32: fieldalignment: struct with 24 pointer bytes could be 8 (govet)
type singleEndpointParseResult struct {
                               ^
pkg/source/gcp/task/gke/k8s_audit/recorder/endpointslicerecorder/recorder.go:45:27: fieldalignment: struct with 24 pointer bytes could be 8 (govet)
type endpointsParseResult struct {
                          ^
cmd/kubernetes-history-inspector/main.go:104:3: exitAfterDefer: os.Exit will exit, and `defer errorreport.CheckAndReportPanic()` will not run (gocritic)
                os.Exit(1)
                ^
cmd/kubernetes-history-inspector/main.go:115:6: shadow: declaration of "err" shadows declaration at line 101 (govet)
                if err := profiler.Start(cfg); err != nil {
                   ^
cmd/kubernetes-history-inspector/main.go:154:4: shadow: declaration of "err" shadows declaration at line 101 (govet)
                        err := accesstoken.DefaultOAuthTokenResolver.SetServer(engine)
                        ^
cmd/kubernetes-history-inspector/main.go:194:23: shadow: declaration of "err" shadows declaration at line 179 (govet)
                        availableFeatures, err := t.FeatureList()
                                           ^
pkg/model/history/history.go:55:2: deprecatedComment: use `Deprecated: ` (note the casing) instead of `DEPRECATED: ` (gocritic)
        // DEPRECATED: This field is no longer used. Will be removed in near future.
        ^
pkg/model/history/builder.go:43:14: fieldalignment: struct with 72 pointer bytes could be 64 (govet)
type Builder struct {
             ^
pkg/model/history/changeset.go:29:16: fieldalignment: struct with 88 pointer bytes could be 64 (govet)
type ChangeSet struct {
               ^
pkg/model/history/resourceinfo/endpoint_slices.go:163:11: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
                        } else {
                               ^
pkg/model/history/resourceinfo/endpoint_slices.go:104:6: S1009: should omit nil check; len() for nil slices is defined as zero (gosimple)
                if current.Endpoints == nil || len(current.Endpoints) == 0 {
                   ^
pkg/model/binarychunk/builder_test.go:85:6: ineffectual assignment to err (ineffassign)
                _, err := b.Build(context.Background(), &result, progress.NewTaskProgress("foo"))
                   ^
pkg/model/binarychunk/builder_test.go:107:18: ineffectual assignment to err (ineffassign)
                        decompressed, err := io.ReadAll(gzipReader)
                                      ^
pkg/testutil/task/util.go:23:1: deprecatedComment: the proper format is `Deprecated: <text>` (gocritic)
// Deprecated. Use testtask package instead.
^
pkg/testutil/task/util.go:30:1: deprecatedComment: the proper format is `Deprecated: <text>` (gocritic)
// Deprecated. Use testtask package instead.
^
pkg/source/gcp/api/quotaproject/header_provider_test.go:48:31: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
                        req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
                                                   ^
pkg/inspection/server.go:87:30: appendAssign: append result not assigned to the same slice (gocritic)
        inspectionTypesCandidate := append(s.inspectionTypes, &newInspectionType)
                                    ^
pkg/source/gcp/task/multicloud_api/parser.go:74:2: ineffectual assignment to operationResourcePath (ineffassign)
        operationResourcePath := resourcepath.ResourcePath{}
        ^
pkg/server/server_test.go:698:29: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
                        req, _ := http.NewRequest(step.RequestMethod, path, requestReader)
                                                 ^
pkg/server/server_test.go:782:29: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
                        req, _ := http.NewRequest(tc.requestMethod, tc.requestPath, bytes.NewReader([]byte{}))
                                                 ^
pkg/common/httpclient/basic_http_client_test.go:51:36: response body must be closed (bodyclose)
                resp, err := client.DoWithContext(context.Background(), req)
                                                 ^
pkg/common/httpclient/basic_http_client_test.go:89:36: response body must be closed (bodyclose)
                resp, err := client.DoWithContext(context.Background(), req)
                                                 ^
pkg/source/gcp/query/queryutil/set_filter.go:130:36: unlambda: replace `func(a, b string) int { return strings.Compare(a, b) }` with `strings.Compare` (gocritic)
        slices.SortFunc(result.Additives, func(a, b string) int { return strings.Compare(a, b) })
                                          ^
make: *** [lint-go] Error 1
```
</details>
