### PR TITLE
Update go version to 1.24

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,7 @@
 run:
   timeout: "30m"
   allow-parallel-runners: true
-  go: "1.23"
+  go: "1.24"
 
 linters:
   disable-all: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ENV ROOT=/go/src/app
 RUN mkdir /built

--- a/README.ja.md
+++ b/README.ja.md
@@ -82,7 +82,7 @@ Kubernetes History Inspector (KHI) は、Kubernetesクラスタのログ可視�
 <summary>動かしてみる (ソースから実行)</summary>
 
 #### 動作環境
-- Go 1.23.*
+- Go 1.24.*
 - Node.js環境 22.13.*
 - [`gcloud` CLI](https://cloud.google.com/sdk/docs/install)
 - [`jq`コマンド](https://jqlang.org/)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For more details, please try [Getting started](./docs/en/getting-started.md).
 <summary>Get Started (Run from source)</summary>
 
 #### Prerequisites
-- Go 1.23.*
+- Go 1.24.*
 - Node.js environment 22.13.*
 - [`gcloud` CLI](https://cloud.google.com/sdk/docs/install)
 - [`jq` command](https://jqlang.org/)


### PR DESCRIPTION
#97 updated go version to 1.24 but 1.23 is left in some places.