### PR TITLE
Added fallbacks when the fields used for main message is not available

### DIFF
--- a/pkg/core/inspection/gcpqueryutil/fieldset_test.go
+++ b/pkg/core/inspection/gcpqueryutil/fieldset_test.go
@@ -81,6 +81,66 @@ func TestGCPMainMessageFieldSet(t *testing.T) {
 			InputYAML: `jsonPayload:
   message: bar`,
 		},
+		{
+			Name:                "from jsonPayload.MESSAGE field",
+			ExpectedMainMessage: "bar",
+			InputYAML: `jsonPayload:
+  MESSAGE: bar`,
+		},
+		{
+			Name:                "from jsonPayload.msg field",
+			ExpectedMainMessage: "bar",
+			InputYAML: `jsonPayload:
+  msg: bar`,
+		},
+		{
+			Name:                "from jsonPayload.log field",
+			ExpectedMainMessage: "bar",
+			InputYAML: `jsonPayload:
+  log: bar`,
+		},
+		{
+			Name:                "from the whole jsonPayload field",
+			ExpectedMainMessage: `{"foo":"bar"}`,
+			InputYAML: `jsonPayload:
+  foo: bar`,
+		},
+		{
+			Name:                "from the whole labels field",
+			ExpectedMainMessage: `{"foo":"bar"}`,
+			InputYAML: `labels:
+  foo: bar`,
+		},
+		{
+			Name:                "ignore when the message is protoPayload even labels are provided",
+			ExpectedMainMessage: "",
+			InputYAML: `labels:
+  foo: bar
+protoPayload:
+  qux: quux`,
+		},
+		{
+			Name:                "empty if no proper field is given",
+			ExpectedMainMessage: "",
+			InputYAML:           `foo: bar`,
+		},
+		{
+			Name:                "prioritize textPayload rather than jsonPayload.msg or labels",
+			ExpectedMainMessage: "bar",
+			InputYAML: `jsonPayload:
+  msg: foo
+textPayload: bar
+labels:
+  qux: quux`,
+		},
+		{
+			Name:                "prioritize jsonPayload.msg over labels",
+			ExpectedMainMessage: "foo",
+			InputYAML: `jsonPayload:
+  msg: foo
+labels:
+  qux: quux`,
+		},
 	}
 	for _, tc := range testCase {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
Container log parsers and several parser tasks are depending on the main message field set reader, but it can show noisy warnings when none of the target log fields are available.

This change fixes the issue by adding fallback fields. Now it uses fields as a main message in the following order:
 `textPayload` > `jsonPayload.****` (**** would be `message`, `msg`...etc) > jsonPayload > labels