### PR TITLE
Use xx-version-file to specify compiler/runtime version on release Github Action script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,12 +32,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: './go.mod'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version-file: './.node-version'
 
       - name: Install Frontend Dependencies
         run: |


### PR DESCRIPTION
The Github Action configuration used for release hard coded its dependency version and it's not the same way of pointing version in the other Github Action script.
This PR aligns the way of specifying the version in the release script.