### PR TITLE
Split the left side of start dialog component

### DIFF
--- a/web/src/app/dialogs/startup/components/startup-header.component.html
+++ b/web/src/app/dialogs/startup/components/startup-header.component.html
@@ -1,0 +1,59 @@
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div class="container">
+  <div class="icon">
+    <img src="assets/icons/khi.svg" />
+  </div>
+
+  <div class="title">
+    <h1>Kubernetes History Inspector</h1>
+    <div class="version">
+      <p>{{ version() }}</p>
+    </div>
+  </div>
+  <button
+    [disabled]="isViewerMode()"
+    class="task-button new-inspection-button"
+    (click)="newInspection.emit()"
+    [matTooltip]="
+      isViewerMode()
+        ? 'This page is hosted as readonly mode. This operation is prohibited.'
+        : ''
+    "
+  >
+    <div class="icon-container"><mat-icon>search</mat-icon></div>
+    <div class="task-button-labels">
+      <div class="task-title"><p>New inspection</p></div>
+      <div class="task-description">
+        <p>Process logs for visualize</p>
+      </div>
+    </div>
+  </button>
+  <button class="task-button open-button" (click)="open.emit()">
+    <div class="icon-container">
+      <mat-icon>file_open</mat-icon>
+    </div>
+    <div class="task-button-labels">
+      <div class="task-title">
+        <p>Open .khi file</p>
+      </div>
+      <div class="task-description">
+        <p>Open .khi file exported before.</p>
+      </div>
+    </div>
+  </button>
+</div>

--- a/web/src/app/dialogs/startup/components/startup-header.component.scss
+++ b/web/src/app/dialogs/startup/components/startup-header.component.scss
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use "sass:color";
+@use "../../../common.scss" as common;
+
+.container {
+  height: 100%;
+  display: grid;
+  grid-template-areas: "icon" "title" "new-inspection-button" "open-button";
+  grid-template-rows: auto auto auto auto;
+  gap: 5px 0px;
+  justify-content: center;
+  align-content: space-around;
+  text-align: center;
+}
+
+.title {
+  grid-area: title;
+  h1 {
+    margin: 0px;
+    color: #666666;
+  }
+  .version {
+    grid-area: version;
+    color: #888;
+  }
+}
+
+@mixin task-button-appearance($front, $background, $cursor) {
+  color: $front;
+  background-color: $background;
+  &:disabled {
+    background-color: dimgray;
+    color: lightgray;
+    cursor: not-allowed;
+  }
+  .task-description {
+    color: color.adjust($front, $lightness: -5%);
+    &:disabled {
+      color: lightgray;
+    }
+  }
+  &:hover:not(:disabled) {
+    background-color: color.adjust($background, $lightness: -5%);
+    cursor: $cursor;
+  }
+}
+
+.new-inspection-button {
+  grid-area: new-inspection-button;
+  @include task-button-appearance(white, #3f51b5, pointer);
+}
+
+.open-button {
+  grid-area: open-button;
+  @include task-button-appearance(black, white, pointer);
+}
+
+.task-button {
+  appearance: none;
+  outline: none;
+  border: none;
+  border-radius: 10px;
+  padding: 8px 0;
+  box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.35);
+
+  display: grid;
+  grid-template-areas: "leftspace icon middlespace labels rightspace";
+  grid-template-columns: 15px 40px 10px 1fr 10px;
+  grid-template-rows: 70px;
+  align-items: center;
+  justify-content: center;
+
+  .icon-container {
+    grid-area: icon;
+    mat-icon {
+      @include common.adjust-mat-icon-size(30px);
+    }
+  }
+
+  .task-button-labels {
+    grid-area: labels;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    .task-title {
+      font-size: 1.5em;
+      font-weight: 600;
+    }
+  }
+
+  p {
+    margin: 0;
+  }
+}

--- a/web/src/app/dialogs/startup/components/startup-header.component.spec.ts
+++ b/web/src/app/dialogs/startup/components/startup-header.component.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StartupHeaderComponent } from './startup-header.component';
+import { By } from '@angular/platform-browser';
+import { MatTooltipModule } from '@angular/material/tooltip';
+// Use a mock or a simplified version if IconRegistryModule has side effects,
+// but for now strict unit tests might just mock the underlying registry if needed.
+// Since IconRegistryModule is simple, we might just include it or mock the registry.
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+describe('StartupHeaderComponent', () => {
+  let component: StartupHeaderComponent;
+  let fixture: ComponentFixture<StartupHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StartupHeaderComponent, MatIconTestingModule, MatTooltipModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StartupHeaderComponent);
+    component = fixture.componentInstance;
+
+    // Set required inputs
+    fixture.componentRef.setInput('version', 'v1.0.0');
+    fixture.componentRef.setInput('isViewerMode', false);
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display version', () => {
+    const versionEl = fixture.debugElement.query(By.css('.version'));
+    expect(versionEl.nativeElement.textContent).toContain('v1.0.0');
+  });
+
+  it('should emit open event when open button is clicked', () => {
+    spyOn(component.open, 'emit');
+    const button = fixture.debugElement.query(By.css('.open-button'));
+    button.nativeElement.click();
+    expect(component.open.emit).toHaveBeenCalled();
+  });
+
+  it('should emit newInspection event when new inspection button is clicked', () => {
+    spyOn(component.newInspection, 'emit');
+    const button = fixture.debugElement.query(By.css('.new-inspection-button'));
+    button.nativeElement.click();
+    expect(component.newInspection.emit).toHaveBeenCalled();
+  });
+
+  it('should disable new inspection button in viewer mode', () => {
+    fixture.componentRef.setInput('isViewerMode', true);
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('.new-inspection-button'));
+    expect(button.nativeElement.disabled).toBeTrue();
+  });
+});

--- a/web/src/app/dialogs/startup/components/startup-header.component.ts
+++ b/web/src/app/dialogs/startup/components/startup-header.component.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatIconModule } from '@angular/material/icon';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+
+@Component({
+  selector: 'khi-startup-header',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTooltipModule,
+    MatIconModule,
+    KHIIconRegistrationModule,
+  ],
+  templateUrl: './startup-header.component.html',
+  styleUrls: ['./startup-header.component.scss'],
+})
+export class StartupHeaderComponent {
+  version = input.required<string>();
+  isViewerMode = input(false);
+
+  open = output<void>();
+  newInspection = output<void>();
+}

--- a/web/src/app/dialogs/startup/components/startup-header.stories.ts
+++ b/web/src/app/dialogs/startup/components/startup-header.stories.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryObj } from '@storybook/angular';
+import { StartupHeaderComponent } from './startup-header.component';
+
+const meta: Meta<StartupHeaderComponent> = {
+  title: 'Startup/StartupHeader',
+  component: StartupHeaderComponent,
+  tags: ['autodocs'],
+  render: (args) => ({
+    props: args,
+    template: `<div style="background-color: #f8f8f8; padding: 20px; position: relative;"><khi-startup-header [version]="version" [isViewerMode]="isViewerMode"></khi-startup-header></div>`,
+  }),
+  argTypes: {
+    version: {
+      control: 'text',
+      description: 'Version string to display',
+    },
+    isViewerMode: {
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<StartupHeaderComponent>;
+
+export const Default: Story = {
+  args: {
+    version: '0.0.1',
+    isViewerMode: false,
+  },
+};
+
+export const ViewerMode: Story = {
+  args: {
+    version: '0.0.1',
+    isViewerMode: true,
+  },
+};


### PR DESCRIPTION
Splitting startup-dialog.component


**The default appearance**
<img width="3360" height="3488" alt="image" src="https://github.com/user-attachments/assets/7ee2abbe-dc93-482b-b230-3600320711a2" />

**The appearance for viewer mode(the new inspection button is disabled)**
<img width="3360" height="3488" alt="image" src="https://github.com/user-attachments/assets/9cf1ab0e-e1ed-408b-a560-10c52e9c748c" />
