### PR TITLE
fix panic error on containerd id finder task

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task.go
@@ -108,8 +108,11 @@ func processPodSandboxIDDiscoveryForLog(ctx context.Context, l *log.Log, relatio
 func findPodSandboxIDInfo(jsonPayloadMessage string) (*googlecloudlogk8snode_contract.PodSandboxIDInfo, error) {
 	// RunPodSandbox for &PodSandboxMetadata{Name:podname,Uid:b86b49f2431d244c613996c6472eb864,Namespace:kube-system,Attempt:0,} returns sandbox id \"6123c6aacf0c78dc38ec4f0ff72edd3cf04eb82ca0e3e7dddd3950ea9753bdf1\"
 	msg, err := logutil.ExtractKLogField(jsonPayloadMessage, "msg")
-	if msg == "" || err != nil {
-		return nil, fmt.Errorf("failed to extract main message")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract main message: %w", err)
+	}
+	if msg == "" {
+		return nil, fmt.Errorf("main message not found in log")
 	}
 	if strings.HasPrefix(msg, "RunPodSandbox") {
 		fields := readGoStructFromString(msg, "PodSandboxMetadata")
@@ -143,8 +146,11 @@ func processContainerIDDiscoveryForLog(ctx context.Context, l *log.Log, relation
 
 func findContainerIDInfo(jsonPayloadMessage string) (*googlecloudlogk8snode_contract.ContainerIDInfo, error) {
 	msg, err := logutil.ExtractKLogField(jsonPayloadMessage, "msg")
-	if msg == "" || err != nil {
-		return nil, fmt.Errorf("failed to extract main message")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract main message: %w", err)
+	}
+	if msg == "" {
+		return nil, fmt.Errorf("main message not found in log")
 	}
 	if strings.HasPrefix(msg, "CreateContainer") {
 		fields := readGoStructFromString(msg, "ContainerMetadata")

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task_test.go
@@ -49,7 +49,7 @@ func TestProcessPodSandboxIDDiscoveryForLog(t *testing.T) {
 			},
 		},
 		{
-			desc: "log message without RunPodSandbox prefix",
+			desc: "empty message",
 			inputComponentFieldSet: &googlecloudlogk8snode_contract.K8sNodeLogCommonFieldSet{
 				Message: "",
 			},


### PR DESCRIPTION
The logutil.ExtractKLogField can return an empty string without error. This can cause panic on the ID finder.