### PR TITLE
fix bug #266: Fixed the grouper to check the manifest type for subresource response & request

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/impl/recorder/commonrecorder/recorder.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/recorder/commonrecorder/recorder.go
@@ -49,7 +49,11 @@ func Register(manager *recorder.RecorderTaskManager) error {
 
 func recordChangeSetForLog(ctx context.Context, resourcePathString string, prevState *commonRecorderStatus, l *commonlogk8saudit_contract.AuditLogParserInput, cs *history.ChangeSet) (*commonRecorderStatus, error) {
 	commonField := log.MustGetFieldSet(l.Log, &log.CommonFieldSet{})
-	resourcePath := resourcepath.FromK8sOperation(*l.Operation)
+	resourcePath := resourcepath.ResourcePath{
+		Path:               resourcePathString,
+		ParentRelationship: enum.RelationshipChild,
+	}
+
 	if l.IsErrorResponse {
 		cs.RecordEvent(resourcePath)
 		cs.RecordLogSeverity(enum.SeverityError)

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/fieldextractor/fieldextractor.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/fieldextractor/fieldextractor.go
@@ -40,12 +40,6 @@ func (g *GCPAuditLogFieldExtractor) ExtractFields(ctx context.Context, l *log.Lo
 	userEmail := l.ReadStringOrDefault("protoPayload.authenticationInfo.principalEmail", "")
 
 	operation := parseKubernetesOperation(resourceName, methodName)
-	// /status subresource contains the actual content of the parent.
-	// It's easier to see timeline merged with the parent timeline instead of showing status as the single subresource timeline.
-	// TODO: There would be the other subresources needed to be cared like this.
-	if operation.SubResourceName == "status" {
-		operation.SubResourceName = ""
-	}
 
 	responseErrorCode := l.ReadIntOrDefault("protoPayload.status.code", 0)
 	responseErrorMessage := l.ReadStringOrDefault("protoPayload.status.message", "")

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/fieldextractor/k8s.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/fieldextractor/k8s.go
@@ -32,7 +32,7 @@ func parseKubernetesOperation(resourceName string, methodName string) *model.Kub
 	switch {
 	case methodNameFragments[4] == "namespaces":
 		// Branch for namespace resource
-		namespace = "Cluster-Scope"
+		namespace = "cluster-scope"
 		name = resourceNameFragments[3]
 		pluralKind = "namespaces"
 		if len(resourceNameFragments) > 4 {
@@ -48,7 +48,7 @@ func parseKubernetesOperation(resourceName string, methodName string) *model.Kub
 			subResourceName = resourceNameFragments[6]
 		}
 	case len(resourceNameFragments) >= 3:
-		namespace = "Cluster-Scope"
+		namespace = "cluster-scope"
 		if len(resourceNameFragments) > 3 {
 			name = resourceNameFragments[3]
 		}

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/fieldextractor/k8s_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/fieldextractor/k8s_test.go
@@ -46,7 +46,7 @@ func TestParseKubernetesOperation(t *testing.T) {
 			MethodName:   "io.k8s.core.v1.nodes.delete",
 			ExpectedK8sOp: &model.KubernetesObjectOperation{
 				APIVersion:      "io.k8s.core/v1",
-				Namespace:       "Cluster-Scope",
+				Namespace:       "cluster-scope",
 				Name:            "foo",
 				PluralKind:      "nodes",
 				SubResourceName: "",
@@ -69,7 +69,7 @@ func TestParseKubernetesOperation(t *testing.T) {
 			MethodName:   "io.k8s.core.v1.namespaces.finalize.update",
 			ExpectedK8sOp: &model.KubernetesObjectOperation{
 				APIVersion:      "core/v1",
-				Namespace:       "Cluster-Scope",
+				Namespace:       "cluster-scope",
 				Name:            "001-jobs",
 				PluralKind:      "namespaces",
 				SubResourceName: "finalize",
@@ -81,7 +81,7 @@ func TestParseKubernetesOperation(t *testing.T) {
 			MethodName:   "io.k8s.core.v1.namespaces.create",
 			ExpectedK8sOp: &model.KubernetesObjectOperation{
 				APIVersion:      "core/v1",
-				Namespace:       "Cluster-Scope",
+				Namespace:       "cluster-scope",
 				Name:            "001-jobs",
 				PluralKind:      "namespaces",
 				SubResourceName: "",

--- a/pkg/task/inspection/ossclusterk8s/impl/extractor.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/extractor.go
@@ -36,9 +36,6 @@ func (g *OSSJSONLAuditLogFieldExtractor) ExtractFields(ctx context.Context, l *l
 	subresource := l.ReadStringOrDefault("objectRef.subresource", "")
 	verb := l.ReadStringOrDefault("verb", "")
 
-	if subresource == "status" {
-		subresource = "" // status subresource response should contain the full body data of its parent
-	}
 	if name == "unknown" && verb == "create" {
 		// the name may be generated from the server side.
 		name = l.ReadStringOrDefault("responseObject.metadata.name", "unknown")


### PR DESCRIPTION
Modified resource timeline is not simply determined from the method name or resource name in the log. A patch against a subresource may contain its parent manifest in its response.

With this change, KHI will display operations against subresource correctly even its response or request contains its parent resource body.

<img width="6694" height="3438" alt="Screenshot 2025-09-08 at 14 52 49" src="https://github.com/user-attachments/assets/d20e5ee9-7ed6-46ba-9ef1-3c05ccdf54ce" />

Left: (Previous version) and Right: (after this change)
(Operations against`finalize` subresource returns its parent(Namespace) as its response body. The record should be directly written on the parent resource and it must not populate a new sub resource.)
 