### PR TITLE
Make metadata package not to depend coretask package

### DIFF
--- a/pkg/inspection/metadata/error/error.go
+++ b/pkg/inspection/metadata/error/error.go
@@ -16,7 +16,6 @@ package error
 
 import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
 )
 
@@ -35,7 +34,7 @@ type ErrorMessageSet struct {
 
 // Labels implements metadata.Metadata.
 func (e *ErrorMessageSet) Labels() *typedmap.ReadonlyTypedMap {
-	return coretask.NewLabelSet(metadata.IncludeInRunResult(), metadata.IncludeInTaskList())
+	return metadata.NewLabelSet(metadata.IncludeInRunResult(), metadata.IncludeInTaskList())
 }
 
 // ToSerializable implements metadata.Metadata.

--- a/pkg/inspection/metadata/form/form.go
+++ b/pkg/inspection/metadata/form/form.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
 	"github.com/GoogleCloudPlatform/khi/pkg/server/upload"
 )
@@ -116,7 +115,7 @@ var _ metadata.Metadata = (*FormFieldSet)(nil)
 
 // Labels implements Metadata.
 func (*FormFieldSet) Labels() *typedmap.ReadonlyTypedMap {
-	return coretask.NewLabelSet(metadata.IncludeInDryRunResult())
+	return metadata.NewLabelSet(metadata.IncludeInDryRunResult())
 }
 
 func (f *FormFieldSet) ToSerializable() interface{} {

--- a/pkg/inspection/metadata/header/header.go
+++ b/pkg/inspection/metadata/header/header.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
 )
 
@@ -40,7 +39,7 @@ var _ metadata.Metadata = (*Header)(nil)
 
 // Labels implements Metadata.
 func (*Header) Labels() *typedmap.ReadonlyTypedMap {
-	return coretask.NewLabelSet(metadata.IncludeInRunResult(), metadata.IncludeInTaskList(), metadata.IncludeInResultBinary())
+	return metadata.NewLabelSet(metadata.IncludeInRunResult(), metadata.IncludeInTaskList(), metadata.IncludeInResultBinary())
 }
 
 func (h *Header) ToSerializable() interface{} {

--- a/pkg/inspection/metadata/label.go
+++ b/pkg/inspection/metadata/label.go
@@ -14,26 +14,24 @@
 
 package metadata
 
-import coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
-
 // TODO: avoid circular dependency and use namespace in the flag name
 var LabelKeyIncludedInRunResultFlag = NewMetadataLabelsKey[bool]("metadata/include-in-run-result")
 var LabelKeyIncludedInDryRunResultFlag = NewMetadataLabelsKey[bool]("metadata/include-in-dry-run-result")
 var LabelKeyIncludedInTaskListFlag = NewMetadataLabelsKey[bool]("metadata/include-in-tasklist")
 var LabelKeyIncludedInResultBinaryFlag = NewMetadataLabelsKey[bool]("metadata/include-in-result-binary")
 
-func IncludeInRunResult() coretask.LabelOpt {
-	return coretask.WithLabelValue(LabelKeyIncludedInRunResultFlag, true)
+func IncludeInRunResult() MetadataLabelOpt {
+	return WithLabelValue(LabelKeyIncludedInRunResultFlag, true)
 }
 
-func IncludeInDryRunResult() coretask.LabelOpt {
-	return coretask.WithLabelValue(LabelKeyIncludedInDryRunResultFlag, true)
+func IncludeInDryRunResult() MetadataLabelOpt {
+	return WithLabelValue(LabelKeyIncludedInDryRunResultFlag, true)
 }
 
-func IncludeInTaskList() coretask.LabelOpt {
-	return coretask.WithLabelValue(LabelKeyIncludedInTaskListFlag, true)
+func IncludeInTaskList() MetadataLabelOpt {
+	return WithLabelValue(LabelKeyIncludedInTaskListFlag, true)
 }
 
-func IncludeInResultBinary() coretask.LabelOpt {
-	return coretask.WithLabelValue(LabelKeyIncludedInResultBinaryFlag, true)
+func IncludeInResultBinary() MetadataLabelOpt {
+	return WithLabelValue(LabelKeyIncludedInResultBinaryFlag, true)
 }

--- a/pkg/inspection/metadata/labelopt.go
+++ b/pkg/inspection/metadata/labelopt.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import "github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+
+type MetadataLabelOpt interface {
+	Write(labels *typedmap.TypedMap)
+}
+
+// Construct the LabelSet with required fields.
+func NewLabelSet(labelOpts ...MetadataLabelOpt) *typedmap.ReadonlyTypedMap {
+	typedMap := typedmap.NewTypedMap()
+	for _, lo := range labelOpts {
+		lo.Write(typedMap)
+	}
+	return typedMap.AsReadonly()
+}
+
+// labelValueOpt stores a label value associating to a label key.
+type labelValueOpt[T any] struct {
+	labelKey MetadataLabelsKey[T]
+	value    T
+}
+
+// Write implements MetadataLabelOpt interface
+func (o *labelValueOpt[T]) Write(labels *typedmap.TypedMap) {
+	typedmap.Set(labels, o.labelKey, o.value)
+}
+
+// WithLabelValue creates a MetadataLabelOpt to store a single value associated to a label key.
+func WithLabelValue[T any](labelKey MetadataLabelsKey[T], value T) MetadataLabelOpt {
+	return &labelValueOpt[T]{
+		labelKey: labelKey,
+		value:    value,
+	}
+}

--- a/pkg/inspection/metadata/logger/logger.go
+++ b/pkg/inspection/metadata/logger/logger.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	inspectioncontract "github.com/GoogleCloudPlatform/khi/pkg/inspection/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/logger"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
@@ -144,7 +143,7 @@ var _ metadata.Metadata = (*Logger)(nil)
 
 // Labels implements metadata.Metadata.
 func (*Logger) Labels() *typedmap.ReadonlyTypedMap {
-	return coretask.NewLabelSet(
+	return metadata.NewLabelSet(
 		metadata.IncludeInRunResult(),
 	)
 }

--- a/pkg/inspection/metadata/plan/plan.go
+++ b/pkg/inspection/metadata/plan/plan.go
@@ -16,7 +16,6 @@ package plan
 
 import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
 )
 
@@ -28,7 +27,7 @@ type InspectionPlan struct {
 
 // Labels implements metadata.Metadata.
 func (*InspectionPlan) Labels() *typedmap.ReadonlyTypedMap {
-	return coretask.NewLabelSet(metadata.IncludeInDryRunResult(), metadata.IncludeInRunResult())
+	return metadata.NewLabelSet(metadata.IncludeInDryRunResult(), metadata.IncludeInRunResult())
 }
 
 // ToSerializable implements metadata.Metadata.

--- a/pkg/inspection/metadata/progress/progress.go
+++ b/pkg/inspection/metadata/progress/progress.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
 )
 
@@ -83,7 +82,7 @@ func NewProgress() *Progress {
 
 // Labels implements Metadata.
 func (*Progress) Labels() *typedmap.ReadonlyTypedMap {
-	return coretask.NewLabelSet(
+	return metadata.NewLabelSet(
 		metadata.IncludeInTaskList(),
 	)
 }

--- a/pkg/inspection/metadata/query/query.go
+++ b/pkg/inspection/metadata/query/query.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/inspection/metadata"
 )
 
@@ -39,7 +38,7 @@ type QueryMetadata struct {
 
 // Labels implements metadata.Metadata.
 func (*QueryMetadata) Labels() *typedmap.ReadonlyTypedMap {
-	return coretask.NewLabelSet(metadata.IncludeInDryRunResult(), metadata.IncludeInRunResult())
+	return metadata.NewLabelSet(metadata.IncludeInDryRunResult(), metadata.IncludeInRunResult())
 }
 
 // ToSerializable implements metadata.Metadata.


### PR DESCRIPTION
Label related operations on metadata types used label related functions designed for task labels. This wasn't intended usage and decoupled these 2 packages