### PR TITLE
Changed embedded frontend file folder due to the Angular compiler update

### DIFF
--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -46,9 +46,9 @@ jobs:
     - name: Backend Test
       run: |
         make generate-backend
-        mkdir -p pkg/server/dist/session
+        mkdir -p pkg/server/dist/browser/session
         # A placeholder frontend code read from backend test
-        echo '<!--INJECT GENERATED CODE HERE FROM BACKEND-->' > ./pkg/server/dist/index.html
+        echo '<!--INJECT GENERATED CODE HERE FROM BACKEND-->' > ./pkg/server/dist/browser/index.html
         go test ./... -args -skip-cloud-logging=true
     - name: Backend Format and Lint Check
       run: |

--- a/pkg/server/embedfs_test.go
+++ b/pkg/server/embedfs_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-//go:embed dist
+//go:embed dist/browser
 var embeddedStaticFolderTest embed.FS
 
 func TestEmbedFolder_Exists(t *testing.T) {
@@ -51,7 +51,7 @@ func TestEmbedFolder_Exists(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			fs := embedFolder(embeddedStaticFolderTest, "dist")
+			fs := embedFolder(embeddedStaticFolderTest, embeddedStaticFolderPath)
 
 			got := fs.Exists(tc.prefix, tc.path)
 			if got != tc.want {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,9 +39,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const embeddedStaticFolderPath = "dist"
+const embeddedStaticFolderPath = "dist/browser"
 
-//go:embed dist
+//go:embed dist/browser
 var embeddedStaticFolder embed.FS
 
 type ServerConfig struct {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -782,11 +782,11 @@ func TestKHIServer_EndpointExistsWithConfigs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error %s", err)
 			}
-			defer testutil.MustPlaceTemporalFile("dist/test.html", "")()
+			defer testutil.MustPlaceTemporalFile(fmt.Sprintf("%s/test.html", embeddedStaticFolderPath), "")()
 			recorer := httptest.NewRecorder()
 			config := ServerConfig{
 				ViewerMode:       tc.viewerMode,
-				StaticFolderPath: "dist",
+				StaticFolderPath: embeddedStaticFolderPath,
 				ResourceMonitor:  &ResourceMonitorMock{UsedMemory: 1000},
 				ServerBasePath:   tc.serverBasePath,
 			}


### PR DESCRIPTION
Angular builder now generates its frontend files under `dist/browser` not directly under `dist` folder.

Ref: https://stackoverflow.com/questions/78544888/angular-18-ng-build-without-browser-folder

