### PR TITLE
fix control plane parser to associate logs to the right PV name when the log has the longer name

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/fieldset.go
@@ -280,7 +280,15 @@ func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFro
 			}
 			result = append(result, resourcepath.NameLayerGeneralItem(pair.APIVersion, pair.KindName, splittedField[0], splittedField[1]))
 		} else {
-			result = append(result, resourcepath.NameLayerGeneralItem(pair.APIVersion, pair.KindName, "cluster-scope", field))
+			resourceName := field
+
+			// Some resource may have longer name with slash e.g. PV volumeName="kubernetes.io/csi/pd.csi.storage.gke.io^projects/UNSPECIFIED/zones/us-central1-a/disks/pvc-fe42fc7f-7618-4d3b-94d1-a2490cfd009d"
+			lastSlashIndex := strings.LastIndex(field, "/")
+			if lastSlashIndex != -1 {
+				resourceName = field[lastSlashIndex+1:]
+			}
+
+			result = append(result, resourcepath.NameLayerGeneralItem(pair.APIVersion, pair.KindName, "cluster-scope", resourceName))
 		}
 	}
 	return result

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/fieldset_test.go
@@ -306,6 +306,14 @@ func TestK8sControllerManagerComponentFieldSetReader_ReadResourceAssociationFrom
 			},
 		},
 		{
+			desc:  "with kind and cluster-scoped key and longer name",
+			input: `"attacherDetacher.DetachVolume started" logger="persistentvolume-attach-detach-controller" node="node-foo" volumeName="kubernetes.io/csi/pd.csi.storage.gke.io^projects/UNSPECIFIED/zones/us-central1-a/disks/pvc-fe42fc7f-7618-4d3b-94d1-a2490cfd009d"`,
+			want: []resourcepath.ResourcePath{
+				resourcepath.NameLayerGeneralItem("core/v1", "node", "cluster-scope", "node-foo"),
+				resourcepath.NameLayerGeneralItem("core/v1", "persistentvolume", "cluster-scope", "pvc-fe42fc7f-7618-4d3b-94d1-a2490cfd009d"),
+			},
+		},
+		{
 			desc:  "without resource",
 			input: `"Finished syncing"`,
 			want:  nil,
@@ -326,6 +334,12 @@ func TestK8sControllerManagerComponentFieldSetReader_ReadResourceAssociationFrom
 						KindName:     "pod",
 						KLogField:    "pod",
 						IsNamespaced: true,
+					},
+					{
+						APIVersion:   "core/v1",
+						KindName:     "persistentvolume",
+						KLogField:    "volumeName",
+						IsNamespaced: false,
 					},
 				},
 			}


### PR DESCRIPTION
Some kube-controller-manager log can include FQDN in its klog property(at least I found this behavior on pv controller).
This PR added logic to extract the resource name from the FQDN.