### PR TITLE
[Airflow] make zombie state color aggressive

### DIFF
--- a/pkg/model/enum/revision_state.go
+++ b/pkg/model/enum/revision_state.go
@@ -214,7 +214,7 @@ var RevisionStates = map[RevisionState]RevisionStateFrontendMetadata{
 	},
 	RevisionStateComposerTiZombie: {
 		EnumKeyName:     "RevisionStateComposerTiZombie",
-		BackgroundColor: "#696969",
+		BackgroundColor: "#4b0082",
 		CSSSelector:     "composer_ti_zombie",
 		Label:           "Task instance is being zombie",
 	},

--- a/pkg/source/apache-airflow/airflow-worker/parser.go
+++ b/pkg/source/apache-airflow/airflow-worker/parser.go
@@ -100,10 +100,8 @@ func (*AirflowWorkerParser) Parse(ctx context.Context, l *log.Log, cs *history.C
 	worker := model.NewAirflowWorker(host)
 	cs.RecordEvent(resourcepath.AirflowWorker(worker))
 	commonField, _ := log.GetFieldSet(l, &log.CommonFieldSet{})
-	mainMessage, err := log.GetFieldSet(l, &log.MainMessageFieldSet{})
-	if err != nil {
-		cs.RecordLogSummary(mainMessage.MainMessage)
-	}
+	mainMessage, _ := log.GetFieldSet(l, &log.MainMessageFieldSet{})
+	cs.RecordLogSummary(mainMessage.MainMessage)
 
 	for _, p := range parsers {
 		ti, err := p.fn(l)


### PR DESCRIPTION
Zombie status is always to be a problem.(overloaded, outages, etc...)

The state color should be more markable and looks dangerous. 
![image](https://github.com/user-attachments/assets/664e5a1e-8dcb-4c87-8a77-0f6ec7261568)
