### PR TITLE
Rename inspectiontaskbase.PreviousTaskResult to CachableTaskResult

### DIFF
--- a/pkg/core/inspection/taskbase/cached_task.go
+++ b/pkg/core/inspection/taskbase/cached_task.go
@@ -25,8 +25,8 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-// PreviousTaskResult is the combination of the cached value and a digest of its dependency.
-type PreviousTaskResult[T any] struct {
+// CachableTaskResult is the combination of the cached value and a digest of its dependency.
+type CachableTaskResult[T any] struct {
 	// Value is the value used previous run.
 	Value T
 	// DependencyDigest is a string representation of digest of its inputs.
@@ -35,11 +35,11 @@ type PreviousTaskResult[T any] struct {
 }
 
 // NewCachedTask generates a task which can reuse the value last time.
-func NewCachedTask[T any](taskID taskid.TaskImplementationID[T], depdendencies []taskid.UntypedTaskReference, f func(ctx context.Context, prevValue PreviousTaskResult[T]) (PreviousTaskResult[T], error), labelOpt ...coretask.LabelOpt) coretask.Task[T] {
+func NewCachedTask[T any](taskID taskid.TaskImplementationID[T], depdendencies []taskid.UntypedTaskReference, f func(ctx context.Context, prevValue CachableTaskResult[T]) (CachableTaskResult[T], error), labelOpt ...coretask.LabelOpt) coretask.Task[T] {
 	return coretask.NewTask(taskID, depdendencies, func(ctx context.Context) (T, error) {
 		inspectionSharedMap := khictx.MustGetValue(ctx, inspectioncore_contract.GlobalSharedMap)
-		cacheKey := typedmap.NewTypedKey[PreviousTaskResult[T]](fmt.Sprintf("cached_result-%s", taskID.String()))
-		cachedResult := typedmap.GetOrDefault(inspectionSharedMap, cacheKey, PreviousTaskResult[T]{
+		cacheKey := typedmap.NewTypedKey[CachableTaskResult[T]](fmt.Sprintf("cached_result-%s", taskID.String()))
+		cachedResult := typedmap.GetOrDefault(inspectionSharedMap, cacheKey, CachableTaskResult[T]{
 			Value:            *new(T),
 			DependencyDigest: "",
 		})

--- a/pkg/core/inspection/taskbase/cached_task_test.go
+++ b/pkg/core/inspection/taskbase/cached_task_test.go
@@ -25,11 +25,11 @@ import (
 )
 
 func TestCachedTask(t *testing.T) {
-	prevValues := []PreviousTaskResult[string]{}
+	prevValues := []CachableTaskResult[string]{}
 	testTaskID := taskid.NewDefaultImplementationID[string]("foo")
-	task := NewCachedTask(testTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context, prevValue PreviousTaskResult[string]) (PreviousTaskResult[string], error) {
+	task := NewCachedTask(testTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context, prevValue CachableTaskResult[string]) (CachableTaskResult[string], error) {
 		prevValues = append(prevValues, prevValue)
-		return PreviousTaskResult[string]{
+		return CachableTaskResult[string]{
 			Value:            "foo",
 			DependencyDigest: "foo",
 		}, nil
@@ -45,7 +45,7 @@ func TestCachedTask(t *testing.T) {
 		t.Errorf("unexpected task error result %v", err)
 	}
 
-	if diff := cmp.Diff(prevValues, []PreviousTaskResult[string]{
+	if diff := cmp.Diff(prevValues, []CachableTaskResult[string]{
 		{
 			Value:            "",
 			DependencyDigest: "",

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task.go
@@ -33,11 +33,11 @@ import (
 var AutocompleteComposerClusterNamesTask = inspectiontaskbase.NewCachedTask(googlecloudclustercomposer_contract.AutocompleteComposerClusterNamesTaskID, []taskid.UntypedTaskReference{
 	googlecloudcommon_contract.InputProjectIdTaskID.Ref(),
 	googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref(),
-}, func(ctx context.Context, prevValue inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
+}, func(ctx context.Context, prevValue inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
 
 	client, err := googlecloudapi.DefaultGCPClientFactory.NewClient()
 	if err != nil {
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, err
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, err
 	}
 
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
@@ -47,7 +47,7 @@ var AutocompleteComposerClusterNamesTask = inspectiontaskbase.NewCachedTask(goog
 	// when the user is inputing these information, abort
 	isWIP := projectID == "" || environment == ""
 	if isWIP {
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 			DependencyDigest: dependencyDigest,
 			Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 				ClusterNames: []string{},
@@ -63,7 +63,7 @@ var AutocompleteComposerClusterNamesTask = inspectiontaskbase.NewCachedTask(goog
 	// fetch all GKE clusters in the project
 	clusters, err := client.GetClusters(ctx, projectID)
 	if err != nil {
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 			DependencyDigest: dependencyDigest,
 			Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 				ClusterNames: []string{},
@@ -76,7 +76,7 @@ var AutocompleteComposerClusterNamesTask = inspectiontaskbase.NewCachedTask(goog
 	// = the gke cluster where the composer is running
 	for _, cluster := range clusters {
 		if cluster.ResourceLabels["goog-composer-environment"] == environment {
-			return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+			return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 				DependencyDigest: dependencyDigest,
 				Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 					ClusterNames: []string{cluster.Name},
@@ -85,7 +85,7 @@ var AutocompleteComposerClusterNamesTask = inspectiontaskbase.NewCachedTask(goog
 		}
 	}
 
-	return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+	return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 		DependencyDigest: dependencyDigest,
 		Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 			ClusterNames: []string{},

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerenvironmentnames_task.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerenvironmentnames_task.go
@@ -30,10 +30,10 @@ import (
 var AutocompleteComposerEnvironmentNamesTask = inspectiontaskbase.NewCachedTask(googlecloudclustercomposer_contract.AutocompleteComposerEnvironmentNamesTaskID, []taskid.UntypedTaskReference{
 	googlecloudcommon_contract.InputLocationsTaskID.Ref(),
 	googlecloudcommon_contract.InputProjectIdTaskID.Ref(),
-}, func(ctx context.Context, prevValue inspectiontaskbase.PreviousTaskResult[[]string]) (inspectiontaskbase.PreviousTaskResult[[]string], error) {
+}, func(ctx context.Context, prevValue inspectiontaskbase.CachableTaskResult[[]string]) (inspectiontaskbase.CachableTaskResult[[]string], error) {
 	client, err := googlecloudapi.DefaultGCPClientFactory.NewClient()
 	if err != nil {
-		return inspectiontaskbase.PreviousTaskResult[[]string]{}, err
+		return inspectiontaskbase.CachableTaskResult[[]string]{}, err
 	}
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
 	location := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputLocationsTaskID.Ref())
@@ -47,17 +47,17 @@ var AutocompleteComposerEnvironmentNamesTask = inspectiontaskbase.NewCachedTask(
 		clusterNames, err := client.GetComposerEnvironmentNames(ctx, projectID, location)
 		if err != nil {
 			// Failed to read the composer environments in the (project,location)
-			return inspectiontaskbase.PreviousTaskResult[[]string]{
+			return inspectiontaskbase.CachableTaskResult[[]string]{
 				DependencyDigest: dependencyDigest,
 				Value:            []string{},
 			}, nil
 		}
-		return inspectiontaskbase.PreviousTaskResult[[]string]{
+		return inspectiontaskbase.CachableTaskResult[[]string]{
 			DependencyDigest: dependencyDigest,
 			Value:            clusterNames,
 		}, nil
 	}
-	return inspectiontaskbase.PreviousTaskResult[[]string]{
+	return inspectiontaskbase.CachableTaskResult[[]string]{
 		DependencyDigest: dependencyDigest,
 		Value:            []string{},
 	}, nil

--- a/pkg/task/inspection/googlecloudclustergdcbaremetal/impl/autocompletegdcvforbaremetalclusternames_task.go
+++ b/pkg/task/inspection/googlecloudclustergdcbaremetal/impl/autocompletegdcvforbaremetalclusternames_task.go
@@ -32,10 +32,10 @@ import (
 // AutocompleteGDCVForBaremetalClusterNamesTask is a task that provides autocomplete suggestions for GDCV for Baremetal cluster names.
 var AutocompleteGDCVForBaremetalClusterNamesTask = inspectiontaskbase.NewCachedTask(googlecloudclustergdcbaremetal_contract.AutocompleteGDCVForBaremetalClusterNamesTaskID, []taskid.UntypedTaskReference{
 	googlecloudcommon_contract.InputProjectIdTaskID.Ref(),
-}, func(ctx context.Context, prevValue inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
+}, func(ctx context.Context, prevValue inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
 	client, err := googlecloudapi.DefaultGCPClientFactory.NewClient()
 	if err != nil {
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, nil
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, nil
 	}
 
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
@@ -47,7 +47,7 @@ var AutocompleteGDCVForBaremetalClusterNamesTask = inspectiontaskbase.NewCachedT
 		clusterNames, err := client.GetAnthosOnBaremetalClusterNames(ctx, projectID)
 		if err != nil {
 			slog.WarnContext(ctx, fmt.Sprintf("Failed to read the cluster names in the project %s\n%s", projectID, err))
-			return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+			return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 				DependencyDigest: projectID,
 				Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 					ClusterNames: []string{},
@@ -55,7 +55,7 @@ var AutocompleteGDCVForBaremetalClusterNamesTask = inspectiontaskbase.NewCachedT
 				},
 			}, nil
 		}
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 			DependencyDigest: projectID,
 			Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 				ClusterNames: clusterNames,
@@ -63,7 +63,7 @@ var AutocompleteGDCVForBaremetalClusterNamesTask = inspectiontaskbase.NewCachedT
 			},
 		}, nil
 	}
-	return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+	return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 		DependencyDigest: projectID,
 		Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 			ClusterNames: []string{},

--- a/pkg/task/inspection/googlecloudclustergdcvmware/impl/autocompletegdcvforvmwareclusternames_task.go
+++ b/pkg/task/inspection/googlecloudclustergdcvmware/impl/autocompletegdcvforvmwareclusternames_task.go
@@ -32,10 +32,10 @@ import (
 // AutocompleteGDCVForVMWareClusterNamesTask is a task that provides autocomplete suggestions for GDCV for VMWare cluster names.
 var AutocompleteGDCVForVMWareClusterNamesTask = inspectiontaskbase.NewCachedTask(googlecloudclustergdcvmware_contract.AutocompleteGDCVForVMWareClusterNamesTaskID, []taskid.UntypedTaskReference{
 	googlecloudcommon_contract.InputProjectIdTaskID.Ref(),
-}, func(ctx context.Context, prevValue inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
+}, func(ctx context.Context, prevValue inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
 	client, err := googlecloudapi.DefaultGCPClientFactory.NewClient()
 	if err != nil {
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, err
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, err
 	}
 
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
@@ -47,7 +47,7 @@ var AutocompleteGDCVForVMWareClusterNamesTask = inspectiontaskbase.NewCachedTask
 		clusterNames, err := client.GetAnthosOnVMWareClusterNames(ctx, projectID)
 		if err != nil {
 			slog.WarnContext(ctx, fmt.Sprintf("Failed to read the cluster names in the project %s\n%s", projectID, err))
-			return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+			return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 				DependencyDigest: projectID,
 				Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 					ClusterNames: []string{},
@@ -55,7 +55,7 @@ var AutocompleteGDCVForVMWareClusterNamesTask = inspectiontaskbase.NewCachedTask
 				},
 			}, nil
 		}
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 			DependencyDigest: projectID,
 			Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 				ClusterNames: clusterNames,
@@ -63,7 +63,7 @@ var AutocompleteGDCVForVMWareClusterNamesTask = inspectiontaskbase.NewCachedTask
 			},
 		}, nil
 	}
-	return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+	return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 		DependencyDigest: projectID,
 		Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 			ClusterNames: []string{},

--- a/pkg/task/inspection/googlecloudclustergke/impl/autocompletegkeclusternames_task.go
+++ b/pkg/task/inspection/googlecloudclustergke/impl/autocompletegkeclusternames_task.go
@@ -32,10 +32,10 @@ import (
 // AutocompleteGKEClusterNamesTask is a task that provides autocomplete suggestions for GKE cluster names.
 var AutocompleteGKEClusterNamesTask = inspectiontaskbase.NewCachedTask(googlecloudclustergke_contract.AutocompleteGKEClusterNamesTaskID, []taskid.UntypedTaskReference{
 	googlecloudcommon_contract.InputProjectIdTaskID.Ref(),
-}, func(ctx context.Context, prevValue inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
+}, func(ctx context.Context, prevValue inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
 	client, err := googlecloudapi.DefaultGCPClientFactory.NewClient()
 	if err != nil {
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, err
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, err
 	}
 
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
@@ -47,7 +47,7 @@ var AutocompleteGKEClusterNamesTask = inspectiontaskbase.NewCachedTask(googleclo
 		clusterNames, err := client.GetClusterNames(ctx, projectID)
 		if err != nil {
 			slog.WarnContext(ctx, fmt.Sprintf("Failed to read the cluster names in the project %s\n%s", projectID, err))
-			return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+			return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 				DependencyDigest: projectID,
 				Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 					ClusterNames: []string{},
@@ -55,7 +55,7 @@ var AutocompleteGKEClusterNamesTask = inspectiontaskbase.NewCachedTask(googleclo
 				},
 			}, nil
 		}
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 			DependencyDigest: projectID,
 			Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 				ClusterNames: clusterNames,
@@ -63,7 +63,7 @@ var AutocompleteGKEClusterNamesTask = inspectiontaskbase.NewCachedTask(googleclo
 			},
 		}, nil
 	}
-	return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+	return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 		DependencyDigest: projectID,
 		Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 			ClusterNames: []string{},

--- a/pkg/task/inspection/googlecloudclustergkeonaws/impl/autocomplete.go
+++ b/pkg/task/inspection/googlecloudclustergkeonaws/impl/autocomplete.go
@@ -32,10 +32,10 @@ import (
 // AutocompleteGKEOnAWSClusterNames is a task that provides a list of GKE on AWS cluster names for autocompletion.
 var AutocompleteGKEOnAWSClusterNames = inspectiontaskbase.NewCachedTask(googlecloudclustergkeonaws_contract.AutocompleteGKEOnAWSClusterNamesTaskID, []taskid.UntypedTaskReference{
 	googlecloudcommon_contract.InputProjectIdTaskID.Ref(),
-}, func(ctx context.Context, prevValue inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
+}, func(ctx context.Context, prevValue inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
 	client, err := googlecloudapi.DefaultGCPClientFactory.NewClient()
 	if err != nil {
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, err
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, err
 	}
 
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
@@ -47,7 +47,7 @@ var AutocompleteGKEOnAWSClusterNames = inspectiontaskbase.NewCachedTask(googlecl
 		clusterNames, err := client.GetAnthosAWSClusterNames(ctx, projectID)
 		if err != nil {
 			slog.WarnContext(ctx, fmt.Sprintf("Failed to read the cluster names in the project %s\n%s", projectID, err))
-			return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+			return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 				DependencyDigest: projectID,
 				Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 					ClusterNames: []string{},
@@ -55,7 +55,7 @@ var AutocompleteGKEOnAWSClusterNames = inspectiontaskbase.NewCachedTask(googlecl
 				},
 			}, nil
 		}
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 			DependencyDigest: projectID,
 			Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 				ClusterNames: clusterNames,
@@ -63,7 +63,7 @@ var AutocompleteGKEOnAWSClusterNames = inspectiontaskbase.NewCachedTask(googlecl
 			},
 		}, nil
 	}
-	return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+	return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 		DependencyDigest: projectID,
 		Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 			ClusterNames: []string{},

--- a/pkg/task/inspection/googlecloudclustergkeonazure/impl/autocomplete.go
+++ b/pkg/task/inspection/googlecloudclustergkeonazure/impl/autocomplete.go
@@ -32,10 +32,10 @@ import (
 // AutocompleteGKEOnAzureClusterNamesTask is a task that provides a list of GKE on Azure cluster names for autocompletion.
 var AutocompleteGKEOnAzureClusterNamesTask = inspectiontaskbase.NewCachedTask(googlecloudclustergkeonazure_contract.AutocompleteGKEOnAzureClusterNamesTaskID, []taskid.UntypedTaskReference{
 	googlecloudcommon_contract.InputProjectIdTaskID.Ref(),
-}, func(ctx context.Context, prevValue inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
+}, func(ctx context.Context, prevValue inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]) (inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList], error) {
 	client, err := googlecloudapi.DefaultGCPClientFactory.NewClient()
 	if err != nil {
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, nil
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{}, nil
 	}
 
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
@@ -47,7 +47,7 @@ var AutocompleteGKEOnAzureClusterNamesTask = inspectiontaskbase.NewCachedTask(go
 		clusterNames, err := client.GetAnthosAzureClusterNames(ctx, projectID)
 		if err != nil {
 			slog.WarnContext(ctx, fmt.Sprintf("Failed to read the cluster names in the project %s\n%s", projectID, err))
-			return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+			return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 				DependencyDigest: projectID,
 				Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 					ClusterNames: []string{},
@@ -55,7 +55,7 @@ var AutocompleteGKEOnAzureClusterNamesTask = inspectiontaskbase.NewCachedTask(go
 				},
 			}, nil
 		}
-		return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+		return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 			DependencyDigest: projectID,
 			Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 				ClusterNames: clusterNames,
@@ -63,7 +63,7 @@ var AutocompleteGKEOnAzureClusterNamesTask = inspectiontaskbase.NewCachedTask(go
 			},
 		}, nil
 	}
-	return inspectiontaskbase.PreviousTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
+	return inspectiontaskbase.CachableTaskResult[*googlecloudk8scommon_contract.AutocompleteClusterNameList]{
 		DependencyDigest: projectID,
 		Value: &googlecloudk8scommon_contract.AutocompleteClusterNameList{
 			ClusterNames: []string{},

--- a/pkg/task/inspection/googlecloudcommon/impl/autocompletelocation_task.go
+++ b/pkg/task/inspection/googlecloudcommon/impl/autocompletelocation_task.go
@@ -30,10 +30,10 @@ var AutocompleteLocationTask = inspectiontaskbase.NewCachedTask(googlecloudcommo
 	[]taskid.UntypedTaskReference{
 		googlecloudcommon_contract.InputProjectIdTaskID.Ref(), // for API restriction
 	},
-	func(ctx context.Context, prevValue inspectiontaskbase.PreviousTaskResult[[]string]) (inspectiontaskbase.PreviousTaskResult[[]string], error) {
+	func(ctx context.Context, prevValue inspectiontaskbase.CachableTaskResult[[]string]) (inspectiontaskbase.CachableTaskResult[[]string], error) {
 		client, err := googlecloudapi.DefaultGCPClientFactory.NewClient()
 		if err != nil {
-			return inspectiontaskbase.PreviousTaskResult[[]string]{}, err
+			return inspectiontaskbase.CachableTaskResult[[]string]{}, err
 		}
 		projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
 		dependencyDigest := fmt.Sprintf("location-%s", projectID)
@@ -42,7 +42,7 @@ var AutocompleteLocationTask = inspectiontaskbase.NewCachedTask(googlecloudcommo
 			return prevValue, nil
 		}
 
-		defaultResult := inspectiontaskbase.PreviousTaskResult[[]string]{
+		defaultResult := inspectiontaskbase.CachableTaskResult[[]string]{
 			DependencyDigest: dependencyDigest,
 			Value:            []string{},
 		}


### PR DESCRIPTION
The name `PreviousTaskResult` didn't express its purpose before. Renaming the name to `CachableTaskResult`.

This PR only contains the nameing.