### PR TITLE
fix bug #267:  manifest generator to be aware of uid change

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/contract/auditlogparserinput.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/auditlogparserinput.go
@@ -44,6 +44,9 @@ type AuditLogParserInput struct {
 	// Current resource body changed by this request.
 	ResourceBodyReader *structured.NodeReader
 	ResourceBodyYaml   string
+
+	// ResourceUID is the `metadata.uid` of the resource.
+	ResourceUID string
 	// The response code from the API server.
 	IsErrorResponse      bool
 	ResponseErrorCode    int

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifestgenerate_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifestgenerate_task.go
@@ -65,8 +65,8 @@ var ManifestGenerateTask = inspectiontaskbase.NewProgressReportableInspectionTas
 	for _, group := range groups {
 		currentGroup := group
 		workerPool.Run(func() {
-			prevRevisionBody := ""
-			prevResourceUID := "unknown"
+			var prevRevisionBody string
+			var prevResourceUID string
 			prevRevisionReader := structured.NewNodeReader(structured.NewEmptyMapNode())
 			for _, log := range currentGroup.PreParsedLogs {
 				var currentRevisionBodyType commonlogk8saudit_contract.RequestResponseType

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifestgenerate_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifestgenerate_task.go
@@ -66,12 +66,14 @@ var ManifestGenerateTask = inspectiontaskbase.NewProgressReportableInspectionTas
 		currentGroup := group
 		workerPool.Run(func() {
 			prevRevisionBody := ""
+			prevResourceUID := "unknown"
 			prevRevisionReader := structured.NewNodeReader(structured.NewEmptyMapNode())
 			for _, log := range currentGroup.PreParsedLogs {
 				var currentRevisionBodyType commonlogk8saudit_contract.RequestResponseType
 				if log.IsErrorResponse || log.GeneratedFromDeleteCollectionOperation {
 					log.ResourceBodyYaml = prevRevisionBody
 					log.ResourceBodyReader = prevRevisionReader
+					log.ResourceUID = prevResourceUID
 					processedCount.Add(1)
 					continue
 				}
@@ -85,9 +87,21 @@ var ManifestGenerateTask = inspectiontaskbase.NewProgressReportableInspectionTas
 				// Manifest is unknown because it doesn't contain request or response in the body.
 				if currentRevisionReader == nil {
 					log.ResourceBodyYaml = bodyPlaceholderForMetadataLevelAuditLog
+					log.ResourceUID = prevResourceUID
 					processedCount.Add(1)
 					continue
+				} else {
+					uid, err := currentRevisionReader.ReadString("metadata.uid")
+					if err == nil {
+						// uid is different from the past. The resource must be newly created.
+						if uid != prevResourceUID {
+							prevRevisionBody = ""
+							prevRevisionReader = structured.NewNodeReader(structured.NewEmptyMapNode())
+							prevResourceUID = uid
+						}
+					}
 				}
+				log.ResourceUID = prevResourceUID
 
 				isPartial := currentRevisionBodyType == commonlogk8saudit_contract.RTypePatch
 				currentRevisionBodyRaw, err := currentRevisionReader.Serialize("", &structured.YAMLNodeSerializer{})


### PR DESCRIPTION
<img width="6720" height="2120" alt="Screenshot 2025-09-12 at 15 00 22" src="https://github.com/user-attachments/assets/4f35356e-1039-4e9e-b7ab-0b7c59663608" />

* Left: wrong old timeline. There are several red(deleted) revisions during deleting period.
* Right: fixed.

---

This change added logic to be aware of `metadata.uid`. When there is a deleteCollection request in a middle of PATCH and an actual DELETE, the previous implementation couldn't merge the resource manifest well because the delete collection request audit log doesn't have its resource body. This change reads the UID field of metadata from logs with resource body and it resets the previous resource manifest status when the uid is changed.

This will be marked as ready after #268 and #271 is reviewed and merged.