### PR TITLE
Add set parameter form types on the backend side

### DIFF
--- a/pkg/core/inspection/formtask/setform.go
+++ b/pkg/core/inspection/formtask/setform.go
@@ -1,0 +1,309 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formtask
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	common_task "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// SetFormValidator is a function to check if the given value is valid or not.
+type SetFormValidator = func(ctx context.Context, value []string) (string, error)
+
+// SetFormDefaultValueGenerator is a function type to generate the default value.
+type SetFormDefaultValueGenerator = func(ctx context.Context, previousValues []string) ([]string, error)
+
+// SetFormOptionsProvider is a function to return the list of options.
+type SetFormOptionsProvider = func(ctx context.Context, previousValues []string) ([]inspectionmetadata.SetParameterFormFieldOptionItem, error)
+
+// SetFormValueConverter is a function type to convert the given string slice value to another type stored in the variable set.
+type SetFormValueConverter[T any] = func(ctx context.Context, value []string) (T, error)
+
+// SetFormHintGenerator is a function type to generate a hint string
+type SetFormHintGenerator = func(ctx context.Context, value []string, convertedValue any) (string, inspectionmetadata.ParameterHintType, error)
+
+// SetFormBoolProvider is a function type to provide boolean flags dynamically.
+type SetFormBoolProvider = func(ctx context.Context) (bool, error)
+
+// SetFormTaskBuilder is an utility to construct an instance of task for input form field.
+type SetFormTaskBuilder[T any] struct {
+	FormTaskBuilderBase[T]
+	defaultValue     SetFormDefaultValueGenerator
+	validator        SetFormValidator
+	optionsProvider  SetFormOptionsProvider
+	hintGenerator    SetFormHintGenerator
+	converter        SetFormValueConverter[T]
+	allowCustomValue SetFormBoolProvider
+	allowAddAll      SetFormBoolProvider
+	allowRemoveAll   SetFormBoolProvider
+}
+
+// NewSetFormTaskBuilder constructs an instance of SetFormTaskBuilder.
+func NewSetFormTaskBuilder[T any](id taskid.TaskImplementationID[T], priority int, fieldLabel string) *SetFormTaskBuilder[T] {
+	return &SetFormTaskBuilder[T]{
+		FormTaskBuilderBase: NewFormTaskBuilderBase(id, priority, fieldLabel),
+		defaultValue: func(ctx context.Context, previousValues []string) ([]string, error) {
+			return nil, nil
+		},
+		validator: func(ctx context.Context, value []string) (string, error) {
+			return "", nil
+		},
+		optionsProvider: func(ctx context.Context, previousValues []string) ([]inspectionmetadata.SetParameterFormFieldOptionItem, error) {
+			return []inspectionmetadata.SetParameterFormFieldOptionItem{}, nil
+		},
+		converter: func(ctx context.Context, value []string) (T, error) {
+			var anyValue any = value
+			if converted, convertible := anyValue.(T); convertible {
+				return converted, nil
+			}
+			return *new(T), fmt.Errorf("value is not convertible to %T in the default converter. Did you forget to set the custom converter?", (*T)(nil))
+		},
+		hintGenerator: func(ctx context.Context, value []string, convertedValue any) (string, inspectionmetadata.ParameterHintType, error) {
+			return "", inspectionmetadata.Info, nil
+		},
+		allowCustomValue: func(ctx context.Context) (bool, error) { return false, nil },
+		allowAddAll:      func(ctx context.Context) (bool, error) { return true, nil },
+		allowRemoveAll:   func(ctx context.Context) (bool, error) { return true, nil },
+	}
+}
+
+func (b *SetFormTaskBuilder[T]) WithDependencies(dependencies []taskid.UntypedTaskReference) *SetFormTaskBuilder[T] {
+	b.FormTaskBuilderBase.WithDependencies(dependencies)
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithDescription(description string) *SetFormTaskBuilder[T] {
+	b.FormTaskBuilderBase.WithDescription(description)
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithValidator(validator SetFormValidator) *SetFormTaskBuilder[T] {
+	b.validator = validator
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithDefaultValueFunc(defFunc SetFormDefaultValueGenerator) *SetFormTaskBuilder[T] {
+	b.defaultValue = defFunc
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithDefaultValueConstant(defValue []string, preferPrevValue bool) *SetFormTaskBuilder[T] {
+	return b.WithDefaultValueFunc(func(ctx context.Context, previousValues []string) ([]string, error) {
+		if preferPrevValue {
+			if len(previousValues) > 0 {
+				return previousValues, nil
+			}
+		}
+		return defValue, nil
+	})
+}
+
+func (b *SetFormTaskBuilder[T]) WithOptionsFunc(optionsFunc SetFormOptionsProvider) *SetFormTaskBuilder[T] {
+	b.optionsProvider = optionsFunc
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithOptionsConstant(options []inspectionmetadata.SetParameterFormFieldOptionItem) *SetFormTaskBuilder[T] {
+	return b.WithOptionsFunc(func(ctx context.Context, previousValues []string) ([]inspectionmetadata.SetParameterFormFieldOptionItem, error) {
+		return options, nil
+	})
+}
+
+func (b *SetFormTaskBuilder[T]) WithOptionsSimple(options []string) *SetFormTaskBuilder[T] {
+	return b.WithOptionsFunc(func(ctx context.Context, previousValues []string) ([]inspectionmetadata.SetParameterFormFieldOptionItem, error) {
+		result := make([]inspectionmetadata.SetParameterFormFieldOptionItem, len(options))
+		for i, opt := range options {
+			result[i] = inspectionmetadata.SetParameterFormFieldOptionItem{
+				ID: opt,
+			}
+		}
+		return result, nil
+	})
+}
+
+func (b *SetFormTaskBuilder[T]) WithAllowCustomValueFunc(allowFunc SetFormBoolProvider) *SetFormTaskBuilder[T] {
+	b.allowCustomValue = allowFunc
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithAllowCustomValue(allow bool) *SetFormTaskBuilder[T] {
+	return b.WithAllowCustomValueFunc(func(ctx context.Context) (bool, error) {
+		return allow, nil
+	})
+}
+
+func (b *SetFormTaskBuilder[T]) WithAllowAddAllFunc(allowFunc SetFormBoolProvider) *SetFormTaskBuilder[T] {
+	b.allowAddAll = allowFunc
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithAllowAddAll(allow bool) *SetFormTaskBuilder[T] {
+	return b.WithAllowAddAllFunc(func(ctx context.Context) (bool, error) {
+		return allow, nil
+	})
+}
+
+func (b *SetFormTaskBuilder[T]) WithAllowRemoveAllFunc(allowFunc SetFormBoolProvider) *SetFormTaskBuilder[T] {
+	b.allowRemoveAll = allowFunc
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithAllowRemoveAll(allow bool) *SetFormTaskBuilder[T] {
+	return b.WithAllowRemoveAllFunc(func(ctx context.Context) (bool, error) {
+		return allow, nil
+	})
+}
+
+func (b *SetFormTaskBuilder[T]) WithHintFunc(hintFunc SetFormHintGenerator) *SetFormTaskBuilder[T] {
+	b.hintGenerator = hintFunc
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) WithConverter(converter SetFormValueConverter[T]) *SetFormTaskBuilder[T] {
+	b.converter = converter
+	return b
+}
+
+func (b *SetFormTaskBuilder[T]) Build(labelOpts ...common_task.LabelOpt) common_task.Task[T] {
+	return common_task.NewTask(b.id, b.dependencies, func(ctx context.Context) (T, error) {
+		m := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+		req := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionTaskInput)
+		taskMode := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionTaskMode)
+		globalSharedMap := khictx.MustGetValue(ctx, inspectioncore_contract.GlobalSharedMap)
+
+		previousValueStoreKey := typedmap.NewTypedKey[[]string](fmt.Sprintf("set-form-pv-%s", b.id))
+		prevValue := typedmap.GetOrDefault(globalSharedMap, previousValueStoreKey, []string{})
+
+		allowCustomValue, err := b.allowCustomValue(ctx)
+		if err != nil {
+			return *new(T), fmt.Errorf("allowCustomValue provider for task `%s` returned an error\n%v", b.id, err)
+		}
+		allowAddAll, err := b.allowAddAll(ctx)
+		if err != nil {
+			return *new(T), fmt.Errorf("allowAddAll provider for task `%s` returned an error\n%v", b.id, err)
+		}
+		allowRemoveAll, err := b.allowRemoveAll(ctx)
+		if err != nil {
+			return *new(T), fmt.Errorf("allowRemoveAll provider for task `%s` returned an error\n%v", b.id, err)
+		}
+
+		field := inspectionmetadata.SetParameterFormField{}
+		field.AllowCustomValue = allowCustomValue
+		field.AllowAddAll = allowAddAll
+		field.AllowRemoveAll = allowRemoveAll
+
+		// Compute the default value
+		var currentValue []string
+		defaultValue, err := b.defaultValue(ctx, prevValue)
+		if err != nil {
+			return *new(T), fmt.Errorf("default value generator for task `%s` returned an error\n%v", b.id, err)
+		}
+		field.Default = defaultValue
+		currentValue = defaultValue
+
+		if valueRaw, exist := req[b.id.ReferenceIDString()]; exist {
+			valueSlice, isSlice := valueRaw.([]interface{})
+			if !isSlice {
+				// Also try to handle string[] (though json unmarshal usually gives []interface{})
+				if strSlice, ok := valueRaw.([]string); ok {
+					currentValue = strSlice
+				} else {
+					return *new(T), fmt.Errorf("request parameter `%s` was not given in array in task %s", b.id, b.id)
+				}
+			} else {
+				// Convert []interface{} to []string
+				strs := make([]string, len(valueSlice))
+				for i, v := range valueSlice {
+					str, ok := v.(string)
+					if !ok {
+						return *new(T), fmt.Errorf("request parameter `%s` contains non-string value at index %d", b.id, i)
+					}
+					strs[i] = str
+				}
+				currentValue = strs
+			}
+		}
+
+		field.Type = inspectionmetadata.Set
+		field.HintType = inspectionmetadata.Info
+
+		b.SetupBaseFormField(&field.ParameterFormFieldBase)
+
+		options, err := b.optionsProvider(ctx, prevValue)
+		if err != nil {
+			return *new(T), fmt.Errorf("options provider for task `%s` returned an error\n%v", b.id, err)
+		}
+		field.Options = options
+
+		validationErr, err := b.validator(ctx, currentValue)
+		if err != nil {
+			return *new(T), fmt.Errorf("validator for task `%s` returned an unrecoverable error\n%v", b.id, err)
+		}
+		if validationErr != "" {
+			// When invalid, fallback to default
+			currentValue, err = b.defaultValue(ctx, prevValue)
+			if err != nil {
+				return *new(T), fmt.Errorf("default value generator for task `%s` returned an error\n%v", b.id, err)
+			}
+		}
+		if validationErr != "" && taskMode == inspectioncore_contract.TaskModeRun {
+			return *new(T), fmt.Errorf("validator for task `%s` returned a validation error in Run mode. \n%v", b.id, validationErr)
+		}
+
+		convertedValue, err := b.converter(ctx, currentValue)
+		if err != nil {
+			return *new(T), fmt.Errorf("failed to convert the value `%v` to the dedicated value in task %s\n%v", currentValue, b.id, err)
+		}
+
+		if validationErr != "" {
+			field.HintType = inspectionmetadata.Error
+			field.Hint = validationErr
+		} else {
+			hint, hintType, err := b.hintGenerator(ctx, currentValue, convertedValue)
+			if err != nil {
+				return *new(T), fmt.Errorf("failed to generate a hint for task %s\n%v", b.id, err)
+			}
+			if hint == "" {
+				hintType = inspectionmetadata.None
+			}
+			field.Hint = hint
+			field.HintType = hintType
+			if taskMode == inspectioncore_contract.TaskModeRun {
+				newValueHistory := currentValue // Store current value as history
+				typedmap.Set(globalSharedMap, previousValueStoreKey, newValueHistory)
+			}
+		}
+
+		formFields, found := typedmap.Get(m, inspectionmetadata.FormFieldSetMetadataKey)
+		if !found {
+			return *new(T), fmt.Errorf("form field set was not found in the metadata set")
+		}
+		err = formFields.SetField(field)
+		if err != nil {
+			return *new(T), fmt.Errorf("failed to configure the form metadata in task `%s`\n%v", b.id, err)
+		}
+		return convertedValue, nil
+	}, append(labelOpts, inspectioncore_contract.NewFormTaskLabelOpt(
+		b.label,
+		b.description,
+	))...)
+}

--- a/pkg/core/inspection/formtask/setform_test.go
+++ b/pkg/core/inspection/formtask/setform_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formtask
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type setFormConfigurator = func(builder *SetFormTaskBuilder[[]string])
+
+func TestSetFormDefinitionBuilder(t *testing.T) {
+	testCases := []struct {
+		Name              string
+		FormConfigurator  setFormConfigurator
+		RequestValue      interface{} // Change to interface{} to allow passing []string or []interface{}
+		ExpectedFormField inspectionmetadata.ParameterFormField
+		ExpectedValue     any
+		ExpectedError     string
+	}{
+		{
+			Name:             "A set form with given parameter",
+			FormConfigurator: func(builder *SetFormTaskBuilder[[]string]) {},
+			RequestValue:     []string{"bar"},
+			ExpectedValue:    []string{"bar"},
+			ExpectedError:    "",
+			ExpectedFormField: inspectionmetadata.SetParameterFormField{
+				AllowCustomValue: false,
+				AllowAddAll:      true,
+				AllowRemoveAll:   true,
+				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
+					HintType: inspectionmetadata.None,
+				},
+				Options: []inspectionmetadata.SetParameterFormFieldOptionItem{},
+			},
+		},
+		{
+			Name: "A set form with default parameter",
+			FormConfigurator: func(builder *SetFormTaskBuilder[[]string]) {
+				builder.WithDefaultValueConstant([]string{"foo-default"}, true)
+			},
+			RequestValue:  nil, // Simulate missing input
+			ExpectedValue: []string{"foo-default"},
+			ExpectedError: "",
+			ExpectedFormField: inspectionmetadata.SetParameterFormField{
+				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
+					HintType: inspectionmetadata.None,
+				},
+				AllowCustomValue: false,
+				AllowAddAll:      true,
+				AllowRemoveAll:   true,
+				Default:          []string{"foo-default"},
+				Options:          []inspectionmetadata.SetParameterFormFieldOptionItem{},
+			},
+		},
+		{
+			Name: "A set form with options",
+			FormConfigurator: func(builder *SetFormTaskBuilder[[]string]) {
+				builder.WithOptionsSimple([]string{"opt1", "opt2"})
+			},
+			RequestValue:  []string{"opt1"},
+			ExpectedValue: []string{"opt1"},
+			ExpectedError: "",
+			ExpectedFormField: inspectionmetadata.SetParameterFormField{
+				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
+					HintType: inspectionmetadata.None,
+				},
+				AllowCustomValue: false,
+				AllowAddAll:      true,
+				AllowRemoveAll:   true,
+				Options: []inspectionmetadata.SetParameterFormFieldOptionItem{
+					{ID: "opt1"},
+					{ID: "opt2"},
+				},
+			},
+		},
+		{
+			Name: "A set form with custom configuration",
+			FormConfigurator: func(builder *SetFormTaskBuilder[[]string]) {
+				builder.WithAllowCustomValue(true).WithAllowAddAll(false).WithAllowRemoveAll(false)
+			},
+			RequestValue:  []string{"custom"},
+			ExpectedValue: []string{"custom"},
+			ExpectedError: "",
+			ExpectedFormField: inspectionmetadata.SetParameterFormField{
+				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
+					HintType: inspectionmetadata.None,
+				},
+				AllowCustomValue: true,
+				AllowAddAll:      false,
+				AllowRemoveAll:   false,
+				Options:          []inspectionmetadata.SetParameterFormFieldOptionItem{},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			originalBuilder := NewSetFormTaskBuilder(taskid.NewDefaultImplementationID[[]string]("foo-set"), 1, "foo label")
+			testCase.FormConfigurator(originalBuilder)
+			taskDef := originalBuilder.Build()
+			formFields := []inspectionmetadata.ParameterFormField{}
+
+			// Execute task as DryRun mode
+			taskCtx := context.Background()
+			taskCtx = inspectiontest.WithDefaultTestInspectionTaskContext(taskCtx)
+
+			inputMap := map[string]any{}
+			if testCase.RequestValue != nil {
+				inputMap["foo-set"] = testCase.RequestValue
+			}
+
+			_, _, err := inspectiontest.RunInspectionTask(taskCtx, taskDef, inspectioncore_contract.TaskModeDryRun, inputMap)
+			if testCase.ExpectedError != "" {
+				if err == nil {
+					t.Errorf("task was expected to be end with an error. But the task finished without an error")
+				} else if err.Error() != testCase.ExpectedError {
+					t.Errorf("task was expected to be end with an error. But the expected error is different.\n expected:%s\nactual:%s", testCase.ExpectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("task was ended with unexpected error\n%s", err)
+				}
+				metadata := khictx.MustGetValue(taskCtx, inspectioncore_contract.InspectionRunMetadata)
+
+				fields, found := typedmap.Get(metadata, inspectionmetadata.FormFieldSetMetadataKey)
+				if !found {
+					t.Fatal("FormFieldSet not found on metadata")
+				}
+				field := fields.DangerouslyGetField("foo-set")
+				formFields = append(formFields, field)
+			}
+
+			// Execute task as Run mode if dry run succeeded
+			if testCase.ExpectedError == "" {
+				taskCtx := context.Background()
+				taskCtx = inspectiontest.WithDefaultTestInspectionTaskContext(taskCtx)
+				result, _, err := inspectiontest.RunInspectionTask(taskCtx, taskDef, inspectioncore_contract.TaskModeRun, inputMap)
+
+				if err != nil {
+					t.Errorf("task was ended with unexpected error\n%s", err)
+				}
+				if diff := cmp.Diff(testCase.ExpectedValue, result); diff != "" {
+					t.Errorf("the result is not matching with the expected value\n%s", diff)
+				}
+				metadata := khictx.MustGetValue(taskCtx, inspectioncore_contract.InspectionRunMetadata)
+
+				fields, found := typedmap.Get(metadata, inspectionmetadata.FormFieldSetMetadataKey)
+				if !found {
+					t.Fatal("FormFieldSet not found on metadata")
+				}
+				field := fields.DangerouslyGetField("foo-set")
+				formFields = append(formFields, field)
+
+				if diff := cmp.Diff(formFields[0], formFields[1], cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("form field is different between DryRun mode and Run mode with same parameter.\n%s", diff)
+				}
+			}
+
+			if len(formFields) > 0 {
+				if diff := cmp.Diff(formFields[0], testCase.ExpectedFormField, cmpopts.IgnoreFields(inspectionmetadata.SetParameterFormField{}, "ID", "Priority", "Type", "Label")); diff != "" {
+					t.Errorf("the generated form field is different from the expected\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/core/inspection/metadata/form_metadata.go
+++ b/pkg/core/inspection/metadata/form_metadata.go
@@ -34,6 +34,8 @@ const (
 	Text ParameterInputType = "text"
 	// File is a type of ParameterInputType. This represents the file type input field.
 	File ParameterInputType = "file"
+	// Set is a type of ParameterInputType. This represents the set type input field.
+	Set ParameterInputType = "set"
 )
 
 // ParameterHintType represents the types of hint message shown at the bottom of parameter forms.
@@ -108,6 +110,29 @@ type TextParameterFormField struct {
 	ValidationTiming TextFormValidationTimingType `json:"validationTiming"`
 }
 
+// SetParameterFormFieldOptionItem represents an option item in SetParameterFormField.
+type SetParameterFormFieldOptionItem struct {
+	// ID is the unique identifier of the option.
+	ID string `json:"id"`
+	// Description is a human readable description of the option.
+	Description string `json:"description"`
+}
+
+// SetParameterFormField represents Set type parameter specific data.
+type SetParameterFormField struct {
+	ParameterFormFieldBase
+	// AllowCustomValue allows users to add custom values not in the options list.
+	AllowCustomValue bool `json:"allowCustomValue"`
+	// AllowAddAll shows a button to add all available options.
+	AllowAddAll bool `json:"allowAddAll"`
+	// AllowRemoveAll shows a button to remove all selected values.
+	AllowRemoveAll bool `json:"allowRemoveAll"`
+	// Options is the list of available options.
+	Options []SetParameterFormFieldOptionItem `json:"options"`
+	// Default is the default selected values of this field.
+	Default []string `json:"default"`
+}
+
 // FileParameterFormField represents File type parameter specific data.
 type FileParameterFormField struct {
 	ParameterFormFieldBase
@@ -180,6 +205,8 @@ func GetParameterFormFieldBase(parameter ParameterFormField) ParameterFormFieldB
 	case GroupParameterFormField:
 		return v.ParameterFormFieldBase
 	case TextParameterFormField:
+		return v.ParameterFormFieldBase
+	case SetParameterFormField:
 		return v.ParameterFormFieldBase
 	case FileParameterFormField:
 		return v.ParameterFormFieldBase


### PR DESCRIPTION
This PR adds `NewSetFormTaskBuilder` to build a task for set typed parameter from backend.

This is similar to the textform.go(https://github.com/GoogleCloudPlatform/khi/blob/main/pkg/core/inspection/formtask/textform.go) but for set type parameter.