### PR TITLE
bugfix: Array merge fails when merge key item is non string type

### DIFF
--- a/pkg/common/structurev2/merger_test.go
+++ b/pkg/common/structurev2/merger_test.go
@@ -149,6 +149,21 @@ quux: 3
 `,
 		},
 		{
+			Name: "$deleteFromPrimitiveList on an int array",
+			Prev: `foo:
+- 1
+- 2
+- 3
+`,
+			Patch: `$deleteFromPrimitiveList/foo:
+  - 1
+  - 3
+`,
+			Expected: `foo:
+    - 2
+`,
+		},
+		{
 			Name: "$retainKeys on a map",
 			Prev: `foo:
   apple: 1
@@ -162,6 +177,22 @@ quux: 3
 			Expected: `foo:
     apple: 1
     grape: 3
+`,
+		},
+		{
+			Name: "$retainKeys on a map with int key",
+			Prev: `foo:
+  1: apple
+  2: banana
+  3: grape
+`,
+			Patch: `$retainKeys/foo:
+  - 1
+  - 3
+`,
+			Expected: `foo:
+    "1": apple
+    "3": grape
 `,
 		},
 		{
@@ -214,6 +245,37 @@ quux: 3
 			},
 		},
 		{
+			Name: "merge sequence of map with merge strategy and int item key without $setElementOrder directive",
+			Prev: `foo:
+- key: 1
+  value: apple
+- key: 2
+  value: banana
+`,
+			Patch: `foo:
+- key: 3
+  value: grape
+- key: 1
+  value: pinapple
+`,
+			Expected: `foo:
+    - key: 2
+      value: banana
+    - key: 3
+      value: grape
+    - key: 1
+      value: pinapple
+`,
+			ArrayMergeStrategy: &merger.MergeConfigResolver{
+				MergeStrategies: map[string]merger.MergeArrayStrategy{
+					"foo": merger.MergeStrategyMerge,
+				},
+				MergeKeys: map[string]string{
+					"foo": "key",
+				},
+			},
+		},
+		{
 			Name: "$setElementOrder with maps",
 			Prev: `foo:
 - key: apple
@@ -246,6 +308,38 @@ quux: 3
 			},
 		},
 		{
+			Name: "$setElementOrder with maps and int item key",
+			Prev: `foo:
+- key: 1
+  value: apple
+- key: 2
+  value: banana
+- key: 3
+  value: grape
+`,
+			Patch: `$setElementOrder/foo:
+  - key: 2
+  - key: 3
+  - key: 1
+`,
+			Expected: `foo:
+    - key: 2
+      value: banana
+    - key: 3
+      value: grape
+    - key: 1
+      value: apple
+`,
+			ArrayMergeStrategy: &merger.MergeConfigResolver{
+				MergeStrategies: map[string]merger.MergeArrayStrategy{
+					"foo": merger.MergeStrategyMerge,
+				},
+				MergeKeys: map[string]string{
+					"foo": "key",
+				},
+			},
+		},
+		{
 			Name: "$setElementOrder item not found in the prev map should be complemented",
 			Prev: `foo:
 - key: apple
@@ -264,6 +358,35 @@ quux: 3
       value: 2
     - key: apple
       value: 1
+`,
+			ArrayMergeStrategy: &merger.MergeConfigResolver{
+				MergeStrategies: map[string]merger.MergeArrayStrategy{
+					"foo": merger.MergeStrategyMerge,
+				},
+				MergeKeys: map[string]string{
+					"foo": "key",
+				},
+			},
+		},
+		{
+			Name: "$setElementOrder item not found in the prev map should be complemented for int item eky",
+			Prev: `foo:
+- key: 2
+  value: apple
+- key: 3
+  value: banana
+`,
+			Patch: `$setElementOrder/foo:
+  - key: 1
+  - key: 2
+  - key: 3
+`,
+			Expected: `foo:
+    - key: 1
+    - key: 2
+      value: apple
+    - key: 3
+      value: banana
 `,
 			ArrayMergeStrategy: &merger.MergeConfigResolver{
 				MergeStrategies: map[string]merger.MergeArrayStrategy{
@@ -450,6 +573,26 @@ bar: qux
 			Expected: `foo:
     - key: apple
     - key: banana
+`,
+			ArrayMergeStrategy: &merger.MergeConfigResolver{
+				MergeStrategies: map[string]merger.MergeArrayStrategy{
+					"foo": merger.MergeStrategyMerge,
+				},
+				MergeKeys: map[string]string{
+					"foo": "key",
+				},
+			},
+		},
+		{
+			Name: "merge sequence of map with $setElementOrder and int key but the array is not found in prev and patch",
+			Prev: ``,
+			Patch: `$setElementOrder/foo:
+  - key: 1
+  - key: 2
+`,
+			Expected: `foo:
+    - key: 1
+    - key: 2
 `,
 			ArrayMergeStrategy: &merger.MergeConfigResolver{
 				MergeStrategies: map[string]merger.MergeArrayStrategy{

--- a/pkg/common/structurev2/reader.go
+++ b/pkg/common/structurev2/reader.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -283,4 +284,29 @@ func getScalarAs[T any](scalarNode Node) (T, error) {
 		return value, nil
 	}
 	return *new(T), fmt.Errorf("failed to cast value %v to type %T", anyValue, *new(T))
+}
+
+// getScalarAsString get the scalar node value as string.
+func getScalarAsString(scalarNode Node) (string, error) {
+	result, err := getScalarAs[string](scalarNode)
+	if err == nil {
+		return result, nil
+	}
+	resultInt, err := getScalarAs[int](scalarNode)
+	if err == nil {
+		return strconv.Itoa(resultInt), nil
+	}
+	resultBool, err := getScalarAs[bool](scalarNode)
+	if err == nil {
+		return strconv.FormatBool(resultBool), nil
+	}
+	resultTime, err := getScalarAs[time.Time](scalarNode)
+	if err == nil {
+		return resultTime.String(), nil
+	}
+	resultFloat, err := getScalarAs[float64](scalarNode)
+	if err == nil {
+		return strconv.FormatFloat(resultFloat, 'f', -1, 64), nil
+	}
+	return "", fmt.Errorf("failed to cast value %v to type string", scalarNode)
 }


### PR DESCRIPTION
This issue would be reproducible with the following manifest on the current main branch version.

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: prestop-sleep-pod-with-ports
spec:
  containers:
  - name: main-container
    image: busybox
    command: ["/bin/sh", "-c", "echo 'Container is running, waiting for termination signal.'; sleep 3600"]
    ports:
    - name: http
      containerPort: 80
      protocol: TCP
    - name: https
      containerPort: 443
      protocol: TCP
    - name: custom-port
      containerPort: 8080
      protocol: TCP
    lifecycle:
      preStop:
        exec:
          command: ["/bin/sh","-c","echo 'PreStop hook is triggered, sleeping for 30 seconds...'; sleep 30; echo 'Slept for 30 seconds, now terminating.'"]
  terminationGracePeriodSeconds: 45
```

The container ports are the key of the array. 
https://github.com/kubernetes/api/blob/v0.32.1/core/v1/types.go#L2806
 