### PR TITLE
Fix the wrong terminology `taskID` in APIs

### DIFF
--- a/cmd/kubernetes-history-inspector/main.go
+++ b/cmd/kubernetes-history-inspector/main.go
@@ -206,7 +206,7 @@ func run() int {
 				exitCh <- 1
 				return
 			}
-			taskId, err := inspectionServer.CreateInspection(*parameters.Job.InspectionType)
+			inspectionID, err := inspectionServer.CreateInspection(*parameters.Job.InspectionType)
 			if err != nil {
 				slog.Error(fmt.Sprintf("Failed to create an inspection with type %s\n%s", *parameters.Job.InspectionType, err.Error()))
 				exitCh <- 1
@@ -214,7 +214,7 @@ func run() int {
 			}
 
 			features := strings.Split(*parameters.Job.InspectionFeatures, ",")
-			t := inspectionServer.GetTask(taskId)
+			t := inspectionServer.GetInspection(inspectionID)
 			// When the features env has `ALL`, it enables every features being available
 			if len(features) == 1 && strings.ToUpper(features[0]) == "ALL" {
 				availableFeatures, err := t.FeatureList()

--- a/pkg/inspection/server.go
+++ b/pkg/inspection/server.go
@@ -59,8 +59,8 @@ type InspectionTaskServer struct {
 	RootTaskSet *task.TaskSet
 	// inspectionTypes are kinds of tasks. Users will select this at first to filter togglable feature tasks.
 	inspectionTypes []*InspectionType
-	// tasks are generated tasks
-	tasks map[string]*InspectionTaskRunner
+	// inspections are generated inspection task runers
+	inspections map[string]*InspectionTaskRunner
 }
 
 func NewServer() (*InspectionTaskServer, error) {
@@ -71,7 +71,7 @@ func NewServer() (*InspectionTaskServer, error) {
 	return &InspectionTaskServer{
 		RootTaskSet:     ns,
 		inspectionTypes: make([]*InspectionType, 0),
-		tasks:           map[string]*InspectionTaskRunner{},
+		inspections:     map[string]*InspectionTaskRunner{},
 	}, nil
 }
 
@@ -106,13 +106,13 @@ func (s *InspectionTaskServer) CreateInspection(inspectionType string) (string, 
 	if err != nil {
 		return "", err
 	}
-	s.tasks[inspectionTask.ID] = inspectionTask
+	s.inspections[inspectionTask.ID] = inspectionTask
 	return inspectionTask.ID, nil
 }
 
 // Inspection returns an instance of an Inspection queried with given inspection ID.
-func (s *InspectionTaskServer) GetTask(taskId string) *InspectionTaskRunner {
-	return s.tasks[taskId]
+func (s *InspectionTaskServer) GetInspection(inspectionID string) *InspectionTaskRunner {
+	return s.inspections[inspectionID]
 }
 
 func (s *InspectionTaskServer) GetAllInspectionTypes() []*InspectionType {
@@ -130,7 +130,7 @@ func (s *InspectionTaskServer) GetInspectionType(inspectionTypeId string) *Inspe
 
 func (s *InspectionTaskServer) GetAllRunners() []*InspectionTaskRunner {
 	inspections := []*InspectionTaskRunner{}
-	for _, value := range s.tasks {
+	for _, value := range s.inspections {
 		inspections = append(inspections, value)
 	}
 	return inspections

--- a/pkg/server/config/type.go
+++ b/pkg/server/config/type.go
@@ -16,7 +16,7 @@ package config
 
 import "github.com/GoogleCloudPlatform/khi/pkg/parameters"
 
-// GetConfigResponse is the response type of /api/v2/config
+// GetConfigResponse is the response type of /api/v3/config
 type GetConfigResponse struct {
 	// ViewerMode is a flag indicating if the server is the viewer mode and not accepting creating a new inspection request.
 	ViewerMode bool `json:"viewerMode"`

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -24,34 +24,34 @@ type ServerStat struct {
 	TotalMemoryAvailable int `json:"totalMemoryAvailable"`
 }
 
-// GetInspectionTypesResponse is the type of the response for /api/v2/inspection/types
+// GetInspectionTypesResponse is the type of the response for /api/v3/inspection/types
 type GetInspectionTypesResponse struct {
 	Types []*inspection.InspectionType `json:"types"`
 }
 
-// GetInspectionTasksResponse is the type of the response for /api/v2/inspection/tasks
-type GetInspectionTasksResponse struct {
-	Tasks      map[string]SerializedMetadata `json:"tasks"`
-	ServerStat *ServerStat                   `json:"serverStat"`
+// GetInspectionsResponse is the type of the response for /api/v3/inspection
+type GetInspectionsResponse struct {
+	Inspections map[string]SerializedMetadata `json:"inspections"`
+	ServerStat  *ServerStat                   `json:"serverStat"`
 }
 
-type PostInspectionTaskResponse struct {
-	InspectionId string `json:"inspectionId"`
+type PostInspectionResponse struct {
+	InspectionID string `json:"inspectionID"`
 }
 
-type PutInspectionTaskFeatureRequest struct {
+type PutInspectionFeatureRequest struct {
 	Features []string `json:"features"`
 }
 
-type PatchInspectionTaskFeatureRequest struct {
+type PatchInspectionFeatureRequest struct {
 	Features map[string]bool `json:"features"`
 }
 
-type PutInspectionTaskFeatureResponse struct {
+type PutInspectionFeatureResponse struct {
 }
 
-type GetInspectionTaskFeatureResponse struct {
+type GetInspectionFeatureResponse struct {
 	Features []inspection.FeatureListItem `json:"features"`
 }
 
-type PostInspectionTaskDryRunRequest = map[string]any
+type PostInspectionDryRunRequest = map[string]any

--- a/pkg/testutil/inspection/conformance.go
+++ b/pkg/testutil/inspection/conformance.go
@@ -78,7 +78,7 @@ func ConformanceTestForInspectionTypes(t *testing.T, preps []inspection.PrepareI
 			if err != nil {
 				t.Errorf("unexpected error\n%v", err)
 			}
-			features, err := testServer.GetTask(taskId).FeatureList()
+			features, err := testServer.GetInspection(taskId).FeatureList()
 			if err != nil {
 				t.Errorf("unexpected error\n%v", err)
 			}

--- a/web/src/app/common/schema/api-types.ts
+++ b/web/src/app/common/schema/api-types.ts
@@ -30,7 +30,7 @@ import {
 } from './metadata-types';
 
 /**
- * Representing a config of this frontend. A returned value type for GET /api/v2/config.
+ * Representing a config of this frontend. A returned value type for GET /api/v3/config.
  */
 export interface GetConfigResponse {
   // ViewerMode is a flag indicating if the server is the viewer mode and not accepting creating a new inspection request.
@@ -63,7 +63,7 @@ export interface InspectionType {
 }
 
 /**
- * The response schema of GET /api/v2/inspection/types .
+ * The response schema of GET /api/v3/inspection/types .
  */
 export interface GetInspectionTypesResponse {
   /**
@@ -73,13 +73,13 @@ export interface GetInspectionTypesResponse {
 }
 
 /**
- * The response schema of POST /api/v2/inspection/types/<InspectionType.id> .
+ * The response schema of POST /api/v3/inspection/types/<InspectionType.id> .
  */
-export interface CreateInspectionTaskResponse {
+export interface CreateInspectionResponse {
   /**
-   * ID of the inspection task created.
+   * ID of the inspection created.
    */
-  inspectionId: string;
+  inspectionID: string;
 }
 
 /**
@@ -108,19 +108,19 @@ export interface InspectionFeature {
 }
 
 /**
- * Response schema of GET /api/v2/inspection/tasks/<task-id>/features .
+ * Response schema of GET /api/v3/inspection/<inspection-id>/features .
  */
-export interface GetInspectionTaskFeatureResponse {
+export interface GetInspectionFeatureResponse {
   /**
-   * List of features for the inspection task.
+   * List of features for the inspection.
    */
   features: InspectionFeature[];
 }
 
 /**
- * Request schema of PUT /api/v2/inspection/tasks/<task-id>/features .
+ * Request schema of PUT /api/v3/inspection/<inspection-id>/features .
  */
-export interface PutInspectionTaskFeatureRequest {
+export interface PutInspectionFeatureRequest {
   /**
    * List of IDs to be enabled.
    */
@@ -128,9 +128,9 @@ export interface PutInspectionTaskFeatureRequest {
 }
 
 /**
- * Request schema of PATCH /api/v2/inspection/tasks/<task-id>/features .
+ * Request schema of PATCH /api/v3/inspection/<inspection-id>/features .
  */
-export interface PatchInspectionTaskFeatureRequest {
+export interface PatchInspectionFeatureRequest {
   /**
    * Map of features mapped against true if enabled
    */
@@ -138,7 +138,7 @@ export interface PatchInspectionTaskFeatureRequest {
 }
 
 /**
- * Response schema of POST /api/v2/inspection/tasks/<inspection task id>/dryrun .
+ * Response schema of POST /api/v3/inspection/<inspection-id>/dryrun .
  */
 export type InspectionDryRunResponse = {
   /**
@@ -152,52 +152,52 @@ export type InspectionDryRunResponse = {
 /**
  * Representing a set of parameters given to the inspection task graph.
  */
-type InspectionTaskGraphArgument = { [key: string]: unknown };
+type InspectionArgument = { [key: string]: unknown };
 
 /**
- * Request schema of POST /api/v2/inspection/tasks/<inspection task id>/dryrun .
+ * Request schema of POST /api/v3/inspection/<inspection-id>/dryrun .
  */
-export type InspectionDryRunRequest = InspectionTaskGraphArgument;
+export type InspectionDryRunRequest = InspectionArgument;
 
 /**
- * Request schema of POST /api/v/inspection/tasks/<inspection task id>/run .
+ * Request schema of POST /api/v3/inspection/<inspection-id>/run .
  */
-export type InspectionRunRequest = InspectionTaskGraphArgument;
+export type InspectionRunRequest = InspectionArgument;
 
 /**
- * Set of metadata generated for a task not having run yet.
+ * Set of metadata generated for a inspection.
  */
 export type InspectionMetadataInDryrun = {
   /**
-   * List of form fields to be filled to run this inspection task.
+   * List of form fields to be filled to run this inspection.
    */
   form: ParameterFormField[];
 
   /**
-   * List of queries to be run with this inspection task.
+   * List of queries to be run with this inspection.
    */
   query: InspectionMetadataQuery[];
 
   /**
-   * The inspection task graph to be run with inspection task.
+   * The inspection task graph in string representation.
    */
   plan: InspectionMetadataPlan;
 };
 
 /**
- * Set of metadata generated for tasks in the task list.
+ * Set of metadata generated for tasks in the inspection.
  */
-export type InspectionMetadataInTaskList = {
+export type InspectionMetadataInInspectionList = {
   /**
-   * Current progress of this inspection task.
+   * Current progress of this inspection.
    */
   progress: InspectionMetadataProgress;
   /**
-   * Summary of this inspection task like name, data size ...etc.
+   * Summary of this inspection like name, data size ...etc.
    */
   header: InspectionMetadataHeader;
   /**
-   * Set of error logs for this inspection task.
+   * Set of error logs for this inspection.
    */
   error: InspectionMetadataErrorSet;
 };
@@ -211,30 +211,30 @@ export type InspectionMetadataOfRunResult = {
    */
   header: InspectionMetadataHeader;
   /**
-   * List of queries having run with this inspection task.
+   * List of queries having run with this inspection.
    */
   query: InspectionMetadataQuery[];
   /**
-   * The inspection task graph having run with inspection task.
+   * The inspection task graph in string representation.
    */
   plan: InspectionMetadataPlan;
   /**
-   * The logs generated from the inspection task itself.
+   * The logs generated from the inspection itself.
    */
   log: InspectionMetadataLog[];
 
   /**
-   * Set of error logs for this inspection task.
+   * Set of error logs for this inspection.
    */
   error: InspectionMetadataErrorSet;
 };
 
 /**
- * Response schema of /api/v2/inspection/tasks .
+ * Response schema of /api/v3/inspection .
  */
-export type GetInspectionTasksResponse = {
-  tasks: {
-    [taskId: string]: InspectionMetadataInTaskList;
+export type GetInspectionResponse = {
+  inspections: {
+    [inspectionId: string]: InspectionMetadataInInspectionList;
   };
   serverStat: {
     totalMemoryAvailable: number;
@@ -244,7 +244,7 @@ export type GetInspectionTasksResponse = {
 export type PopupFormType = 'text' | 'popup_redirect';
 
 /**
- * PopupFormRequest is a type returned on the endpoint GET /api/v2/popup.
+ * PopupFormRequest is a type returned on the endpoint GET /api/v3/popup.
  * Note this request is from backend with polling. Thus this is also a response in HTTP.
  */
 export interface PopupFormRequest {
@@ -263,7 +263,7 @@ export interface PopupFormRequest {
 }
 
 /**
- * PopupAnswerResponse is a type replied to the server with the endpoint POST /api/v2/popup/answer or POST /api/v2/popup/validate
+ * PopupAnswerResponse is a type replied to the server with the endpoint POST /api/v3/popup/answer or POST /api/v3/popup/validate
  */
 export interface PopupAnswerResponse {
   id: string;
@@ -271,7 +271,7 @@ export interface PopupAnswerResponse {
 }
 
 /**
- * PopupValidationResult is a type returned from server on POST /api/v2/popup/validate
+ * PopupValidationResult is a type returned from server on POST /api/v3/popup/validate
  */
 export interface PopupAnswerValidationResult {
   id: string;

--- a/web/src/app/dialogs/startup/startup.component.spec.ts
+++ b/web/src/app/dialogs/startup/startup.component.spec.ts
@@ -26,7 +26,7 @@ import { of, ReplaySubject, Subject } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import {
   GetConfigResponse,
-  GetInspectionTasksResponse,
+  GetInspectionResponse,
 } from 'src/app/common/schema/api-types';
 import {
   EXTENSION_STORE,
@@ -36,7 +36,7 @@ import {
 describe('StartupDialogComponent', () => {
   let component: ComponentFixture<StartupDialogComponent>;
   let backendConnectionSpy: jasmine.SpyObj<BackendConnectionService>;
-  let taskListSubject: Subject<GetInspectionTasksResponse>;
+  let taskListSubject: Subject<GetInspectionResponse>;
   beforeEach(async () => {
     taskListSubject = new ReplaySubject(1);
     backendConnectionSpy = jasmine.createSpyObj<BackendConnectionService>(
@@ -92,7 +92,7 @@ describe('StartupDialogComponent', () => {
 
   it('should show empty list with hint message when given task list is empty', fakeAsync(() => {
     taskListSubject.next({
-      tasks: {
+      inspections: {
         a: {
           header: {
             inspectionType: 'foo',

--- a/web/src/app/dialogs/startup/startup.component.ts
+++ b/web/src/app/dialogs/startup/startup.component.ts
@@ -108,13 +108,13 @@ export class StartupDialogComponent {
     this.tasks,
   ]).pipe(
     map(([, tp]) => {
-      const keys = Object.keys(tp.tasks).sort(
+      const keys = Object.keys(tp.inspections).sort(
         (a, b) =>
-          tp.tasks[a].header.inspectTimeUnixSeconds -
-          tp.tasks[b].header.inspectTimeUnixSeconds,
+          tp.inspections[a].header.inspectTimeUnixSeconds -
+          tp.inspections[b].header.inspectTimeUnixSeconds,
       );
       return keys.map((key) => {
-        const taskMetadata = tp.tasks[key];
+        const taskMetadata = tp.inspections[key];
         return {
           id: key,
           label: taskMetadata.header.inspectionType,

--- a/web/src/app/services/api/backend-api-interface.ts
+++ b/web/src/app/services/api/backend-api-interface.ts
@@ -17,8 +17,8 @@
 import { Observable } from 'rxjs';
 import {
   GetConfigResponse,
-  GetInspectionTaskFeatureResponse,
-  GetInspectionTasksResponse,
+  GetInspectionFeatureResponse,
+  GetInspectionResponse,
   GetInspectionTypesResponse,
   InspectionDryRunRequest,
   InspectionDryRunResponse,
@@ -28,7 +28,7 @@ import {
   PopupAnswerValidationResult,
   PopupFormRequest,
 } from '../../common/schema/api-types';
-import { InspectionTaskClient } from './backend-api.service';
+import { InspectionClient } from './backend-api.service';
 import { InjectionToken } from '@angular/core';
 import { UploadToken } from 'src/app/common/schema/form-types';
 import { HttpEvent } from '@angular/common/http';
@@ -43,110 +43,115 @@ export const BACKEND_API = new InjectionToken<BackendAPI>('BACKEND_API');
 export interface BackendAPI {
   /**
    * Get configuration applied on this frontend.
-   * Expected called endpoint: GET /api/v2/config
+   * Expected called endpoint: GET /api/v3/config
    */
   getConfig(): Observable<GetConfigResponse>;
   /**
    * Get the list of inspection types.
-   * Expected called endpoint: GET /api/v2/inspection/types
+   * Expected called endpoint: GET /api/v3/inspection/types
    */
   getInspectionTypes(): Observable<GetInspectionTypesResponse>;
 
   /**
    * List the status of tasks.
-   * Expected called endpoint: GET /api/v2/inspection/tasks
+   * Expected called endpoint: GET /api/v3/inspection
    */
-  getTaskStatuses(): Observable<GetInspectionTasksResponse>;
+  getInspections(): Observable<GetInspectionResponse>;
 
   /**
    * Create an inspection.
-   * Expected called endpoint: POST /api/v2/inspection/types/<inspection-type>
+   * Expected called endpoint: POST /api/v3/inspection/types/<inspection-type>
    *
    * This function will return a http client for operating the generated task instead of returning the API response directly.
    *
    * @param inspectionTypeId the type of inspection id listed in the result of `getInspectionTypes()`
    */
-  createInspection(inspectionTypeId: string): Observable<InspectionTaskClient>;
+  createInspection(inspectionTypeId: string): Observable<InspectionClient>;
 
   /**
    * List the features selectable of this task.
-   * Expected called endpoint: GET /api/v2/inspection/tasks/<task-id>/features
+   * Expected called endpoint: GET /api/v3/inspection/<inspection-id>/features
    *
-   * @param taskId inspection task ID to list the feature
+   * @param inspectionID inspection ID to list the feature
    */
-  getFeatureList(taskId: string): Observable<GetInspectionTaskFeatureResponse>;
+  getFeatureList(
+    inspectionID: string,
+  ): Observable<GetInspectionFeatureResponse>;
 
   /**
    * Set the selected features of this task.
-   * Expected called endpoint: PUT /api/v2/inspection/tasks/<task-id>/features
+   * Expected called endpoint: PUT /api/v3/inspection/<inspection-id>/features
    *
-   * @param taskId inspection task ID to set the selected feature
+   * @param inspectionID inspection ID to set the selected feature
    * @param featureStatusMap Map of features mapped against true if enabled
    */
   setEnabledFeatures(
-    taskId: string,
+    inspectionID: string,
     featureStatusMap: { [key: string]: boolean },
   ): Observable<void>;
 
   /**
    * Get the metadata of an inspection with taskId.
-   * Expected called endpoint: GET /api/v2/inspection/tasks/<task-id>/metadata
+   * Expected called endpoint: GET /api/v3/inspection/<inspection-id>/metadata
    *
-   * @param taskId inspection task ID to download the metadata
+   * @param inspectionID inspection ID to download the metadata
    */
   getInspectionMetadata(
-    taskId: string,
+    inspectionID: string,
   ): Observable<InspectionMetadataOfRunResult>;
 
   /**
    * Request running a task.
-   * Expected called endpoint: POST /api/v2/inspection/tasks/<task-id>/run
+   * Expected called endpoint: POST /api/v3/inspection/<inspection-id>/run
    *
-   * @param taskId inspection taskId to run
+   * @param inspectionID inspection taskId to run
    * @param request parameter of the task
    */
-  runTask(taskId: string, request: InspectionRunRequest): Observable<void>;
+  runInspection(
+    inspectionID: string,
+    request: InspectionRunRequest,
+  ): Observable<void>;
 
   /**
    * Request dry run a task.
-   * Expected called endpoint: POST /api/v2/inspection/tasks/<task-id>/dryrun
-   * @param taskId inspection taskId to dryrun
+   * Expected called endpoint: POST /api/v3/inspection/<inspection-id>/dryrun
+   * @param inspectionID inspection taskId to dryrun
    * @param request parameter of the task
    */
-  dryRunTask(
-    taskId: string,
+  dryRunInspection(
+    inspectionID: string,
     request: InspectionDryRunRequest,
   ): Observable<InspectionDryRunResponse>;
 
   /**
    * Get the inspection data with taskId.
-   * Expected called endpoint: GET /api/v2/inspection/tasks/<task-id>/data
+   * Expected called endpoint: GET /api/v3/inspection/<inspection-id>/data
    *
-   * @param taskId inspection task ID to download the result.
+   * @param inspectionID inspection ID to download the result.
    * @param reporter task progress reporter.
    */
   getInspectionData(
-    taskId: string,
+    inspectionID: string,
     reporter: DownloadProgressReporter,
   ): Observable<Blob | null>;
 
   /**
    * Cancel the inspection task.
-   * Expected called endpoint: POST /api/v2/inspection/tasks/<task-id>/cancel
+   * Expected called endpoint: POST /api/v3/inspection/<inspection-id>/cancel
    *
-   * @param taskId inspection task ID to cancel
+   * @param inspectionID inspection ID to cancel
    */
-  cancelInspection(taskId: string): Observable<void>;
+  cancelInspection(inspectionID: string): Observable<void>;
 
   /**
    * Get the current popup request.
-   * Expected called endpoint: GET /api/v2/popup
+   * Expected called endpoint: GET /api/v3/popup
    */
   getPopup(): Observable<PopupFormRequest | null>;
 
   /**
    * Validate the request for the current popup
-   * Expected called endpoint: POST /api/v2/popup/validate
+   * Expected called endpoint: POST /api/v3/popup/validate
    */
   validatePopupAnswer(
     answer: PopupAnswerResponse,
@@ -154,7 +159,7 @@ export interface BackendAPI {
 
   /**
    * Answer the current request for the popup
-   * Expected called endpoint: POST /api/v2/popup/answer
+   * Expected called endpoint: POST /api/v3/popup/answer
    */
   answerPopup(answer: PopupAnswerResponse): Observable<void>;
 

--- a/web/src/app/services/api/backend-api.service.spec.ts
+++ b/web/src/app/services/api/backend-api.service.spec.ts
@@ -20,13 +20,13 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { BackendAPIImpl, InspectionTaskClient } from './backend-api.service';
+import { BackendAPIImpl, InspectionClient } from './backend-api.service';
 import { ViewStateService } from '../view-state.service';
 import {
-  CreateInspectionTaskResponse,
+  CreateInspectionResponse,
   GetConfigResponse,
-  GetInspectionTaskFeatureResponse,
-  GetInspectionTasksResponse,
+  GetInspectionFeatureResponse,
+  GetInspectionResponse,
   GetInspectionTypesResponse,
   InspectionDryRunRequest,
   InspectionDryRunResponse,
@@ -54,8 +54,8 @@ describe('BackendAPIImpl testing', () => {
   });
 
   it('read server-base-path from meta tag', () => {
-    document.head.innerHTML += `<meta id="server-base-path" content="/api/v2">`;
-    expect(BackendAPIImpl.getServerBasePath()).toEqual('/api/v2');
+    document.head.innerHTML += `<meta id="server-base-path" content="/api/v3">`;
+    expect(BackendAPIImpl.getServerBasePath()).toEqual('/api/v3');
     document.getElementById('server-base-path')?.remove();
     expect(BackendAPIImpl.getServerBasePath()).toEqual('');
   });
@@ -74,7 +74,7 @@ describe('BackendAPIImpl testing', () => {
         viewerMode: true,
       });
     });
-    const req = httpTestingController.expectOne('/api/v2/config');
+    const req = httpTestingController.expectOne('/api/v3/config');
     expect(req.request.method).toEqual('GET');
     req.flush(testData);
   });
@@ -94,39 +94,39 @@ describe('BackendAPIImpl testing', () => {
     api.getInspectionTypes().subscribe((data) => {
       expect(data).toEqual(testData);
     });
-    const req = httpTestingController.expectOne('/api/v2/inspection/types');
+    const req = httpTestingController.expectOne('/api/v3/inspection/types');
 
     expect(req.request.method).toEqual('GET');
     req.flush(testData);
   });
 
   it('can call getTaskStatuses', () => {
-    const testData: GetInspectionTasksResponse = {
-      tasks: {},
+    const testData: GetInspectionResponse = {
+      inspections: {},
       serverStat: {
         totalMemoryAvailable: 10,
       },
     };
 
-    api.getTaskStatuses().subscribe((data) => {
+    api.getInspections().subscribe((data) => {
       expect(data).toEqual(testData);
     });
-    const req = httpTestingController.expectOne('/api/v2/inspection/tasks');
+    const req = httpTestingController.expectOne('/api/v3/inspection');
 
     expect(req.request.method).toEqual('GET');
     req.flush(testData);
   });
 
   it('can call createInspection', () => {
-    const testData: CreateInspectionTaskResponse = {
-      inspectionId: 'test',
+    const testData: CreateInspectionResponse = {
+      inspectionID: 'test',
     };
 
     api.createInspection('test-inspection-type').subscribe((result) => {
-      expect(result.taskId).toEqual('test');
+      expect(result.inspectionID).toEqual('test');
     });
     const req = httpTestingController.expectOne(
-      '/api/v2/inspection/types/test-inspection-type',
+      '/api/v3/inspection/types/test-inspection-type',
     );
 
     expect(req.request.method).toEqual('POST');
@@ -134,7 +134,7 @@ describe('BackendAPIImpl testing', () => {
   });
 
   it('can call downloadFeatureList', () => {
-    const testData: GetInspectionTaskFeatureResponse = {
+    const testData: GetInspectionFeatureResponse = {
       features: [],
     };
 
@@ -142,7 +142,7 @@ describe('BackendAPIImpl testing', () => {
       expect(data).toEqual(testData);
     });
     const req = httpTestingController.expectOne(
-      '/api/v2/inspection/tasks/test/features',
+      '/api/v3/inspection/test/features',
     );
 
     expect(req.request.method).toEqual('GET');
@@ -155,7 +155,7 @@ describe('BackendAPIImpl testing', () => {
       apiSpy();
     });
     const req = httpTestingController.expectOne(
-      '/api/v2/inspection/tasks/test/features',
+      '/api/v3/inspection/test/features',
     );
 
     expect(req.request.method).toEqual('PATCH');
@@ -188,7 +188,7 @@ describe('BackendAPIImpl testing', () => {
       expect(data).toEqual(testData);
     });
     const req = httpTestingController.expectOne(
-      '/api/v2/inspection/tasks/test/metadata',
+      '/api/v3/inspection/test/metadata',
     );
 
     expect(req.request.method).toEqual('GET');
@@ -200,10 +200,8 @@ describe('BackendAPIImpl testing', () => {
       test: 'foo',
     };
 
-    api.runTask('test', testParameters).subscribe(() => {});
-    const req = httpTestingController.expectOne(
-      '/api/v2/inspection/tasks/test/run',
-    );
+    api.runInspection('test', testParameters).subscribe(() => {});
+    const req = httpTestingController.expectOne('/api/v3/inspection/test/run');
 
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual(testParameters);
@@ -224,12 +222,12 @@ describe('BackendAPIImpl testing', () => {
       },
     };
 
-    api.dryRunTask('test', testParameters).subscribe((response) => {
+    api.dryRunInspection('test', testParameters).subscribe((response) => {
       expect(response).toBe(testResponse);
       done();
     });
     const req = httpTestingController.expectOne(
-      '/api/v2/inspection/tasks/test/dryrun',
+      '/api/v3/inspection/test/dryrun',
     );
 
     expect(req.request.method).toEqual('POST');
@@ -240,7 +238,7 @@ describe('BackendAPIImpl testing', () => {
   it('can call cancelInspection', () => {
     api.cancelInspection('test').subscribe(() => {});
     const req = httpTestingController.expectOne(
-      '/api/v2/inspection/tasks/test/cancel',
+      '/api/v3/inspection/test/cancel',
     );
     expect(req.request.method).toEqual('POST');
 
@@ -261,7 +259,7 @@ describe('BackendAPIImpl testing', () => {
       expect(data).toBe(testResponse);
       done();
     });
-    const req = httpTestingController.expectOne('/api/v2/popup');
+    const req = httpTestingController.expectOne('/api/v3/popup');
 
     expect(req.request.method).toBe('GET');
     req.flush(testResponse);
@@ -281,7 +279,7 @@ describe('BackendAPIImpl testing', () => {
       expect(data).toBe(testResponse);
       done();
     });
-    const req = httpTestingController.expectOne('/api/v2/popup/validate');
+    const req = httpTestingController.expectOne('/api/v3/popup/validate');
 
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toBe(testRequest);
@@ -297,7 +295,7 @@ describe('BackendAPIImpl testing', () => {
     api.answerPopup(testRequest).subscribe(() => {
       done();
     });
-    const req = httpTestingController.expectOne('/api/v2/popup/answer');
+    const req = httpTestingController.expectOne('/api/v3/popup/answer');
 
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toBe(testRequest);
@@ -306,7 +304,7 @@ describe('BackendAPIImpl testing', () => {
 });
 
 describe('InspectionTaskClient testing', () => {
-  let taskClient: InspectionTaskClient;
+  let taskClient: InspectionClient;
   let backendAPISpy: jasmine.SpyObj<BackendAPI>;
 
   beforeEach(() => {
@@ -318,8 +316,8 @@ describe('InspectionTaskClient testing', () => {
       'getFeatureList',
       'setEnabledFeatures',
       'getInspectionMetadata',
-      'runTask',
-      'dryRunTask',
+      'runInspection',
+      'dryRunInspection',
     ]);
     backendAPISpy.getFeatureList.and.returnValue(
       of({
@@ -340,8 +338,8 @@ describe('InspectionTaskClient testing', () => {
       }),
     );
     backendAPISpy.setEnabledFeatures.and.returnValue(of(undefined));
-    backendAPISpy.runTask.and.returnValue(of(undefined));
-    backendAPISpy.dryRunTask.and.returnValue(
+    backendAPISpy.runInspection.and.returnValue(of(undefined));
+    backendAPISpy.dryRunInspection.and.returnValue(
       of({
         metadata: {
           query: [],
@@ -352,7 +350,7 @@ describe('InspectionTaskClient testing', () => {
         },
       }),
     );
-    taskClient = new InspectionTaskClient(
+    taskClient = new InspectionClient(
       backendAPISpy as unknown as BackendAPI,
       'test',
       new ViewStateService(),
@@ -402,7 +400,7 @@ describe('InspectionTaskClient testing', () => {
         test: 'foo',
       })
       .subscribe(() => {
-        expect(backendAPISpy.runTask).toHaveBeenCalledWith('test', {
+        expect(backendAPISpy.runInspection).toHaveBeenCalledWith('test', {
           test: 'foo',
 
           timezoneShift: -new Date().getTimezoneOffset() / 60, // This parameter should come from view state
@@ -426,7 +424,7 @@ describe('InspectionTaskClient testing', () => {
         test: 'foo',
       })
       .subscribe((response) => {
-        expect(backendAPISpy.dryRunTask).toHaveBeenCalledWith('test', {
+        expect(backendAPISpy.dryRunInspection).toHaveBeenCalledWith('test', {
           test: 'foo',
 
           timezoneShift: -new Date().getTimezoneOffset() / 60, // This parameter should come from view state

--- a/web/src/app/services/api/backend-connection-interface.ts
+++ b/web/src/app/services/api/backend-connection-interface.ts
@@ -16,7 +16,7 @@
 
 import { Observable } from 'rxjs';
 import {
-  GetInspectionTasksResponse,
+  GetInspectionResponse,
   GetInspectionTypesResponse,
 } from 'src/app/common/schema/api-types';
 
@@ -32,5 +32,5 @@ export interface BackendConnectionService {
   /**
    * Return an observable to monitor the task lists on the backend.
    */
-  tasks(): Observable<GetInspectionTasksResponse>;
+  tasks(): Observable<GetInspectionResponse>;
 }

--- a/web/src/app/services/api/backend-connection.service.ts
+++ b/web/src/app/services/api/backend-connection.service.ts
@@ -27,7 +27,7 @@ import { BACKEND_API, BackendAPI } from './backend-api-interface';
 import { BackendConnectionService } from './backend-connection-interface';
 import {
   GetInspectionTypesResponse,
-  GetInspectionTasksResponse,
+  GetInspectionResponse,
 } from 'src/app/common/schema/api-types';
 
 /**
@@ -66,7 +66,7 @@ export class BackendConnectionServiceImpl implements BackendConnectionService {
   private taskProgressObservable = interval(
     BackendConnectionServiceImpl.PROGRESS_POLLING_INTERVAL,
   ).pipe(
-    exhaustMap(() => this.backendApi.getTaskStatuses()),
+    exhaustMap(() => this.backendApi.getInspections()),
     tap({
       error: (err) => {
         console.warn(
@@ -87,7 +87,7 @@ export class BackendConnectionServiceImpl implements BackendConnectionService {
   inspectionTypes(): Observable<GetInspectionTypesResponse> {
     return this.inspectionTypesObservable;
   }
-  tasks(): Observable<GetInspectionTasksResponse> {
+  tasks(): Observable<GetInspectionResponse> {
     return this.taskProgressObservable;
   }
 }


### PR DESCRIPTION
This is related to #119.

* The `taskID` used in server code was `inspectionID` in the task graph terminology. Use `inspectionID` instead of `taskID` in server related codes to reduce the confusion.

* Simplify API paths
  * Bumped API version from /api/v2 => /api/v3
  * /api/v2/inspection/tasks/:taskID -> /api/v3/inspection/:inspectionID
  * /api/v2/inspection/tasks -> /api/v3/inspection