### PR TITLE
bugfix: Fix panic on container log parser

### DIFF
--- a/pkg/source/gcp/task/gke/k8s_container/parser.go
+++ b/pkg/source/gcp/task/gke/k8s_container/parser.go
@@ -79,14 +79,12 @@ func (*k8sContainerParser) Parse(ctx context.Context, l *log.Log, cs *history.Ch
 	}
 
 	if mainMessage == "" {
-		var yaml string
 		yamlRaw, err := l.Serialize("", &structurev2.YAMLNodeSerializer{})
 		if err != nil {
-			yaml = "!!ERROR failed to dump in yaml"
+			slog.WarnContext(ctx, fmt.Sprintf("failed to extract main message from a container log then failed to serialize the log content.\nError message:\n%v", err))
 		} else {
-			yaml = string(yamlRaw)
+			slog.WarnContext(ctx, fmt.Sprintf("failed to extract main message from a container log.\nLog content:\n%s", string(yamlRaw)))
 		}
-		slog.WarnContext(ctx, fmt.Sprintf("Failed to extract main message from container log.\nError: %s\n\nLog content: %s", err.Error(), yaml))
 		mainMessage = "(unknown)"
 	}
 	severityOverride := ParseSeverity(mainMessage)

--- a/pkg/source/gcp/task/gke/k8s_container/parser_test.go
+++ b/pkg/source/gcp/task/gke/k8s_container/parser_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s_container
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/log"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	gcp_log "github.com/GoogleCloudPlatform/khi/pkg/source/gcp/log"
+)
+
+func TestK8sContainerParserReceivingLogNotContainingMainMessage(t *testing.T) {
+	parser := k8sContainerParser{}
+	l, err := log.NewLogFromYAMLString("insertID: foo")
+	if err != nil {
+		t.Fatalf("unexpected error on constructing log instance\n%v", err)
+	}
+	l.SetFieldSetReader(&gcp_log.GCPMainMessageFieldSetReader{})
+	cs := history.NewChangeSet(l)
+	err = parser.Parse(context.Background(), l, cs, nil)
+	if err != nil {
+		t.Errorf("parser returned error\n%v", err)
+	}
+}

--- a/pkg/task/runner.go
+++ b/pkg/task/runner.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/errorreport"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	task_contextkey "github.com/GoogleCloudPlatform/khi/pkg/task/contextkey"
@@ -88,6 +89,7 @@ func (r *LocalRunner) Run(ctx context.Context) error {
 		for i := range tasks {
 			taskDefIndex := i
 			currentErrGrp.Go(func() error {
+				defer errorreport.CheckAndReportPanic()
 				err := r.runTask(currentErrCtx, taskDefIndex)
 				if err != nil {
 					cancel()


### PR DESCRIPTION
Current container parser could raise nil dereference error when the log had no main message extracted from `textPayload` field or `jsonPayload` field.

* Fix the bug and add test at least for checking it won't throw an error
* Add a panic recover logic on task runner

fixes #191