### PR TITLE
refactor(common): rename package structurev2 to structured

### DIFF
--- a/pkg/common/structured/govalue.go
+++ b/pkg/common/structured/govalue.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"slices"

--- a/pkg/common/structured/govalue_test.go
+++ b/pkg/common/structured/govalue_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"testing"

--- a/pkg/common/structured/mergeoption.go
+++ b/pkg/common/structured/mergeoption.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"strings"

--- a/pkg/common/structured/merger.go
+++ b/pkg/common/structured/merger.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"fmt"

--- a/pkg/common/structured/merger_test.go
+++ b/pkg/common/structured/merger_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"fmt"

--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"encoding/json"

--- a/pkg/common/structured/reader_test.go
+++ b/pkg/common/structured/reader_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"testing"

--- a/pkg/common/structured/serializer.go
+++ b/pkg/common/structured/serializer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"gopkg.in/yaml.v3"

--- a/pkg/common/structured/serializer_test.go
+++ b/pkg/common/structured/serializer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"testing"

--- a/pkg/common/structured/standard.go
+++ b/pkg/common/structured/standard.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"bytes"

--- a/pkg/common/structured/standard_test.go
+++ b/pkg/common/structured/standard_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"testing"

--- a/pkg/common/structured/structure.go
+++ b/pkg/common/structured/structure.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import "errors"
 

--- a/pkg/common/structured/yaml.go
+++ b/pkg/common/structured/yaml.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"errors"

--- a/pkg/common/structured/yaml_test.go
+++ b/pkg/common/structured/yaml_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structurev2
+package structured
 
 import (
 	"fmt"

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"sync/atomic"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 )
@@ -35,7 +35,7 @@ type FieldSet interface {
 
 type FieldSetReader interface {
 	// Read attempts to read the log fields into its field.
-	Read(reader *structurev2.NodeReader) (FieldSet, error)
+	Read(reader *structured.NodeReader) (FieldSet, error)
 
 	// FieldSetKind identifies the set of fields. It must be same if the result type has same fields.
 	FieldSetKind() string
@@ -44,14 +44,14 @@ type FieldSetReader interface {
 // Log represents a log handled in KHI.
 // It provides direct access to its fields and abstracted cached access via FieldSet interface.
 type Log struct {
-	*structurev2.NodeReader
+	*structured.NodeReader
 	fields  *typedmap.TypedMap
 	ID      string
 	LogType enum.LogType
 }
 
 // NewLog returns a log instance from NodeReader instance.
-func NewLog(reader *structurev2.NodeReader) *Log {
+func NewLog(reader *structured.NodeReader) *Log {
 	return &Log{
 		ID:         strconv.Itoa(int(logInstanceID.Add(1))),
 		NodeReader: reader,
@@ -62,11 +62,11 @@ func NewLog(reader *structurev2.NodeReader) *Log {
 
 // NewLogFromYAMLString instanciate a new Log from the given YAML string.
 func NewLogFromYAMLString(yaml string) (*Log, error) {
-	node, err := structurev2.FromYAML(yaml)
+	node, err := structured.FromYAML(yaml)
 	if err != nil {
 		return nil, err
 	}
-	return NewLog(structurev2.NewNodeReader(node)), nil
+	return NewLog(structured.NewNodeReader(node)), nil
 }
 
 // SetFieldSetReader reads set of fields with the FieldSetReader and keep it in the log.

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -17,7 +17,7 @@ package log
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 
 	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
 )
@@ -42,7 +42,7 @@ func (t *TestFieldSetReader) FieldSetKind() string {
 	return (&TestFieldSet{}).Kind()
 }
 
-func (t *TestFieldSetReader) Read(reader *structurev2.NodeReader) (FieldSet, error) {
+func (t *TestFieldSetReader) Read(reader *structured.NodeReader) (FieldSet, error) {
 	testField, err := reader.ReadString("test_field")
 	if err != nil {
 		return nil, err
@@ -53,11 +53,11 @@ func (t *TestFieldSetReader) Read(reader *structurev2.NodeReader) (FieldSet, err
 }
 
 func TestGetField(t *testing.T) {
-	yamlNode, err := structurev2.FromYAML(`test_field: foo`)
+	yamlNode, err := structured.FromYAML(`test_field: foo`)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	nodeReader := structurev2.NewNodeReader(yamlNode)
+	nodeReader := structured.NewNodeReader(yamlNode)
 
 	l := NewLog(nodeReader)
 	l.SetFieldSetReader(&TestFieldSetReader{})

--- a/pkg/model/history/builder.go
+++ b/pkg/model/history/builder.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/progress"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/binarychunk"
@@ -269,7 +269,7 @@ func (builder *Builder) PrepareParseLogs(ctx context.Context, entireLogs []*log.
 					slog.WarnContext(ctx, fmt.Sprintf("duplicated consumed log %s", logId))
 					continue
 				}
-				yaml, err := l.Serialize("", &structurev2.YAMLNodeSerializer{})
+				yaml, err := l.Serialize("", &structured.YAMLNodeSerializer{})
 				if err != nil {
 					builder.logIdToSerializableLog.ReleaseShard(logId)
 					return err

--- a/pkg/model/history/builder_test.go
+++ b/pkg/model/history/builder_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
@@ -43,7 +43,7 @@ func (t *testCommonFieldSetReader) FieldSetKind() string {
 }
 
 // Read implements log.FieldSetReader.
-func (t *testCommonFieldSetReader) Read(reader *structurev2.NodeReader) (log.FieldSet, error) {
+func (t *testCommonFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	result := &log.CommonFieldSet{}
 	result.DisplayID = reader.ReadStringOrDefault("insertId", "unknown")
 	result.Severity = enum.SeverityUnknown

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/errorreport"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectioncontract "github.com/GoogleCloudPlatform/khi/pkg/inspection/contract"
 	inspection_task_interface "github.com/GoogleCloudPlatform/khi/pkg/inspection/interface"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata/progress"
@@ -151,7 +151,7 @@ func NewParserTaskFromParser(taskId taskid.TaskImplementationID[struct{}], parse
 						logCounterChannel <- struct{}{}
 						if err != nil {
 							var yaml string
-							yamlBytes, err2 := l.Serialize("", &structurev2.YAMLNodeSerializer{})
+							yamlBytes, err2 := l.Serialize("", &structured.YAMLNodeSerializer{})
 							if err2 != nil {
 								yaml = "ERROR!! failed to dump in yaml"
 							} else {

--- a/pkg/source/common/k8s_audit/manifestutil/manifestutil.go
+++ b/pkg/source/common/k8s_audit/manifestutil/manifestutil.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 )
@@ -32,7 +32,7 @@ const (
 )
 
 // ParseDeletionStatus returns the current deletion status and deletion time of this resource.
-func ParseDeletionStatus(ctx context.Context, resourceBodyReader *structurev2.NodeReader, operation *model.KubernetesObjectOperation) DeletionStatus {
+func ParseDeletionStatus(ctx context.Context, resourceBodyReader *structured.NodeReader, operation *model.KubernetesObjectOperation) DeletionStatus {
 	gracefulSeconds := -1
 	var deletionTime *time.Time = nil
 	if resourceBodyReader != nil {
@@ -62,7 +62,7 @@ func ParseDeletionStatus(ctx context.Context, resourceBodyReader *structurev2.No
 }
 
 // ParseCreationTime returns the creation time from the resource body.
-func ParseCreationTime(resourceBodyReader *structurev2.NodeReader, defaultTime time.Time) time.Time {
+func ParseCreationTime(resourceBodyReader *structured.NodeReader, defaultTime time.Time) time.Time {
 	if resourceBodyReader != nil {
 		creationTimestamp, err := getCreationTimeFromManifest(resourceBodyReader)
 		if err != nil {
@@ -73,7 +73,7 @@ func ParseCreationTime(resourceBodyReader *structurev2.NodeReader, defaultTime t
 	return defaultTime
 }
 
-func getCreationTimeFromManifest(resourceBodyReader *structurev2.NodeReader) (time.Time, error) {
+func getCreationTimeFromManifest(resourceBodyReader *structured.NodeReader) (time.Time, error) {
 	creationTimestamp, err := resourceBodyReader.ReadString("metadata.creationTimestamp")
 	if err != nil {
 		return time.Time{}, err

--- a/pkg/source/common/k8s_audit/recorder/containerstatusrecorder/recorder.go
+++ b/pkg/source/common/k8s_audit/recorder/containerstatusrecorder/recorder.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
@@ -48,7 +48,7 @@ func recordChangeSetForLog(ctx context.Context, resourcePath string, l *types.Au
 	commonFieldSet := log.MustGetFieldSet(l.Log, &log.CommonFieldSet{})
 
 	var pod corev1.Pod
-	err := structurev2.ReadReflectK8sRuntimeObject(l.ResourceBodyReader, "", &pod)
+	err := structured.ReadReflectK8sRuntimeObject(l.ResourceBodyReader, "", &pod)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/source/common/k8s_audit/recorder/containerstatusrecorder/recorder_test.go
+++ b/pkg/source/common/k8s_audit/recorder/containerstatusrecorder/recorder_test.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/common/k8s_audit/types"
@@ -224,11 +224,11 @@ allocatedresourcesstatus: []
 				}
 				manifestStr := testutil.MustReadText(tc.manifestPaths[i])
 				rsLog.ResourceBodyYaml = manifestStr
-				node, err := structurev2.FromYAML(manifestStr)
+				node, err := structured.FromYAML(manifestStr)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
-				rsLog.ResourceBodyReader = structurev2.NewNodeReader(node)
+				rsLog.ResourceBodyReader = structured.NewNodeReader(node)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}

--- a/pkg/source/common/k8s_audit/recorder/endpointslicerecorder/recorder.go
+++ b/pkg/source/common/k8s_audit/recorder/endpointslicerecorder/recorder.go
@@ -20,7 +20,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
@@ -65,7 +65,7 @@ func Register(manager *recorder.RecorderTaskManager) error {
 func recordChangeSetForLog(ctx context.Context, l *types.AuditLogParserInput, prevEndpointSlices *model.EndpointSlice, cs *history.ChangeSet, builder *history.Builder) (*model.EndpointSlice, error) {
 	commonFieldSet := log.MustGetFieldSet(l.Log, &log.CommonFieldSet{})
 	var endpointSlice model.EndpointSlice
-	err := structurev2.ReadReflect(l.ResourceBodyReader, "", &endpointSlice)
+	err := structured.ReadReflect(l.ResourceBodyReader, "", &endpointSlice)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/source/common/k8s_audit/recorder/statusrecorder/recorder.go
+++ b/pkg/source/common/k8s_audit/recorder/statusrecorder/recorder.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
@@ -47,7 +47,7 @@ func Register(manager *recorder.RecorderTaskManager) error {
 func recordChangeSetForLog(ctx context.Context, resourcePath string, l *types.AuditLogParserInput, prevStatus *model.K8sResourceContainingStatus, cs *history.ChangeSet, builder *history.Builder) (*model.K8sResourceContainingStatus, error) {
 	commonFieldSet := log.MustGetFieldSet(l.Log, &log.CommonFieldSet{})
 	var resourceContainingStatus model.K8sResourceContainingStatus
-	err := structurev2.ReadReflect(l.ResourceBodyReader, "", &resourceContainingStatus)
+	err := structured.ReadReflect(l.ResourceBodyReader, "", &resourceContainingStatus)
 	if err != nil {
 		return prevStatus, err
 	}

--- a/pkg/source/common/k8s_audit/rtype/rtype.go
+++ b/pkg/source/common/k8s_audit/rtype/rtype.go
@@ -15,7 +15,7 @@
 package rtype
 
 import (
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 )
 
 // rtype.Type indicates the schema of log bodies under request or response.
@@ -36,7 +36,7 @@ var AtTypesOnGCPAuditLog map[string]Type = map[string]Type{
 }
 
 // RtypeFromOSSK8sObject returns the type of resource from given requestObject or responseObject in OSS k8s audit log.
-func RtypeFromOSSK8sObject(bodyReader *structurev2.NodeReader) Type {
+func RtypeFromOSSK8sObject(bodyReader *structured.NodeReader) Type {
 	apiVersion := bodyReader.ReadStringOrDefault("apiVersion", "unknown")
 	kind := bodyReader.ReadStringOrDefault("kind", "unknown")
 	if apiVersion == "meta.k8s.io/v1" && kind == "DeleteOptions" {

--- a/pkg/source/common/k8s_audit/types/type.go
+++ b/pkg/source/common/k8s_audit/types/type.go
@@ -17,7 +17,7 @@ package types
 import (
 	"context"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
 	"github.com/GoogleCloudPlatform/khi/pkg/source/common/k8s_audit/rtype"
@@ -37,13 +37,13 @@ type AuditLogParserInput struct {
 	// Kubernetes operation read from resource name and method name
 	Operation *model.KubernetesObjectOperation
 	// The request field of this log. This can be nil depending on the audit policy.
-	Request     *structurev2.NodeReader
+	Request     *structured.NodeReader
 	RequestType rtype.Type
 	// The response field of this log. This can be nil depending on the audit policy.
-	Response     *structurev2.NodeReader
+	Response     *structured.NodeReader
 	ResponseType rtype.Type
 	// Current resource body changed by this request.
-	ResourceBodyReader *structurev2.NodeReader
+	ResourceBodyReader *structured.NodeReader
 	ResourceBodyYaml   string
 	// The response code from the API server.
 	IsErrorResponse      bool

--- a/pkg/source/gcp/api/gcp_client.go
+++ b/pkg/source/gcp/api/gcp_client.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/httpclient"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/token"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 )
@@ -643,11 +643,11 @@ func (c *GCPClientImpl) ListLogEntries(ctx context.Context, resourceNames []stri
 				return err
 			}
 
-			yamlNode, err := structurev2.FromYAML(string(rawResponse))
+			yamlNode, err := structured.FromYAML(string(rawResponse))
 			if err != nil {
 				return fmt.Errorf("failed to parse a log as YAML. %s", err.Error())
 			}
-			responseYAMLNodeReader := structurev2.NewNodeReader(yamlNode)
+			responseYAMLNodeReader := structured.NewNodeReader(yamlNode)
 			entriesReader, err := responseYAMLNodeReader.GetReader("entries")
 			if err != nil {
 				queryEnd = true

--- a/pkg/source/gcp/log/fieldset.go
+++ b/pkg/source/gcp/log/fieldset.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 
@@ -39,7 +39,7 @@ func (c *GCPCommonFieldSetReader) FieldSetKind() string {
 	return (&log.CommonFieldSet{}).Kind()
 }
 
-func (c *GCPCommonFieldSetReader) Read(reader *structurev2.NodeReader) (log.FieldSet, error) {
+func (c *GCPCommonFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	result := &log.CommonFieldSet{}
 	result.DisplayID = reader.ReadStringOrDefault("insertId", "unknown")
 	result.Timestamp = reader.ReadTimestampOrDefault("timestamp", time.Time{})
@@ -57,7 +57,7 @@ func (g *GCPMainMessageFieldSetReader) FieldSetKind() string {
 	return (&log.MainMessageFieldSet{}).Kind()
 }
 
-func (g *GCPMainMessageFieldSetReader) Read(reader *structurev2.NodeReader) (log.FieldSet, error) {
+func (g *GCPMainMessageFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	result := &log.MainMessageFieldSet{}
 	textPayload, err := reader.ReadString("textPayload")
 	if err == nil {

--- a/pkg/source/gcp/task/gke/autoscaler/parser.go
+++ b/pkg/source/gcp/task/gke/autoscaler/parser.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
@@ -77,7 +77,7 @@ func (p *autoscalerLogParser) Parse(ctx context.Context, l *log.Log, cs *history
 		err := parseDecision(ctx, clusterName, l, cs, builder)
 		if err != nil {
 			var yaml string
-			yamlBytes, err := l.Serialize("", &structurev2.YAMLNodeSerializer{})
+			yamlBytes, err := l.Serialize("", &structured.YAMLNodeSerializer{})
 			if err != nil {
 				yaml = "ERROR!! Failed to dump in YAML"
 			} else {

--- a/pkg/source/gcp/task/gke/autoscaler/types.go
+++ b/pkg/source/gcp/task/gke/autoscaler/types.go
@@ -17,7 +17,7 @@ package autoscaler
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 )
 
 type decision struct {
@@ -163,27 +163,27 @@ func (m mig) Id() string {
 	return fmt.Sprintf("%s/%s/%s", m.Nodepool, m.Zone, m.Name)
 }
 
-func parseDecisionFromReader(decisionReader *structurev2.NodeReader) (*decision, error) {
+func parseDecisionFromReader(decisionReader *structured.NodeReader) (*decision, error) {
 	var result decision
-	err := structurev2.ReadReflect(decisionReader, "", &result)
+	err := structured.ReadReflect(decisionReader, "", &result)
 	if err != nil {
 		return nil, err
 	}
 	return &result, err
 }
 
-func parseNoDecisionFromReader(noDecisionReader *structurev2.NodeReader) (*noDecisionStatus, error) {
+func parseNoDecisionFromReader(noDecisionReader *structured.NodeReader) (*noDecisionStatus, error) {
 	var result noDecisionStatus
-	err := structurev2.ReadReflect(noDecisionReader, "", &result)
+	err := structured.ReadReflect(noDecisionReader, "", &result)
 	if err != nil {
 		return nil, err
 	}
 	return &result, err
 }
 
-func parseResultInfoFromReader(resultInfoReader *structurev2.NodeReader) (*resultInfo, error) {
+func parseResultInfoFromReader(resultInfoReader *structured.NodeReader) (*resultInfo, error) {
 	var result resultInfo
-	err := structurev2.ReadReflect(resultInfoReader, "", &result)
+	err := structured.ReadReflect(resultInfoReader, "", &result)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/source/gcp/task/gke/compute_api/parser.go
+++ b/pkg/source/gcp/task/gke/compute_api/parser.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
@@ -86,7 +86,7 @@ func (*computeAPIParser) Parse(ctx context.Context, l *log.Log, cs *history.Chan
 			state = enum.RevisionStateOperationFinished
 			verb = enum.RevisionVerbOperationFinish
 		}
-		requestBodyRaw, _ := l.Serialize("protoPayload.request", &structurev2.YAMLNodeSerializer{}) // ignore the error to set the empty body when the field is not available in the log.
+		requestBodyRaw, _ := l.Serialize("protoPayload.request", &structured.YAMLNodeSerializer{}) // ignore the error to set the empty body when the field is not available in the log.
 		operationPath := resourcepath.Operation(nodeResourcePath, methodNameSplitted[len(methodNameSplitted)-1], operationId)
 		cs.RecordRevision(operationPath, &history.StagingResourceRevision{
 			Body:       string(requestBodyRaw),

--- a/pkg/source/gcp/task/gke/gke_audit/parser.go
+++ b/pkg/source/gcp/task/gke/gke_audit/parser.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
@@ -85,7 +85,7 @@ func (p *gkeAuditLogParser) Parse(ctx context.Context, l *log.Log, cs *history.C
 		clusterResourcePath := resourcepath.Cluster(clusterName)
 		if shouldRecordResourceRevision {
 			if strings.HasSuffix(methodName, "CreateCluster") {
-				bodyRaw, _ := l.Serialize("protoPayload.request.cluster", &structurev2.YAMLNodeSerializer{}) // Ignore the error and use "" as the body of the cluster setting when the field is not available.
+				bodyRaw, _ := l.Serialize("protoPayload.request.cluster", &structured.YAMLNodeSerializer{}) // Ignore the error and use "" as the body of the cluster setting when the field is not available.
 				state := enum.RevisionStateExisting
 				if isFirst {
 					state = enum.RevisionStateProvisioning
@@ -124,7 +124,7 @@ func (p *gkeAuditLogParser) Parse(ctx context.Context, l *log.Log, cs *history.C
 		nodepoolResourcePath := resourcepath.Nodepool(clusterName, nodepoolName)
 		if shouldRecordResourceRevision {
 			if strings.HasSuffix(methodName, "CreateNodePool") {
-				bodyRaw, _ := l.Serialize("protoPayload.request.nodePool", &structurev2.YAMLNodeSerializer{}) // Ignore the error and use "" as the body of the nodepool setting when the field is not available.
+				bodyRaw, _ := l.Serialize("protoPayload.request.nodePool", &structured.YAMLNodeSerializer{}) // Ignore the error and use "" as the body of the nodepool setting when the field is not available.
 				state := enum.RevisionStateExisting
 				if isFirst {
 					state = enum.RevisionStateProvisioning
@@ -161,7 +161,7 @@ func (p *gkeAuditLogParser) Parse(ctx context.Context, l *log.Log, cs *history.C
 
 	// If this was an operation, it will be recorded as operation data
 	if !(isLast && isFirst) && (isLast || isFirst) && shouldRecordResourceRevision {
-		requestBodyRaw, _ := l.Serialize("protoPayload.request", &structurev2.YAMLNodeSerializer{}) // ignore the error to set the empty body when the field is not available in the log.
+		requestBodyRaw, _ := l.Serialize("protoPayload.request", &structured.YAMLNodeSerializer{}) // ignore the error to set the empty body when the field is not available in the log.
 		state := enum.RevisionStateOperationStarted
 		verb := enum.RevisionVerbOperationStart
 		if isLast {

--- a/pkg/source/gcp/task/gke/k8s_container/parser.go
+++ b/pkg/source/gcp/task/gke/k8s_container/parser.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
@@ -79,7 +79,7 @@ func (*k8sContainerParser) Parse(ctx context.Context, l *log.Log, cs *history.Ch
 	}
 
 	if mainMessage == "" {
-		yamlRaw, err := l.Serialize("", &structurev2.YAMLNodeSerializer{})
+		yamlRaw, err := l.Serialize("", &structured.YAMLNodeSerializer{})
 		if err != nil {
 			slog.WarnContext(ctx, fmt.Sprintf("failed to extract main message from a container log then failed to serialize the log content.\nError message:\n%v", err))
 		} else {

--- a/pkg/source/gcp/task/gke/network_api/parser.go
+++ b/pkg/source/gcp/task/gke/network_api/parser.go
@@ -20,7 +20,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
@@ -105,7 +105,7 @@ func (*gceNetworkParser) Parse(ctx context.Context, l *log.Log, cs *history.Chan
 		method := methodNameSplitted[len(methodNameSplitted)-1]
 		if method == "detachNetworkEndpoints" || method == "attachNetworkEndpoints" {
 			isDetach := strings.HasPrefix(method, "detach")
-			requestBody, err := l.Serialize("protoPayload.request", &structurev2.YAMLNodeSerializer{})
+			requestBody, err := l.Serialize("protoPayload.request", &structured.YAMLNodeSerializer{})
 			if err != nil {
 				return err
 			}

--- a/pkg/source/gcp/task/multicloud_api/parser.go
+++ b/pkg/source/gcp/task/multicloud_api/parser.go
@@ -20,7 +20,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
@@ -84,7 +84,7 @@ func (*multiCloudAuditLogParser) Parse(ctx context.Context, l *log.Log, cs *hist
 		clusterResourcePath := resourcepath.Cluster(resource.ClusterName)
 		if filterMethodNameOperation(methodName, "Create", "Cluster") && isFirst && isSucceedRequest {
 			// Cluster info is stored at protoPayload.request.(aws|azure)Cluster
-			bodyRaw, err := l.Serialize(fmt.Sprintf("protoPayload.request.%sCluster", resource.ClusterType), &structurev2.YAMLNodeSerializer{})
+			bodyRaw, err := l.Serialize(fmt.Sprintf("protoPayload.request.%sCluster", resource.ClusterType), &structured.YAMLNodeSerializer{})
 			if err != nil {
 				slog.WarnContext(ctx, fmt.Sprintf("Failed to get the cluster info from the log\n%v", err))
 			}
@@ -115,7 +115,7 @@ func (*multiCloudAuditLogParser) Parse(ctx context.Context, l *log.Log, cs *hist
 		nodepoolResourcePath := resourcepath.Nodepool(resource.ClusterName, resource.NodepoolName)
 		if filterMethodNameOperation(methodName, "Create", "NodePool") && isFirst && isSucceedRequest {
 			// NodePool info is stored at protoPayload.request.(aws|azure)NodePool
-			bodyRaw, err := l.Serialize(fmt.Sprintf("protoPayload.request.%sNodePool", resource.ClusterType), &structurev2.YAMLNodeSerializer{})
+			bodyRaw, err := l.Serialize(fmt.Sprintf("protoPayload.request.%sNodePool", resource.ClusterType), &structured.YAMLNodeSerializer{})
 			if err != nil {
 				slog.WarnContext(ctx, fmt.Sprintf("Failed to get the nodepool info from the log\n%v", err))
 			}

--- a/pkg/source/gcp/task/onprem_api/parser.go
+++ b/pkg/source/gcp/task/onprem_api/parser.go
@@ -20,7 +20,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
@@ -83,7 +83,7 @@ func (*onpremCloudAuditLogParser) Parse(ctx context.Context, l *log.Log, cs *his
 		clusterResourcePath := resourcepath.Cluster(resource.ClusterName)
 		if filterMethodNameOperation(methodName, "Create", "Cluster") && isFirst && isSucceedRequest {
 			// Cluster info is stored at protoPayload.request.(aws|azure)Cluster
-			bodyRaw, err := l.Serialize(fmt.Sprintf("protoPayload.request.%sCluster", resource.ClusterType), &structurev2.YAMLNodeSerializer{})
+			bodyRaw, err := l.Serialize(fmt.Sprintf("protoPayload.request.%sCluster", resource.ClusterType), &structured.YAMLNodeSerializer{})
 			if err != nil {
 				slog.WarnContext(ctx, fmt.Sprintf("Failed to get the cluster info from the log\n%v", err))
 			}
@@ -98,7 +98,7 @@ func (*onpremCloudAuditLogParser) Parse(ctx context.Context, l *log.Log, cs *his
 		}
 		if filterMethodNameOperation(methodName, "Enroll", "Cluster") && !isFirst && isSucceedRequest {
 			// Cluster info is stored at protoPayload.request.(aws|azure)Cluster
-			bodyRaw, err := l.Serialize("protoPayload.response", &structurev2.YAMLNodeSerializer{})
+			bodyRaw, err := l.Serialize("protoPayload.response", &structured.YAMLNodeSerializer{})
 			if err != nil {
 				slog.WarnContext(ctx, fmt.Sprintf("Failed to get the cluster info from the log\n%v", err))
 			}
@@ -139,7 +139,7 @@ func (*onpremCloudAuditLogParser) Parse(ctx context.Context, l *log.Log, cs *his
 		nodepoolResourcePath := resourcepath.Nodepool(resource.ClusterName, resource.NodepoolName)
 		if filterMethodNameOperation(methodName, "Create", "NodePool") && isFirst && isSucceedRequest {
 			// NodePool info is stored at protoPayload.request.(aws|azure)NodePool
-			bodyRaw, err := l.Serialize("protoPayload.request", &structurev2.YAMLNodeSerializer{})
+			bodyRaw, err := l.Serialize("protoPayload.request", &structured.YAMLNodeSerializer{})
 			if err != nil {
 				slog.WarnContext(ctx, fmt.Sprintf("Failed to get the nodepool info from the log\n%v", err))
 			}

--- a/pkg/source/oss/log/fieldset_reader.go
+++ b/pkg/source/oss/log/fieldset_reader.go
@@ -17,7 +17,7 @@ package log
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 )
@@ -30,7 +30,7 @@ func (o *OSSK8sAuditLogCommonFieldSetReader) FieldSetKind() string {
 }
 
 // Read implements log.FieldSetReader.
-func (o *OSSK8sAuditLogCommonFieldSetReader) Read(reader *structurev2.NodeReader) (log.FieldSet, error) {
+func (o *OSSK8sAuditLogCommonFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	var err error
 	result := &log.CommonFieldSet{}
 	result.DisplayID = reader.ReadStringOrDefault("auditID", "unknown")

--- a/pkg/testutil/testlog/base.go
+++ b/pkg/testutil/testlog/base.go
@@ -17,18 +17,18 @@ package testlog
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 )
 
 // YAML function returns a TestLogOpt generating the structure node with given YAML string.
 func YAML(yamlStr string) TestLogOpt {
-	return func(original structurev2.Node) (structurev2.Node, error) {
+	return func(original structured.Node) (structured.Node, error) {
 		if original != nil {
 			return nil, fmt.Errorf("BaseYaml expects no previous TestLogOpt is given. But an instance of node was given")
 		}
 		if yamlStr == "" {
-			return structurev2.NewEmptyMapNode(), nil
+			return structured.NewEmptyMapNode(), nil
 		}
-		return structurev2.FromYAML(yamlStr)
+		return structured.FromYAML(yamlStr)
 	}
 }

--- a/pkg/testutil/testlog/base_test.go
+++ b/pkg/testutil/testlog/base_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 )
 
 func TestBaseYamlTestLogOpt(t *testing.T) {
@@ -53,7 +53,7 @@ func TestBaseYamlTestLogOpt(t *testing.T) {
 					t.Errorf("Expecting an error but no error returned.")
 				}
 			} else {
-				yamlStr, err := reader.Serialize("", &structurev2.YAMLNodeSerializer{})
+				yamlStr, err := reader.Serialize("", &structured.YAMLNodeSerializer{})
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
 				}

--- a/pkg/testutil/testlog/field.go
+++ b/pkg/testutil/testlog/field.go
@@ -17,23 +17,23 @@ package testlog
 import (
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 )
 
 // StringField returns a TestLogOpt modifying the field at the specified fieldPath to the value.
 // It creates maps in ancestor when it doens't exist.
 func StringField(fieldPath string, value string) TestLogOpt {
-	return func(original structurev2.Node) (structurev2.Node, error) {
+	return func(original structured.Node) (structured.Node, error) {
 		fieldPathInArray := strings.Split(fieldPath, ".")
-		return structurev2.WithScalarField(original, fieldPathInArray, value)
+		return structured.WithScalarField(original, fieldPathInArray, value)
 	}
 }
 
 // IntField returns a TestLogOpt modifying the field at the specified fieldPath to the value.
 // It creates maps in ancestor when it doens't exist.
 func IntField(fieldPath string, value int) TestLogOpt {
-	return func(original structurev2.Node) (structurev2.Node, error) {
+	return func(original structured.Node) (structured.Node, error) {
 		fieldPathInArray := strings.Split(fieldPath, ".")
-		return structurev2.WithScalarField(original, fieldPathInArray, value)
+		return structured.WithScalarField(original, fieldPathInArray, value)
 	}
 }

--- a/pkg/testutil/testlog/field_test.go
+++ b/pkg/testutil/testlog/field_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 )
 
 func TestStringField(t *testing.T) {
@@ -90,7 +90,7 @@ foo:
 				if err != nil {
 					t.Fatal(err.Error())
 				}
-				yamlStr, err := reader.Serialize("", &structurev2.YAMLNodeSerializer{})
+				yamlStr, err := reader.Serialize("", &structured.YAMLNodeSerializer{})
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
 				}

--- a/pkg/testutil/testlog/mock.go
+++ b/pkg/testutil/testlog/mock.go
@@ -15,18 +15,18 @@
 package testlog
 
 import (
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 )
 
 // MustLogFromYAML returns a log.Log instance from given YAML string.
 // This method is for testing only.
 func MustLogFromYAML(text string, fieldReaders ...log.FieldSetReader) *log.Log {
-	yamlNode, err := structurev2.FromYAML(text)
+	yamlNode, err := structured.FromYAML(text)
 	if err != nil {
 		panic(err.Error())
 	}
-	l := log.NewLog(structurev2.NewNodeReader(yamlNode))
+	l := log.NewLog(structured.NewNodeReader(yamlNode))
 	for _, fieldReader := range fieldReaders {
 		err := l.SetFieldSetReader(fieldReader)
 		if err != nil {
@@ -37,7 +37,7 @@ func MustLogFromYAML(text string, fieldReaders ...log.FieldSetReader) *log.Log {
 }
 
 func NewEmptyLogWithID(id string) *log.Log {
-	l := log.NewLog(structurev2.NewNodeReader(structurev2.NewEmptyMapNode()))
+	l := log.NewLog(structured.NewNodeReader(structured.NewEmptyMapNode()))
 	l.ID = id
 	return l
 }

--- a/pkg/testutil/testlog/testlog.go
+++ b/pkg/testutil/testlog/testlog.go
@@ -15,11 +15,11 @@
 package testlog
 
 import (
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structurev2"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
 )
 
-type TestLogOpt = func(original structurev2.Node) (structurev2.Node, error)
+type TestLogOpt = func(original structured.Node) (structured.Node, error)
 
 // TestLog is a type to generate mock log data effectively for test.
 type TestLog struct {
@@ -42,8 +42,8 @@ func (b *TestLog) With(additionalOpts ...TestLogOpt) *TestLog {
 	}
 }
 
-func (b *TestLog) BuildReader() (*structurev2.NodeReader, error) {
-	var node structurev2.Node
+func (b *TestLog) BuildReader() (*structured.NodeReader, error) {
+	var node structured.Node
 	var err error
 	for _, opt := range b.opts {
 		node, err = opt(node)
@@ -51,7 +51,7 @@ func (b *TestLog) BuildReader() (*structurev2.NodeReader, error) {
 			return nil, err
 		}
 	}
-	return structurev2.NewNodeReader(node), nil
+	return structured.NewNodeReader(node), nil
 }
 
 func (b *TestLog) MustBuildYamlString() string {
@@ -59,7 +59,7 @@ func (b *TestLog) MustBuildYamlString() string {
 	if err != nil {
 		panic(err)
 	}
-	serializedRaw, err := reader.Serialize("", &structurev2.YAMLNodeSerializer{})
+	serializedRaw, err := reader.Serialize("", &structured.YAMLNodeSerializer{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
To improve code clarity and better reflect its purpose, the 'structurev2' package has been renamed to 'structured'.

This commit applies the necessary changes to all import paths and usages throughout the 'pkg' directory.

This PR is part of the refactoring proposed in this another PR before.
https://github.com/GoogleCloudPlatform/khi/pull/210