### PR TITLE
Standardize Task Package Structure to Resolve Initialization Order Issues

### DIFF
--- a/docs/en/khi-task-system-concept.md
+++ b/docs/en/khi-task-system-concept.md
@@ -188,6 +188,40 @@ task.NewTask(TaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) 
 })
 ```
 
+### Package structure for tasks
+
+> [!WARNING]
+> We are starting migration to this package structure. Many of current package structure is not following this rule but newer packages must follow.
+
+Tasks are often defined as package-level global variables. However, the initialization order of global variables within the same package is not guaranteed by the Go language. This can lead to errors where a task is initialized with a reference to another `TaskID` that is still `nil`.
+
+To solve this issue reliably, we separate a task's **"contract"** (including task IDs and types used by them) from its **"implementation"** into distinct packages. Because the implementation package imports the contract package, Go guarantees that the contract (and its `TaskID`s) is fully initialized before the implementation.
+
+We use the following standard structure. For example, for a feature named `foo`:
+
+```plaintext
+pkg/a subpackage of somewhere/foo/
+├── contracts/
+│   └── ids.go          // package foocontracts
+├── impl/
+│   └── parsertask.go   // package fooimpl
+└── registration.go     // package foo
+```
+
+Role of Each Component
+
+- `contracts/` (package foocontracts)
+
+    It contains the TaskID variables and defines the result types used as type parameters for the TaskIDs. Contracts package may contains task label keys and types used in its type parameters.
+    Contract package must not depend on the implementation package.
+- `impl/` (package fooimpl)
+
+    This package contains the actual implementation logic of the task.
+    It imports the contracts package to safely reference the TaskID.
+- `registration.go` (package foo)
+
+    It typically contains an function registering the task instance (from the fooimpl package) with a central task registry. This function is called from upper layer package or initialization step of a file in `cmd/kubernetes-history-inspector/`.
+
 ### Testing tasks
 
 For testing tasks, use one of the following two helper functions:

--- a/docs/en/khi-task-system-concept.md
+++ b/docs/en/khi-task-system-concept.md
@@ -193,7 +193,7 @@ task.NewTask(TaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) 
 > [!WARNING]
 > We are starting migration to this package structure. Many of current package structure is not following this rule but newer packages must follow.
 
-Tasks are often defined as package-level global variables. However, the initialization order of global variables within the same package is not guaranteed by the Go language. This can lead to errors where a task is initialized with a reference to another `TaskID` that is still `nil`.
+Tasks are often defined as package-level global variables. However, the initialization order of global variables within the same package is not guaranteed by the Go language. [reference: The Go Programming Language Specification](https://go.dev/ref/spec#Package_initialization) This can lead to errors where a task is initialized with a reference to another `TaskID` that is still `nil`.
 
 To solve this issue reliably, we separate a task's **"contract"** (including task IDs and types used by them) from its **"implementation"** into distinct packages. Because the implementation package imports the contract package, Go guarantees that the contract (and its `TaskID`s) is fully initialized before the implementation.
 

--- a/pkg/inspection/task/label.go
+++ b/pkg/inspection/task/label.go
@@ -15,6 +15,8 @@
 package inspection_task
 
 import (
+	"fmt"
+
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	common_task "github.com/GoogleCloudPlatform/khi/pkg/task"
@@ -79,6 +81,12 @@ func (ftl *FeatureTaskLabelImpl) WithDescription(description string) *FeatureTas
 var _ common_task.LabelOpt = (*FeatureTaskLabelImpl)(nil)
 
 func FeatureTaskLabel(title string, description string, logType enum.LogType, isDefaultFeature bool, inspectionTypes ...string) *FeatureTaskLabelImpl {
+	for i, t := range inspectionTypes {
+		if t == "" {
+			panic(fmt.Sprintf(`Invalid inspection type at index at #%d. Empty inspection type was given to FeatureTaskLabel function. This may be caused because of initialization order issue of global variables.
+Please define task IDs and types used in its type parameter in a different package.`, i))
+		}
+	}
 	return &FeatureTaskLabelImpl{
 		title:            title,
 		description:      description,
@@ -102,6 +110,12 @@ var _ common_task.LabelOpt = (*InspectionTypeLabelImpl)(nil)
 // InspectionTypeLabel returns a LabelOpt to mark the task only to be used in the specified inspection types.
 // This label must not be used in the feature task. Use the FeatureTaskLabel in feature tasks.
 func InspectionTypeLabel(types ...string) *InspectionTypeLabelImpl {
+	for i, t := range types {
+		if t == "" {
+			panic(fmt.Sprintf(`Invalid inspection type at index at #%d. Empty inspection type was given to InspectionTypeLabel function. This may be caused because of initialization order issue of global variables.
+Please define task IDs and types used in its type parameter in a different package.`, i))
+		}
+	}
 	return &InspectionTypeLabelImpl{
 		inspectionTypes: types,
 	}


### PR DESCRIPTION
# Background
In the current KHI task system, TaskID and Task objects are often defined as package-level global variables. However, the Go language does not guarantee the initialization order of global variables within the same package.

This creates a potential risk of runtime errors when a dependent TaskID is referenced before it has been initialized (i.e., while it is still nil). This makes the codebase fragile and complicates adding or refactoring tasks.

## Proposed Solution
1. Proposing introducing a standard package structure based on the following convention.
This structure separates a task's `contract` from its `implementation` into distinct packages, leveraging Go's package initialization guarantees to resolve the initialization order problem.
2. Add verification logics on defining tasks to catch empty ids given to initialization process unintentionally.

## Alternatives I considered

1. Make the task initialization lazy process
By defining its dependencies or ids with function not the constant reference at the `NewTask` calls, we can delay these ID usage until the actual task registration happens. But this increases code volumes a bit to define a task and make the task definition code to be harder to read.

2. Using DI containers like wire
We can align these package initialization process with some DI container package like wire. This also makes defining task harder.
