### PR TITLE
Fix the warning of @angular-eslint/prefer-inject lint

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -31,8 +31,7 @@
           }
         ],
         "@typescript-eslint/no-unused-vars": "error",
-        "@typescript-eslint/no-explicit-any": "error",
-        "@angular-eslint/prefer-inject": "warn"
+        "@typescript-eslint/no-explicit-any": "error"
       }
     },
     {

--- a/web/src/app/annotator/common-field-annotator.component.ts
+++ b/web/src/app/annotator/common-field-annotator.component.ts
@@ -108,12 +108,15 @@ export class CommonFieldAnnotatorComponent {
     return (l?: LogEntry | null) => {
       if (!l) return DECISION_HIDDEN;
       const viewState = inject(ViewStateService);
-      const tsflongPipe = new LongTimestampFormatPipe(viewState);
       return {
         inputs: {
           icon,
           label,
-          value: tsflongPipe.transform(l.time),
+          value: viewState.timezoneShift.pipe(
+            map((t) =>
+              LongTimestampFormatPipe.toLongDisplayTimestamp(l.time, t),
+            ),
+          ),
         },
       };
     };

--- a/web/src/app/app.route.guard.spec.ts
+++ b/web/src/app/app.route.guard.spec.ts
@@ -26,6 +26,25 @@ import {
 } from './services/frame-connection/window-connector.service';
 import { InMemoryWindowConnectionProvider } from './services/frame-connection/window-connection-provider.service';
 
+/**
+ * getUniqueWindowConnectorService returns a new instance of WindowConnectorService to emulate inter-frame connection.
+ * WindowConnectorService generates a frameID for each window frames.
+ * This function reset the TestBed to get a new instance of WindowConnectorService because if Angular injector shares a same instance for each injection, it can't emulate the inter-frame connection.
+ */
+function getUniqueWindowConnectorService(
+  connectionProvider: WindowConnectionProvider,
+) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      WindowConnectorService,
+      { provide: WINDOW_CONNECTION_PROVIDER, useValue: connectionProvider },
+    ],
+  });
+  const windowConnector = TestBed.inject(WindowConnectorService);
+  return windowConnector;
+}
+
 function createActivateRouteSnapshotWithSessionId(
   sessionId: string,
 ): ActivatedRouteSnapshot {
@@ -72,11 +91,10 @@ describe('SessionHostGuard', () => {
 
   it('should redirect with incrementing sessionId when the given session ID is used', async () => {
     const route = createActivateRouteSnapshotWithSessionId('0');
-    const connectionProvider = TestBed.inject<WindowConnectionProvider>(
-      WINDOW_CONNECTION_PROVIDER,
-    );
-    const connector = new WindowConnectorService(connectionProvider);
+    const connectionProvider = new InMemoryWindowConnectionProvider();
+    const connector = getUniqueWindowConnectorService(connectionProvider);
     await connector.createSession(0);
+    getUniqueWindowConnectorService(connectionProvider); // Forcibly reset TestBed to create a new window connector in the later injection.
 
     const guardResult = TestBed.runInInjectionContext(() =>
       SessionHostGuard(route),
@@ -114,11 +132,10 @@ describe('SessionChildGuard', () => {
 
   it('should accept when the main window with same session ID is existing', async () => {
     const route = createActivateRouteSnapshotWithSessionId('11');
-    const connectionProvider = TestBed.inject<WindowConnectionProvider>(
-      WINDOW_CONNECTION_PROVIDER,
-    );
-    const connector = new WindowConnectorService(connectionProvider);
+    const connectionProvider = new InMemoryWindowConnectionProvider();
+    const connector = getUniqueWindowConnectorService(connectionProvider);
     await connector.createSession(11);
+    getUniqueWindowConnectorService(connectionProvider); // Forcibly reset TestBed to create a new window connector in the later injection.
 
     const guardResult = TestBed.runInInjectionContext(() =>
       SessionChildGuard('Diagram')(route),

--- a/web/src/app/app.route.guard.spec.ts
+++ b/web/src/app/app.route.guard.spec.ts
@@ -29,7 +29,7 @@ import { InMemoryWindowConnectionProvider } from './services/frame-connection/wi
 /**
  * getUniqueWindowConnectorService returns a new instance of WindowConnectorService to emulate inter-frame connection.
  * WindowConnectorService generates a frameID for each window frames.
- * This function reset the TestBed to get a new instance of WindowConnectorService because if Angular injector shares a same instance for each injection, it can't emulate the inter-frame connection.
+ * This function resets the TestBed to get a new instance of WindowConnectorService because if Angular injector shares the same instance for each injection, it can't emulate the inter-frame connection.
  */
 function getUniqueWindowConnectorService(
   connectionProvider: WindowConnectionProvider,

--- a/web/src/app/common/resolve-text.pipe.ts
+++ b/web/src/app/common/resolve-text.pipe.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 import { InspectionDataStoreService } from '../services/inspection-data-store.service';
 import { Observable, switchMap } from 'rxjs';
 import { TextReference } from './loader/interface';
@@ -27,7 +27,8 @@ import { TextReference } from './loader/interface';
   name: 'resolveText',
 })
 export class ResolveTextPipe implements PipeTransform {
-  constructor(private dataStore: InspectionDataStoreService) {}
+  private dataStore = inject(InspectionDataStoreService);
+
   transform(value: TextReference): Observable<string> {
     return this.dataStore.referenceResolver.pipe(
       switchMap((bs) => bs?.getText(value) ?? 'error'),

--- a/web/src/app/common/timestamp-format.pipe.spec.ts
+++ b/web/src/app/common/timestamp-format.pipe.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import {
   LongTimestampFormatPipe,
@@ -31,41 +32,76 @@ function generateViewStateServiceWithTimeShift(
 
 describe('TimestampFormatPipe', () => {
   it('create an instance', () => {
-    const pipe = new TimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(0),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        TimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(0),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(TimestampFormatPipe);
     expect(pipe).toBeTruthy();
   });
   it('should timestamp transform works valid', () => {
-    const pipe = new TimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(0),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        TimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(0),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(TimestampFormatPipe);
     const time = new Date('2022-03-04T17:06:07.000+00:00');
     const date = pipe.transform(time.getTime());
     date.subscribe((d) => expect(d).toBe('17:06:07'));
   });
   it('should timestamp transform works valid with positive time offset', () => {
-    const pipe = new TimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(3),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        TimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(3),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(TimestampFormatPipe);
     const time = new Date('2022-03-04T17:06:07.000+00:00');
     const date = pipe.transform(time.getTime());
     date.subscribe((d) => expect(d).toBe('20:06:07'));
   });
 
   it('should timestamp transform works valid with negative time offset', () => {
-    const pipe = new TimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(-5),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        TimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(-5),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(TimestampFormatPipe);
     const time = new Date('2022-03-04T17:06:07.000+00:00');
     let date = pipe.transform(time.getTime());
     date = pipe.transform(time.getTime());
     date.subscribe((d) => expect(d).toBe('12:06:07'));
   });
   it('should timestamp transform works valid with float point offset', () => {
-    const pipe = new TimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(1.5),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        TimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(1.5),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(TimestampFormatPipe);
     const time = new Date('2022-03-04T17:06:07.000+00:00');
     let date = pipe.transform(time.getTime());
     date = pipe.transform(time.getTime());
@@ -75,32 +111,60 @@ describe('TimestampFormatPipe', () => {
 
 describe('LongTimestampFormatPipe', () => {
   it('create an instance', () => {
-    const pipe = new LongTimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(0),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        LongTimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(0),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(LongTimestampFormatPipe);
     expect(pipe).toBeTruthy();
   });
   it('should timestamp transform works valid', () => {
-    const pipe = new LongTimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(0),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        LongTimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(0),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(LongTimestampFormatPipe);
     const time = new Date('2022-03-04T17:06:07.800+00:00');
     const date = pipe.transform(time.getTime());
     date.subscribe((d) => expect(d).toBe('2022-03-04T17:06:07.800+00:00'));
   });
   it('should timestamp transform works valid with positive time offset', () => {
-    const pipe = new LongTimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(3),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        LongTimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(3),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(LongTimestampFormatPipe);
     const time = new Date('2022-03-04T17:06:07.800+00:00');
     const date = pipe.transform(time.getTime());
     date.subscribe((d) => expect(d).toBe('2022-03-04T20:06:07.800+03:00'));
   });
 
   it('should timestamp transform works valid with negative time offset', () => {
-    const pipe = new LongTimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(-5),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        LongTimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(-5),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(LongTimestampFormatPipe);
     const time = new Date('2022-03-04T17:06:07.800+00:00');
     let date = pipe.transform(time.getTime());
     date = pipe.transform(time.getTime());
@@ -109,9 +173,16 @@ describe('LongTimestampFormatPipe', () => {
     );
   });
   it('should timestamp transform works valid with float point offset', () => {
-    const pipe = new LongTimestampFormatPipe(
-      generateViewStateServiceWithTimeShift(1.5),
-    );
+    TestBed.configureTestingModule({
+      providers: [
+        LongTimestampFormatPipe,
+        {
+          provide: ViewStateService,
+          useValue: generateViewStateServiceWithTimeShift(1.5),
+        },
+      ],
+    });
+    const pipe = TestBed.inject(LongTimestampFormatPipe);
     const time = new Date('2022-03-04T17:06:07.800+00:00');
     let date = pipe.transform(time.getTime());
     date = pipe.transform(time.getTime());

--- a/web/src/app/common/timestamp-format.pipe.ts
+++ b/web/src/app/common/timestamp-format.pipe.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 import { map, Observable } from 'rxjs';
 import { ViewStateService } from '../services/view-state.service';
 
@@ -22,7 +22,7 @@ import { ViewStateService } from '../services/view-state.service';
   name: 'tsf',
 })
 export class TimestampFormatPipe implements PipeTransform {
-  constructor(private readonly _viewStateService: ViewStateService) {}
+  private readonly _viewStateService = inject(ViewStateService);
 
   transform(unix_time: number): Observable<string> {
     return this._viewStateService.timezoneShift.pipe(
@@ -42,7 +42,7 @@ export class TimestampFormatPipe implements PipeTransform {
   name: 'tsflong',
 })
 export class LongTimestampFormatPipe implements PipeTransform {
-  constructor(private readonly _viewStateService: ViewStateService) {}
+  private readonly _viewStateService = inject(ViewStateService);
 
   transform(unix_time: number): Observable<string> {
     return this._viewStateService.timezoneShift.pipe(

--- a/web/src/app/dialogs/inspection-metadata/inspection-metadata.component.ts
+++ b/web/src/app/dialogs/inspection-metadata/inspection-metadata.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { InspectionMetadataOfRunResult } from '../../common/schema/api-types';
 import { MatCardModule } from '@angular/material/card';
@@ -26,7 +26,5 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule, MatCardModule],
 })
 export class InspectionMetadataDialogComponent {
-  constructor(
-    @Inject(MAT_DIALOG_DATA) public data: InspectionMetadataOfRunResult,
-  ) {}
+  data = inject<InspectionMetadataOfRunResult>(MAT_DIALOG_DATA);
 }

--- a/web/src/app/dialogs/inspection-metadata/inspection-metadata.component.ts
+++ b/web/src/app/dialogs/inspection-metadata/inspection-metadata.component.ts
@@ -26,5 +26,5 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule, MatCardModule],
 })
 export class InspectionMetadataDialogComponent {
-  data = inject<InspectionMetadataOfRunResult>(MAT_DIALOG_DATA);
+  readonly data = inject<InspectionMetadataOfRunResult>(MAT_DIALOG_DATA);
 }

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.ts
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Component,
-  inject,
-  Inject,
-  OnDestroy,
-  signal,
-  ViewChild,
-} from '@angular/core';
+import { Component, inject, OnDestroy, signal, ViewChild } from '@angular/core';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import {
   BehaviorSubject,
@@ -125,6 +118,13 @@ export function openNewInspectionDialog(dialog: MatDialog) {
   ],
 })
 export class NewInspectionDialogComponent implements OnDestroy {
+  private readonly dialogRef =
+    inject<MatDialogRef<object, NewInspectionDialogResult>>(MatDialogRef);
+  private readonly backendConnection =
+    inject<BackendConnectionService>(BACKEND_CONNECTION);
+  private readonly apiClient = inject<BackendAPI>(BACKEND_API);
+  private readonly extension = inject<ExtensionStore>(EXTENSION_STORE);
+
   static readonly STEP_INDEX_CLUSTER_TYPE = 0;
   static readonly STEP_INDEX_FEATURE_SELECTION = 1;
   static readonly STEP_INDEX_PARAMETER_INPUT = 2;
@@ -138,13 +138,7 @@ export class NewInspectionDialogComponent implements OnDestroy {
    */
   public hadRun = signal(false);
 
-  constructor(
-    private readonly dialogRef: MatDialogRef<object, NewInspectionDialogResult>,
-    @Inject(BACKEND_CONNECTION)
-    private readonly backendConnection: BackendConnectionService,
-    @Inject(BACKEND_API) private readonly apiClient: BackendAPI,
-    @Inject(EXTENSION_STORE) private readonly extension: ExtensionStore,
-  ) {
+  constructor() {
     this.featureToggleRequest
       .pipe(
         takeUntil(this.destroyed),

--- a/web/src/app/dialogs/progress/progress.component.ts
+++ b/web/src/app/dialogs/progress/progress.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import {
   PROGRESS_DIALOG_STATUS_OBSERVER,
@@ -28,10 +28,9 @@ import {
   imports: [CommonModule, MatProgressBarModule],
 })
 export class ProgressDialogComponent {
-  public currentStatus = this.progressObserver.status();
+  private progressObserver = inject<ProgressDialogStatusObserver>(
+    PROGRESS_DIALOG_STATUS_OBSERVER,
+  );
 
-  constructor(
-    @Inject(PROGRESS_DIALOG_STATUS_OBSERVER)
-    private progressObserver: ProgressDialogStatusObserver,
-  ) {}
+  public currentStatus = this.progressObserver.status();
 }

--- a/web/src/app/dialogs/progress/progress.component.ts
+++ b/web/src/app/dialogs/progress/progress.component.ts
@@ -28,7 +28,7 @@ import {
   imports: [CommonModule, MatProgressBarModule],
 })
 export class ProgressDialogComponent {
-  private progressObserver = inject<ProgressDialogStatusObserver>(
+  private readonly progressObserver = inject<ProgressDialogStatusObserver>(
     PROGRESS_DIALOG_STATUS_OBSERVER,
   );
 

--- a/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.ts
+++ b/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.ts
@@ -67,7 +67,7 @@ const nextButtonLabel: { [key: string]: string } = {
   ],
 })
 export class RequestUserActionPopupComponent implements OnInit, OnDestroy {
-  data = inject<RequestUserActionPopupRequest>(MAT_DIALOG_DATA);
+  readonly data = inject<RequestUserActionPopupRequest>(MAT_DIALOG_DATA);
   private readonly dialogRef = inject<MatDialogRef<object, void>>(MatDialogRef);
 
   /**
@@ -104,11 +104,8 @@ export class RequestUserActionPopupComponent implements OnInit, OnDestroy {
   nextButtonText = '';
 
   constructor() {
-    const data = this.data;
-    const dialogRef = this.dialogRef;
-
-    dialogRef.disableClose = true;
-    this.formRequest = data.formRequest;
+    this.dialogRef.disableClose = true;
+    this.formRequest = this.data.formRequest;
     this.nextButtonText = nextButtonLabel[this.formRequest.type];
   }
 

--- a/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.ts
+++ b/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
@@ -67,6 +67,9 @@ const nextButtonLabel: { [key: string]: string } = {
   ],
 })
 export class RequestUserActionPopupComponent implements OnInit, OnDestroy {
+  data = inject<RequestUserActionPopupRequest>(MAT_DIALOG_DATA);
+  private readonly dialogRef = inject<MatDialogRef<object, void>>(MatDialogRef);
+
   /**
    * The request from server to show the popup.
    */
@@ -100,10 +103,10 @@ export class RequestUserActionPopupComponent implements OnInit, OnDestroy {
 
   nextButtonText = '';
 
-  constructor(
-    @Inject(MAT_DIALOG_DATA) public data: RequestUserActionPopupRequest,
-    private readonly dialogRef: MatDialogRef<object, void>,
-  ) {
+  constructor() {
+    const data = this.data;
+    const dialogRef = this.dialogRef;
+
     dialogRef.disableClose = true;
     this.formRequest = data.formRequest;
     this.nextButtonText = nextButtonLabel[this.formRequest.type];

--- a/web/src/app/dialogs/startup/startup.component.ts
+++ b/web/src/app/dialogs/startup/startup.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import {
   ReplaySubject,
@@ -86,6 +86,16 @@ export type TaskListViewModel = {
   imports: [CommonModule, MatIconModule, MatTooltipModule, MatButtonModule],
 })
 export class StartupDialogComponent {
+  private readonly dialog = inject(MatDialog);
+  private readonly dialogRef = inject<MatDialogRef<void>>(MatDialogRef);
+  private readonly backendAPI = inject<BackendAPI>(BACKEND_API);
+  private readonly backendConnection =
+    inject<BackendConnectionService>(BACKEND_CONNECTION);
+  private readonly loader = inject(InspectionDataLoaderService);
+  private readonly progress = inject<ProgressDialogStatusUpdator>(
+    PROGRESS_DIALOG_STATUS_UPDATOR,
+  );
+
   /**
    * The interval to refresh the start time of each tasks written as `xx seconds ago`.
    */
@@ -154,17 +164,6 @@ export class StartupDialogComponent {
   );
 
   serverStat = this.tasks.pipe(map((resp) => resp.serverStat));
-
-  constructor(
-    private readonly dialog: MatDialog,
-    private readonly dialogRef: MatDialogRef<void>,
-    @Inject(BACKEND_API) private readonly backendAPI: BackendAPI,
-    @Inject(BACKEND_CONNECTION)
-    private readonly backendConnection: BackendConnectionService,
-    private readonly loader: InspectionDataLoaderService,
-    @Inject(PROGRESS_DIALOG_STATUS_UPDATOR)
-    private readonly progress: ProgressDialogStatusUpdator,
-  ) {}
 
   private durationToTimeSeconds(duration: number): string {
     const hour = 1000 * 60 * 60;

--- a/web/src/app/diff/diff-view.component.ts
+++ b/web/src/app/diff/diff-view.component.ts
@@ -91,6 +91,9 @@ type DiffViewViewModel = {
   ],
 })
 export class DiffViewComponent implements OnInit, OnDestroy {
+  private _inspectionDataStore = inject(InspectionDataStoreService);
+  private _selectionManager = inject(SelectionManagerService);
+
   private readonly envInjector = inject(EnvironmentInjector);
 
   private readonly timelineAnnotatorResolver = inject(
@@ -106,11 +109,6 @@ export class DiffViewComponent implements OnInit, OnDestroy {
   );
 
   private destoroyed = new Subject<void>();
-
-  constructor(
-    private _inspectionDataStore: InspectionDataStoreService,
-    private _selectionManager: SelectionManagerService,
-  ) {}
 
   ngOnDestroy(): void {
     this.destoroyed.next();

--- a/web/src/app/diff/diff-view.component.ts
+++ b/web/src/app/diff/diff-view.component.ts
@@ -91,8 +91,8 @@ type DiffViewViewModel = {
   ],
 })
 export class DiffViewComponent implements OnInit, OnDestroy {
-  private _inspectionDataStore = inject(InspectionDataStoreService);
-  private _selectionManager = inject(SelectionManagerService);
+  private readonly _inspectionDataStore = inject(InspectionDataStoreService);
+  private readonly _selectionManager = inject(SelectionManagerService);
 
   private readonly envInjector = inject(EnvironmentInjector);
 

--- a/web/src/app/extensions/extension-common/extension.ts
+++ b/web/src/app/extensions/extension-common/extension.ts
@@ -26,6 +26,15 @@ import { LifecycleHookExtension } from './extension-types/lifecycle-hook';
 export const KHI_FRONTEND_EXTENSION_BUNDLE =
   new InjectionToken<KHIExtensionBundle>('KHI_FRONTEND_EXTENSION_BUNDLE');
 
+/**
+ * THe injection token to receive the multi KHI_FRONTEND_EXTENSION_BUNDLE.
+ * This is a workaround for https://github.com/angular/angular/issues/51675.
+ *
+ */
+export const KHI_FRONTEND_EXTENSION_BUNDLES = new InjectionToken<
+  KHIExtensionBundle[]
+>('KHI_FRONTEND_EXTENSION_BUNDLE');
+
 export type KHIExtensionInitHandler = (extension: KHIExtensionBundle) => void;
 
 /**

--- a/web/src/app/header/graph-menu.component.ts
+++ b/web/src/app/header/graph-menu.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { DownloadService } from '../pages/graph/services/donwload-service';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
@@ -27,7 +27,7 @@ import { MatButtonModule } from '@angular/material/button';
   imports: [MatMenuModule, MatIconModule, MatButtonModule],
 })
 export class GraphMenuComponent {
-  constructor(private downloadService: DownloadService) {}
+  private downloadService = inject(DownloadService);
 
   downloadAsPng() {
     this.downloadService.downloadAsPng();

--- a/web/src/app/header/graph-menu.component.ts
+++ b/web/src/app/header/graph-menu.component.ts
@@ -27,7 +27,7 @@ import { MatButtonModule } from '@angular/material/button';
   imports: [MatMenuModule, MatIconModule, MatButtonModule],
 })
 export class GraphMenuComponent {
-  private downloadService = inject(DownloadService);
+  private readonly downloadService = inject(DownloadService);
 
   downloadAsPng() {
     this.downloadService.downloadAsPng();

--- a/web/src/app/header/main-menu.component.ts
+++ b/web/src/app/header/main-menu.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { StartupDialogComponent } from '../dialogs/startup/startup.component';
 import { MatIconModule } from '@angular/material/icon';
@@ -27,7 +27,7 @@ import { MatButtonModule } from '@angular/material/button';
   imports: [MatIconModule, MatButtonModule],
 })
 export class MainMenuComponent {
-  constructor(private readonly dialog: MatDialog) {}
+  private readonly dialog = inject(MatDialog);
 
   openStartupMenu() {
     this.dialog.open(StartupDialogComponent, {

--- a/web/src/app/header/titlebar.component.ts
+++ b/web/src/app/header/titlebar.component.ts
@@ -38,6 +38,8 @@ import { BACKEND_API } from '../services/api/backend-api-interface';
   ],
 })
 export class TitleBarComponent {
+  private readonly windowConnector = inject(WindowConnectorService);
+
   @Input()
   pageName = 'N/A';
 
@@ -57,8 +59,6 @@ export class TitleBarComponent {
   );
 
   sessionPages = this.windowConnector.sessionPages;
-
-  constructor(private readonly windowConnector: WindowConnectorService) {}
 
   focusWindow(frameId: string) {
     this.windowConnector.focusWindow(frameId);

--- a/web/src/app/header/toolbar.component.ts
+++ b/web/src/app/header/toolbar.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, Inject, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import {
   BehaviorSubject,
@@ -67,6 +67,11 @@ type ToolbarPopupStatus =
   ],
 })
 export class ToolbarComponent implements OnInit, OnDestroy {
+  private selectionManager = inject(SelectionManagerService);
+  readonly viewStateService = inject(ViewStateService);
+  private inspectionDataStore = inject(InspectionDataStoreService);
+  private timelineFilter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
+
   private destoroyed = new Subject<void>();
 
   private breakpointObserver = inject(BreakpointObserver);
@@ -119,13 +124,6 @@ export class ToolbarComponent implements OnInit, OnDestroy {
   ]).pipe(map(([l, t]) => l == null || t == null));
 
   popupStatus: ToolbarPopupStatus = 'NONE_OPEN';
-
-  constructor(
-    private selectionManager: SelectionManagerService,
-    public readonly viewStateService: ViewStateService,
-    private inspectionDataStore: InspectionDataStoreService,
-    @Inject(DEFAULT_TIMELINE_FILTER) private timelineFilter: TimelineFilter,
-  ) {}
   ngOnDestroy(): void {
     this.destoroyed.next();
   }

--- a/web/src/app/header/toolbar.component.ts
+++ b/web/src/app/header/toolbar.component.ts
@@ -67,10 +67,12 @@ type ToolbarPopupStatus =
   ],
 })
 export class ToolbarComponent implements OnInit, OnDestroy {
-  private selectionManager = inject(SelectionManagerService);
   readonly viewStateService = inject(ViewStateService);
-  private inspectionDataStore = inject(InspectionDataStoreService);
-  private timelineFilter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
+  private readonly selectionManager = inject(SelectionManagerService);
+  private readonly timelineFilter = inject<TimelineFilter>(
+    DEFAULT_TIMELINE_FILTER,
+  );
+  private readonly inspectionDataStore = inject(InspectionDataStoreService);
 
   private destoroyed = new Subject<void>();
 

--- a/web/src/app/log/header.component.ts
+++ b/web/src/app/log/header.component.ts
@@ -36,10 +36,10 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule],
 })
 export class LogHeaderComponent {
-  private logAnnotatorResolver = inject<LogAnnotatorResolver>(
+  private readonly logAnnotatorResolver = inject<LogAnnotatorResolver>(
     LOG_ANNOTATOR_RESOLVER,
   );
-  private _inspectionDataStore = inject(InspectionDataStoreService);
+  private readonly inspectionDataStore = inject(InspectionDataStoreService);
 
   private readonly envInjector = inject(EnvironmentInjector);
 
@@ -52,7 +52,7 @@ export class LogHeaderComponent {
 
   public logEntryObservable = this.logIndexObservable.pipe(
     startWith(0),
-    withLatestFrom(this._inspectionDataStore.allLogs),
+    withLatestFrom(this.inspectionDataStore.allLogs),
     map(([i, all]) => all[i]),
     shareReplay(1),
   );

--- a/web/src/app/log/header.component.ts
+++ b/web/src/app/log/header.component.ts
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Component,
-  EnvironmentInjector,
-  Inject,
-  Input,
-  inject,
-} from '@angular/core';
+import { Component, EnvironmentInjector, Input, inject } from '@angular/core';
 import { InspectionDataStoreService } from '../services/inspection-data-store.service';
 import {
   ReplaySubject,
@@ -42,6 +36,11 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule],
 })
 export class LogHeaderComponent {
+  private logAnnotatorResolver = inject<LogAnnotatorResolver>(
+    LOG_ANNOTATOR_RESOLVER,
+  );
+  private _inspectionDataStore = inject(InspectionDataStoreService);
+
   private readonly envInjector = inject(EnvironmentInjector);
 
   @Input()
@@ -62,10 +61,4 @@ export class LogHeaderComponent {
     this.logEntryObservable,
     this.envInjector,
   );
-
-  constructor(
-    @Inject(LOG_ANNOTATOR_RESOLVER)
-    private logAnnotatorResolver: LogAnnotatorResolver,
-    private _inspectionDataStore: InspectionDataStoreService,
-  ) {}
 }

--- a/web/src/app/log/log-view.component.ts
+++ b/web/src/app/log/log-view.component.ts
@@ -81,8 +81,8 @@ interface LogViewSelectionMoveCommand {
   ],
 })
 export class LogViewComponent implements OnInit, AfterViewInit, OnDestroy {
-  private inspectionDataStore = inject(InspectionDataStoreService);
-  private selectionManager = inject(SelectionManagerService);
+  private readonly inspectionDataStore = inject(InspectionDataStoreService);
+  private readonly selectionManager = inject(SelectionManagerService);
 
   /**
    * The minimal size of log list.

--- a/web/src/app/log/log-view.component.ts
+++ b/web/src/app/log/log-view.component.ts
@@ -27,6 +27,7 @@ import {
   OnDestroy,
   OnInit,
   ViewChild,
+  inject,
 } from '@angular/core';
 import {
   BehaviorSubject,
@@ -80,6 +81,9 @@ interface LogViewSelectionMoveCommand {
   ],
 })
 export class LogViewComponent implements OnInit, AfterViewInit, OnDestroy {
+  private inspectionDataStore = inject(InspectionDataStoreService);
+  private selectionManager = inject(SelectionManagerService);
+
   /**
    * The minimal size of log list.
    */
@@ -155,10 +159,7 @@ export class LogViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   disableScrollForNext = false;
 
-  constructor(
-    private inspectionDataStore: InspectionDataStoreService,
-    private selectionManager: SelectionManagerService,
-  ) {
+  constructor() {
     this.logBodyViewHeight.next(LogViewComponent.MINIMUM_LOG_LIST_SIZE); // initial value of the log view size.
     this.logViewSelectionMoveCommand
       .pipe(

--- a/web/src/app/pages/diff/diff.component.ts
+++ b/web/src/app/pages/diff/diff.component.ts
@@ -32,6 +32,8 @@ import { ResourceTimeline } from 'src/app/store/timeline';
   imports: [CommonModule, TitleBarComponent, SideBySideDiffComponent],
 })
 export class DiffComponent {
+  private readonly diffPageSource = inject(DiffPageDataSource);
+
   private readonly envInjector = inject(EnvironmentInjector);
 
   private readonly timelineAnnotatorResolver = inject(
@@ -68,6 +70,4 @@ export class DiffComponent {
     this.changePair,
     this.envInjector,
   );
-
-  constructor(private readonly diffPageSource: DiffPageDataSource) {}
 }

--- a/web/src/app/pages/graph/architecture-graph/architecture-graph.component.ts
+++ b/web/src/app/pages/graph/architecture-graph/architecture-graph.component.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  ViewChild,
+  inject,
+} from '@angular/core';
 import { GraphRenderer } from './graph/renderer';
 import { emptyGraphData } from '../../../common/schema/graph-schema';
 import { DownloadService } from '../services/donwload-service';
@@ -25,10 +31,8 @@ import { GraphPageDataSource } from 'src/app/services/frame-connection/frames/gr
   styleUrls: ['./architecture-graph.component.scss'],
 })
 export class ArchitectureGraphComponent implements AfterViewInit {
-  constructor(
-    private dataStore: GraphPageDataSource,
-    private downloadService: DownloadService,
-  ) {}
+  private dataStore = inject(GraphPageDataSource);
+  private downloadService = inject(DownloadService);
 
   @ViewChild('graphContainer')
   graphContainer!: ElementRef<HTMLDivElement>;

--- a/web/src/app/pages/main/main.component.ts
+++ b/web/src/app/pages/main/main.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, Inject, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import {
   animationFrames,
   BehaviorSubject,
@@ -63,6 +63,9 @@ import { HeaderComponent } from 'src/app/header/header.component';
   ],
 })
 export class AppComponent implements OnInit, OnDestroy {
+  private extensionStore = inject<ExtensionStore>(EXTENSION_STORE);
+  private dialog = inject(MatDialog);
+
   readonly destroyed = new Subject<void>();
   readonly showLogPane = new BehaviorSubject<boolean>(true);
   readonly showHistoryPane = new BehaviorSubject<boolean>(true);
@@ -119,11 +122,6 @@ export class AppComponent implements OnInit, OnDestroy {
       resizeRatio: 0,
     },
   ]);
-
-  constructor(
-    @Inject(EXTENSION_STORE) private extensionStore: ExtensionStore,
-    private dialog: MatDialog,
-  ) {}
 
   ngOnInit() {
     if (!this.extensionStore.tryOpenDataFromURL()) {

--- a/web/src/app/root.module.ts
+++ b/web/src/app/root.module.ts
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Inject,
-  Injector,
-  NgModule,
-  Optional,
-  importProvidersFrom,
-  inject,
-} from '@angular/core';
+import { Injector, NgModule, importProvidersFrom, inject } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -54,10 +47,7 @@ import {
 import { DiffPageDataSource } from './services/frame-connection/frames/diff-page-datasource.service';
 import { DiffPageDataSourceServer } from './services/frame-connection/frames/diff-page-datasource-server.service';
 import { GraphPageDataSourceServer } from './services/frame-connection/frames/graph-page-datasource-server.service';
-import {
-  KHI_FRONTEND_EXTENSION_BUNDLE,
-  KHIExtensionBundle,
-} from './extensions/extension-common/extension';
+import { KHI_FRONTEND_EXTENSION_BUNDLES } from './extensions/extension-common/extension';
 import { environment } from 'src/environments/environment';
 import {
   EXTENSION_STORE,
@@ -190,15 +180,13 @@ import {
   bootstrap: [RootComponent],
 })
 export class RootModule {
-  constructor(
-    injector: Injector,
-    @Inject(EXTENSION_STORE) extensionStore: ExtensionStore,
-    iconRegistry: MatIconRegistry,
-    notificationManager: NotificationManager,
-    @Optional()
-    @Inject(KHI_FRONTEND_EXTENSION_BUNDLE)
-    extensions: KHIExtensionBundle[] | null,
-  ) {
+  constructor() {
+    const injector = inject(Injector);
+    const extensionStore = inject<ExtensionStore>(EXTENSION_STORE);
+    const iconRegistry = inject(MatIconRegistry);
+    const notificationManager = inject(NotificationManager);
+    let extensions = inject(KHI_FRONTEND_EXTENSION_BUNDLES, { optional: true });
+
     extensionStore.injector = injector;
     if (!extensions) extensions = [];
     iconRegistry.setDefaultFontSetClass('material-symbols-outlined');

--- a/web/src/app/services/api/backend-api.service.spec.ts
+++ b/web/src/app/services/api/backend-api.service.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { HttpClient } from '@angular/common/http';
 import {
   HttpClientTestingModule,
   HttpTestingController,
@@ -46,10 +45,10 @@ describe('BackendAPIImpl testing', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
+      providers: [BackendAPIImpl, ViewStateService],
     });
 
-    const httpClient = TestBed.inject(HttpClient);
-    api = new BackendAPIImpl(httpClient, new ViewStateService());
+    api = TestBed.inject(BackendAPIImpl);
     httpTestingController = TestBed.inject(HttpTestingController);
   });
 

--- a/web/src/app/services/api/backend-api.service.ts
+++ b/web/src/app/services/api/backend-api.service.ts
@@ -62,7 +62,7 @@ import { UploadToken } from 'src/app/common/schema/form-types';
   providedIn: 'root',
 })
 export class BackendAPIImpl implements BackendAPI {
-  private http = inject(HttpClient);
+  private readonly http = inject(HttpClient);
   private readonly viewState = inject(ViewStateService);
 
   private readonly API_BASE_PATH = '/api/v3';

--- a/web/src/app/services/api/backend-api.service.ts
+++ b/web/src/app/services/api/backend-api.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   GetInspectionTypesResponse,
   CreateInspectionResponse,
@@ -62,6 +62,9 @@ import { UploadToken } from 'src/app/common/schema/form-types';
   providedIn: 'root',
 })
 export class BackendAPIImpl implements BackendAPI {
+  private http = inject(HttpClient);
+  private readonly viewState = inject(ViewStateService);
+
   private readonly API_BASE_PATH = '/api/v3';
 
   private readonly MAX_INSPECTION_DATA_DOWNLOAD_CHUNK_SIZE = 16 * 1024 * 1024;
@@ -76,10 +79,7 @@ export class BackendAPIImpl implements BackendAPI {
 
   private readonly getConfigObservable: Observable<GetConfigResponse>;
 
-  constructor(
-    private http: HttpClient,
-    private readonly viewState: ViewStateService,
-  ) {
+  constructor() {
     this.baseUrl = BackendAPIImpl.getServerBasePath() + this.API_BASE_PATH;
 
     const getConfigUrl = this.baseUrl + '/config';

--- a/web/src/app/services/api/backend-connection.service.ts
+++ b/web/src/app/services/api/backend-connection.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { Injectable, InjectionToken, inject } from '@angular/core';
 import {
   Observable,
   exhaustMap,
@@ -42,6 +42,8 @@ export const BACKEND_CONNECTION = new InjectionToken<BackendConnectionService>(
  */
 @Injectable()
 export class BackendConnectionServiceImpl implements BackendConnectionService {
+  private backendApi = inject<BackendAPI>(BACKEND_API);
+
   /**
    * Interval to poll task progresses.
    */
@@ -81,8 +83,6 @@ export class BackendConnectionServiceImpl implements BackendConnectionService {
     }),
     retry(),
   );
-
-  constructor(@Inject(BACKEND_API) private backendApi: BackendAPI) {}
 
   inspectionTypes(): Observable<GetInspectionTypesResponse> {
     return this.inspectionTypesObservable;

--- a/web/src/app/services/api/backend-connection.service.ts
+++ b/web/src/app/services/api/backend-connection.service.ts
@@ -42,7 +42,7 @@ export const BACKEND_CONNECTION = new InjectionToken<BackendConnectionService>(
  */
 @Injectable()
 export class BackendConnectionServiceImpl implements BackendConnectionService {
-  private backendApi = inject<BackendAPI>(BACKEND_API);
+  private readonly backendApi = inject<BackendAPI>(BACKEND_API);
 
   /**
    * Interval to poll task progresses.

--- a/web/src/app/services/data-loader.service.ts
+++ b/web/src/app/services/data-loader.service.ts
@@ -49,12 +49,12 @@ import { ProgressUtil } from './progress/progress-util';
 
 @Injectable()
 export class InspectionDataLoaderService {
-  private progress = inject<ProgressDialogStatusUpdator>(
+  private readonly progress = inject<ProgressDialogStatusUpdator>(
     PROGRESS_DIALOG_STATUS_UPDATOR,
   );
-  private inspectionDataStore = inject(InspectionDataStoreService);
-  private backendService = inject<BackendAPI>(BACKEND_API);
-  private extension = inject<ExtensionStore>(EXTENSION_STORE);
+  private readonly inspectionDataStore = inject(InspectionDataStoreService);
+  private readonly backendService = inject<BackendAPI>(BACKEND_API);
+  private readonly extension = inject<ExtensionStore>(EXTENSION_STORE);
 
   private eventDataToViewEvents(
     events: KHIFileResourceEvent[],

--- a/web/src/app/services/data-loader.service.ts
+++ b/web/src/app/services/data-loader.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { InspectionDataStoreService } from './inspection-data-store.service';
 import { InspectionData, TimeRange } from '../store/inspection-data';
 import {
@@ -49,13 +49,12 @@ import { ProgressUtil } from './progress/progress-util';
 
 @Injectable()
 export class InspectionDataLoaderService {
-  constructor(
-    @Inject(PROGRESS_DIALOG_STATUS_UPDATOR)
-    private progress: ProgressDialogStatusUpdator,
-    private inspectionDataStore: InspectionDataStoreService,
-    @Inject(BACKEND_API) private backendService: BackendAPI,
-    @Inject(EXTENSION_STORE) private extension: ExtensionStore,
-  ) {}
+  private progress = inject<ProgressDialogStatusUpdator>(
+    PROGRESS_DIALOG_STATUS_UPDATOR,
+  );
+  private inspectionDataStore = inject(InspectionDataStoreService);
+  private backendService = inject<BackendAPI>(BACKEND_API);
+  private extension = inject<ExtensionStore>(EXTENSION_STORE);
 
   private eventDataToViewEvents(
     events: KHIFileResourceEvent[],

--- a/web/src/app/services/frame-connection/frames/diff-page-datasource-server.service.ts
+++ b/web/src/app/services/frame-connection/frames/diff-page-datasource-server.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WindowConnectorService } from '../window-connector.service';
 import {
   DIFF_PAGE_OPEN,
@@ -29,10 +29,8 @@ import { withLatestFrom } from 'rxjs';
  */
 @Injectable()
 export class DiffPageDataSourceServer {
-  constructor(
-    private connector: WindowConnectorService,
-    private selectionManager: SelectionManagerService,
-  ) {}
+  private connector = inject(WindowConnectorService);
+  private selectionManager = inject(SelectionManagerService);
 
   public activate() {
     // Send the current selected revision and timeline to newly activated diff page

--- a/web/src/app/services/frame-connection/frames/diff-page-datasource.service.ts
+++ b/web/src/app/services/frame-connection/frames/diff-page-datasource.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { InterframeDatasource } from '../inter-frame-datasource.service';
 import { distinctUntilChanged, map, Subject } from 'rxjs';
 import { WindowConnectorService } from '../window-connector.service';
@@ -28,14 +28,14 @@ import { ResourceTimeline, TimelineLayer } from 'src/app/store/timeline';
 
 @Injectable()
 export class DiffPageDataSource extends InterframeDatasource<DiffPageViewModel> {
+  private connector = inject(WindowConnectorService);
+  private router = inject(Router);
+
   private navigationCandidate: Subject<string> = new Subject();
 
   private enabled = false;
 
-  constructor(
-    private connector: WindowConnectorService,
-    private router: Router,
-  ) {
+  constructor() {
     super();
 
     this.navigationCandidate

--- a/web/src/app/services/frame-connection/frames/diff-page-datasource.service.ts
+++ b/web/src/app/services/frame-connection/frames/diff-page-datasource.service.ts
@@ -28,10 +28,10 @@ import { ResourceTimeline, TimelineLayer } from 'src/app/store/timeline';
 
 @Injectable()
 export class DiffPageDataSource extends InterframeDatasource<DiffPageViewModel> {
-  private connector = inject(WindowConnectorService);
-  private router = inject(Router);
+  private readonly connector = inject(WindowConnectorService);
+  private readonly router = inject(Router);
 
-  private navigationCandidate: Subject<string> = new Subject();
+  private readonly navigationCandidate: Subject<string> = new Subject();
 
   private enabled = false;
 

--- a/web/src/app/services/frame-connection/frames/graph-page-datasource-server.service.ts
+++ b/web/src/app/services/frame-connection/frames/graph-page-datasource-server.service.ts
@@ -31,10 +31,10 @@ import {
 
 @Injectable()
 export class GraphPageDataSourceServer {
-  private graphConverter = inject(GraphDataConverterService);
-  private connector = inject(WindowConnectorService);
-  private selectionManager = inject(SelectionManagerService);
-  private filter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
+  private readonly graphConverter = inject(GraphDataConverterService);
+  private readonly connector = inject(WindowConnectorService);
+  private readonly selectionManager = inject(SelectionManagerService);
+  private readonly filter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
 
   public activate() {
     this.connector

--- a/web/src/app/services/frame-connection/frames/graph-page-datasource-server.service.ts
+++ b/web/src/app/services/frame-connection/frames/graph-page-datasource-server.service.ts
@@ -22,7 +22,7 @@ import { GraphDataConverterService } from '../../graph-converter.service';
 import { SelectionManagerService } from '../../selection-manager.service';
 import { WindowConnectorService } from '../window-connector.service';
 import { withLatestFrom } from 'rxjs';
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { UpdateGraphMessage } from './graph-page-datasource.service';
 import {
   DEFAULT_TIMELINE_FILTER,
@@ -31,12 +31,10 @@ import {
 
 @Injectable()
 export class GraphPageDataSourceServer {
-  constructor(
-    private graphConverter: GraphDataConverterService,
-    private connector: WindowConnectorService,
-    private selectionManager: SelectionManagerService,
-    @Inject(DEFAULT_TIMELINE_FILTER) private filter: TimelineFilter,
-  ) {}
+  private graphConverter = inject(GraphDataConverterService);
+  private connector = inject(WindowConnectorService);
+  private selectionManager = inject(SelectionManagerService);
+  private filter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
 
   public activate() {
     this.connector

--- a/web/src/app/services/frame-connection/frames/graph-page-datasource.service.ts
+++ b/web/src/app/services/frame-connection/frames/graph-page-datasource.service.ts
@@ -16,7 +16,7 @@
 
 import { GraphData } from 'src/app/common/schema/graph-schema';
 import { InterframeDatasource } from '../inter-frame-datasource.service';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WindowConnectorService } from '../window-connector.service';
 import {
   GRAPH_PAGE_OPEN,
@@ -29,11 +29,9 @@ export interface UpdateGraphMessage {
 
 @Injectable()
 export class GraphPageDataSource extends InterframeDatasource<GraphData> {
-  private enabled = false;
+  private connector = inject(WindowConnectorService);
 
-  constructor(private connector: WindowConnectorService) {
-    super();
-  }
+  private enabled = false;
   override enable(): void {
     if (this.enabled) {
       return;

--- a/web/src/app/services/frame-connection/frames/graph-page-datasource.service.ts
+++ b/web/src/app/services/frame-connection/frames/graph-page-datasource.service.ts
@@ -29,7 +29,7 @@ export interface UpdateGraphMessage {
 
 @Injectable()
 export class GraphPageDataSource extends InterframeDatasource<GraphData> {
-  private connector = inject(WindowConnectorService);
+  private readonly connector = inject(WindowConnectorService);
 
   private enabled = false;
   override enable(): void {

--- a/web/src/app/services/frame-connection/window-connector.service.spec.ts
+++ b/web/src/app/services/frame-connection/window-connector.service.spec.ts
@@ -34,7 +34,7 @@ function waitFor(msec: number): Promise<void> {
 /**
  * getUniqueWindowConnectorService returns a new instance of WindowConnectorService to emulate inter-frame connection.
  * WindowConnectorService generates a frameID for each window frames.
- * This function reset the TestBed to get a new instance of WindowConnectorService because if Angular injector shares a same instance for each injection, it can't emulate the inter-frame connection.
+ * This function resets the TestBed to get a new instance of WindowConnectorService because if Angular injector shares the same instance for each injection, it can't emulate the inter-frame connection.
  */
 function getUniqueWindowConnectorService(
   connectionProvider: WindowConnectionProvider,

--- a/web/src/app/services/frame-connection/window-connector.service.spec.ts
+++ b/web/src/app/services/frame-connection/window-connector.service.spec.ts
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+import { TestBed } from '@angular/core/testing';
 import { InMemoryWindowConnectionProvider } from './window-connection-provider.service';
 import {
   KHIWindowPacket,
   WindowConnectorService,
+  WINDOW_CONNECTION_PROVIDER,
+  WindowConnectionProvider,
 } from './window-connector.service';
 
 function waitFor(msec: number): Promise<void> {
@@ -28,14 +31,37 @@ function waitFor(msec: number): Promise<void> {
   });
 }
 
+/**
+ * getUniqueWindowConnectorService returns a new instance of WindowConnectorService to emulate inter-frame connection.
+ * WindowConnectorService generates a frameID for each window frames.
+ * This function reset the TestBed to get a new instance of WindowConnectorService because if Angular injector shares a same instance for each injection, it can't emulate the inter-frame connection.
+ */
+function getUniqueWindowConnectorService(
+  connectionProvider: WindowConnectionProvider,
+) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      WindowConnectorService,
+      { provide: WINDOW_CONNECTION_PROVIDER, useValue: connectionProvider },
+    ],
+  });
+  const windowConnector = TestBed.inject(WindowConnectorService);
+  return windowConnector;
+}
+
 describe('WindowConnectorService', () => {
   it('should route broadcasted packet to all frames', async () => {
     const connectionProvider = new InMemoryWindowConnectionProvider();
-    const windowConnector1 = new WindowConnectorService(connectionProvider);
+
+    const windowConnector1 =
+      getUniqueWindowConnectorService(connectionProvider);
     expect(await windowConnector1.createSession(1)).toBe(true);
-    const windowConnector2 = new WindowConnectorService(connectionProvider);
+    const windowConnector2 =
+      getUniqueWindowConnectorService(connectionProvider);
     expect(await windowConnector2.joinSession(1, 'Diagram')).toBe(true);
-    const windowConnector3 = new WindowConnectorService(connectionProvider);
+    const windowConnector3 =
+      getUniqueWindowConnectorService(connectionProvider);
     expect(await windowConnector3.joinSession(1, 'Diagram')).toBe(true);
     const connector1Packets: KHIWindowPacket<unknown>[] = [];
     const connector2Packets: KHIWindowPacket<unknown>[] = [];
@@ -62,12 +88,16 @@ describe('WindowConnectorService', () => {
 
   it('should route unicasted packet to a destination', async () => {
     const connectionProvider = new InMemoryWindowConnectionProvider();
-    const windowConnector1 = new WindowConnectorService(connectionProvider);
-    await windowConnector1.createSession(1);
-    const windowConnector2 = new WindowConnectorService(connectionProvider);
-    await windowConnector2.createSession(1);
-    const windowConnector3 = new WindowConnectorService(connectionProvider);
-    await windowConnector3.createSession(1);
+
+    const windowConnector1 =
+      getUniqueWindowConnectorService(connectionProvider);
+    expect(await windowConnector1.createSession(1)).toBeTrue();
+    const windowConnector2 =
+      getUniqueWindowConnectorService(connectionProvider);
+    expect(await windowConnector2.createSession(1)).toBeFalse();
+    const windowConnector3 =
+      getUniqueWindowConnectorService(connectionProvider);
+    expect(await windowConnector3.createSession(1)).toBeFalse();
     const connector1Packets: KHIWindowPacket<unknown>[] = [];
     const connector2Packets: KHIWindowPacket<unknown>[] = [];
     const connector3Packets: KHIWindowPacket<unknown>[] = [];
@@ -92,10 +122,12 @@ describe('WindowConnectorService', () => {
 
   it('should ignore packet sent in the another session', async () => {
     const connectionProvider = new InMemoryWindowConnectionProvider();
-    const windowConnector1 = new WindowConnectorService(connectionProvider);
-    await windowConnector1.createSession(1);
-    const windowConnector2 = new WindowConnectorService(connectionProvider);
-    await windowConnector2.createSession(1);
+    const windowConnector1 =
+      getUniqueWindowConnectorService(connectionProvider);
+    expect(await windowConnector1.createSession(1)).toBeTrue();
+    const windowConnector2 =
+      getUniqueWindowConnectorService(connectionProvider);
+    expect(await windowConnector2.createSession(1)).toBeFalse();
     const connector1Packets: KHIWindowPacket<unknown>[] = [];
     const connector2Packets: KHIWindowPacket<unknown>[] = [];
     windowConnector1

--- a/web/src/app/services/frame-connection/window-connector.service.ts
+++ b/web/src/app/services/frame-connection/window-connector.service.ts
@@ -75,7 +75,7 @@ interface SessionStatusNotificationMessage {
  */
 @Injectable({ providedIn: 'root' })
 export class WindowConnectorService {
-  private connectionProvider = inject<WindowConnectionProvider>(
+  private readonly connectionProvider = inject<WindowConnectionProvider>(
     WINDOW_CONNECTION_PROVIDER,
   );
 

--- a/web/src/app/services/frame-connection/window-connector.service.ts
+++ b/web/src/app/services/frame-connection/window-connector.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { Injectable, InjectionToken, inject } from '@angular/core';
 import {
   BehaviorSubject,
   filter,
@@ -75,6 +75,10 @@ interface SessionStatusNotificationMessage {
  */
 @Injectable({ providedIn: 'root' })
 export class WindowConnectorService {
+  private connectionProvider = inject<WindowConnectionProvider>(
+    WINDOW_CONNECTION_PROVIDER,
+  );
+
   sessionId = -1;
 
   readonly sessionEstablished = new ReplaySubject(1);
@@ -107,10 +111,7 @@ export class WindowConnectorService {
 
   private focusWindowSubscription?: Subscription;
 
-  constructor(
-    @Inject(WINDOW_CONNECTION_PROVIDER)
-    private connectionProvider: WindowConnectionProvider,
-  ) {
+  constructor() {
     this.frameId = randomString();
     this.messageSource = this.connectionProvider.receive().pipe(
       filter(

--- a/web/src/app/services/graph-converter.service.ts
+++ b/web/src/app/services/graph-converter.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import {
   ArchGraphCondition,
@@ -52,7 +52,7 @@ interface MappedTimelineEntry {
   providedIn: 'root',
 })
 export class GraphDataConverterService {
-  constructor(private _viewStateService: ViewStateService) {}
+  private _viewStateService = inject(ViewStateService);
 
   private $timeZoneShift: BehaviorSubject<number> = asBehaviorSubject(
     this._viewStateService.timezoneShift,

--- a/web/src/app/services/graph-converter.service.ts
+++ b/web/src/app/services/graph-converter.service.ts
@@ -52,7 +52,7 @@ interface MappedTimelineEntry {
   providedIn: 'root',
 })
 export class GraphDataConverterService {
-  private _viewStateService = inject(ViewStateService);
+  private readonly _viewStateService = inject(ViewStateService);
 
   private $timeZoneShift: BehaviorSubject<number> = asBehaviorSubject(
     this._viewStateService.timezoneShift,

--- a/web/src/app/services/popup/popup-manager-impl.ts
+++ b/web/src/app/services/popup/popup-manager-impl.ts
@@ -35,7 +35,7 @@ import {
   PopupFormRequest,
 } from 'src/app/common/schema/api-types';
 import { BACKEND_API, BackendAPI } from '../api/backend-api-interface';
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 export const NilPopupFormRequest: PopupFormRequest = {
   id: 'none',
@@ -48,6 +48,8 @@ export const NilPopupFormRequest: PopupFormRequest = {
 
 @Injectable({ providedIn: 'any' })
 export class PopupManagerImpl implements PopupManager {
+  private backendAPI = inject<BackendAPI>(BACKEND_API);
+
   private popupRequest = interval(1000).pipe(
     exhaustMap(
       () => this.backendAPI.getPopup() as Observable<PopupFormRequest>,
@@ -60,8 +62,6 @@ export class PopupManagerImpl implements PopupManager {
       refCount: true,
     }),
   );
-
-  constructor(@Inject(BACKEND_API) private backendAPI: BackendAPI) {}
 
   requests(): Observable<PopupFormRequestWithClient> {
     return this.popupRequest.pipe(

--- a/web/src/app/services/popup/popup-manager-impl.ts
+++ b/web/src/app/services/popup/popup-manager-impl.ts
@@ -48,9 +48,9 @@ export const NilPopupFormRequest: PopupFormRequest = {
 
 @Injectable({ providedIn: 'any' })
 export class PopupManagerImpl implements PopupManager {
-  private backendAPI = inject<BackendAPI>(BACKEND_API);
+  private readonly backendAPI = inject<BackendAPI>(BACKEND_API);
 
-  private popupRequest = interval(1000).pipe(
+  private readonly popupRequest = interval(1000).pipe(
     exhaustMap(
       () => this.backendAPI.getPopup() as Observable<PopupFormRequest>,
     ),

--- a/web/src/app/services/progress/progress-dialog.service.ts
+++ b/web/src/app/services/progress/progress-dialog.service.ts
@@ -30,7 +30,7 @@ import { Injectable, Provider, inject } from '@angular/core';
 export class ProgressDialogService
   implements ProgressDialogStatusObserver, ProgressDialogStatusUpdator
 {
-  private _dialog = inject(MatDialog);
+  private readonly _dialog = inject(MatDialog);
 
   /**
    * Returns Angular providers for interfaces implemented on this class.

--- a/web/src/app/services/progress/progress-dialog.service.ts
+++ b/web/src/app/services/progress/progress-dialog.service.ts
@@ -24,12 +24,14 @@ import {
   ProgressDialogStatusObserver,
   ProgressDialogStatusUpdator,
 } from './progress-interface';
-import { Injectable, Provider } from '@angular/core';
+import { Injectable, Provider, inject } from '@angular/core';
 
 @Injectable()
 export class ProgressDialogService
   implements ProgressDialogStatusObserver, ProgressDialogStatusUpdator
 {
+  private _dialog = inject(MatDialog);
+
   /**
    * Returns Angular providers for interfaces implemented on this class.
    */
@@ -59,8 +61,6 @@ export class ProgressDialogService
    * The dismiss() function will close the dialog only when this count become 0.
    */
   private showCount = 0;
-
-  constructor(private _dialog: MatDialog) {}
 
   status(): Observable<CurrentProgress> {
     return this.currentStatusSubject;

--- a/web/src/app/services/selection-manager.service.ts
+++ b/web/src/app/services/selection-manager.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   BehaviorSubject,
   combineLatest,
@@ -40,6 +40,8 @@ type LogHighlightQuery = LogSelectionQuery | number[];
  */
 @Injectable({ providedIn: 'root' })
 export class SelectionManagerService {
+  private inspectionDataStore = inject(InspectionDataStoreService);
+
   private logSelectionQuery: Subject<LogSelectionQuery> = new Subject();
 
   /**
@@ -193,7 +195,7 @@ export class SelectionManagerService {
       refCount: true,
     }),
   );
-  constructor(private inspectionDataStore: InspectionDataStoreService) {
+  constructor() {
     // Change selection status when current timeline selection was changed.
     this.selectedTimeline
       .pipe(

--- a/web/src/app/services/timeline-selection.service.ts
+++ b/web/src/app/services/timeline-selection.service.ts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, filter, firstValueFrom, map } from 'rxjs';
 import { InspectionDataStoreService } from './inspection-data-store.service';
 import { SelectionManagerService } from './selection-manager.service';
 
 @Injectable({ providedIn: 'root' })
 export class TimelineSelectionService {
+  private _inspectionDataStore = inject(InspectionDataStoreService);
+  private _logSelectionManager = inject(SelectionManagerService);
+
   private logs = this._inspectionDataStore.allLogs;
 
   private $currentTime: BehaviorSubject<number> = new BehaviorSubject(0);
 
-  constructor(
-    private _inspectionDataStore: InspectionDataStoreService,
-    private _logSelectionManager: SelectionManagerService,
-  ) {
+  constructor() {
     this._logSelectionManager.selectedLog
       .pipe(
         filter((log) => log !== null),

--- a/web/src/app/services/timeline-selection.service.ts
+++ b/web/src/app/services/timeline-selection.service.ts
@@ -21,8 +21,8 @@ import { SelectionManagerService } from './selection-manager.service';
 
 @Injectable({ providedIn: 'root' })
 export class TimelineSelectionService {
-  private _inspectionDataStore = inject(InspectionDataStoreService);
-  private _logSelectionManager = inject(SelectionManagerService);
+  private readonly _inspectionDataStore = inject(InspectionDataStoreService);
+  private readonly _logSelectionManager = inject(SelectionManagerService);
 
   private logs = this._inspectionDataStore.allLogs;
 

--- a/web/src/app/services/title-strategy.service.ts
+++ b/web/src/app/services/title-strategy.service.ts
@@ -16,16 +16,14 @@
 
 import { Title } from '@angular/platform-browser';
 import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 /**
  * Control the window title regarding routing paths
  */
 @Injectable()
 export class KHITitleStrategy extends TitleStrategy {
-  constructor(private readonly title: Title) {
-    super();
-  }
+  private readonly title = inject(Title);
 
   override updateTitle(snapshot: RouterStateSnapshot): void {
     const sessionId = snapshot.root.firstChild?.params['sessionId'];

--- a/web/src/app/timeline/CanvasKeyEventHandler.ts
+++ b/web/src/app/timeline/CanvasKeyEventHandler.ts
@@ -44,12 +44,12 @@ interface MoveVerticalSelectionCommand {
  */
 @Injectable({ providedIn: 'root' })
 export class CanvasKeyEventHandler {
-  private selectionManager = inject(SelectionManagerService);
+  private readonly selectionManager = inject(SelectionManagerService);
 
-  private moveHorizontalSelectionCommand =
+  private readonly moveHorizontalSelectionCommand =
     new Subject<MoveHorizontalSelectionCommand>();
 
-  private moveVerticalSelectionCommand =
+  private readonly moveVerticalSelectionCommand =
     new Subject<MoveVerticalSelectionCommand>();
 
   constructor() {

--- a/web/src/app/timeline/CanvasKeyEventHandler.ts
+++ b/web/src/app/timeline/CanvasKeyEventHandler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { SelectionManagerService } from '../services/selection-manager.service';
 import { Subject, withLatestFrom } from 'rxjs';
 import { ResourceTimeline, TimelineLayer } from '../store/timeline';
@@ -44,16 +44,18 @@ interface MoveVerticalSelectionCommand {
  */
 @Injectable({ providedIn: 'root' })
 export class CanvasKeyEventHandler {
+  private selectionManager = inject(SelectionManagerService);
+
   private moveHorizontalSelectionCommand =
     new Subject<MoveHorizontalSelectionCommand>();
 
   private moveVerticalSelectionCommand =
     new Subject<MoveVerticalSelectionCommand>();
 
-  constructor(
-    private selectionManager: SelectionManagerService,
-    @Inject(DEFAULT_TIMELINE_FILTER) filter: TimelineFilter,
-  ) {
+  constructor() {
+    const selectionManager = this.selectionManager;
+    const filter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
+
     // For revision selection
     this.moveHorizontalSelectionCommand
       .pipe(

--- a/web/src/app/timeline/TimelineScrollStrategy.ts
+++ b/web/src/app/timeline/TimelineScrollStrategy.ts
@@ -44,7 +44,9 @@ export interface PerRowScrollingProperty {
 
 @Injectable()
 export class TimelinesScrollStrategy {
-  private timelineFilter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
+  private readonly timelineFilter = inject<TimelineFilter>(
+    DEFAULT_TIMELINE_FILTER,
+  );
 
   /**
    * Extra margin at the bottom in pixels.

--- a/web/src/app/timeline/TimelineScrollStrategy.ts
+++ b/web/src/app/timeline/TimelineScrollStrategy.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Inject, Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   BehaviorSubject,
   Observable,
@@ -44,6 +44,8 @@ export interface PerRowScrollingProperty {
 
 @Injectable()
 export class TimelinesScrollStrategy {
+  private timelineFilter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
+
   /**
    * Extra margin at the bottom in pixels.
    * This is needed not to stick the bottom element at the bottom of screen.
@@ -180,9 +182,7 @@ export class TimelinesScrollStrategy {
    */
   scrollToTimelineVerticallyCommand: Subject<ResourceTimeline> = new Subject();
 
-  constructor(
-    @Inject(DEFAULT_TIMELINE_FILTER) private timelineFilter: TimelineFilter,
-  ) {
+  constructor() {
     // Calculate properties needed for scrolling behavior from updated timeline array.
     this.timelineFilter.filteredTimeline
       .pipe(

--- a/web/src/app/timeline/canvas/timeline_renderer.service.ts
+++ b/web/src/app/timeline/canvas/timeline_renderer.service.ts
@@ -53,10 +53,10 @@ import { TimelineGLResourceManager } from './timeline_gl_resource_manager';
 
 @Injectable()
 export class TimelineRendererService {
-  private dataStore = inject(InspectionDataStoreService);
-  private selectionManager = inject(SelectionManagerService);
-  private scrollingStrategy = inject(TimelinesScrollStrategy);
-  private viewState = inject(ViewStateService);
+  private readonly dataStore = inject(InspectionDataStoreService);
+  private readonly selectionManager = inject(SelectionManagerService);
+  private readonly scrollingStrategy = inject(TimelinesScrollStrategy);
+  private readonly viewState = inject(ViewStateService);
 
   /**
    * The time in ms not to refresh screen when the previous render request was happened recently.

--- a/web/src/app/timeline/canvas/timeline_renderer.service.ts
+++ b/web/src/app/timeline/canvas/timeline_renderer.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   BehaviorSubject,
   Observable,
@@ -53,6 +53,11 @@ import { TimelineGLResourceManager } from './timeline_gl_resource_manager';
 
 @Injectable()
 export class TimelineRendererService {
+  private dataStore = inject(InspectionDataStoreService);
+  private selectionManager = inject(SelectionManagerService);
+  private scrollingStrategy = inject(TimelinesScrollStrategy);
+  private viewState = inject(ViewStateService);
+
   /**
    * The time in ms not to refresh screen when the previous render request was happened recently.
    */
@@ -101,12 +106,7 @@ export class TimelineRendererService {
   private mouseClickPointerLocation: Subject<CanvasMouseLocation | null> =
     new BehaviorSubject<CanvasMouseLocation | null>(null);
 
-  constructor(
-    private dataStore: InspectionDataStoreService,
-    private selectionManager: SelectionManagerService,
-    private scrollingStrategy: TimelinesScrollStrategy,
-    private viewState: ViewStateService,
-  ) {
+  constructor() {
     this.initSubscribers();
   }
 

--- a/web/src/app/timeline/timeline.component.ts
+++ b/web/src/app/timeline/timeline.component.ts
@@ -18,11 +18,11 @@ import {
   AfterViewInit,
   Component,
   ElementRef,
-  Inject,
   Input,
   OnDestroy,
   OnInit,
   ViewChild,
+  inject,
 } from '@angular/core';
 import {
   BehaviorSubject,
@@ -144,6 +144,14 @@ const DEFAULT_HOVER_VIEW_STATE: HoverViewState = {
   ],
 })
 export class TimelineComponent implements OnInit, AfterViewInit, OnDestroy {
+  private _viewStateService = inject(ViewStateService);
+  private _inspectionDataStore = inject(InspectionDataStoreService);
+  private selectionManager = inject(SelectionManagerService);
+  private timelineScrollStrategy = inject(TimelinesScrollStrategy);
+  private timelineRenderer = inject(TimelineRendererService);
+  private keyEventHandler = inject(CanvasKeyEventHandler);
+  private timelineFilter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
+
   /**
    * Ignores scroll request when the target log entry is already in between [left edge + padding, right edge - padding].
    */
@@ -242,16 +250,6 @@ export class TimelineComponent implements OnInit, AfterViewInit, OnDestroy {
   canvasParent!: ElementRef<HTMLDivElement>;
   canvasParentSizeSubject: Subject<CanvasSize> = new ReplaySubject(1);
   canvasParentSizeObserver!: ResizeObserver;
-
-  constructor(
-    private _viewStateService: ViewStateService,
-    private _inspectionDataStore: InspectionDataStoreService,
-    private selectionManager: SelectionManagerService,
-    private timelineScrollStrategy: TimelinesScrollStrategy,
-    private timelineRenderer: TimelineRendererService,
-    private keyEventHandler: CanvasKeyEventHandler,
-    @Inject(DEFAULT_TIMELINE_FILTER) private timelineFilter: TimelineFilter,
-  ) {}
   ngOnDestroy(): void {
     this.destoroyed.next();
   }

--- a/web/src/app/timeline/timeline.component.ts
+++ b/web/src/app/timeline/timeline.component.ts
@@ -144,13 +144,15 @@ const DEFAULT_HOVER_VIEW_STATE: HoverViewState = {
   ],
 })
 export class TimelineComponent implements OnInit, AfterViewInit, OnDestroy {
-  private _viewStateService = inject(ViewStateService);
-  private _inspectionDataStore = inject(InspectionDataStoreService);
-  private selectionManager = inject(SelectionManagerService);
-  private timelineScrollStrategy = inject(TimelinesScrollStrategy);
-  private timelineRenderer = inject(TimelineRendererService);
-  private keyEventHandler = inject(CanvasKeyEventHandler);
-  private timelineFilter = inject<TimelineFilter>(DEFAULT_TIMELINE_FILTER);
+  private readonly _viewStateService = inject(ViewStateService);
+  private readonly _inspectionDataStore = inject(InspectionDataStoreService);
+  private readonly selectionManager = inject(SelectionManagerService);
+  private readonly timelineScrollStrategy = inject(TimelinesScrollStrategy);
+  private readonly timelineRenderer = inject(TimelineRendererService);
+  private readonly keyEventHandler = inject(CanvasKeyEventHandler);
+  private readonly timelineFilter = inject<TimelineFilter>(
+    DEFAULT_TIMELINE_FILTER,
+  );
 
   /**
    * Ignores scroll request when the target log entry is already in between [left edge + padding, right edge - padding].


### PR DESCRIPTION
After updating angular from 19 to 20, `@angular-eslint/prefer-inject` lint rule was introduced.
This PR fixes these lint errors and test errors due to naive conversion from constructor injection to the injector method.