### PR TITLE
k8s audit task graph bug fix on GKE

### DIFF
--- a/pkg/source/gcp/task/gke/gke_audit/taskid/taskid.go
+++ b/pkg/source/gcp/task/gke/gke_audit/taskid/taskid.go
@@ -16,12 +16,10 @@ package gke_audit_taskid
 
 import (
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
-	common_k8saudit_taskid "github.com/GoogleCloudPlatform/khi/pkg/source/common/k8s_audit/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/query"
 	gcp_task "github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/task/taskid"
 )
 
 var GKEAuditLogQueryTaskID = taskid.NewDefaultImplementationID[[]*log.LogEntity](query.GKEQueryPrefix + "gke-audit")
-var GKEAuditLogSourceTaskID = taskid.NewImplementationID(common_k8saudit_taskid.CommonAuitLogSource, "gcp")
 var GKEAuditParserTaskID = taskid.NewDefaultImplementationID[struct{}](gcp_task.GCPPrefix + "feature/gke-audit-parser")

--- a/pkg/source/gcp/task/gke/k8s_audit/parser_v2.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/parser_v2.go
@@ -32,7 +32,6 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/source/common/k8s_audit/recorder/statusrecorder"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/common/k8s_audit/types"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/inspectiontype"
-	gke_audit_taskid "github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/gke_audit/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/fieldextractor"
 	gke_k8saudit_taskid "github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task/gke/k8s_audit/taskid"
 
@@ -41,13 +40,13 @@ import (
 )
 
 // GCPK8sAuditLogSourceTask receives logs generated from the previous tasks specific to OSS audit log parsing and inject dependencies specific to this OSS inspection type.
-var GCPK8sAuditLogSourceTask = inspection_task.NewInspectionTask(gke_audit_taskid.GKEAuditLogSourceTaskID, []taskid.UntypedTaskReference{
-	gke_audit_taskid.GKEAuditLogQueryTaskID,
+var GCPK8sAuditLogSourceTask = inspection_task.NewInspectionTask(gke_k8saudit_taskid.GKEK8sAuditLogSourceTaskID, []taskid.UntypedTaskReference{
+	gke_k8saudit_taskid.K8sAuditQueryTaskID,
 }, func(ctx context.Context, taskMode inspection_task_interface.InspectionTaskMode, progress *progress.TaskProgress) (*types.AuditLogParserLogSource, error) {
 	if taskMode == inspection_task_interface.TaskModeDryRun {
 		return nil, nil
 	}
-	logs := task.GetTaskResult(ctx, gke_audit_taskid.GKEAuditLogQueryTaskID.GetTaskReference())
+	logs := task.GetTaskResult(ctx, gke_k8saudit_taskid.K8sAuditQueryTaskID.GetTaskReference())
 
 	return &types.AuditLogParserLogSource{
 		Logs:      logs,

--- a/pkg/source/gcp/task/gke/k8s_audit/taskid/taskid.go
+++ b/pkg/source/gcp/task/gke/k8s_audit/taskid/taskid.go
@@ -16,9 +16,11 @@ package gke_k8saudit_taskid
 
 import (
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
+	common_k8saudit_taskid "github.com/GoogleCloudPlatform/khi/pkg/source/common/k8s_audit/taskid"
 	gcp_task "github.com/GoogleCloudPlatform/khi/pkg/source/gcp/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/task/taskid"
 )
 
 var K8sAuditQueryTaskID = taskid.NewDefaultImplementationID[[]*log.LogEntity](gcp_task.GCPPrefix + "query/k8s_audit")
 var K8sAuditParseTaskID = taskid.NewDefaultImplementationID[struct{}](gcp_task.GCPPrefix + "/feature/audit-parser-v2")
+var GKEK8sAuditLogSourceTaskID = taskid.NewImplementationID(common_k8saudit_taskid.CommonAuitLogSource, "gcp")


### PR DESCRIPTION
The GKE k8s audit log parser in the main branch was broken because the GKE k8s audit log parser task wrongly depends on GKE audit log. Fixed the dependency relationships on the task definitions.