### PR TITLE
style: fix an issue that prevents inspection from scrolling

### DIFF
--- a/web/src/app/dialogs/new-inspection/new-inspection.component.scss
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.scss
@@ -40,11 +40,8 @@ mat-step {
 }
 
 :host::ng-deep {
-  .mat-horizontal-stepper-wrapper {
-    height: 100%;
-  }
-
-  .mat-horizontal-stepper-content.mat-horizontal-stepper-content-current {
+  .mat-horizontal-stepper-wrapper,
+  .mat-horizontal-stepper-content {
     height: 100%;
   }
 


### PR DESCRIPTION
This was probably unintentionally commited in #202.

@kyasbal This is preventing the new inspection screen from scrolling, then the inspection became not usable.
However, I'm not sure why it was changed, so please take a look at this again.

Thank you!