### PR TITLE
refactor(common): introduce IDGenerator interface and implementations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 
 require (
 	github.com/crazy3lf/colorconv v1.2.0
-	github.com/google/uuid v1.6.0
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/api v0.218.0

--- a/pkg/common/idgenerator/fixed_length_id_generator.go
+++ b/pkg/common/idgenerator/fixed_length_id_generator.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idgenerator
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+const (
+	defaultCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
+
+// fixedLengthIDGenerator is a thread-safe ID generator that creates IDs with a fixed length.
+type fixedLengthIDGenerator struct {
+	length  int
+	charset string
+	rng     *rand.Rand
+	mu      sync.Mutex
+}
+
+// NewFixedLengthIDGenerator creates a new FixedLengthIDGenerator.
+func NewFixedLengthIDGenerator(length int) IDGenerator {
+	return &fixedLengthIDGenerator{
+		length:  length,
+		charset: defaultCharset,
+		rng:     rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// Generate returns a new unique ID.
+func (g *fixedLengthIDGenerator) Generate() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	b := make([]byte, g.length)
+	for i := range b {
+		b[i] = g.charset[g.rng.Intn(len(g.charset))]
+	}
+	return string(b)
+}

--- a/pkg/common/idgenerator/fixed_length_id_generator.go
+++ b/pkg/common/idgenerator/fixed_length_id_generator.go
@@ -15,9 +15,7 @@
 package idgenerator
 
 import (
-	"math/rand"
-	"sync"
-	"time"
+	"math/rand/v2"
 )
 
 const (
@@ -28,8 +26,6 @@ const (
 type fixedLengthIDGenerator struct {
 	length  int
 	charset string
-	rng     *rand.Rand
-	mu      sync.Mutex
 }
 
 // NewFixedLengthIDGenerator creates a new FixedLengthIDGenerator.
@@ -37,17 +33,14 @@ func NewFixedLengthIDGenerator(length int) IDGenerator {
 	return &fixedLengthIDGenerator{
 		length:  length,
 		charset: defaultCharset,
-		rng:     rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
 // Generate returns a new unique ID.
 func (g *fixedLengthIDGenerator) Generate() string {
-	g.mu.Lock()
-	defer g.mu.Unlock()
 	b := make([]byte, g.length)
 	for i := range b {
-		b[i] = g.charset[g.rng.Intn(len(g.charset))]
+		b[i] = g.charset[rand.N(len(g.charset))]
 	}
 	return string(b)
 }

--- a/pkg/common/idgenerator/fixed_length_id_generator_test.go
+++ b/pkg/common/idgenerator/fixed_length_id_generator_test.go
@@ -59,6 +59,7 @@ func TestFixedLengthIDGenerator_Generate_Concurrent(t *testing.T) {
 	generatedIDs := make(map[string]bool)
 	var mu sync.Mutex
 
+	// Probability colliding generated IDs are low enough. (3.54*E-27 %) Duplicated IDs indicate problems on its logic.
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
 			defer wg.Done()

--- a/pkg/common/idgenerator/fixed_length_id_generator_test.go
+++ b/pkg/common/idgenerator/fixed_length_id_generator_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idgenerator
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestFixedLengthIDGenerator_Generate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{
+			name:   "Test with length 10",
+			length: 10,
+		},
+		{
+			name:   "Test with length 32",
+			length: 32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewFixedLengthIDGenerator(tt.length)
+			id := g.Generate()
+			if len(id) != tt.length {
+				t.Errorf("Generate() length = %v, want %v", len(id), tt.length)
+			}
+		})
+	}
+}
+
+func TestFixedLengthIDGenerator_Generate_Concurrent(t *testing.T) {
+	t.Parallel()
+	g := NewFixedLengthIDGenerator(16)
+	numGoroutines := 100
+	idsPerGoroutine := 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	generatedIDs := make(map[string]bool)
+	var mu sync.Mutex
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < idsPerGoroutine; j++ {
+				id := g.Generate()
+				mu.Lock()
+				if _, exists := generatedIDs[id]; exists {
+					t.Errorf("Duplicate ID generated: %s", id)
+				}
+				generatedIDs[id] = true
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	expectedNumIDs := numGoroutines * idsPerGoroutine
+	if len(generatedIDs) != expectedNumIDs {
+		t.Errorf("Expected %d unique IDs, but got %d", expectedNumIDs, len(generatedIDs))
+	}
+}

--- a/pkg/common/idgenerator/id_generator.go
+++ b/pkg/common/idgenerator/id_generator.go
@@ -1,0 +1,20 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idgenerator
+
+// IDGenerator generates a unique ID.
+type IDGenerator interface {
+	Generate() string
+}

--- a/pkg/common/idgenerator/idgenerator_test.go
+++ b/pkg/common/idgenerator/idgenerator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package idgenerator
 
-import "github.com/google/uuid"
-
-// NewUUID returns the random UUID in string
-func NewUUID() string {
-	return uuid.Must(uuid.NewUUID()).String()
-}
+import (
+	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
+)

--- a/pkg/common/idgenerator/prefix_id_generator.go
+++ b/pkg/common/idgenerator/prefix_id_generator.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package idgenerator
 
 import (
-	"testing"
-
-	_ "github.com/GoogleCloudPlatform/khi/internal/testflags"
+	"fmt"
+	"sync/atomic"
 )
 
-func TestNewUUID(t *testing.T) {
-	uuid1 := NewUUID()
-	if uuid1 == "" {
-		t.Error("NewUUID returned an empty string")
-	}
+// prefixIDGenerator is a thread-safe ID generator that creates IDs with a prefix.
+type prefixIDGenerator struct {
+	prefix  string
+	counter uint64
+}
 
-	uuid2 := NewUUID()
-	if uuid1 == uuid2 {
-		t.Error("NewUUID returned the same UUID twice")
-	}
+// NewPrefixIDGenerator creates a new PrefixIDGenerator.
+func NewPrefixIDGenerator(prefix string) IDGenerator {
+	return &prefixIDGenerator{prefix: prefix}
+}
+
+// Generate returns a new unique ID.
+func (g *prefixIDGenerator) Generate() string {
+	id := atomic.AddUint64(&g.counter, 1)
+	return fmt.Sprintf("%s%d", g.prefix, id)
 }

--- a/pkg/common/idgenerator/prefix_id_generator_test.go
+++ b/pkg/common/idgenerator/prefix_id_generator_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idgenerator
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestPrefixIDGenerator_Generate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		prefix string
+		want   []string
+	}{
+		{
+			name:   "Test with prefix",
+			prefix: "test-",
+			want:   []string{"test-1", "test-2", "test-3"},
+		},
+		{
+			name:   "Test with empty prefix",
+			prefix: "",
+			want:   []string{"1", "2", "3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewPrefixIDGenerator(tt.prefix)
+			for _, want := range tt.want {
+				if got := g.Generate(); got != want {
+					t.Errorf("Generate() = %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestPrefixIDGenerator_Generate_Concurrent(t *testing.T) {
+	t.Parallel()
+	g := NewPrefixIDGenerator("concurrent-")
+	numGoroutines := 100
+	idsPerGoroutine := 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	generatedIDs := make(map[string]bool)
+	var mu sync.Mutex
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < idsPerGoroutine; j++ {
+				id := g.Generate()
+				mu.Lock()
+				if _, exists := generatedIDs[id]; exists {
+					t.Errorf("Duplicate ID generated: %s", id)
+				}
+				generatedIDs[id] = true
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	expectedNumIDs := numGoroutines * idsPerGoroutine
+	if len(generatedIDs) != expectedNumIDs {
+		t.Errorf("Expected %d unique IDs, but got %d", expectedNumIDs, len(generatedIDs))
+	}
+
+	// Check if all numbers from 1 to expectedNumIDs are present
+	for i := 1; i <= expectedNumIDs; i++ {
+		expectedID := fmt.Sprintf("concurrent-%d", i)
+		if !generatedIDs[expectedID] {
+			t.Errorf("Expected ID %s was not generated", expectedID)
+		}
+	}
+}

--- a/pkg/model/history/builder_test.go
+++ b/pkg/model/history/builder_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/idgenerator"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
 	"github.com/GoogleCloudPlatform/khi/pkg/log"
@@ -308,16 +308,17 @@ func generateBuilderWithTimelines(resourcePaths []string) *Builder {
 
 func TestGetTimelineBuilderThreadSafety(t *testing.T) {
 	builder := NewBuilder("/tmp")
+	idg := idgenerator.NewPrefixIDGenerator("test-")
 	threadCount := 100
 	timelineCountPerThread := 1000000
 	pool := worker.NewPool(threadCount)
 	pool.Run(func() {
 		for i := 0; i < timelineCountPerThread; i++ {
-			uuid1 := common.NewUUID()
-			uuid2 := common.NewUUID()
-			uuid3 := common.NewUUID()
-			uuid4 := common.NewUUID()
-			uuid5 := common.NewUUID()
+			uuid1 := idg.Generate()
+			uuid2 := idg.Generate()
+			uuid3 := idg.Generate()
+			uuid4 := idg.Generate()
+			uuid5 := idg.Generate()
 			builder.GetTimelineBuilder(resourcepath.SubresourceLayerGeneralItem(uuid1[:3], uuid2[:3], uuid3[:3], uuid4[:3], uuid5[:3]).Path)
 		}
 	})

--- a/pkg/model/history/builder_test.go
+++ b/pkg/model/history/builder_test.go
@@ -308,18 +308,22 @@ func generateBuilderWithTimelines(resourcePaths []string) *Builder {
 
 func TestGetTimelineBuilderThreadSafety(t *testing.T) {
 	builder := NewBuilder("/tmp")
-	idg := idgenerator.NewPrefixIDGenerator("test-")
+	apiVersionGenerator := idgenerator.NewPrefixIDGenerator("apiversion-")
+	kindGenerator := idgenerator.NewPrefixIDGenerator("kind-")
+	namespaceGenerator := idgenerator.NewPrefixIDGenerator("namespace-")
+	nameGenerator := idgenerator.NewPrefixIDGenerator("name-")
+	subresourceGenerator := idgenerator.NewPrefixIDGenerator("subresource-")
 	threadCount := 100
-	timelineCountPerThread := 1000000
+	timelineCountPerThread := 100000
 	pool := worker.NewPool(threadCount)
 	pool.Run(func() {
 		for i := 0; i < timelineCountPerThread; i++ {
-			uuid1 := idg.Generate()
-			uuid2 := idg.Generate()
-			uuid3 := idg.Generate()
-			uuid4 := idg.Generate()
-			uuid5 := idg.Generate()
-			builder.GetTimelineBuilder(resourcepath.SubresourceLayerGeneralItem(uuid1[:3], uuid2[:3], uuid3[:3], uuid4[:3], uuid5[:3]).Path)
+			randomAPIVersion := apiVersionGenerator.Generate()
+			randomKind := kindGenerator.Generate()
+			randomNamespace := namespaceGenerator.Generate()
+			randomResourceName := nameGenerator.Generate()
+			randomSubresource := subresourceGenerator.Generate()
+			builder.GetTimelineBuilder(resourcepath.SubresourceLayerGeneralItem(randomAPIVersion, randomKind, randomNamespace, randomResourceName, randomSubresource).Path)
 		}
 	})
 	pool.Wait()

--- a/pkg/popup/types.go
+++ b/pkg/popup/types.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/idgenerator"
 )
+
+var popupIDGenerator = idgenerator.NewPrefixIDGenerator("popup-")
 
 var PopupOptionRedirectTargetKey = "redirectTo"
 
@@ -91,7 +93,7 @@ func NewPopupManager() *PopupManager {
 
 // ShowPopup shows the popup UI on frontend side and wait until receiving the input.
 func (p *PopupManager) ShowPopup(popup PopupForm) (string, error) {
-	id := common.NewUUID()
+	id := popupIDGenerator.Generate()
 	metadata := popup.GetMetadata()
 	p.newPopupLock.Lock()
 	defer p.newPopupLock.Unlock()

--- a/pkg/source/gcp/task/gke/serialport/query_test.go
+++ b/pkg/source/gcp/task/gke/serialport/query_test.go
@@ -16,11 +16,10 @@ package serialport
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/idgenerator"
 	inspection_task_interface "github.com/GoogleCloudPlatform/khi/pkg/inspection/interface"
-
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
@@ -106,9 +105,12 @@ labels."compute.googleapis.com/resource_name":("node-1")`,
 }
 
 func TestMaximumNodeCountNotHittingQueryLengthLimit(t *testing.T) {
+	idg46 := idgenerator.NewFixedLengthIDGenerator(46)
+	idg8 := idgenerator.NewFixedLengthIDGenerator(8)
+	idg4 := idgenerator.NewFixedLengthIDGenerator(4)
 	nodeNames := []string{}
 	for i := 0; i < MaxNodesPerQuery*2+1; i++ { // This query must be splitted with 3 sub groups.
-		nodeNames = append(nodeNames, fmt.Sprintf(`gke-%s-%s-%s`, randomString(46), randomString(8), randomString(4)))
+		nodeNames = append(nodeNames, fmt.Sprintf(`gke-%s-%s-%s`, idg46.Generate(), idg8.Generate(), idg4.Generate()))
 	}
 	query := GenerateSerialPortQuery(inspection_task_interface.TaskModeRun, nodeNames, []string{})
 	if len(query) != 3 {
@@ -152,13 +154,4 @@ func Test_generateNodeNameSubstringLogFilter(t *testing.T) {
 			}
 		})
 	}
-}
-
-func randomString(length int) string {
-	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-	randomid := make([]rune, length)
-	for i := range randomid {
-		randomid[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(randomid)
 }


### PR DESCRIPTION
Introduces a new `IDGenerator` interface in `pkg/common/idgenerator` to standardize ID creation throughout the application. This change replaces multiple disparate, ad-hoc ID generation functions with a unified, extensible, and testable approach.

The following implementations are provided:
- `PrefixIDGenerator`: Creates thread-safe, auto-incrementing IDs with a specified prefix.
- `FixedLengthIDGenerator`: Creates thread-safe, random, fixed-length alphanumeric IDs for testing purposes.

The following areas have been refactored to use the new `IDGenerator`:
- `pkg/popup`: Now uses `PrefixIDGenerator` for popup instance IDs.
- `pkg/inspection`: The `InspectionTaskServer` now uses a `PrefixIDGenerator` to assign unique IDs to new inspection runners. The `InspectionTaskRunner` uses a separate `PrefixIDGenerator` to assign unique IDs to each run.
- `pkg/model/history`: The thread-safety test now uses `PrefixIDGenerator`.
- `pkg/source/gcp/task/gke/serialport`: The query test now uses `FixedLengthIDGenerator` to generate random node names, replacing a local utility function.

This refactoring removes the old `pkg/common/id.go` and consolidates all ID generation logic into the new `pkg/common/idgenerator` package, improving code organization and maintainability.