### PR TITLE
Show ephemeralContainerStatus on the container subresource timeline under Pods

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/impl/recorder/containerstatusrecorder/recorder.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/recorder/containerstatusrecorder/recorder.go
@@ -67,6 +67,7 @@ func recordChangeSetForLog(ctx context.Context, resourcePath string, l *commonlo
 	statuses := []corev1.ContainerStatus{}
 	statuses = append(statuses, pod.Status.ContainerStatuses...)
 	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	statuses = append(statuses, pod.Status.EphemeralContainerStatuses...)
 	for i, status := range statuses {
 		statusYaml, err := yaml.Marshal(status)
 		if err != nil {


### PR DESCRIPTION
Added epehemral containers to be shown on the timeline!

<img width="6720" height="3488" alt="image" src="https://github.com/user-attachments/assets/5bd0be59-49d1-4c46-9d52-755d36374f3d" />


(The ephemeral container used in `kubectl debug` sounds new but it surprisingly has been added from 1.16. 😮 )