### PR TITLE
feat: Change container image repository to gcr.io

### DIFF
--- a/.cloudbuild/github-deploy-beta.yaml
+++ b/.cloudbuild/github-deploy-beta.yaml
@@ -48,7 +48,9 @@ steps:
       - '-c'
       - |
         docker buildx create --driver docker-container --name container --use
-        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/release:beta -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} --push .
+        # TODO(#21): Remove asia.gcr.io from the build targets.
+        # The new repository is gcr.io, but we will keep the old one for a while.
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/release:beta -t gcr.io/kubernetes-history-inspector/release:beta -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} -t gcr.io/kubernetes-history-inspector/release:${TAG_NAME} --push .
     id: build_container
     waitFor:
       - build_web

--- a/.cloudbuild/github-deploy-latest.yaml
+++ b/.cloudbuild/github-deploy-latest.yaml
@@ -48,7 +48,9 @@ steps:
       - '-c'
       - |
         docker buildx create --driver docker-container --name container --use
-        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/release:latest -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} --push .
+        # TODO(#21): Remove asia.gcr.io from the build targets.
+        # The new repository is gcr.io, but we will keep the old one for a while.
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/release:latest -t gcr.io/kubernetes-history-inspector/release:latest -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} -t gcr.io/kubernetes-history-inspector/release:${TAG_NAME} --push .
     id: build_container
     waitFor:
       - build_web

--- a/.cloudbuild/github-deploy-ondemand.yaml
+++ b/.cloudbuild/github-deploy-ondemand.yaml
@@ -48,7 +48,7 @@ steps:
       - '-c'
       - |
         docker buildx create --driver docker-container --name container --use
-        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA --push .
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA --push .
     id: build_container
     waitFor:
       - build_web

--- a/README.ja.md
+++ b/README.ja.md
@@ -81,18 +81,18 @@ KHIは、Google Cloud サポートチームが開発し、その後オープン�
 #### KHI の実行
 
 1. [Cloud Shell](https://shell.cloud.google.com) を開きます。
-2. `docker run -p 127.0.0.1:8080:8080 asia.gcr.io/kubernetes-history-inspector/release:latest` を実行します。
+2. `docker run -p 127.0.0.1:8080:8080 gcr.io/kubernetes-history-inspector/release:latest` を実行します。
 3. ターミナル上のリンク `http://localhost:8080` をクリックして、KHI の使用を開始してください！
+
+> [!WARNING]
+> コンテナイメージのレポジトリが `asia.gcr.io` から `gcr.io` に変更されました。古いレポジトリも当面の間利用可能ですが、将来的には廃止される予定のため、新しいレポジトリへの切り替えを推奨します。
 
 > [!TIP]
 > メタデータサーバーが利用できない他の環境で KHI を実行する場合は、プログラム引数でアクセストークンを渡します。
 >
 > ```bash
-> docker run -p 127.0.0.1:8080:8080 asia.gcr.io/kubernetes-history-inspector/release:latest -access-token=`gcloud auth print-access-token`
+> docker run -p 127.0.0.1:8080:8080 gcr.io/kubernetes-history-inspector/release:latest -access-token=`gcloud auth print-access-token`
 > ```
-
-> [!NOTE]
-> コンテナイメージの配信元は近いうちに変更される可能性があります。 #21
 
 詳細は [Getting Started](/docs/en/tutorial/getting-started.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -74,20 +74,20 @@ KHI is originally developed by the Google Cloud Support team before it became op
 #### Run KHI
 
 1. Open [Cloud Shell](https://shell.cloud.google.com)
-1. Run `docker run -p 127.0.0.1:8080:8080 asia.gcr.io/kubernetes-history-inspector/release:latest`
+1. Run `docker run -p 127.0.0.1:8080:8080 gcr.io/kubernetes-history-inspector/release:latest`
 1. Click the link `http://localhost:8080` on the terminal and start working with KHI!
+
+> [!WARNING]
+> The container image repository has been moved from `asia.gcr.io` to `gcr.io`. While the old repository is still available, we recommend switching to the new one as the old one will be deprecated in the future.
 
 > [!TIP]
 > If you want to run KHI with the other environment where the metadata server is not available,
 > you can pass the access token via the program argument.
 >
 >```bash
->docker run -p 127.0.0.1:8080:8080 asia.gcr.io/kubernetes-history-inspector/release:latest -access-token=`gcloud auth print-access-token`
+>docker run -p 127.0.0.1:8080:8080 gcr.io/kubernetes-history-inspector/release:latest -access-token=`gcloud auth print-access-token`
 >```
 >
-
-> [!NOTE]
-> The container image source may change in the near future. #21
 
 For more details, try [Getting started](/docs/en/tutorial/getting-started.md).
 

--- a/docs/en/development-contribution/development-guide.md
+++ b/docs/en/development-contribution/development-guide.md
@@ -133,12 +133,12 @@ These tag creations are restricted only for our repository admins.
 
 * Pre-release
   * Name tag with `vx.y.z-beta` then it will be deployed at the following addresses:
-    * `asia.gcr.io/kubernetes-history-inspector/release:beta`
-    * `asia.gcr.io/kubernetes-history-inspector/release:vx.y.z-beta`
+    * `gcr.io/kubernetes-history-inspector/release:beta`
+    * `gcr.io/kubernetes-history-inspector/release:vx.y.z-beta`
 * Release
   * Name tag with `vx.y.z` then it will be deployed at the following address:
-    * `asia.gcr.io/kubernetes-history-inspector/release:vx.y.z`
-    * `asia.gcr.io/kubernetes-history-inspector/release:latest`
+    * `gcr.io/kubernetes-history-inspector/release:vx.y.z`
+    * `gcr.io/kubernetes-history-inspector/release:latest`
 
 > [!NOTE]
 > The deployment process begins after the release entry being created. It may take an hour to push the image on the repository.
@@ -146,7 +146,7 @@ These tag creations are restricted only for our repository admins.
 ### Using on-demand build for pull request code
 
 Repository admins can run `github-deploy-ondemand` check on a Pull request.
-It will deploy the image on `asia.gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA`.
+It will deploy the image on `gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA`.
 
 > [!NOTE]
 > The image is only for the last check. Please check the code is right on your environment first.

--- a/docs/en/setup-guide/oss-kubernetes-clusters.md
+++ b/docs/en/setup-guide/oss-kubernetes-clusters.md
@@ -307,7 +307,7 @@ Start the KHI server using Docker:
 
 ```bash
 # You don't need to pass Google Cloud credentials to the container.
-docker run --rm -p 127.0.0.1:8080:8080 asia.gcr.io/kubernetes-history-inspector/release:latest
+docker run --rm -p 127.0.0.1:8080:8080 gcr.io/kubernetes-history-inspector/release:latest
 ```
 
 You should see output indicating the server is running:

--- a/docs/en/tutorial/getting-started.md
+++ b/docs/en/tutorial/getting-started.md
@@ -82,7 +82,7 @@ First, let's create a Deployment, scale it out, roll it out, and see what it loo
 Kubernetes audit logs about these changes have been recorded in Cloud Logging. Let's use KHI to see how Kubernetes has operated in the past. KHI is available as a container image, so you can start it with Docker (or podman).
 
 ```bash
-docker run -p 8080:8080 asia.gcr.io/kubernetes-history-inspector/release:latest -access-token=`gcloud auth print-access-token`
+docker run -p 8080:8080 gcr.io/kubernetes-history-inspector/release:latest -access-token=`gcloud auth print-access-token`
 ```
 
 This command starts KHI, and the Web UI is available on port 8080. Access `http://localhost:8080` in your web browser to display the KHI Web UI.

--- a/docs/ja/development-contribution/development-guide.md
+++ b/docs/ja/development-contribution/development-guide.md
@@ -131,19 +131,19 @@ GitHubでリリースを作成すると、専用のタグが自動的に生成�
 
 * プレリリース
   * tagを `vx.y.z-beta`として命名すると、 下記のアドレスとしてデプロイされます。
-    * `asia.gcr.io/kubernetes-history-inspector/release:beta`
-    * `asia.gcr.io/kubernetes-history-inspector/release:vx.y.z-beta`
+    * `gcr.io/kubernetes-history-inspector/release:beta`
+    * `gcr.io/kubernetes-history-inspector/release:vx.y.z-beta`
 * リリース
   * tagを`vx.y.z` として命名すると、 下記のアドレスとしてデプロイされます。
-    * `asia.gcr.io/kubernetes-history-inspector/release:vx.y.z`
-    * `asia.gcr.io/kubernetes-history-inspector/release:latest`
+    * `gcr.io/kubernetes-history-inspector/release:vx.y.z`
+    * `gcr.io/kubernetes-history-inspector/release:latest`
 
 > [!NOTE]
 > リリースの作成後にデプロイプロセスが開始されます。イメージがリポジトリにプッシュされるまで1時間ほどかかる場合があります。
 
 ### プルリクエストのコードに対するオンデマンドビルドの使用
 
-レポジトリ管理者は、プルしクエストに対して `github-deploy-ondemand` チェックを実行できます。これによりイメージが`asia.gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA`にデプロイされます。
+レポジトリ管理者は、プルリクエストに対して `github-deploy-ondemand` チェックを実行できます。これによりイメージが`gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA`にデプロイされます。
 
 > [!NOTE]
 > このイメージは、最後のチェックのためだけのものです。まず、あなたの環境でコードが正しいことを確認してください。

--- a/docs/ja/setup-guide/oss-kubernetes-clusters.md
+++ b/docs/ja/setup-guide/oss-kubernetes-clusters.md
@@ -305,7 +305,7 @@ Docckerを使用してKHIサーバーを実行します。
 
 ```bash
 # You don't need to pass Google Cloud credentials to the container.
-docker run --rm -p 127.0.0.1:8080:8080 asia.gcr.io/kubernetes-history-inspector/release:latest
+docker run --rm -p 127.0.0.1:8080:8080 gcr.io/kubernetes-history-inspector/release:latest
 ```
 
 サーバーが稼働していることを示す出力が表示されるはずです。


### PR DESCRIPTION
The container image repository has been moved from `asia.gcr.io` to `gcr.io`.

- Update image paths in documentation to point to the new repository.
- Add a warning to README files to notify users of the change.
- Update CI/CD configurations to push images to both the old and new repositories to maintain backward compatibility.