### PR TITLE
Refactor inspection data store

### DIFF
--- a/cmd/kubernetes-history-inspector/main.go
+++ b/cmd/kubernetes-history-inspector/main.go
@@ -257,6 +257,7 @@ func run() int {
 				exitCh <- 1
 				return
 			}
+			defer reader.Close()
 			file, err := os.OpenFile(*parameters.Job.ExportDestination, os.O_WRONLY|os.O_CREATE, 0644)
 			if err != nil {
 				slog.Error(fmt.Sprintf("Failed to open the destination file \n%s", err.Error()))

--- a/pkg/inspection/inspectiondata/result_repository_test.go
+++ b/pkg/inspection/inspectiondata/result_repository_test.go
@@ -35,15 +35,15 @@ func TestFileSystemResultRepository(t *testing.T) {
 		if writeErr != nil {
 			t.Errorf("writeErr: want nil, got %s", writeErr)
 		}
+		defer writer.Close()
 		writer.Write(testInspectionData)
-		repo.Close()
 		received, readErr := repo.GetReader()
-		var readTarget = make([]byte, 5)
+		readTarget := make([]byte, 5)
 		_, err := received.Read(readTarget)
 		if err != nil {
 			t.Errorf("unexpected errir %s", err)
 		}
-		repo.Close()
+		defer received.Close()
 
 		if readErr != nil {
 			t.Errorf("readErr: want nil, got %s", readErr)

--- a/pkg/inspection/task/serializer/serializer.go
+++ b/pkg/inspection/task/serializer/serializer.go
@@ -51,15 +51,12 @@ var SerializeTask = inspection_task.NewInspectionTask(SerializerTaskID, []taskid
 	if err != nil {
 		return nil, err
 	}
+	defer writer.Close()
 	resultMetadata, err := metadata.GetSerializableSubsetMapFromMetadataSet(metadataSet, filter.NewEqualFilter(metadata.LabelKeyIncludedInResultBinaryFlag, true, false))
 	if err != nil {
 		return nil, err
 	}
 	fileSize, err := builder.Finalize(ctx, resultMetadata, writer, progress)
-	if err != nil {
-		return nil, err
-	}
-	err = store.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -314,7 +314,7 @@ func CreateKHIServer(inspectionServer *inspection.InspectionTaskServer, serverCo
 				ctx.String(http.StatusInternalServerError, err.Error())
 				return
 			}
-			defer result.ResultStore.Close()
+			defer inspectionDataReader.Close()
 			fileSize, err := result.ResultStore.GetInspectionResultSizeInBytes()
 			if err != nil {
 				ctx.String(http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
The current implementation of the store has improvement area:

1. `file` holds a pointer for only the last file. This is a bit fragile because if a caller calls reader/writer multiple times, fd could leak.
2. `lock` could also be leaked if os failed to open the file or could result with deadlock.
3. Callers must know implementation details to prevent above resource leaks even there is an interface.

This new implementation is lock free and state free (except filepath for construct) - should be more robust.
Returning `io.Closer` explicitly tells callers that they are responsible for closing the resources.