### PR TITLE
Support default value updated dynamically

### DIFF
--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.html
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.html
@@ -24,6 +24,9 @@
       }
     }
     <p class="label">{{ param.label }}</p>
+    @if (store.watchDirty(param.id) | async) {
+      <mat-icon class="dirty" [matTooltip]="dirtyIconTooltip">edit</mat-icon>
+    }
   </div>
   <p class="description" [innerHTML]="param.description | breakline"></p>
 </div>

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.sass
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.sass
@@ -19,14 +19,23 @@
 
 $verified-icon-color: mat.m2-get-color-from-palette(mat.$m2-indigo-palette,400)
 $error-icon-color: mat.m2-get-color-from-palette(mat.$m2-red-palette,400)
+$dirty-icon-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 400)
+
+$dirty-icon-size: 15px
 
 .label-row
-    display: flex
+    display: grid
+    grid-template-areas: "validation title dirty"
+    gap: 3px
+    justify-content: start
     align-items: center
-    mat-icon
-        margin: 0px 4px
-        transform: scale(80%)
 
+    .dirty
+        color: $dirty-icon-color
+        width: $dirty-icon-size
+        height: $dirty-icon-size
+        font-size: $dirty-icon-size
+    
 .label
     flex: 1
     font-weight: 600

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.spec.ts
@@ -27,6 +27,10 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { MatIconHarness } from '@angular/material/icon/testing';
 import { ParameterHintType } from 'src/app/common/schema/form-types';
+import {
+  DefaultParameterStore,
+  PARAMETER_STORE,
+} from './service/parameter-store';
 describe('ParameterHeaderComponent', () => {
   let fixture: ComponentFixture<ParameterHeaderComponent>;
   let harnessLoader: HarnessLoader;
@@ -43,6 +47,12 @@ describe('ParameterHeaderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule],
+      providers: [
+        {
+          provide: PARAMETER_STORE,
+          useValue: new DefaultParameterStore(),
+        },
+      ],
     }).compileComponents();
     const matIconRegistry = TestBed.inject(MatIconRegistry);
     matIconRegistry.setDefaultFontSetClass('material-symbols-outlined');

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.ts
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.ts
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-import { Component, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { BreaklinePipe } from 'src/app/common/breakline.pipe';
 import {
   ParameterFormFieldBase,
   ParameterHintType,
 } from 'src/app/common/schema/form-types';
+import { PARAMETER_STORE } from './service/parameter-store';
+import { CommonModule } from '@angular/common';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 /**
  * Component of common parameter headers used in new inspection dialog.
@@ -29,10 +32,13 @@ import {
   selector: 'khi-new-inspection-parameter-header',
   templateUrl: './parameter-header.component.html',
   styleUrls: ['./parameter-header.component.sass'],
-  imports: [BreaklinePipe, MatIconModule],
+  imports: [CommonModule, BreaklinePipe, MatIconModule, MatTooltipModule],
 })
 export class ParameterHeaderComponent {
   readonly ParameterHintType = ParameterHintType;
+
+  readonly dirtyIconTooltip =
+    "This field modified once and won't follow the default value when KHI updated the default dynamatically.";
   /**
    * The spec of this text type parameter.
    */
@@ -42,4 +48,6 @@ export class ParameterHeaderComponent {
    * If the status of validation should show on header or not.
    */
   showValidationStatus = input(true);
+
+  store = inject(PARAMETER_STORE);
 }

--- a/web/src/app/dialogs/new-inspection/components/service/parameter-store.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/service/parameter-store.spec.ts
@@ -68,5 +68,54 @@ describe('DefaultParameterStore', () => {
         await lastValueFrom(parameterStore.watch('foo').pipe(take(1))),
       ).toBe('qux');
     });
+
+    it('update the value if the previous value is same as the default value', async () => {
+      parameterStore.setDefaultValues({ foo: 'bar' });
+      parameterStore.set('foo', 'bar');
+      parameterStore.setDefaultValues({ foo: 'qux' });
+
+      expect(
+        await lastValueFrom(parameterStore.watch('foo').pipe(take(1))),
+      ).toBe('qux');
+    });
+  });
+
+  describe('watchDirty', () => {
+    it("becomes false when the value hasn't set", async () => {
+      parameterStore.setDefaultValues({ foo: 'bar' });
+
+      expect(
+        await lastValueFrom(parameterStore.watchDirty('foo').pipe(take(1))),
+      ).toBe(false);
+    });
+
+    it('becomes false when the value has set', async () => {
+      parameterStore.setDefaultValues({ foo: 'bar' });
+      parameterStore.set('foo', 'qux');
+
+      expect(
+        await lastValueFrom(parameterStore.watchDirty('foo').pipe(take(1))),
+      ).toBe(true);
+    });
+
+    it('becomes false when the previous value returned to the same as the default value', async () => {
+      parameterStore.setDefaultValues({ foo: 'bar' });
+      parameterStore.set('foo', 'qux');
+      parameterStore.set('foo', 'bar');
+
+      expect(
+        await lastValueFrom(parameterStore.watchDirty('foo').pipe(take(1))),
+      ).toBe(false);
+    });
+
+    it('becomes false when the default value was updated and it matched the current value', async () => {
+      parameterStore.setDefaultValues({ foo: 'bar' });
+      parameterStore.set('foo', 'qux');
+      parameterStore.setDefaultValues({ foo: 'qux' });
+
+      expect(
+        await lastValueFrom(parameterStore.watchDirty('foo').pipe(take(1))),
+      ).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
* Update the parameter store to update the parameter when backend upadates the form default value dynamically. It updates the parameter only when the parameter was the previous default value.

This is needed for supporting log view support. The form default value can change when user modified the project ID field.