### PR TITLE
Make ClientFactory extensible for adding caller options to specific client

### DIFF
--- a/pkg/api/googlecloudv2/calloptions.go
+++ b/pkg/api/googlecloudv2/calloptions.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudv2
+
+import (
+	"time"
+
+	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/grpc/codes"
+)
+
+// DefaultRetryPolicy is the default retry policy widely used to access Google Cloud API.
+var DefaultRetryPolicy = gax.WithRetry(func() gax.Retryer {
+	return gax.OnCodes([]codes.Code{
+		codes.Aborted,
+		codes.Canceled,
+		codes.Internal,
+		codes.ResourceExhausted,
+		codes.Unknown,
+		codes.Unavailable,
+		codes.DeadlineExceeded,
+	}, gax.Backoff{
+		Initial:    100 * time.Millisecond,
+		Max:        5000 * time.Millisecond,
+		Multiplier: 1.30,
+	})
+})
+
+// NeverTimeout is gax.CallOption that never reaches the timeout.
+var NeverTimeout = gax.WithTimeout(1<<63 - 1)

--- a/pkg/api/googlecloudv2/clientfactory_test.go
+++ b/pkg/api/googlecloudv2/clientfactory_test.go
@@ -45,17 +45,17 @@ func TestNewClientFactory(t *testing.T) {
 			name: "With options",
 			options: []ClientFactoryOption{
 				func(s *ClientFactory) error {
-					s.contextModifiers = append(s.contextModifiers, nopContextModifier)
+					s.ContextModifiers = append(s.ContextModifiers, nopContextModifier)
 					return nil
 				},
 				func(s *ClientFactory) error {
-					s.clientOptions = append(s.clientOptions, nopOptionsModifier)
+					s.ClientOptions = append(s.ClientOptions, nopOptionsModifier)
 					return nil
 				},
 			},
 			want: &ClientFactory{
-				contextModifiers: []ClientFactoryContextModifiers{nopContextModifier},
-				clientOptions:    []ClientFactoryOptionsModifiers{nopOptionsModifier},
+				ContextModifiers: []ClientFactoryContextModifiers{nopContextModifier},
+				ClientOptions:    []ClientFactoryOptionsModifiers{nopOptionsModifier},
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestNewClientFactory(t *testing.T) {
 				t.Errorf("NewClientFactory() error = %v, expectError %v", err, tc.wantErr)
 				return
 			}
-			if !tc.wantErr && (len(factory.contextModifiers) != len(tc.want.contextModifiers) || len(factory.clientOptions) != len(tc.want.clientOptions)) {
+			if !tc.wantErr && (len(factory.ContextModifiers) != len(tc.want.ContextModifiers) || len(factory.ClientOptions) != len(tc.want.ClientOptions)) {
 				t.Errorf("NewClientFactory() = %v, want %v", factory, tc.want)
 			}
 		})
@@ -109,14 +109,14 @@ func TestClientFactory_context(t *testing.T) {
 		{
 			name: "Multiple modifiers",
 			factory: &ClientFactory{
-				contextModifiers: []ClientFactoryContextModifiers{modifier1, modifier2},
+				ContextModifiers: []ClientFactoryContextModifiers{modifier1, modifier2},
 			},
 			expectedCtx: map[interface{}]interface{}{"key1": "value1", "key2": "value2"},
 		},
 		{
 			name: "Modifier returns error",
 			factory: &ClientFactory{
-				contextModifiers: []ClientFactoryContextModifiers{errorModifier},
+				ContextModifiers: []ClientFactoryContextModifiers{errorModifier},
 			},
 			expectError: true,
 		},
@@ -165,14 +165,14 @@ func TestClientFactory_options(t *testing.T) {
 		{
 			name: "Multiple modifiers",
 			factory: &ClientFactory{
-				clientOptions: []ClientFactoryOptionsModifiers{modifier1, modifier2},
+				ClientOptions: []ClientFactoryOptionsModifiers{modifier1, modifier2},
 			},
 			expectedCount: 2,
 		},
 		{
 			name: "Modifier returns error",
 			factory: &ClientFactory{
-				clientOptions: []ClientFactoryOptionsModifiers{errorModifier},
+				ClientOptions: []ClientFactoryOptionsModifiers{errorModifier},
 			},
 			expectError: true,
 		},
@@ -180,7 +180,7 @@ func TestClientFactory_options(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			opts, err := tc.factory.options(Project("test-project"))
+			opts, err := tc.factory.options(Project("test-project"), []ClientFactoryOptionsModifiers{})
 			if (err != nil) != tc.expectError {
 				t.Errorf("options() error = %v, expectError %v", err, tc.expectError)
 				return

--- a/pkg/api/googlecloudv2/options/clientfactoryoptions.go
+++ b/pkg/api/googlecloudv2/options/clientfactoryoptions.go
@@ -21,48 +21,55 @@ import (
 	"google.golang.org/api/option"
 )
 
-// ServiceAccountKey returns a googlecloudv2.ClientFactoryOptionsModifiers to use the given service account key for any projects.
-func ServiceAccountKey(keyPath string) googlecloudv2.ClientFactoryOptionsModifiers {
-	return func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
-		opts = append(opts, option.WithCredentialsFile(keyPath))
-		return opts, nil
+func fromClientFactoryOptionsModifier(modifier googlecloudv2.ClientFactoryOptionsModifiers) googlecloudv2.ClientFactoryOption {
+	return func(s *googlecloudv2.ClientFactory) error {
+		s.ClientOptions = append(s.ClientOptions, modifier)
+		return nil
 	}
 }
 
-// ServiceAccountKeyForProject returns a googlecloudv2.ClientFactoryOptionsModifiers to use the given service account key for a specific project.
-func ServiceAccountKeyForProject(keyPath string, projectID string) googlecloudv2.ClientFactoryOptionsModifiers {
-	return func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
+// ServiceAccountKey returns a googlecloudv2.ClientFactoryOption to use the given service account key for any projects.
+func ServiceAccountKey(keyPath string) googlecloudv2.ClientFactoryOption {
+	return fromClientFactoryOptionsModifier(func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
+		opts = append(opts, option.WithCredentialsFile(keyPath))
+		return opts, nil
+	})
+}
+
+// ServiceAccountKeyForProject returns a googlecloudv2.ClientFactoryOption to use the given service account key for a specific project.
+func ServiceAccountKeyForProject(keyPath string, projectID string) googlecloudv2.ClientFactoryOption {
+	return fromClientFactoryOptionsModifier(func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
 		if p, ok := c.(googlecloudv2.ProjectResourceContainer); ok && p.ProjectID() == projectID {
 			opts = append(opts, option.WithCredentialsFile(keyPath))
 		}
 		return opts, nil
-	}
+	})
 }
 
-// TokenSource returns a googlecloudv2.ClientFactoryOptionsModifiers to use the given oauth2.TokenSource for any projects.
-func TokenSource(source oauth2.TokenSource) googlecloudv2.ClientFactoryOptionsModifiers {
-	return func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
+// TokenSource returns a googlecloudv2.ClientFactoryOption to use the given oauth2.TokenSource for any projects.
+func TokenSource(source oauth2.TokenSource) googlecloudv2.ClientFactoryOption {
+	return fromClientFactoryOptionsModifier(func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
 		opts = append(opts, option.WithTokenSource(source))
 		return opts, nil
-	}
+	})
 }
 
-// TokenSourceForProject returns a googlecloudv2.ClientFactoryOptionsModifiers to use the given oauth2.TokenSource for a specific project.
-func TokenSourceForProject(projectID string, source oauth2.TokenSource) googlecloudv2.ClientFactoryOptionsModifiers {
-	return func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
+// TokenSourceForProject returns a googlecloudv2.ClientFactoryOption to use the given oauth2.TokenSource for a specific project.
+func TokenSourceForProject(projectID string, source oauth2.TokenSource) googlecloudv2.ClientFactoryOption {
+	return fromClientFactoryOptionsModifier(func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
 		if p, ok := c.(googlecloudv2.ProjectResourceContainer); ok && p.ProjectID() == projectID {
 			opts = append(opts, option.WithTokenSource(source))
 		}
 		return opts, nil
-	}
+	})
 }
 
-// OAuth returns a googlecloudv2.ClientFactoryOptionsModifiers that configures the client to use
+// OAuth returns a googlecloudv2.ClientFactoryOption that configures the client to use
 // the oauth2.TokenSource provided by the given oauth.OAuthServer.
 // This allows the Google Cloud client to obtain access tokens via an OAuth 2.0 flow managed by the OAuthServer.
-func OAuth(server *oauth.OAuthServer) googlecloudv2.ClientFactoryOptionsModifiers {
-	return func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
+func OAuth(server *oauth.OAuthServer) googlecloudv2.ClientFactoryOption {
+	return fromClientFactoryOptionsModifier(func(opts []option.ClientOption, c googlecloudv2.ResourceContainer) ([]option.ClientOption, error) {
 		opts = append(opts, option.WithTokenSource(server.TokenSource()))
 		return opts, nil
-	}
+	})
 }

--- a/pkg/api/googlecloudv2/options/clientfactoryoptions_test.go
+++ b/pkg/api/googlecloudv2/options/clientfactoryoptions_test.go
@@ -44,12 +44,21 @@ func (c *nonProjectContainer) GetType() googlecloudv2.ResourceContainerType {
 var _ googlecloudv2.ResourceContainer = (*nonProjectContainer)(nil)
 
 func TestServiceAccountKey(t *testing.T) {
-	modifier := ServiceAccountKey("test-key-path")
+	optionFunc := ServiceAccountKey("test-key-path")
 	container := googlecloudv2.Project("any-project")
-
-	opts, err := modifier([]option.ClientOption{}, container)
+	clientFactory := googlecloudv2.ClientFactory{}
+	err := optionFunc(&clientFactory)
 	if err != nil {
-		t.Fatalf("modifier returned an unexpected error: %v", err)
+		t.Errorf("optionFunc returned an unexpected error: %v", err)
+	}
+	clientOpts := clientFactory.ClientOptions
+	if len(clientOpts) != 1 {
+		t.Errorf("Expected 1 option to be added, but got %d", len(clientOpts))
+	}
+
+	opts, err := clientOpts[0]([]option.ClientOption{}, container)
+	if err != nil {
+		t.Errorf("client option returned an unexpected error: %v", err)
 	}
 
 	if len(opts) != 1 {
@@ -85,11 +94,21 @@ func TestServiceAccountKeyForProject(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			modifier := ServiceAccountKeyForProject(keyPath, projectID)
-			opts, err := modifier([]option.ClientOption{}, tc.container)
+			optionFunc := ServiceAccountKeyForProject(keyPath, projectID)
 
+			clientFactory := googlecloudv2.ClientFactory{}
+			err := optionFunc(&clientFactory)
 			if err != nil {
-				t.Fatalf("modifier returned an unexpected error: %v", err)
+				t.Errorf("optionFunc returned an unexpected error: %v", err)
+			}
+			clientOpts := clientFactory.ClientOptions
+			if len(clientOpts) != 1 {
+				t.Errorf("Expected 1 option to be added, but got %d", len(clientOpts))
+			}
+
+			opts, err := clientOpts[0]([]option.ClientOption{}, tc.container)
+			if err != nil {
+				t.Errorf("client option returned an unexpected error: %v", err)
 			}
 
 			expectedLen := 0
@@ -106,12 +125,22 @@ func TestServiceAccountKeyForProject(t *testing.T) {
 
 func TestTokenSource(t *testing.T) {
 	source := &mockTokenSource{}
-	modifier := TokenSource(source)
+	optionFunc := TokenSource(source)
 	container := googlecloudv2.Project("any-project")
 
-	opts, err := modifier([]option.ClientOption{}, container)
+	clientFactory := googlecloudv2.ClientFactory{}
+	err := optionFunc(&clientFactory)
 	if err != nil {
-		t.Fatalf("modifier returned an unexpected error: %v", err)
+		t.Errorf("optionFunc returned an unexpected error: %v", err)
+	}
+	clientOpts := clientFactory.ClientOptions
+	if len(clientOpts) != 1 {
+		t.Errorf("Expected 1 option to be added, but got %d", len(clientOpts))
+	}
+
+	opts, err := clientOpts[0]([]option.ClientOption{}, container)
+	if err != nil {
+		t.Errorf("client option returned an unexpected error: %v", err)
 	}
 
 	if len(opts) != 1 {
@@ -147,11 +176,20 @@ func TestTokenSourceForProject(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			modifier := TokenSourceForProject(projectID, source)
-			opts, err := modifier([]option.ClientOption{}, tc.container)
-
+			optionFunc := TokenSourceForProject(projectID, source)
+			clientFactory := googlecloudv2.ClientFactory{}
+			err := optionFunc(&clientFactory)
 			if err != nil {
-				t.Fatalf("modifier returned an unexpected error: %v", err)
+				t.Errorf("optionFunc returned an unexpected error: %v", err)
+			}
+			clientOpts := clientFactory.ClientOptions
+			if len(clientOpts) != 1 {
+				t.Errorf("Expected 1 option to be added, but got %d", len(clientOpts))
+			}
+
+			opts, err := clientOpts[0]([]option.ClientOption{}, tc.container)
+			if err != nil {
+				t.Errorf("client option returned an unexpected error: %v", err)
 			}
 
 			expectedLen := 0
@@ -171,11 +209,21 @@ func TestOAuth(t *testing.T) {
 	engine := gin.New()
 	conf := &oauth2.Config{}
 	server := oauth.NewOAuthServer(engine, conf, "/callback", "-suffix")
-	modifier := OAuth(server)
+	optionFunc := OAuth(server)
 	container := googlecloudv2.Project("any-project")
-	opts, err := modifier([]option.ClientOption{}, container)
+	clientFactory := googlecloudv2.ClientFactory{}
+	err := optionFunc(&clientFactory)
 	if err != nil {
-		t.Fatalf("modifier returned an unexpected error: %v", err)
+		t.Errorf("optionFunc returned an unexpected error: %v", err)
+	}
+	clientOpts := clientFactory.ClientOptions
+	if len(clientOpts) != 1 {
+		t.Errorf("Expected 1 option to be added, but got %d", len(clientOpts))
+	}
+
+	opts, err := clientOpts[0]([]option.ClientOption{}, container)
+	if err != nil {
+		t.Errorf("client option returned an unexpected error: %v", err)
 	}
 	if len(opts) != 1 {
 		t.Errorf("Expected 1 option to be added, but got %d", len(opts))


### PR DESCRIPTION
This change added options field in ClientFactory to allow Option to extend specific API client.

The motivation behind this change is logging client may have different retry logic and currently the ClientFactory supplies the same client options always.