### PR TITLE
Changed processing order in commonlogk8saudit recorder tasks

### DIFF
--- a/pkg/model/history/resourcepath/type.go
+++ b/pkg/model/history/resourcepath/type.go
@@ -14,7 +14,11 @@
 
 package resourcepath
 
-import "github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+import (
+	"strings"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+)
 
 // ResourcePath contains the path representing location of a timeline in the history.
 type ResourcePath struct {
@@ -25,4 +29,13 @@ type ResourcePath struct {
 	// ParentRelationship explains between the location represented with this ResourcePath and its parent.
 	// KHI shows various resources in a single history with mixing many types of children. It's not only like child-parent relationship, but also pseudo relationship like node-node's component relationship.
 	ParentRelationship enum.ParentRelationship
+}
+
+// GetParentPathString returns the string representation of the parent path.
+func (p *ResourcePath) GetParentPathString() string {
+	parts := strings.Split(p.Path, "#")
+	if len(parts) <= 1 {
+		return ""
+	}
+	return strings.Join(parts[:len(parts)-1], "#")
 }

--- a/pkg/model/history/resourcepath/type_test.go
+++ b/pkg/model/history/resourcepath/type_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcepath
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+)
+
+func TestResourcePath_GetParentPathString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		path     ResourcePath
+		expected string
+	}{
+		{
+			name: "path with multiple parts",
+			path: ResourcePath{
+				Path:               "A#B#C",
+				ParentRelationship: enum.RelationshipChild,
+			},
+			expected: "A#B",
+		},
+		{
+			name: "path with single part",
+			path: ResourcePath{
+				Path:               "A",
+				ParentRelationship: enum.RelationshipChild,
+			},
+			expected: "",
+		},
+		{
+			name: "empty path",
+			path: ResourcePath{
+				Path:               "",
+				ParentRelationship: enum.RelationshipChild,
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.path.GetParentPathString()
+			if actual != tc.expected {
+				t.Errorf("unexpected parent path: got %q, want %q", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifestgenerate_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifestgenerate_task.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -136,6 +137,11 @@ var ManifestGenerateTask = inspectiontaskbase.NewProgressReportableInspectionTas
 		})
 	}
 	workerPool.Wait()
+
+	slices.SortFunc(groups, func(a, b *commonlogk8saudit_contract.TimelineGrouperResult) int {
+		return strings.Compare(a.TimelineResourcePath, b.TimelineResourcePath)
+	})
+
 	return groups, nil
 })
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/recorder/task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/recorder/task.go
@@ -17,11 +17,12 @@ package recorder
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/progressutil"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
@@ -34,12 +35,38 @@ import (
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 )
 
+// LogGroupFilterFunc defines a function signature for filtering log groups based on their resource path.
 type LogGroupFilterFunc = func(ctx context.Context, resourcePath string) bool
 
+// LogFilterFunc defines a function signature for filtering individual audit logs.
 type LogFilterFunc = func(ctx context.Context, l *commonlogk8saudit_contract.AuditLogParserInput) bool
 
 // RecorderFunc records events/revisions...etc on the given ChangeSet. If it returns an error, then the result is ignored.
 type RecorderFunc = func(ctx context.Context, resourcePath string, currentLog *commonlogk8saudit_contract.AuditLogParserInput, prevStateInGroup any, cs *history.ChangeSet, builder *history.Builder) (any, error)
+
+// hierarcicalTimelineGroupWorker represents a node in a hierarchical tree structure of timeline groups.
+// It is used to organize and process timeline groups based on their resource paths to process them from ancestor to children.
+type hierarcicalTimelineGroupWorker struct {
+	children map[string]*hierarcicalTimelineGroupWorker
+	group    *commonlogk8saudit_contract.TimelineGrouperResult
+}
+
+// Run traverses the hierarchical timeline group structure and executes a given function `f`
+// for each `TimelineGrouperResult` found. It uses a worker pool to process groups concurrently.
+func (h *hierarcicalTimelineGroupWorker) Run(ctx context.Context, f func(group *commonlogk8saudit_contract.TimelineGrouperResult)) {
+	if h.group != nil {
+		f(h.group)
+	}
+	wg := sync.WaitGroup{}
+	for _, child := range h.children {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			child.Run(ctx, f)
+		}()
+	}
+	wg.Wait()
+}
 
 // RecorderTaskManager provides the way of extending resource specific
 type RecorderTaskManager struct {
@@ -56,6 +83,8 @@ func NewAuditRecorderTaskManager(taskID taskid.TaskImplementationID[struct{}], r
 	}
 }
 
+// AddRecorder adds a new recorder task to the manager.
+// Each recorder task processes grouped audit logs and applies custom recording logic.
 func (r *RecorderTaskManager) AddRecorder(name string, dependencies []taskid.UntypedTaskReference, recorder RecorderFunc, logGroupFilter LogGroupFilterFunc, logFilter LogFilterFunc) {
 	dependenciesBase := []taskid.UntypedTaskReference{
 		commonlogk8saudit_contract.LogConvertTaskID.Ref(),
@@ -77,37 +106,36 @@ func (r *RecorderTaskManager) AddRecorder(name string, dependencies []taskid.Unt
 		})
 		updator.Start(ctx)
 		defer updator.Done()
-		workerPool := worker.NewPool(16)
-		for _, loopGroup := range filteredLogs {
-			group := loopGroup
+
+		hierarchicalGroupedLogs := convertTimelineGroupListToHierarcicalTimelineGroup(filteredLogs)
+
+		hierarchicalGroupedLogs.Run(ctx, func(group *commonlogk8saudit_contract.TimelineGrouperResult) {
 			var prevState any = nil
-			workerPool.Run(func() {
-				for _, l := range group.PreParsedLogs {
-					if !logFilter(ctx, l) {
-						processedLogCount.Add(1)
-						continue
-					}
-					cs := history.NewChangeSet(l.Log)
-					currentState, err := recorder(ctx, group.TimelineResourcePath, l, prevState, cs, builder)
-					if err != nil {
-						processedLogCount.Add(1)
-						continue
-					}
-					prevState = currentState
-					cp, err := cs.FlushToHistory(builder)
-					if err != nil {
-						processedLogCount.Add(1)
-						continue
-					}
-					for _, path := range cp {
-						tb := builder.GetTimelineBuilder(path)
-						tb.Sort()
-					}
+			for _, l := range group.PreParsedLogs {
+				if !logFilter(ctx, l) {
 					processedLogCount.Add(1)
+					continue
 				}
-			})
-		}
-		workerPool.Wait()
+				cs := history.NewChangeSet(l.Log)
+				currentState, err := recorder(ctx, group.TimelineResourcePath, l, prevState, cs, builder)
+				if err != nil {
+					processedLogCount.Add(1)
+					continue
+				}
+				prevState = currentState
+				cp, err := cs.FlushToHistory(builder)
+				if err != nil {
+					processedLogCount.Add(1)
+					continue
+				}
+				for _, path := range cp {
+					tb := builder.GetTimelineBuilder(path)
+					tb.Sort()
+				}
+				processedLogCount.Add(1)
+			}
+		})
+
 		return struct{}{}, nil
 	})
 	r.recorderTasks = append(r.recorderTasks, newTask)
@@ -144,4 +172,31 @@ func filterMatchedGroupedLogs(ctx context.Context, logGroups []*commonlogk8saudi
 		}
 	}
 	return result, totalLogCount
+}
+
+// convertTimelineGroupListToHierarcicalTimelineGroup converts a flat list of `TimelineGrouperResult`
+// into a hierarchical tree structure represented by `hierarcicalTimelineGroupWorker`.
+// logGroup must be sorted by its path because this assume parent must appear before its children.
+func convertTimelineGroupListToHierarcicalTimelineGroup(logGroup []*commonlogk8saudit_contract.TimelineGrouperResult) *hierarcicalTimelineGroupWorker {
+	root := &hierarcicalTimelineGroupWorker{
+		children: map[string]*hierarcicalTimelineGroupWorker{},
+		group:    nil,
+	}
+	for _, group := range logGroup {
+		current := root
+		segments := strings.Split(group.TimelineResourcePath, "#")
+		for i, segment := range segments {
+			if _, ok := current.children[segment]; !ok {
+				current.children[segment] = &hierarcicalTimelineGroupWorker{
+					children: map[string]*hierarcicalTimelineGroupWorker{},
+					group:    nil,
+				}
+			}
+			current = current.children[segment]
+			if i == len(segments)-1 {
+				current.group = group
+			}
+		}
+	}
+	return root
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/recorder/task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/recorder/task_test.go
@@ -1,0 +1,223 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recorder
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConvertTimelineGroupListToHierarcicalTimelineGroup(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []*commonlogk8saudit_contract.TimelineGrouperResult
+		want  *hierarcicalTimelineGroupWorker
+	}{
+		{
+			name:  "empty",
+			input: []*commonlogk8saudit_contract.TimelineGrouperResult{},
+			want: &hierarcicalTimelineGroupWorker{
+				children: map[string]*hierarcicalTimelineGroupWorker{},
+				group:    nil,
+			},
+		},
+		{
+			name: "flat",
+			input: []*commonlogk8saudit_contract.TimelineGrouperResult{
+				{TimelineResourcePath: "a"},
+				{TimelineResourcePath: "b"},
+			},
+			want: &hierarcicalTimelineGroupWorker{
+				children: map[string]*hierarcicalTimelineGroupWorker{
+					"a": {
+						children: map[string]*hierarcicalTimelineGroupWorker{},
+						group:    &commonlogk8saudit_contract.TimelineGrouperResult{TimelineResourcePath: "a"},
+					},
+					"b": {
+						children: map[string]*hierarcicalTimelineGroupWorker{},
+						group:    &commonlogk8saudit_contract.TimelineGrouperResult{TimelineResourcePath: "b"},
+					},
+				},
+			},
+		},
+		{
+			name: "three levels",
+			input: []*commonlogk8saudit_contract.TimelineGrouperResult{
+				{TimelineResourcePath: "a"},
+				{TimelineResourcePath: "a#b"},
+				{TimelineResourcePath: "a#b#c"},
+			},
+			want: &hierarcicalTimelineGroupWorker{
+				children: map[string]*hierarcicalTimelineGroupWorker{
+					"a": {
+						children: map[string]*hierarcicalTimelineGroupWorker{
+							"b": {
+								children: map[string]*hierarcicalTimelineGroupWorker{
+									"c": {
+										children: map[string]*hierarcicalTimelineGroupWorker{},
+										group:    &commonlogk8saudit_contract.TimelineGrouperResult{TimelineResourcePath: "a#b#c"},
+									},
+								},
+								group: &commonlogk8saudit_contract.TimelineGrouperResult{TimelineResourcePath: "a#b"},
+							},
+						},
+						group: &commonlogk8saudit_contract.TimelineGrouperResult{TimelineResourcePath: "a"},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple children",
+			input: []*commonlogk8saudit_contract.TimelineGrouperResult{
+				{TimelineResourcePath: "a"},
+				{TimelineResourcePath: "a#b"},
+				{TimelineResourcePath: "a#c"},
+			},
+			want: &hierarcicalTimelineGroupWorker{
+				children: map[string]*hierarcicalTimelineGroupWorker{
+					"a": {
+						children: map[string]*hierarcicalTimelineGroupWorker{
+							"b": {
+								children: map[string]*hierarcicalTimelineGroupWorker{},
+								group:    &commonlogk8saudit_contract.TimelineGrouperResult{TimelineResourcePath: "a#b"},
+							},
+							"c": {
+								children: map[string]*hierarcicalTimelineGroupWorker{},
+								group:    &commonlogk8saudit_contract.TimelineGrouperResult{TimelineResourcePath: "a#c"},
+							},
+						},
+						group: &commonlogk8saudit_contract.TimelineGrouperResult{TimelineResourcePath: "a"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertTimelineGroupListToHierarcicalTimelineGroup(tt.input)
+			opts := []cmp.Option{
+				cmp.AllowUnexported(hierarcicalTimelineGroupWorker{}),
+			}
+			if diff := cmp.Diff(tt.want, got, opts...); diff != "" {
+				t.Errorf("convertTimelineGroupListToHierarcicalTimelineGroup() mismatch (-want +got): \n %s", diff)
+			}
+		})
+	}
+}
+
+func TestHierarcicalTimelineGroupWorker_Run(t *testing.T) {
+	// callRecord is a type to memory call timing for each group paths. This is used for verifying if its parent is called before its children.
+	type callRecord struct {
+		path      string
+		timestamp time.Time
+	}
+	tests := []struct {
+		name          string
+		inputGroups   []*commonlogk8saudit_contract.TimelineGrouperResult
+		expectedPaths []string
+	}{
+		{
+			name:          "empty tree",
+			inputGroups:   []*commonlogk8saudit_contract.TimelineGrouperResult{},
+			expectedPaths: []string{},
+		},
+		{
+			name: "flat tree",
+			inputGroups: []*commonlogk8saudit_contract.TimelineGrouperResult{
+				{TimelineResourcePath: "a"},
+				{TimelineResourcePath: "b"},
+			},
+			expectedPaths: []string{"a", "b"},
+		},
+		{
+			name: "hierarchical tree",
+			inputGroups: []*commonlogk8saudit_contract.TimelineGrouperResult{
+				{TimelineResourcePath: "a"},
+				{TimelineResourcePath: "a#b"},
+				{TimelineResourcePath: "a#b#c"},
+				{TimelineResourcePath: "d"},
+			},
+			expectedPaths: []string{"a", "a#b", "a#b#c", "d"},
+		},
+		{
+			name: "hierarchical tree with intermediate node without group",
+			inputGroups: []*commonlogk8saudit_contract.TimelineGrouperResult{
+				// "a" is an intermediate node without a group
+				{TimelineResourcePath: "a#b"},
+				{TimelineResourcePath: "c"},
+			},
+			expectedPaths: []string{"a#b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := convertTimelineGroupListToHierarcicalTimelineGroup(tt.inputGroups)
+
+			ctx := context.Background()
+
+			var records []callRecord
+			var mu sync.Mutex
+
+			f := func(group *commonlogk8saudit_contract.TimelineGrouperResult) {
+				time.Sleep(1 * time.Millisecond)
+				mu.Lock()
+				defer mu.Unlock()
+				records = append(records, callRecord{
+					path:      group.TimelineResourcePath,
+					timestamp: time.Now(),
+				})
+			}
+
+			root.Run(ctx, f)
+
+			// Verification1: if all groups are processed.
+			processedPaths := make([]string, len(records))
+			for i, r := range records {
+				processedPaths[i] = r.path
+			}
+			sort.Strings(processedPaths)
+			sort.Strings(tt.expectedPaths)
+			if diff := cmp.Diff(tt.expectedPaths, processedPaths); diff != "" {
+				t.Errorf("Run() processed paths mismatch (-want +got):\n%s", diff)
+			}
+
+			// Verification2: if parent element is processed before its children
+			recordMap := make(map[string]time.Time)
+			for _, r := range records {
+				recordMap[r.path] = r.timestamp
+			}
+
+			for path, ts := range recordMap {
+				if i := strings.LastIndex(path, "#"); i != -1 {
+					parentPath := path[:i]
+					if parentTs, ok := recordMap[parentPath]; ok {
+						if parentTs.After(ts) {
+							t.Errorf("parent %q (%v) was processed after child %q (%v)", parentPath, parentTs, path, ts)
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change enforce the recorder tasks to process parent timelines before its children. This change is nccessary for fixing bug #274 in following commit.

There are no change on its outcome expected with this change because current log parsers don't expect the other timelines processed before the timeline. It only expect log processing order within a timeline. With this change, subreosurce timeline can read its parent deletion revision on processing to show them as deleted revision.

---

This PR is against the feature branch `fix/issues-274`.