### PR TITLE
Add generator tool files to generated files deps

### DIFF
--- a/scripts/make/codegen.mk
+++ b/scripts/make/codegen.mk
@@ -1,6 +1,11 @@
 # codegen.mk
 # This file contains make tasks for generating config or source code.
 
+FRONTEND_CODEGEN_DIR = scripts/frontend-codegen
+ENUM_GO_ALL_FILES := $(wildcard pkg/model/enum/*.go)
+ENUM_GO_FILES := $(filter-out %_test.go,$(ENUM_GO_ALL_FILES))
+FRONTEND_CODEGEN_DEPS := $(wildcard $(FRONTEND_CODEGEN_DIR)/*.go $(FRONTEND_CODEGEN_DIR)/templates/*)
+
 # prepare-frontend make task generates source code or configurations needed for building frontend code.
 # This task needs to be set as a dependency of any make tasks using frontend code.
 .PHONY=prepare-frontend
@@ -10,8 +15,8 @@ web/angular.json: scripts/generate-angular-json.sh web/angular-template.json web
 	./scripts/generate-angular-json.sh > ./web/angular.json
 
 # These frontend files are generated from Golang template.
-web/src/app/generated.sass web/src/app/generated.ts: pkg/model/enum/log_type.go pkg/model/enum/parent_relationship.go pkg/model/enum/revision_state.go pkg/model/enum/severity.go pkg/model/enum/verb.go 
-	go run ./scripts/frontend-codegen
+web/src/app/generated.sass web/src/app/generated.ts: $(ENUM_GO_FILES) $(FRONTEND_CODEGEN_DEPS)
+	go run ./$(FRONTEND_CODEGEN_DIR)
 
 # Generate web/src/environments/version.dev.ts and web/src/environments/version.prod.ts
 web/src/environments/version.*.ts: VERSION
@@ -22,5 +27,5 @@ add-licenses:
 	$(GOPATH)/bin/addlicense  -c "Google LLC" -l apache .
 
 .PHONY=generate-reference
-generate-reference: 
+generate-reference:
 	go run ./cmd/reference-generator/


### PR DESCRIPTION
Files under scripts/frontend-codegen were not dependencies of the generated files (sass, ts).

For example, even I edited a file, make doesn't do anything.

```
$ make prepare-frontend
go run ./scripts/frontend-codegen
$ touch scripts/frontend-codegen/templates/generated.sass.gtpl
$ make prepare-frontend
make: Nothing to be done for 'prepare-frontend'.
```

Adding the deps into the targets will kick regenerating the targets.

```
$ make prepare-frontend
make: Nothing to be done for 'prepare-frontend'.
$ touch scripts/frontend-codegen/templates/generated.sass.gtpl
$ make prepare-frontend
go run ./scripts/frontend-codegen
```