### PR TITLE
Minor style updates and UX improvement for adding subtractive item

### DIFF
--- a/web/src/app/dialogs/new-inspection/components/set-parameter.component.html
+++ b/web/src/app/dialogs/new-inspection/components/set-parameter.component.html
@@ -27,13 +27,14 @@
     [allowCustomValues]="param.allowCustomValue"
     [chipTemplate]="aliasChip"
     [optionTemplate]="optionItem"
+    [allowSubtractiveValue]="true"
   ></khi-shared-set-input>
+  @if (param.hintType !== ParameterHintType.None) {
+    <khi-new-inspection-parameter-hint
+      [parameter]="param"
+    ></khi-new-inspection-parameter-hint>
+  }
 </div>
-@if (param.hintType !== ParameterHintType.None) {
-  <khi-new-inspection-parameter-hint
-    [parameter]="param"
-  ></khi-new-inspection-parameter-hint>
-}
 
 <ng-template #aliasChip let-item let-remove="remove">
   <khi-new-inspection-alias-chip

--- a/web/src/app/shared/components/set-input/set-input.component.scss
+++ b/web/src/app/shared/components/set-input/set-input.component.scss
@@ -15,16 +15,14 @@
  */
 @use "sass:color";
 
-@use "src/app/common.scss" as common;
-
 .container {
   width: 100%;
 }
 
 mat-form-field {
   width: 100%;
-  --mat-form-field-container-height: 40px;
-  --mat-form-field-container-vertical-padding: 8px;
+  --mat-form-field-container-height: 50px;
+  --mat-form-field-container-vertical-padding: 4px;
 }
 
 .buttons {
@@ -35,10 +33,4 @@ mat-form-field {
   mat-icon {
     margin: 0 5px 0 -5px;
   }
-}
-
-.chip-grid {
-  max-height: 400px;
-
-  @include common.show-vertical-scrollbar-always;
 }

--- a/web/src/app/shared/components/set-input/set-input.component.ts
+++ b/web/src/app/shared/components/set-input/set-input.component.ts
@@ -97,6 +97,9 @@ export class SetInputComponent {
   /** Whether to show the "Remove all" button. Defaults to true. */
   public showRemoveAll = input<boolean>(true);
 
+  /** Whether to allow subtractive values. Defaults to false. */
+  public allowSubtractiveValue = input<boolean>(false);
+
   /** Emits the updated list of selected item IDs when selection changes. */
   public selectedItemsChange = output<string[]>();
 
@@ -134,7 +137,10 @@ export class SetInputComponent {
     const available = this.choices().filter((c) => !selectedIdSet.has(c.id));
 
     if (!name) return available;
-    const lowerName = name.toLowerCase();
+    let lowerName = name.toLowerCase();
+    if (this.allowSubtractiveValue() && lowerName.startsWith('-')) {
+      lowerName = lowerName.substring(1);
+    }
     // Simple filtering by id
     return available.filter((item) =>
       item.id.toLowerCase().includes(lowerName),
@@ -192,7 +198,11 @@ export class SetInputComponent {
   /** Handle selection from autocomplete. */
   selected(event: MatAutocompleteSelectedEvent): void {
     const id = event.option.value as string;
-    const newItems = this.getUniqueString([...this.selectedItems(), id]);
+    let newItem = id;
+    if (this.allowSubtractiveValue() && this.inputValue().startsWith('-')) {
+      newItem = '-' + id;
+    }
+    const newItems = this.getUniqueString([...this.selectedItems(), newItem]);
     this.selectedItemsChange.emit(newItems);
     this.inputElement.nativeElement.value = '';
     this.inputCtrl.setValue('');


### PR DESCRIPTION
The new inspection form has several set typed inputs that accepts subtractive item with prefix `-`.
Previous auto complete logic could hide possible items when user input `-`, this PR solve this issue and fixes some cosmetic issues on the control.