### PR TITLE
fix(web): Fix the bug on frontend extension registration

### DIFF
--- a/web/src/app/extensions/extension-common/extension.ts
+++ b/web/src/app/extensions/extension-common/extension.ts
@@ -21,15 +21,7 @@ import { URLDataOpenerExtension } from './extension-types/url-data-opener';
 import { LifecycleHookExtension } from './extension-types/lifecycle-hook';
 
 /**
- * The injection token for KHIExtensionBundle
- */
-export const KHI_FRONTEND_EXTENSION_BUNDLE =
-  new InjectionToken<KHIExtensionBundle>('KHI_FRONTEND_EXTENSION_BUNDLE');
-
-/**
  * THe injection token to receive the multi KHI_FRONTEND_EXTENSION_BUNDLE.
- * This is a workaround for https://github.com/angular/angular/issues/51675.
- *
  */
 export const KHI_FRONTEND_EXTENSION_BUNDLES = new InjectionToken<
   KHIExtensionBundle[]
@@ -48,7 +40,7 @@ export class KHIExtensionBundle {
   public static forExtension(init: KHIExtensionInitHandler): Provider {
     return {
       multi: true,
-      provide: KHI_FRONTEND_EXTENSION_BUNDLE,
+      provide: KHI_FRONTEND_EXTENSION_BUNDLES,
       useValue: new KHIExtensionBundle(init),
     };
   }

--- a/web/src/app/root.module.ts
+++ b/web/src/app/root.module.ts
@@ -91,7 +91,7 @@ import {
     BrowserAnimationsModule,
     RouterModule.forRoot(KHIRoutes),
     // Standoalone components
-    environment.pluginModules,
+    ...environment.pluginModules,
   ],
   providers: [
     { provide: EXTENSION_STORE, useValue: new ExtensionStore() },
@@ -186,7 +186,6 @@ export class RootModule {
     const iconRegistry = inject(MatIconRegistry);
     const notificationManager = inject(NotificationManager);
     let extensions = inject(KHI_FRONTEND_EXTENSION_BUNDLES, { optional: true });
-
     extensionStore.injector = injector;
     if (!extensions) extensions = [];
     iconRegistry.setDefaultFontSetClass('material-symbols-outlined');


### PR DESCRIPTION
I was misunderstanding how to use the multi provider with the InjectionToken. Another InjectionToken with the same string parameter is regarded as another injection token.
This PR will fix the bug happened due to unloaded plugins like no node name showing up on Pod timeline.