### PR TITLE
remove global @angular/cli from devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -121,6 +121,3 @@ WORKDIR /workspace
 
 # Copy and setup .bashrc
 COPY --chown=${USERNAME}:${USERNAME} .bashrc /home/${USERNAME}/.bashrc
-
-# Install Development Dependencies
-RUN npm install -g @angular/cli


### PR DESCRIPTION
we didn't use global ng command; use `npx ng` instead