### PR TITLE
fix broken style on new-inspection dialog

### DIFF
--- a/web/src/app/dialogs/new-inspection/new-inspection.component.scss
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.scss
@@ -50,6 +50,11 @@ mat-step {
 
   .mat-horizontal-content-container {
     padding: 0px 24px 0px 24px;
+    flex: 1;
+  }
+
+  .mat-horizontal-stepper-header-container {
+    flex: 0;
   }
 }
 


### PR DESCRIPTION
Fixed the broken style. The bug seems to be introduced due to the previous update around frontend dependency.

<img width="1912" height="3194" alt="image" src="https://github.com/user-attachments/assets/29203167-1bc5-40d8-a8ec-b3aec420e64d" />
