### PR TITLE
Add stale PR/Issue workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Close inactive pull requests
+on:
+  schedule:
+    # slightly offset from midnight 00:00 UTC to avoid potential spike issues.
+    - cron: "10 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-label: "stale"
+          days-before-pr-stale: 28
+          days-before-pr-close: 7
+          stale-pr-message: "This pull request is stale because it has been open for 4 weeks with no activity. Please update this PR or this will be closed in 7 days."
+          close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding a GitHub action to close stale pull requests.

1. If a PR has no updates over 28 days, this action will mark it as stale
2. Even after 7 days, there was no updates in the PR, this action will close the PR
3. This action will be executed every day at 0:10 UTC

For issues, settings are disabled for now.