### PR TITLE
[feat #285 5-7-1/N] Adding a progress reportable log client with the new logging client

### DIFF
--- a/pkg/core/inspection/gcpqueryutil/logfetcher.go
+++ b/pkg/core/inspection/gcpqueryutil/logfetcher.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpqueryutil
+
+import (
+	"context"
+
+	logging "cloud.google.com/go/logging/apiv2"
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+	"google.golang.org/api/iterator"
+)
+
+// LogFetcher is an interface for fetching logs from Cloud Logging with a given filter
+// and sending them to a specified channel.
+// The implementation must close the destination channel after the query is done.
+type LogFetcher interface {
+	FetchLogs(dest chan<- *loggingpb.LogEntry, ctx context.Context, filter string, resourceContainers []string) error
+}
+
+// logFetcherImpl is the implementation of LogFetcher actually accessing to the Cloud Logging API.
+type logFetcherImpl struct {
+	client   *logging.Client
+	pageSize int32
+	orderBy  string
+}
+
+// NewLogFetcher returns the instance of LogFetcher initialized with the given logging client.
+func NewLogFetcher(client *logging.Client, pageSize int32) LogFetcher {
+	return &logFetcherImpl{
+		client:   client,
+		pageSize: pageSize,
+		orderBy:  "timestamp asc",
+	}
+}
+
+// FetchLogs implements LogFetcher.
+func (l *logFetcherImpl) FetchLogs(dest chan<- *loggingpb.LogEntry, ctx context.Context, filter string, resourceContainers []string) error {
+	defer close(dest)
+
+	iter := l.client.ListLogEntries(ctx, &loggingpb.ListLogEntriesRequest{
+		ResourceNames: resourceContainers,
+		Filter:        filter,
+		OrderBy:       l.orderBy,
+		PageSize:      l.pageSize,
+	})
+
+	for {
+		entry, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		select {
+		// Check the context cancel first
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err != nil {
+			return err
+		}
+		select {
+		case dest <- entry:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+	}
+	return nil
+}

--- a/pkg/core/inspection/gcpqueryutil/logfetcher_test.go
+++ b/pkg/core/inspection/gcpqueryutil/logfetcher_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpqueryutil
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	logging "cloud.google.com/go/logging/apiv2"
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloudv2"
+)
+
+// getLoggingClientImpl returns a logging client for testing project.
+func getLoggingClientImpl(t *testing.T) *logging.Client {
+	t.Helper()
+
+	cf, err := googlecloudv2.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to instanciate client factory: %v", err)
+	}
+
+	logging, err := cf.LoggingClient(t.Context(), googlecloudv2.Project("kubernetes-history-inspector"))
+	if err != nil {
+		t.Fatalf("failed to instanciate logging client:%v", err)
+	}
+	return logging
+}
+
+func TestLogFetcherImpl_FetchLogs(t *testing.T) {
+	if *testflags.SkipCloudLogging {
+		t.Skip()
+		return
+	}
+
+	fetcher := logFetcherImpl{
+		client:   getLoggingClientImpl(t),
+		pageSize: 1,
+		orderBy:  "timestamp desc", // just need the latest log. getting oldest log takes longer time.
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	destChan := make(chan *loggingpb.LogEntry)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		select {
+		// Test time out is 30 sec by default and getting a single log for 20 sec timeout must be fine.
+		case <-time.After(20 * time.Second):
+			t.Errorf("no logs returned for the first 20 sec")
+		case _, ok := <-destChan:
+			if !ok {
+				t.Errorf("channel closed before receiving any response")
+			}
+			cancel() // this test just receive a log. Cancel context after receiving one.
+		}
+	}()
+
+	err := fetcher.FetchLogs(destChan, ctx, "", []string{"projects/kubernetes-history-inspector"})
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("failed to fetch logs:%v", err)
+	}
+	wg.Wait()
+}
+
+func TestLogFetcherImpl_FetchLogsIsCancellable(t *testing.T) {
+	if *testflags.SkipCloudLogging {
+		t.Skip()
+		return
+	}
+
+	fetcher := logFetcherImpl{
+		client:   getLoggingClientImpl(t),
+		pageSize: 1000,
+	}
+
+	fetchLogFinished := make(chan struct{})
+	destChan := make(chan *loggingpb.LogEntry)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	go func() {
+		<-time.After(100 * time.Millisecond)
+		cancel()
+	}()
+
+	go func() {
+		select {
+		case <-time.After(500 * time.Millisecond):
+			t.Errorf("the request wasn't cancelled after 500ms")
+		case <-fetchLogFinished:
+			return
+		}
+	}()
+
+	err := fetcher.FetchLogs(destChan, ctx, "", []string{"projects/kubernetes-history-inspector"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("the request wasn't ended with canceled but got %v", err)
+	}
+	close(fetchLogFinished)
+}

--- a/pkg/core/inspection/gcpqueryutil/progressreportablelogfetcher.go
+++ b/pkg/core/inspection/gcpqueryutil/progressreportablelogfetcher.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpqueryutil
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+)
+
+// LogFetchProgress represents the progress of a log fetching operation.
+type LogFetchProgress struct {
+	// LogCount is the total number of logs fetched so far.
+	LogCount int
+	// Progress indicates the completion status, ranging from 0.0 to 1.0.
+	Progress float32
+}
+
+type ProgressReportableLogFetcher interface {
+	// FetchLogsWithProgress fetches logs while periodically reporting its progress through a separate channel.
+	// Implementations must close both the dest and progress channels upon completion.
+	FetchLogsWithProgress(dest chan<- *loggingpb.LogEntry, progress chan<- LogFetchProgress, ctx context.Context, beginTime, endTime time.Time, filterWithoutTimeRange string, resourceContainers []string) error
+}
+
+// StandardProgressReportableLogFetcher is a decorator for a LogFetcher that adds the ability
+// to report the progress of log fetching.
+type StandardProgressReportableLogFetcher struct {
+	fetcher        LogFetcher
+	reportInterval time.Duration
+}
+
+// NewProgressReportableLogFetcher creates a new instance of ProgressReportableLogFetcher.
+func NewStandardProgressReportableLogFetcher(fetcher LogFetcher, interval time.Duration) *StandardProgressReportableLogFetcher {
+	return &StandardProgressReportableLogFetcher{
+		fetcher:        fetcher,
+		reportInterval: interval,
+	}
+}
+
+// FetchLogsWithProgress implements FetchLogsWithProgress.
+func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<- *loggingpb.LogEntry, progress chan<- LogFetchProgress, ctx context.Context, beginTime, endTime time.Time, filterWithoutTimeRange string, resourceContainers []string) error {
+	defer close(dest)
+	defer close(progress)
+
+	ticker := time.NewTicker(s.reportInterval)
+	defer ticker.Stop() // ticker must be closed before closing progress
+
+	stubChan := make(chan *loggingpb.LogEntry)
+	subroutineCtx, cancelSubroutine := context.WithCancel(ctx)
+
+	filter := fmt.Sprintf("%s\n%s", filterWithoutTimeRange, TimeRangeQuerySection(beginTime, endTime, false))
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	logCount := atomic.Int32{}
+	latestLogTime := &beginTime
+	totalDurationInSeconds := endTime.Sub(beginTime).Seconds()
+
+	if totalDurationInSeconds == 0 {
+		totalDurationInSeconds = 1
+	}
+
+	// Consume logs from log fetcher and record count and the latest time for reporting progress
+	go func() {
+		defer wg.Done() // fetcher.FetchLogs is expected to run in sync. But make sure all the logs are consumed in this go routine.
+		for {
+			select {
+			case <-subroutineCtx.Done():
+				return
+			case logEntry, ok := <-stubChan:
+				if !ok {
+					return
+				}
+				logCount.Add(1)
+				t := logEntry.Timestamp.AsTime()
+				latestLogTime = &t
+				select {
+				case <-subroutineCtx.Done():
+					return
+				case dest <- logEntry:
+				}
+			}
+		}
+	}()
+
+	// Report progress for every reportInterval
+	go func() {
+		defer wg.Done()
+		// Send initial progress
+		select {
+		case progress <- LogFetchProgress{}:
+		case <-subroutineCtx.Done():
+			return
+		}
+
+		for {
+			select {
+			case <-subroutineCtx.Done():
+				return
+			case <-ticker.C:
+				latestLogTimeFromBeginTimeInSeconds := latestLogTime.Sub(beginTime).Seconds()
+				select {
+				case progress <- LogFetchProgress{
+					LogCount: int(logCount.Load()),
+					Progress: float32(latestLogTimeFromBeginTimeInSeconds) / float32(totalDurationInSeconds),
+				}:
+				case <-subroutineCtx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	err := s.fetcher.FetchLogs(stubChan, ctx, filter, resourceContainers)
+	if err != nil {
+		cancelSubroutine()
+		return err
+	}
+
+	cancelSubroutine()
+	wg.Wait()
+
+	// Send final progress report.
+	select {
+	case progress <- LogFetchProgress{LogCount: int(logCount.Load()), Progress: 1.0}:
+	case <-ctx.Done():
+	}
+	return nil
+}
+
+var _ ProgressReportableLogFetcher = (*StandardProgressReportableLogFetcher)(nil)

--- a/pkg/core/inspection/gcpqueryutil/progressreportablelogfetcher_test.go
+++ b/pkg/core/inspection/gcpqueryutil/progressreportablelogfetcher_test.go
@@ -1,0 +1,313 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpqueryutil
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// mockLogFetcher is a mock implementation of the LogFetcher interface for testing purposes.
+type mockLogFetcher struct {
+	logUpstream func(filter string) chan *loggingpb.LogEntry
+	errUpstream func(filter string) chan error
+}
+
+// FetchLogs simulates fetching logs from an upstream source.
+// It sends logs from `m.logUpstream` and errors from `m.errUpstream` to the `dest` channel.
+// It respects context cancellation.
+func (m *mockLogFetcher) FetchLogs(dest chan<- *loggingpb.LogEntry, ctx context.Context, filter string, resourceContainers []string) error {
+	errUpstream := m.errUpstream(filter)
+	logUpstream := m.logUpstream(filter)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		case err, ok := <-errUpstream:
+			if ok {
+				return err
+			}
+		case l, ok := <-logUpstream:
+			if !ok {
+				close(dest)
+				return nil
+			}
+			dest <- l
+		}
+	}
+}
+
+var _ LogFetcher = (*mockLogFetcher)(nil)
+
+// fakeLogUpstreamPair represents a pair of channels (log and error) for a specific filter,
+// used to simulate log fetching in tests.
+type fakeLogUpstreamPair struct {
+	filter    string
+	logChan   chan *loggingpb.LogEntry
+	errChan   chan error
+	startLock chan struct{}
+}
+
+// getMockFetcherFromFakeLogUpstreamPairs creates a mockLogFetcher that uses the provided
+// fakeLogUpstreamPair instances to simulate log and error streams based on the filter.
+func getMockFetcherFromFakeLogUpstreamPairs(t *testing.T, fakeLogUpstreams []fakeLogUpstreamPair) *mockLogFetcher {
+	logUpstream := func(filter string) chan *loggingpb.LogEntry {
+		for _, pair := range fakeLogUpstreams {
+			if pair.filter == filter {
+				<-pair.startLock
+				return pair.logChan
+			}
+		}
+		t.Errorf("given filter is not matching any available fake log upstream: %v", filter)
+		return nil
+	}
+	errUpstream := func(filter string) chan error {
+		for _, pair := range fakeLogUpstreams {
+			if pair.filter == filter {
+				return pair.errChan
+			}
+		}
+		t.Errorf("given filter is not matching any available fake log upstream: %v", filter)
+		return nil
+	}
+	return &mockLogFetcher{
+		logUpstream: logUpstream,
+		errUpstream: errUpstream,
+	}
+}
+
+// newFakeLogUpstreamPair creates a new fakeLogUpstreamPair.
+// It takes a filter string and a function `f` that simulates the log fetching logic,
+// sending logs and errors to the provided channels.
+func newFakeLogUpstreamPair(filter string, f func(logSource chan<- *loggingpb.LogEntry, errSource chan<- error)) fakeLogUpstreamPair {
+	logSource := make(chan *loggingpb.LogEntry)
+	errSource := make(chan error)
+	startLock := make(chan struct{})
+	go func() {
+		startLock <- struct{}{}
+		f(logSource, errSource)
+		close(logSource)
+		close(errSource)
+	}()
+	return fakeLogUpstreamPair{
+		filter:    filter,
+		logChan:   logSource,
+		errChan:   errSource,
+		startLock: startLock,
+	}
+}
+
+// channelToArrayParallel reads values from a channel of type T and appends them to a slice `resultTo`.
+// It runs in a separate goroutine and stops when the context is canceled or the channel is closed.
+// It uses a `sync.WaitGroup` to signal completion.
+func channelToArrayParallel[T any](ctx context.Context, wg *sync.WaitGroup, resultTo *[]T) chan<- T {
+	channel := make(chan T)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case v, open := <-channel:
+				if !open {
+					return
+				}
+				*resultTo = append(*resultTo, v)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestProgressReportableLogFetcher(t *testing.T) {
+	tick := 100 * time.Millisecond
+	beginTime := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
+	testErr := errors.New("test error")
+	testCases := []struct {
+		desc             string
+		fetcherFactory   func(t *testing.T) *mockLogFetcher
+		duration         time.Duration
+		cancelAfter      time.Duration
+		wantCompleteTime time.Duration
+		wantErr          error
+		wantLogs         []*loggingpb.LogEntry
+		wantProgresses   []LogFetchProgress
+	}{
+		{
+			desc: "standard result",
+			fetcherFactory: func(t *testing.T) *mockLogFetcher {
+				return getMockFetcherFromFakeLogUpstreamPairs(t, []fakeLogUpstreamPair{
+					newFakeLogUpstreamPair(`test filter
+timestamp >= "2025-01-01T00:00:00+0000"
+timestamp < "2025-01-01T01:00:00+0000"`, func(logSource chan<- *loggingpb.LogEntry, errSource chan<- error) {
+						<-time.After(tick / 2) // delta to prevent freaky test
+						<-time.After(tick)     // <- 1st progress tick
+						logSource <- &loggingpb.LogEntry{LogName: "foo", Timestamp: timestamppb.New(beginTime.Add(15 * time.Minute))}
+						<-time.After(tick) // <- 2nd progress tick
+						logSource <- &loggingpb.LogEntry{LogName: "bar", Timestamp: timestamppb.New(beginTime.Add(30 * time.Minute))}
+						<-time.After(2 * tick) // <- 3rd & 4th progress tick
+					}),
+				})
+			},
+			duration:         time.Hour,
+			wantCompleteTime: 5 * tick,
+			wantErr:          nil,
+			wantLogs: []*loggingpb.LogEntry{
+				{
+					LogName: "foo", Timestamp: timestamppb.New(beginTime.Add(15 * time.Minute)),
+				},
+				{
+					LogName: "bar", Timestamp: timestamppb.New(beginTime.Add(30 * time.Minute)),
+				},
+			},
+			wantProgresses: []LogFetchProgress{
+				{},
+				{},
+				{LogCount: 1, Progress: 0.25},
+				{LogCount: 2, Progress: 0.50},
+				{LogCount: 2, Progress: 0.50},
+				{LogCount: 2, Progress: 1},
+			},
+		},
+		{
+			desc: "with error",
+			fetcherFactory: func(t *testing.T) *mockLogFetcher {
+				return getMockFetcherFromFakeLogUpstreamPairs(t, []fakeLogUpstreamPair{
+					newFakeLogUpstreamPair(`test filter
+timestamp >= "2025-01-01T00:00:00+0000"
+timestamp < "2025-01-01T01:00:00+0000"`, func(logSource chan<- *loggingpb.LogEntry, errSource chan<- error) {
+						<-time.After(tick / 2) // delta to prevent freaky test
+						<-time.After(tick)     // <- 1st progress tick
+						logSource <- &loggingpb.LogEntry{LogName: "foo", Timestamp: timestamppb.New(beginTime.Add(15 * time.Minute))}
+						<-time.After(tick) // <- 2nd progress tick
+						errSource <- testErr
+						<-time.After(2 * tick)
+					}),
+				})
+			},
+			duration:         time.Hour,
+			wantCompleteTime: 3 * tick,
+			wantErr:          testErr,
+			wantLogs: []*loggingpb.LogEntry{
+				{
+					LogName: "foo", Timestamp: timestamppb.New(beginTime.Add(15 * time.Minute)),
+				},
+			},
+			wantProgresses: []LogFetchProgress{
+				{},
+				{},
+				{LogCount: 1, Progress: 0.25},
+			},
+		},
+		{
+			desc: "with cancel",
+			fetcherFactory: func(t *testing.T) *mockLogFetcher {
+				return getMockFetcherFromFakeLogUpstreamPairs(t, []fakeLogUpstreamPair{
+					newFakeLogUpstreamPair(`test filter
+timestamp >= "2025-01-01T00:00:00+0000"
+timestamp < "2025-01-01T01:00:00+0000"`, func(logSource chan<- *loggingpb.LogEntry, errSource chan<- error) {
+						<-time.After(tick / 2) // delta to prevent freaky test
+						<-time.After(tick)     // <- 1st progress tick
+						logSource <- &loggingpb.LogEntry{LogName: "foo", Timestamp: timestamppb.New(beginTime.Add(15 * time.Minute))}
+						<-time.After(tick) // <- 2nd progress tick
+						// cancel happens here
+						<-time.After(10 * tick)
+					}),
+				})
+			},
+			duration:         time.Hour,
+			wantCompleteTime: 4 * tick,
+			cancelAfter:      time.Duration(2.5 * float64(tick)),
+			wantErr:          context.Canceled,
+			wantLogs: []*loggingpb.LogEntry{
+				{
+					LogName: "foo", Timestamp: timestamppb.New(beginTime.Add(15 * time.Minute)),
+				},
+			},
+			wantProgresses: []LogFetchProgress{
+				{},
+				{},
+				{LogCount: 1, Progress: 0.25},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			wg := sync.WaitGroup{}
+			endTime := beginTime.Add(tc.duration)
+			fetcher := tc.fetcherFactory(t)
+
+			var logs []*loggingpb.LogEntry
+			var progresses []LogFetchProgress
+			logReceiveChan := channelToArrayParallel(t.Context(), &wg, &logs)
+			progressReceiveChan := channelToArrayParallel(t.Context(), &wg, &progresses)
+
+			progressReportableFetcher := NewStandardProgressReportableLogFetcher(fetcher, tick)
+
+			afterFetchDone := make(chan struct{})
+			go func() {
+				select {
+				case <-time.After(tc.wantCompleteTime):
+					t.Errorf("FetchLogWithProgress didn't return within expected completion time %d ms. ", tc.wantCompleteTime.Microseconds())
+				case <-afterFetchDone:
+					return
+				}
+			}()
+
+			cancellableCtx, cancel := context.WithCancel(t.Context())
+			if tc.cancelAfter != 0 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-time.After(tc.cancelAfter)
+					cancel()
+				}()
+			}
+
+			err := progressReportableFetcher.FetchLogsWithProgress(logReceiveChan, progressReceiveChan, cancellableCtx, beginTime, endTime, "test filter", []string{})
+			if tc.wantErr == nil && err != nil {
+				t.Errorf("FetchLogsWithProgress() returned unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && err == nil && !errors.Is(err, tc.wantErr) {
+				t.Errorf("FetchLogsWithProgress() didn't return expected error. Returned error: %v", err)
+			}
+			wg.Wait()
+			close(afterFetchDone)
+
+			slices.SortFunc(logs, func(a, b *loggingpb.LogEntry) int { return a.Timestamp.AsTime().Compare(b.Timestamp.AsTime()) })
+
+			if diff := cmp.Diff(tc.wantLogs, logs, protocmp.Transform(), cmpopts.IgnoreUnexported()); diff != "" {
+				t.Errorf("FetchLogsWithProgress() produced non expected result: (-want, +got):\n%v", diff)
+			}
+			if diff := cmp.Diff(tc.wantProgresses, progresses); diff != "" {
+				t.Errorf("FetchLogsWithProgress() produced non expected progress: (-want, +got):\n%v", diff)
+			}
+			cancel()
+		})
+	}
+}


### PR DESCRIPTION
This change introduced a new interface `LogFetcher` ,its default implementation using the new client `LogFetcherImpl` and `ProgressReportableLogFetcher` which is a decorator type of `LogFetcher` to report the progress of log retrieving.
