### PR TITLE
Add Angular proxy configuration to simplify development workflow

### DIFF
--- a/docs/en/development-guide.md
+++ b/docs/en/development-guide.md
@@ -68,7 +68,7 @@ To develop frontend code, we usually start Angular dev server on port 4200 with 
 $ make watch-web
 ```
 
-This will build the frontend code with [the configuration to access APIs on `localhost:8080`](../../web/src/environments/environment.dev.ts).
+Angular development server on KHI proxies requests to `localhost:4200/api` to `localhost:8080`. ([the proxy config](../../web/proxy.conf.mjs))
 You can use KHI with accessing `localhost:4200` instead of `localhost:8080`. Angular dev server automatically build and serve the new build when you change the frontend code.
 
 ### Run test

--- a/scripts/make/build.mk
+++ b/scripts/make/build.mk
@@ -3,9 +3,9 @@
 
 .PHONY=watch-web
 watch-web: prepare-frontend
-	cd web && NG_APP_BACKEND_URL_PREFIX="http://localhost:8080" npx ng serve -c dev
+	cd web && npx ng serve -c dev
 
 
 .PHONY=build-web
 build-web: prepare-frontend
-	cd web &&NG_APP_VERSION="$(VERSION)"  npx ng build --output-path ../dist -c prod
+	cd web && npx ng build --output-path ../dist -c prod

--- a/web/angular-template.json
+++ b/web/angular-template.json
@@ -37,6 +37,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.mjs"
+          },
           "configurations": {},
           "defaultConfiguration": "dev-oss"
         },

--- a/web/proxy.conf.mjs
+++ b/web/proxy.conf.mjs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-export const environment = {
-  production: false,
-  bugReportUrl: '',
-  documentUrl: '',
-  pluginModules: [],
-  options: {} as Record<string, unknown>,
+/**
+ * Angular Proxy Configuration
+ * 
+ * This file defines the proxy configuration for the Angular development server.
+ * During development, requests to the /api/ path are forwarded to localhost:8080.
+ */
+
+export default {
+  '/api': {
+    target: 'http://localhost:8080',
+    secure: false,
+    changeOrigin: true,
+    logLevel: 'debug'
+  }
 };

--- a/web/src/app/services/api/backend-api.service.ts
+++ b/web/src/app/services/api/backend-api.service.ts
@@ -59,7 +59,6 @@ import { ViewStateService } from '../view-state.service';
 import { BackendAPI, DownloadProgressReporter } from './backend-api-interface';
 import { ProgressDialogStatusUpdator } from '../progress/progress-interface';
 import { ProgressUtil } from '../progress/progress-util';
-import { environment } from 'src/environments/environment';
 
 /**
  * An implementation of BackendAPI interface.
@@ -75,8 +74,6 @@ export class BackendAPIImpl implements BackendAPI {
    * The base address of the backend server.
    *
    * The index HTML file contains `<base>` tag to control the base address of resources in frontend to supporting KHI to be hosted with path rewriting behind reverse proxies.
-   * This backend address can't rely on this feature, because the backend can be placed on the other servers from this frontend and addresses in this class must be in the absolute format. (any path beginning with `/` or the address begining with `http`).
-   * (The development server usually runs the backend with the port 8080, but runs the angular development server for frontend with the port 4200. The origin is different and frontend needs to access the backend.)
    */
   private readonly baseUrl: string;
 
@@ -86,14 +83,13 @@ export class BackendAPIImpl implements BackendAPI {
     private http: HttpClient,
     private readonly viewState: ViewStateService,
   ) {
-    const urlPrefix = environment.apiBaseUrl;
-    this.baseUrl = urlPrefix + BackendAPIImpl.getServerBasePath();
+    this.baseUrl = BackendAPIImpl.getServerBasePath();
 
     const getConfigUrl = this.baseUrl + '/api/v2/config';
     this.getConfigObservable = this.http
       .get<GetConfigResponse>(getConfigUrl)
       .pipe(
-        retry(),
+        retry({ delay: 1000 }),
         shareReplay(1), // the config is cached at the first time of the loading.
       );
   }

--- a/web/src/environments/environment.dev.ts
+++ b/web/src/environments/environment.dev.ts
@@ -18,9 +18,6 @@ import { PublicKHIExtension } from 'src/app/extensions/public/module';
 
 export const environment = {
   production: false,
-  // apiBaseUrl is rewritten on development mode.
-  // We expect developers runs frontend code with Angular server served on localhost:4200, but the backend API should run with localhost:8080.
-  apiBaseUrl: 'http://localhost:8080',
   bugReportUrl:
     'https://github.com/GoogleCloudPlatform/khi/issues/new?template=Blank+issue',
   documentUrl: 'https://github.com/GoogleCloudPlatform/khi',

--- a/web/src/environments/environment.prod.ts
+++ b/web/src/environments/environment.prod.ts
@@ -18,8 +18,6 @@ import { PublicKHIExtension } from 'src/app/extensions/public/module';
 
 export const environment = {
   production: true,
-  // For production builds, backend API origin is always matching with the one serving frontend.
-  apiBaseUrl: '',
   bugReportUrl:
     'https://github.com/GoogleCloudPlatform/khi/issues/new?template=Blank+issue',
   documentUrl: 'https://github.com/GoogleCloudPlatform/khi',


### PR DESCRIPTION
## Overview
This PR adds proxy configuration to the Angular development server, integrating the frontend and backend development environments. This eliminates the need to manage two different ports (Angular: 4200, Golang: 8080) separately during development.

## Changes
* Added `web/proxy.conf.mjs` file implementing proxy configuration that forwards requests to the `/api` path to `localhost:8080`
* Updated angular-template.json file to reference the proxy configuration
* Additionally fixed the retry settings in the logic to get the configruation from backend. (I've found massive retry request made server and frontend extremely heavy when I run frontend without starting the backend)

## References

https://angular.dev/tools/cli/serve#proxying-to-a-backend-server