### PR TITLE
docs(readme): add featured session about KubeCon JP 2025

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,8 +7,11 @@
 
 Language: [English](./README.md) | 日本語
 
-<hr/>
+> [!NOTE]
+> 🎉 **KubeCon + CloudNativeCon Japan 2025**でKHIを絡めたKubernetesのダウンタイム調査に関連する発表をしました！
+> KHIによるダウンタイム調査にご興味のある方はぜひご覧ください。[詳細はこちら](#登壇情報)。
 
+<hr/>
 # Kubernetes History Inspector
 
 Kubernetes History Inspector (KHI) は、Kubernetes クラスタのログ可視化ツールです。
@@ -185,3 +188,9 @@ KHIは、Google Cloud サポートチームが開発し、その後オープン�
 ## 免責事項
 
 KHI は Google Cloud の公式製品ではございません。不具合のご報告や機能に関するご要望がございましたら、お手数ですが当リポジトリの[Github issues](https://github.com/GoogleCloudPlatform/khi/issues/new?template=Blank+issue)にご登録ください。可能な範囲で対応させていただきます。
+
+## 登壇情報
+
+本セッションでは、Kubernetesの監査ログからKHIが生成するリソースのdiffを活用し、ダウンタイムの根本原因を効率的に調査する方法を紹介しています。
+
+- **セッション:** [Safeguarding Your Applications: Achieving Zero Downtime During Kubernetes Upgrades](https://kccncjpn2025.sched.com/event/1x71p/safeguarding-your-applications-achieving-zero-downtime-during-kubernetes-upgrades-kazuki-uchima-kakeru-ishii-google-cloud?iframe=no)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 Language: English | [日本語](./README.ja.md)
 
+> [!NOTE]
+> 🎉 Presented at **KubeCon + CloudNativeCon Japan 2025**! Learn how KHI helps investigate Kubernetes cluster downtime. [Check the details](#featured-session).
+
 <hr/>
 
 # Kubernetes History Inspector
@@ -180,3 +183,9 @@ If you'd like to contribute to the project KHI, read [Contribution Guide](/docs/
 ## Disclaimer
 
 Please note that this tool is not an officially supported Google Cloud product. If you find any issues and have a feature request, [file a Github issue on this repository](https://github.com/GoogleCloudPlatform/khi/issues/new?template=Blank+issue) and we are happy to check them on best-effort basis.
+
+## Featured Session
+
+This session demonstrates how to efficiently investigate the root cause of downtime by leveraging the resource diffs that KHI generates from Kubernetes audit logs.
+
+- **Session:** [Safeguarding Your Applications: Achieving Zero Downtime During Kubernetes Upgrades](https://kccncjpn2025.sched.com/event/1x71p/safeguarding-your-applications-achieving-zero-downtime-during-kubernetes-upgrades-kazuki-uchima-kakeru-ishii-google-cloud?iframe=no)


### PR DESCRIPTION
Adds a 'Featured Session' section to both README.md and README.ja.md to highlight the presentation at KubeCon + CloudNativeCon Japan 2025.

This section includes a link to the session and a brief description explaining how KHI can be used to investigate downtime by analyzing resource diffs from audit logs. A callout was also added to the top of the READMEs to draw attention to the presentation.