### PR TITLE
Support collapsing group parameter form type

### DIFF
--- a/pkg/inspection/metadata/form/form.go
+++ b/pkg/inspection/metadata/form/form.go
@@ -78,6 +78,12 @@ type GroupParameterFormField struct {
 	ParameterFormFieldBase
 	// Children is the children of this field.
 	Children []ParameterFormField `json:"children"`
+
+	// Collapsible is true when user can collapse or expand the grouped fields.
+	Collapsible bool `json:"collapsible"`
+
+	// CollapsedByDefault is true when the form is collapsed at first time when the form shows up.
+	CollapsedByDefault bool `json:"collapsedByDefault"`
 }
 
 // TextParameterFormField represents Text type parameter specific data.

--- a/web/src/app/common/schema/form-types.ts
+++ b/web/src/app/common/schema/form-types.ts
@@ -73,6 +73,17 @@ export interface GroupParameterFormField extends ParameterFormFieldBase {
    * List of child parameters.
    */
   children: ParameterFormField[];
+
+  /**
+   * If this group is collapsible or not.
+   */
+  collapsible: boolean;
+
+  /**
+   * If this group is collapsed by default.
+   * `collapsible` must be true when this value is true.
+   */
+  collapsedByDefault: boolean;
 }
 
 /**

--- a/web/src/app/dialogs/new-inspection/components/group-parameter.component.html
+++ b/web/src/app/dialogs/new-inspection/components/group-parameter.component.html
@@ -15,12 +15,22 @@
 -->
 
 @let param = parameter();
-<div class="container">
-  <khi-new-inspection-parameter-header
-    [parameter]="param"
-    [showValidationStatus]="false"
-  ></khi-new-inspection-parameter-header>
-  <div class="children">
+<div class="container" [ngClass]="{ collapsable: param.collapsible }">
+  <div class="header" (click)="toggle()">
+    <button
+      class="expander"
+      mat-icon-button
+      color="primary"
+      [@expander-animation]="childrenStatus()"
+    >
+      <mat-icon>expand_more</mat-icon>
+    </button>
+    <khi-new-inspection-parameter-header
+      [parameter]="param"
+      [showValidationStatus]="false"
+    ></khi-new-inspection-parameter-header>
+  </div>
+  <div class="children" [@children-animation]="childrenStatus()">
     @for (parameter of param.children; track parameter.id) {
       @if (!$first) {
         <div class="separator"></div>

--- a/web/src/app/dialogs/new-inspection/components/group-parameter.component.sass
+++ b/web/src/app/dialogs/new-inspection/components/group-parameter.component.sass
@@ -19,9 +19,24 @@
 
 $separator-color:  mat.m2-get-color-from-palette(mat.$m2-gray-palette,100)
 
-.children
-    padding: 0px 0px 0px 10px
-
+.container
+    .header
+        display: grid
+        grid-template-areas: "expander header"
+        grid-template-columns: auto 1fr
+        .expander
+            display: none
+    .children
+        padding: 0px 0px 0px 10px
+        overflow: hidden
+    &.collapsable
+        .header
+            .expander
+                display: block
+            &:hover
+                background-color: lightgray
+                cursor: pointer
+    
 .separator
     height: 4px
     width: 20px

--- a/web/src/app/dialogs/new-inspection/components/group-parameter.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/group-parameter.component.spec.ts
@@ -33,6 +33,7 @@ import {
   DefaultParameterStore,
   PARAMETER_STORE,
 } from './service/parameter-store';
+import { By } from '@angular/platform-browser';
 
 describe('GroupParameterComponent', () => {
   let fixture: ComponentFixture<GroupParameterComponent>;
@@ -76,6 +77,8 @@ describe('GroupParameterComponent', () => {
       type: ParameterInputType.Group,
       label: 'group',
       hintType: ParameterHintType.None,
+      collapsible: false,
+      collapsedByDefault: false,
       children: [
         {
           type: ParameterInputType.Text,
@@ -118,5 +121,52 @@ describe('GroupParameterComponent', () => {
     } as GroupParameterFormField);
     fixture.detectChanges();
     expect(fixture.componentInstance).toBeTruthy();
+
+    const containerElement = fixture.debugElement.query(By.css('.container'));
+    expect(containerElement.classes['collapsable']).toBeFalsy();
+  });
+
+  it('becomes collapsable when `collapsable` = true', () => {
+    fixture.componentRef.setInput('parameter', {
+      type: ParameterInputType.Group,
+      label: 'group',
+      description: 'this is a test description',
+      collapsible: true,
+      collapsedByDefault: true,
+      hintType: ParameterHintType.None,
+      children: [
+        {
+          type: ParameterInputType.Text,
+          label: 'text-form-1',
+          hintType: ParameterHintType.None,
+        },
+      ],
+    } as GroupParameterFormField);
+    fixture.detectChanges();
+
+    const containerElement = fixture.debugElement.query(By.css('.container'));
+    expect(containerElement.classes['collapsable']).toBeTruthy();
+    expect(fixture.componentInstance.childrenStatus()).toBe('collapsed');
+  });
+
+  it('expands by default when `collapsedByDefault` = false', () => {
+    fixture.componentRef.setInput('parameter', {
+      type: ParameterInputType.Group,
+      label: 'group',
+      description: 'this is a test description',
+      collapsable: true,
+      collapsedByDefault: false,
+      hintType: ParameterHintType.None,
+      children: [
+        {
+          type: ParameterInputType.Text,
+          label: 'text-form-1',
+          hintType: ParameterHintType.None,
+        },
+      ],
+    } as GroupParameterFormField);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.childrenStatus()).toBe('expanded');
   });
 });

--- a/web/src/app/dialogs/new-inspection/components/group-parameter.component.ts
+++ b/web/src/app/dialogs/new-inspection/components/group-parameter.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input } from '@angular/core';
+import { Component, computed, input, signal } from '@angular/core';
 import {
   GroupParameterFormField,
   ParameterInputType,
@@ -23,6 +23,16 @@ import { TextParameterComponent } from './text-parameter.component';
 import { FileParameterComponent } from './file-parameter.component';
 import { ParameterHeaderComponent } from './parameter-header.component';
 import { ParameterHintComponent } from './parameter-hint.component';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
 
 /**
  * A collection of form fields.
@@ -32,10 +42,47 @@ import { ParameterHintComponent } from './parameter-hint.component';
   templateUrl: './group-parameter.component.html',
   styleUrls: ['./group-parameter.component.sass'],
   imports: [
+    CommonModule,
+    MatIconModule,
+    MatButtonModule,
     TextParameterComponent,
     FileParameterComponent,
     ParameterHeaderComponent,
     ParameterHintComponent,
+  ],
+  animations: [
+    trigger('children-animation', [
+      state(
+        'expanded',
+        style({
+          height: '*',
+        }),
+      ),
+      state(
+        'collapsed',
+        style({
+          height: '0',
+        }),
+      ),
+      transition('expanded => collapsed', animate('500ms ease-in')),
+      transition('collapsed => expanded', animate('500ms ease-out')),
+    ]),
+    trigger('expander-animation', [
+      state(
+        'expanded',
+        style({
+          transform: 'rotate(0deg)',
+        }),
+      ),
+      state(
+        'collapsed',
+        style({
+          transform: 'rotate(-90deg)',
+        }),
+      ),
+      transition('expanded => collapsed', animate('500ms ease-in')),
+      transition('collapsed => expanded', animate('500ms ease-out')),
+    ]),
   ],
 })
 export class GroupParameterComponent {
@@ -44,4 +91,19 @@ export class GroupParameterComponent {
    * The setting of this group type form field.
    */
   parameter = input.required<GroupParameterFormField>();
+
+  private readonly collapsedFromUserInput = signal<boolean | null>(null);
+
+  childrenStatus = computed(() => {
+    const fromUserInput = this.collapsedFromUserInput();
+    const fromDefaultValue = this.parameter().collapsedByDefault;
+    return (fromUserInput ?? fromDefaultValue) ? 'collapsed' : 'expanded';
+  });
+
+  /**
+   * Toggle the collapsed status for children.
+   */
+  toggle() {
+    this.collapsedFromUserInput.set(this.childrenStatus() === 'collapsed');
+  }
 }

--- a/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.spec.ts
+++ b/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.spec.ts
@@ -69,6 +69,7 @@ describe('RequestUserActionPopup in dialog context', () => {
     });
     const dialogs = await loader.getAllHarnesses(MatDialogHarness);
     expect(dialogs.length).toBe(1);
+    matDialog.closeAll();
   }
 
   it('should be instanciated with type=text', async () => {


### PR DESCRIPTION
This is added because the log view support needs to add text inputs for each log queries and these are usually OK with default values. Adding collapsing group parameter feature to improve the usability even after adding these multiple forms.