### PR TITLE
fix bug StandardProgressReportableLogFetcher may send a data to channel after close on error

### DIFF
--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
@@ -133,6 +133,7 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 	err := s.fetcher.FetchLogs(stubChan, ctx, filter, container, resourceContainers)
 	if err != nil {
 		cancelSubroutine()
+		wg.Wait()
 		return err
 	}
 


### PR DESCRIPTION
StandardProgressReportableLogFetcher didn't close the progress channel after stopping its subroutine on error.