### PR TITLE
Add a fieldset type to parse audit logs on Google Cloud

### DIFF
--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khierrors"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+)
+
+type GCPAuditLogFieldSet struct {
+	OperationID    string
+	OperationFirst bool
+	OperationLast  bool
+	MethodName     string
+	ResourceName   string
+	PrincipalEmail string
+	Status         int
+	Request        *structured.NodeReader
+	Response       *structured.NodeReader
+}
+
+// Kind implements log.FieldSet.
+func (g *GCPAuditLogFieldSet) Kind() string {
+	return "gcp_operation"
+}
+
+// Starting returns true when the operation is long running operation and the log entry is for the starting timing.
+func (g *GCPAuditLogFieldSet) Starting() bool {
+	return g.OperationFirst && !g.OperationLast
+}
+
+// Ending returns true when the operation is long running operation and the log entry is for the ending timing.
+func (g *GCPAuditLogFieldSet) Ending() bool {
+	return g.OperationLast && !g.OperationFirst
+}
+
+// ImmediateOperation returns true when the log represents an operation completes immediately.
+func (g *GCPAuditLogFieldSet) ImmediateOperation() bool {
+	return (g.OperationFirst && g.OperationLast) || (!g.OperationFirst && !g.OperationLast)
+}
+
+// OperationPath returns the resource path for the operation.
+func (g *GCPAuditLogFieldSet) OperationPath(pathToParent resourcepath.ResourcePath) resourcepath.ResourcePath {
+	if g.ImmediateOperation() {
+		return pathToParent // operation logs immediately completes must be written on its parent resource.
+	}
+	methodNameSplitted := strings.Split(g.MethodName, ".")
+	shortMethodName := "unknown"
+	if len(methodNameSplitted) > 0 {
+		shortMethodName = methodNameSplitted[len(methodNameSplitted)-1]
+	}
+	return resourcepath.Operation(pathToParent, shortMethodName, g.OperationID)
+}
+
+// RequestString returns the request body as a YAML string.
+func (g *GCPAuditLogFieldSet) RequestString() (string, error) {
+	if g.Request != nil {
+		requestBodyRaw, err := g.Request.Serialize("", &structured.YAMLNodeSerializer{})
+		if err != nil {
+			return "", err
+		}
+		return string(requestBodyRaw), nil
+	}
+	return "", fmt.Errorf("protoPayload.request field is absent: %w", khierrors.ErrNotFound)
+}
+
+// ResponseString returns the response body as a YAML string.
+func (g *GCPAuditLogFieldSet) ResponseString() (string, error) {
+	if g.Response != nil {
+		responseBodyRaw, err := g.Response.Serialize("", &structured.YAMLNodeSerializer{})
+		if err != nil {
+			return "", err
+		}
+		return string(responseBodyRaw), nil
+	}
+	return "", fmt.Errorf("protoPayload.response field is absent: %w", khierrors.ErrNotFound)
+}
+
+var _ (log.FieldSet) = (*GCPAuditLogFieldSet)(nil)
+
+type GCPOperationAuditLogFieldSetReader struct {
+}
+
+// FieldSetKind implements log.FieldSetReader.
+func (g *GCPOperationAuditLogFieldSetReader) FieldSetKind() string {
+	return (&GCPAuditLogFieldSet{}).Kind()
+}
+
+// Read implements log.FieldSetReader.
+func (g *GCPOperationAuditLogFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
+	var result GCPAuditLogFieldSet
+	result.OperationID = reader.ReadStringOrDefault("operation.id", "")
+	result.OperationFirst = reader.ReadBoolOrDefault("operation.first", false)
+	result.OperationLast = reader.ReadBoolOrDefault("operation.last", false)
+	result.MethodName = reader.ReadStringOrDefault("protoPayload.methodName", "unknown")
+	result.ResourceName = reader.ReadStringOrDefault("protoPayload.resourceName", "unknown")
+	result.PrincipalEmail = reader.ReadStringOrDefault("protoPayload.authenticationInfo.principalEmail", "unknown")
+	result.Status = reader.ReadIntOrDefault("protoPayload.status.code", -1)
+	result.Request, _ = reader.GetReader("protoPayload.request")
+	result.Response, _ = reader.GetReader("protoPayload.response")
+	return &result, nil
+}
+
+var _ (log.FieldSetReader) = (*GCPOperationAuditLogFieldSetReader)(nil)

--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
@@ -1,0 +1,245 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khierrors"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGCPAuditLogFieldSetReader(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input string
+		want  *GCPAuditLogFieldSet
+	}{
+		{
+			desc: "basic input",
+			input: `
+operation:
+  id: "12345"
+  first: true
+  last: false
+protoPayload:
+  methodName: "test.method"
+  resourceName: "projects/123/resources/abc"
+  authenticationInfo:
+    principalEmail: "user@example.com"
+  status:
+    code: 200
+`,
+			want: &GCPAuditLogFieldSet{
+				OperationID:    "12345",
+				OperationFirst: true,
+				OperationLast:  false,
+				MethodName:     "test.method",
+				ResourceName:   "projects/123/resources/abc",
+				PrincipalEmail: "user@example.com",
+				Status:         200,
+				Request:        nil,
+				Response:       nil,
+			},
+		},
+		{
+			desc:  "default input",
+			input: "{}",
+			want: &GCPAuditLogFieldSet{
+				OperationID:    "",
+				OperationFirst: false,
+				OperationLast:  false,
+				MethodName:     "unknown",
+				ResourceName:   "unknown",
+				PrincipalEmail: "unknown",
+				Status:         -1,
+				Request:        nil,
+				Response:       nil,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l, err := log.NewLogFromYAMLString(tc.input)
+			if err != nil {
+				t.Fatalf("failed to parse YAML test input to log: %v", err)
+			}
+			err = l.SetFieldSetReader(&GCPOperationAuditLogFieldSetReader{})
+			if err != nil {
+				t.Errorf("failed to run GCPOperationAuditLogFieldSetReader.Read(): %v", err)
+			}
+			got := log.MustGetFieldSet(l, &GCPAuditLogFieldSet{})
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GCPOperationAuditLogFieldSet mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGCPAuditLogFieldSet_OperationMethods(t *testing.T) {
+	operationPathParent := resourcepath.Node("node-foo")
+	testCases := []struct {
+		desc                   string
+		input                  GCPAuditLogFieldSet
+		wantStarting           bool
+		wantEnding             bool
+		wantImmediateOperation bool
+		wantOperationPath      resourcepath.ResourcePath
+	}{
+		{
+			desc: "operation started",
+			input: GCPAuditLogFieldSet{
+				OperationID:    "op-1",
+				OperationFirst: true,
+				OperationLast:  false,
+				MethodName:     "compute.instances.insert",
+			},
+			wantStarting:           true,
+			wantEnding:             false,
+			wantImmediateOperation: false,
+			wantOperationPath:      resourcepath.Operation(operationPathParent, "insert", "op-1"),
+		},
+		{
+			desc: "operation ended",
+			input: GCPAuditLogFieldSet{
+				OperationID:    "op-1",
+				OperationFirst: false,
+				OperationLast:  true,
+				MethodName:     "compute.instances.insert",
+			},
+			wantStarting:           false,
+			wantEnding:             true,
+			wantImmediateOperation: false,
+			wantOperationPath:      resourcepath.Operation(operationPathParent, "insert", "op-1"),
+		},
+		{
+			desc: "immediate operation",
+			input: GCPAuditLogFieldSet{
+				OperationID:    "op-2",
+				OperationFirst: true,
+				OperationLast:  true,
+				MethodName:     "compute.instances.delete",
+			},
+			wantStarting:           false,
+			wantEnding:             false,
+			wantImmediateOperation: true,
+			wantOperationPath:      operationPathParent,
+		},
+		{
+			// this is not expected to happen
+			desc: "neither start nor end",
+			input: GCPAuditLogFieldSet{
+				OperationID:    "op-3",
+				OperationFirst: false,
+				OperationLast:  false,
+				MethodName:     "compute.instances.update",
+			},
+			wantStarting:           false,
+			wantEnding:             false,
+			wantImmediateOperation: true,
+			wantOperationPath:      operationPathParent,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotStarting := tc.input.Starting()
+			gotEnding := tc.input.Ending()
+			gotImmediateOperation := tc.input.ImmediateOperation()
+			gotOperationPath := tc.input.OperationPath(operationPathParent)
+
+			if gotStarting != tc.wantStarting {
+				t.Errorf("GCPAuditLogFieldSet.Starting() = %v, want %v", gotStarting, tc.wantStarting)
+			}
+			if gotEnding != tc.wantEnding {
+				t.Errorf("GCPAuditLogFieldSet.Ending() = %v, want %v", gotEnding, tc.wantEnding)
+			}
+			if gotImmediateOperation != tc.wantImmediateOperation {
+				t.Errorf("GCPAuditLogFieldSet.ImmediateOperation() = %v, want %v", gotImmediateOperation, tc.wantImmediateOperation)
+			}
+			if diff := cmp.Diff(tc.wantOperationPath, gotOperationPath); diff != "" {
+				t.Errorf("GCPAuditLogFieldSet.OperationPath() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGCPAuditLogFieldSet_RequestResponseString(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		input           string
+		wantRequest     string
+		wantRequestErr  error
+		wantResponse    string
+		wantResponseErr error
+	}{
+		{
+			desc: "request and response present",
+			input: `
+protoPayload:
+  request:
+    foo: bar
+  response:
+    status: ok
+`,
+			wantRequest:     "foo: bar\n",
+			wantRequestErr:  nil,
+			wantResponse:    "status: ok\n",
+			wantResponseErr: nil,
+		},
+		{
+			desc: "request and response absent",
+			input: `
+protoPayload: {}
+`,
+			wantRequest:     "",
+			wantRequestErr:  khierrors.ErrNotFound,
+			wantResponse:    "",
+			wantResponseErr: khierrors.ErrNotFound,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l, err := log.NewLogFromYAMLString(tc.input)
+			if err != nil {
+				t.Fatalf("failed to parse YAML test input to log: %v", err)
+			}
+			err = l.SetFieldSetReader(&GCPOperationAuditLogFieldSetReader{})
+			if err != nil {
+				t.Errorf("failed to run GCPOperationAuditLogFieldSetReader.Read(): %v", err)
+			}
+			fieldSet := log.MustGetFieldSet(l, &GCPAuditLogFieldSet{})
+
+			gotRequest, gotRequestErr := fieldSet.RequestString()
+			gotResponse, gotResponseErr := fieldSet.ResponseString()
+
+			if gotRequest != tc.wantRequest {
+				t.Errorf("RequestString() got = %v, want %v", gotRequest, tc.wantRequest)
+			}
+			if tc.wantRequestErr != nil && !errors.Is(gotRequestErr, tc.wantRequestErr) {
+				t.Errorf("RequestString() error got = %v, want %v", gotRequestErr, tc.wantRequestErr)
+			}
+			if gotResponse != tc.wantResponse {
+				t.Errorf("ResponseString() got = %v, want %v", gotResponse, tc.wantResponse)
+			}
+			if tc.wantResponseErr != nil && !errors.Is(gotResponseErr, tc.wantResponseErr) {
+				t.Errorf("ResponseString() error got = %v, want %v", gotResponseErr, tc.wantResponseErr)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This change introduce a new FieldSet and FieldSetReader implementation for audit log on GoogleCloud.
All parsers added later should use this type to read these fields from the log not directly reading them from reader methods.