### PR TITLE
Fixed 2 bugs related to scroll

### DIFF
--- a/web/src/app/timeline/components/calculator/vertical-scroll-calculator.ts
+++ b/web/src/app/timeline/components/calculator/vertical-scroll-calculator.ts
@@ -140,6 +140,7 @@ export class VerticalScrollCalculator {
       this.style.heightsByLayer[TimelineLayer.Kind] +
       this.style.heightsByLayer[TimelineLayer.Namespace];
     let i = bisectRight(this.accumulatedHeights, scrollY + stickyHeaderSize); // Starting from the timeline that is at least visible behind the sticky header
+    i = Math.min(i, this.timelines.length - 1);
     let namespaceTimeline: ResourceTimeline | null = null;
     for (; i >= 0; i--) {
       if (this.timelines[i].layer === TimelineLayer.Namespace) {

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -723,6 +723,21 @@ export class TimelineFrameComponent implements AfterViewInit {
         });
       }
     });
+    effect(() => {
+      const verticalCalculator = this.verticalScrollCalculator();
+      const container = this.container();
+      if (!container) {
+        return;
+      }
+      const maxScrollTop =
+        verticalCalculator.totalHeight - this.viewportHeight();
+      if (container.nativeElement.scrollTop > maxScrollTop) {
+        container.nativeElement.scrollTo({
+          top: maxScrollTop,
+          behavior: 'smooth',
+        });
+      }
+    });
   }
 
   handleTimelineEventForIndex(


### PR DESCRIPTION
This PR fixes 2 issues:

* When user scrolls vertically to the end of the timelines, then KHI will crash due to accessing outside of array.
* When user filter timelines with scrolling at the end, user's scroll is remained at blank area. 