### PR TITLE
docs(gemini): Prohibit using "`" in multiline commands

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -95,7 +95,7 @@
 
     When constructing the string for `printf`, I must pay close attention to shell expansions and escape sequences.
   * **Newlines** must be explicitly written as `\n`.
-  * **Special characters** such as double quotes (`"`) and backticks (``` ` ```) within the message must be properly escaped with a backslash (`\`) to prevent shell misinterpretation.
+  * **Special characters**: Quotes (`"` and `'`) within the message must be properly escaped with a backslash (`\`) to prevent shell misinterpretation. Do not use backticks (`) in the message.
 
     ```bash
     # Example: Using printf with proper escaping


### PR DESCRIPTION
Gemini CLI can't run shell commands including '`'.
This causes the frequent git command fails. Add instruction not to use the back quote in the multiline shell tool call.
