### PR TITLE
Chore: Enable unit test ci with skipping flag

### DIFF
--- a/.github/workflows/pr-request.yaml
+++ b/.github/workflows/pr-request.yaml
@@ -64,8 +64,7 @@ jobs:
       run: |
         mkdir -p dist/session
         # A placeholder frontend code read from backend test
-        echo "" > ./dist/index.html
-        echo "" > ./dist/session/100
+        echo '<!--INJECT GENERATED CODE HERE FROM BACKEND-->' > ./dist/index.html
         go test ./... -args -skip-cloud-logging=true
 
     - name: Backend Format and Lint Check

--- a/.github/workflows/pr-request.yaml
+++ b/.github/workflows/pr-request.yaml
@@ -58,6 +58,11 @@ jobs:
     #     echo "" > ./dist/index.html
     #     make coverage-go
 
+    # For now, we skip the cloud logging test
+    # TODO: Remove the flag after the cloud logging test is ready
+    - name: Backend Test
+      run: go test ./... -args -skip-cloud-logging=true
+
     - name: Backend Format and Lint Check
       run: |
         make check-format-go

--- a/.github/workflows/pr-request.yaml
+++ b/.github/workflows/pr-request.yaml
@@ -62,10 +62,10 @@ jobs:
     # TODO: Remove the flag after the cloud logging test is ready
     - name: Backend Test
       run: |
-        mkdir dist
+        mkdir -p dist/session
         # A placeholder frontend code read from backend test
         echo "" > ./dist/index.html
-        make build-web
+        echo "" > ./dist/session/100
         go test ./... -args -skip-cloud-logging=true
 
     - name: Backend Format and Lint Check

--- a/.github/workflows/pr-request.yaml
+++ b/.github/workflows/pr-request.yaml
@@ -65,6 +65,7 @@ jobs:
         mkdir dist
         # A placeholder frontend code read from backend test
         echo "" > ./dist/index.html
+        make build-web
         go test ./... -args -skip-cloud-logging=true
 
     - name: Backend Format and Lint Check

--- a/.github/workflows/pr-request.yaml
+++ b/.github/workflows/pr-request.yaml
@@ -61,7 +61,11 @@ jobs:
     # For now, we skip the cloud logging test
     # TODO: Remove the flag after the cloud logging test is ready
     - name: Backend Test
-      run: go test ./... -args -skip-cloud-logging=true
+      run: |
+        mkdir dist
+        # A placeholder frontend code read from backend test
+        echo "" > ./dist/index.html
+        go test ./... -args -skip-cloud-logging=true
 
     - name: Backend Format and Lint Check
       run: |

--- a/pkg/document/generator/generator_test.go
+++ b/pkg/document/generator/generator_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestGenerateDocumentString(t *testing.T) {

--- a/pkg/inspection/task/label/query_test.go
+++ b/pkg/inspection/task/label/query_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/task"
+
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
 
 func TestQueryTaskLabelOpt(t *testing.T) {


### PR DESCRIPTION
ref. #29, #57 

## What

- Enable unit test CI _**without using**_ cloud logging

## Background

In #57, a flag was implemented to enable running only unit test that does not use cloud logging. 
With this flag, it has become possible to run unit test CI on PR (`on.pull_request`).

