### PR TITLE
Show a snackbar message when VirtualScroller failed to scroll to find the requested scrolling target

### DIFF
--- a/web/src/app/timeline/TimelineScrollStrategy.ts
+++ b/web/src/app/timeline/TimelineScrollStrategy.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_TIMELINE_FILTER,
   TimelineFilter,
 } from '../services/timeline-filter.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 /**
  * Set of properties needed for scrolling behaviors and computed values of TimelineEntry.
@@ -47,6 +48,8 @@ export class TimelinesScrollStrategy {
   private readonly timelineFilter = inject<TimelineFilter>(
     DEFAULT_TIMELINE_FILTER,
   );
+
+  private snackBar = inject(MatSnackBar);
 
   /**
    * Extra margin at the bottom in pixels.
@@ -220,14 +223,23 @@ export class TimelinesScrollStrategy {
       )
       .subscribe(([timeline, timelines, rows, range]) => {
         const index = timelines.indexOf(timeline);
+        if (index === -1) {
+          this.snackBar.open(
+            `Can't navigate to the selected timeline. Did you filtered it out? [path:${timeline.resourcePath}]`,
+            'Close',
+            {
+              duration: 1500,
+            },
+          );
+          return;
+        }
         if (
-          index !== -1 &&
-          (range.start +
+          range.start +
             TimelinesScrollStrategy.VERTICAL_SCROLL_ENABLING_IN_VISIBLE_RANGE_PADDING_INDICES_FROM_EDGE >=
             index ||
-            range.end -
-              TimelinesScrollStrategy.VERTICAL_SCROLL_ENABLING_IN_VISIBLE_RANGE_PADDING_INDICES_FROM_EDGE <=
-              index)
+          range.end -
+            TimelinesScrollStrategy.VERTICAL_SCROLL_ENABLING_IN_VISIBLE_RANGE_PADDING_INDICES_FROM_EDGE <=
+            index
         ) {
           const offset = this.getOffsetForIndex(rows, index);
           this.viewport.scroll({

--- a/web/src/app/timeline/TimelineScrollStrategy.ts
+++ b/web/src/app/timeline/TimelineScrollStrategy.ts
@@ -225,10 +225,10 @@ export class TimelinesScrollStrategy {
         const index = timelines.indexOf(timeline);
         if (index === -1) {
           this.snackBar.open(
-            `Can't navigate to the selected timeline. Did you filtered it out? [path:${timeline.resourcePath}]`,
+            `Can't scroll to the selected log. Maybe filtered out? [path:${timeline.resourcePath}]`,
             'Close',
             {
-              duration: 1500,
+              duration: 2000,
             },
           );
           return;


### PR DESCRIPTION
When user selected a log associates to a resource being filtered out, KHI didn't show any messages to the frontend but won't scroll it to the target timeline. This behavior wasn't intuitive for users.

I added a SnackBar error message in VirtualScrollStrategy as a temporal solution for this.
For long-term, we should think these async parallel UI method return Observable to handle errors on the caller side.