### PR TITLE
Fix issues after upgrading markdown lint

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,20 +7,20 @@ assignees: ''
 
 ---
 
-### Overview
+## Overview
 
-#### Describe the bug
+### Describe the bug
 <!-- A clear and concise description of what the bug is. -->
 
-#### Current behavior
+### Current behavior
 <!-- A clear and concise description of what happens now.-->
 
-#### Expected behavior
+### Expected behavior
 <!-- A clear and concise description of what you expected to happen.-->
 
-### Debugging resources
+## Debugging resources
 
-#### Reproductive steps
+### Reproductive steps
 <!-- 
 1. Go to '...'
 2. Click on '....'
@@ -28,13 +28,13 @@ assignees: ''
 4. See error
 -->
 
-#### Screenshots
+### Screenshots
 <!-- Please add screenshots to help explain your problem if applicable.-->
 
-#### .khi files (Optional)
+### .khi files (Optional)
 <!-- If possible, please attach the .khi file.-->
 
-### Environments
+## Environments
 
 * [Image version](https://github.com/GoogleCloudPlatform/khi/pkgs/container/khi) used : <FILL_HERE>
 * [ ] I use the latest Chrome when I observed this issue

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-### Is your feature request related to a problem? Please describe
+## Is your feature request related to a problem? Please describe
 <!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]-->
 
-### Describe the solution you'd like
+## Describe the solution you'd like
 <!--A clear and concise description of what you want to happen.-->
 
-### Describe alternatives you've considered
+## Describe alternatives you've considered
 <!--A clear and concise description of any alternative solutions or features you've considered.-->
 
-### Additional context
+## Additional context
 <!--Add any other context or screenshots about the feature request here.-->

--- a/.github/workflows/pr-request.yaml
+++ b/.github/workflows/pr-request.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # 19.1.0
+        uses: DavidAnson/markdownlint-cli2-action@30a0e04f1870d58f8d717450cc6134995f993c63 # 19.1.0
 
   backend-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Markdown lint started complaining about the header levels on templates after upgrade. Fixing them.