### PR TITLE
Add progress reporting feature during loading jsonl file

### DIFF
--- a/pkg/inspection/metadata/progress/progress_util.go
+++ b/pkg/inspection/metadata/progress/progress_util.go
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package progress
+
+import "fmt"
+
+// ReportProgressFromArraySync reports progress of processing an array synchronously.
+// It updates the given TaskProgress with the current count and percentage.
+// The process function is called for each element in the source array.
+// If the process function returns an error, the reporting stops and the error is returned.
+func ReportProgressFromArraySync[T any](progress *TaskProgress, source []T, process func(int, T) error) error {
+	fLen := float32(len(source))
+	progress.Update(0, fmt.Sprintf("%d/%d", 0, len(source)))
+	for i := 0; i < len(source); i++ {
+		err := process(i, source[i])
+		if err != nil {
+			return err
+		}
+		progress.Update(float32(i+1)/fLen, fmt.Sprintf("%d/%d", i+1, len(source)))
+	}
+	return nil
+}

--- a/pkg/inspection/metadata/progress/progress_util_test.go
+++ b/pkg/inspection/metadata/progress/progress_util_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package progress
+
+import (
+	"errors"
+	"testing"
+)
+
+// updateRecord records a single progress update
+type updateRecord struct {
+	percentage float32
+	message    string
+}
+
+// TestReportProgressFromArraySync tests the ReportProgressFromArraySync function
+func TestReportProgressFromArraySync(t *testing.T) {
+	tests := []struct {
+		name          string
+		source        []int
+		process       func(int, int) error
+		expectedError bool
+		expectedCalls int
+		checkUpdates  func([]updateRecord) bool
+	}{
+		{
+			name:   "Normal case - all items processed successfully",
+			source: []int{1, 2, 3, 4, 5},
+			process: func(i int, val int) error {
+				return nil
+			},
+			expectedError: false,
+			expectedCalls: 6, // Initial 0% + 5 updates
+			checkUpdates: func(updates []updateRecord) bool {
+				if updates[0].percentage != 0 || updates[0].message != "0/5" {
+					return false
+				}
+
+				lastIdx := len(updates) - 1
+				if updates[lastIdx].percentage != 1 || updates[lastIdx].message != "5/5" {
+					return false
+				}
+
+				return true
+			},
+		},
+		{
+			name:   "Error case - processing fails at specific index",
+			source: []int{1, 2, 3, 4, 5},
+			process: func(i int, val int) error {
+				if i == 1 {
+					return errors.New("error at index 1")
+				}
+				return nil
+			},
+			expectedError: true,
+			expectedCalls: 3, // Initial 0% + 2 successful updates
+			checkUpdates: func(updates []updateRecord) bool {
+				// Only processed up to index 2 (error occurs here)
+				return len(updates) == 3
+			},
+		},
+		{
+			name:   "Edge case - empty array",
+			source: []int{},
+			process: func(i int, val int) error {
+				return nil
+			},
+			expectedError: false,
+			expectedCalls: 1, // Just initial 0%
+			checkUpdates: func(updates []updateRecord) bool {
+				return len(updates) == 1 && updates[0].message == "0/0"
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a real TaskProgress
+			progress := NewTaskProgress("test")
+
+			// Set up a recorder to capture updates
+			var updates []updateRecord
+
+			err := ReportProgressFromArraySync(progress, tc.source, func(i int, val int) error {
+				updates = append(updates, updateRecord{
+					percentage: progress.Percentage,
+					message:    progress.Message,
+				})
+				return tc.process(i, val)
+			})
+			if (err != nil) != tc.expectedError {
+				t.Errorf("Expected error: %v, got: %v", tc.expectedError, err != nil)
+			}
+
+			updates = append(updates, updateRecord{
+				percentage: progress.Percentage,
+				message:    progress.Message,
+			})
+
+			// Check number of progress updates
+			if len(updates) != tc.expectedCalls {
+				t.Errorf("Expected %d progress updates, got: %d", tc.expectedCalls, len(updates))
+				for i, u := range updates {
+					t.Logf("Update %d: percentage=%f, message=%s", i, u.percentage, u.message)
+				}
+			}
+
+			// Check update content
+			if !tc.checkUpdates(updates) {
+				t.Errorf("Progress updates did not match expected pattern")
+				for i, u := range updates {
+					t.Logf("Update %d: percentage=%f, message=%s", i, u.percentage, u.message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
OSS audit log file reader always reports 0 to the progress reporter.
I added a general progress reporter for array processing and used it in the task.