### PR TITLE
Automating the deployment process

### DIFF
--- a/.cloudbuild/github-deploy-beta.yaml
+++ b/.cloudbuild/github-deploy-beta.yaml
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: 'node:22'
+    args:
+      - '-c'
+      - |
+        cd ./web
+        npm ci
+    id: dependency_web
+    waitFor:
+      - '-'
+    entrypoint: /bin/bash
+  - name: 'golang:1.24'
+    args:
+      - '-c'
+      - |
+        echo ${TAG_NAME} > VERSION
+        apt-get update && apt-get install jq -y
+        make prepare-frontend
+    id: pre_build_web
+    waitFor:
+      - npm install
+    entrypoint: /bin/bash
+  - name: 'node:18'
+    args:
+      - '-c'
+      - |
+        make build-web
+    id: build_web
+    waitFor:
+      - pre_build_web
+    entrypoint: /bin/bash
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - '-c'
+      - >
+        docker buildx create --driver docker-container --name container --use
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/release:beta -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} --push .
+    id: build_container
+    waitFor:
+      - build_web
+    entrypoint: /bin/bash
+options:
+  machineType: E2_HIGHCPU_32
+  logging: CLOUD_LOGGING_ONLY
+serviceAccount: >-
+  projects/kubernetes-history-inspector/serviceAccounts/oss-khi-cicd@kubernetes-history-inspector.iam.gserviceaccount.com

--- a/.cloudbuild/github-deploy-latest.yaml
+++ b/.cloudbuild/github-deploy-latest.yaml
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: 'node:22'
+    args:
+      - '-c'
+      - |
+        cd ./web
+        npm ci
+    id: dependency_web
+    waitFor:
+      - '-'
+    entrypoint: /bin/bash
+  - name: 'golang:1.24'
+    args:
+      - '-c'
+      - |
+        echo ${TAG_NAME} > VERSION
+        apt-get update && apt-get install jq -y
+        make prepare-frontend
+    id: pre_build_web
+    waitFor:
+      - npm install
+    entrypoint: /bin/bash
+  - name: 'node:18'
+    args:
+      - '-c'
+      - |
+        make build-web
+    id: build_web
+    waitFor:
+      - pre_build_web
+    entrypoint: /bin/bash
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - '-c'
+      - >
+        docker buildx create --driver docker-container --name container --use
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/release:latest -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} --push .
+    id: build_container
+    waitFor:
+      - build_web
+    entrypoint: /bin/bash
+options:
+  machineType: E2_HIGHCPU_32
+  logging: CLOUD_LOGGING_ONLY
+serviceAccount: >-
+  projects/kubernetes-history-inspector/serviceAccounts/oss-khi-cicd@kubernetes-history-inspector.iam.gserviceaccount.com

--- a/.cloudbuild/github-deploy-ondemand.yaml
+++ b/.cloudbuild/github-deploy-ondemand.yaml
@@ -1,0 +1,62 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: 'node:22'
+    args:
+      - '-c'
+      - |
+        cd ./web
+        npm ci
+    id: dependency_web
+    waitFor:
+      - '-'
+    entrypoint: /bin/bash
+  - name: 'golang:1.24'
+    args:
+      - '-c'
+      - |
+        echo "dev-${SHORT_SHA}" > VERSION
+        apt-get update && apt-get install jq -y
+        make prepare-frontend
+    id: pre_build_web
+    waitFor:
+      - npm install
+    entrypoint: /bin/bash
+  - name: 'node:18'
+    args:
+      - '-c'
+      - |
+        make build-web
+    id: build_web
+    waitFor:
+      - pre_build_web
+    entrypoint: /bin/bash
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - '-c'
+      - >
+        docker buildx create --driver docker-container --name container --use
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA --push .
+    id: build_container
+    waitFor:
+      - build_web
+    entrypoint: /bin/bash
+images:
+- asia.gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA
+options:
+  machineType: E2_HIGHCPU_32
+  logging: CLOUD_LOGGING_ONLY
+serviceAccount: >-
+  projects/kubernetes-history-inspector/serviceAccounts/oss-khi-cicd@kubernetes-history-inspector.iam.gserviceaccount.com

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+changelog:
+  categories:
+    - title: New features 🎉
+      labels:
+        - features
+    - title: Other Changes 🛠
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - features
+          - dependencies
+    - title: Dependencies ⏫
+      labels:
+        - dependencies


### PR DESCRIPTION
# Releasing image

This CD configurations are configured to run on creations of specific tags:

* `vx.y.z-beta` -> Trigger beta image build pipeline and push it to asia.gcr.io/kubernetes-history-inspector/release:beta, asia.gcr.io/kubernetes-history-inspector/release:vx.y.z-beta
* `vx.y.z` -> Trigger latest image build pipeline and push it to asia.gcr.io/kubernetes-history-inspector/release:latest -t asia.gcr.io/kubernetes-history-inspector/release:vx.y.z

Creating tags on this repository is restricted only for repository admins.

# Build test image

This also pushes images to asia.gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA on pull requests.
This requires approval on Cloud Build side. This is also restricted only for repository admins.

# Release note template

Added `.github/release.yml`.
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
