### PR TITLE
:bug: renderer wrongly uses cached gl resources and memory leak on cache

### DIFF
--- a/web/src/app/store/inspection-data.ts
+++ b/web/src/app/store/inspection-data.ts
@@ -37,6 +37,11 @@ export class TimeRange {
  */
 export class InspectionData {
   /**
+   * A unique ID for this inspection data generated when the data is loaded.
+   */
+  public readonly uniqueID = Math.random().toString(36).substring(2, 15);
+
+  /**
    * Set of namespace names included in this inspection data.
    */
   public readonly namespaces: Set<string>;

--- a/web/src/app/timeline/components/canvas/timeline-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-renderer.ts
@@ -114,6 +114,11 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
   private eventRenderers!: LRUCache<string, TimelineEventsRenderer>;
 
   /**
+   * The unique ID of the current inspection data on cache.
+   */
+  private cachedInspectionDataUniqueID: string | null = null;
+
+  /**
    * Queue of renderers that need to be disposed (GPU resources freed) when evicted from cache.
    */
   private disposeQueue: IDisposableRenderer[] = [];
@@ -166,6 +171,15 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
    */
   render(gl: WebGL2RenderingContext, args: TimelineRendererRenderArgs): void {
     if (!this.chartViewModel || !this.chartStyle) return;
+    if (
+      this.chartViewModel.inspectionDataUniqueID !==
+      this.cachedInspectionDataUniqueID
+    ) {
+      this.revisionRenderers.clear();
+      this.eventRenderers.clear();
+      this.cachedInspectionDataUniqueID =
+        this.chartViewModel.inspectionDataUniqueID;
+    }
     gl.viewport(0, 0, this.width, this.height);
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/web/src/app/timeline/components/timeline-chart.viewmodel.ts
+++ b/web/src/app/timeline/components/timeline-chart.viewmodel.ts
@@ -17,6 +17,7 @@
 import { ResourceTimeline } from 'src/app/store/timeline';
 
 export interface TimelineChartViewModel {
+  inspectionDataUniqueID: string;
   timelinesInDrawArea: ResourceTimeline[];
   logBeginTime: number;
   logEndTime: number;

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -162,6 +162,12 @@ export class TimelineFrameComponent implements AfterViewInit {
    * The list of timelines to display.
    */
   readonly timelines = input<ResourceTimeline[]>([]);
+
+  /**
+   * The unique ID of the inspection data.
+   * This is used to detect when the inspection data has changed to refresh timeline renderer cache.
+   */
+  readonly inspectionDataUniqueID = input<string>('');
   /**
    * The minimum time in milliseconds for the query range.
    * This is used as the start time for the timeline view.
@@ -399,6 +405,7 @@ export class TimelineFrameComponent implements AfterViewInit {
    */
   protected readonly chartViewModel = computed<TimelineChartViewModel>(() => {
     return {
+      inspectionDataUniqueID: this.inspectionDataUniqueID(),
       timelinesInDrawArea: this.visibleTimelines(),
       logBeginTime: this.minQueryLogTimeMS(),
       logEndTime: this.maxQueryLogTimeMS(),
@@ -411,6 +418,7 @@ export class TimelineFrameComponent implements AfterViewInit {
   protected readonly stickyChartViewModel = computed<TimelineChartViewModel>(
     () => {
       return {
+        inspectionDataUniqueID: this.inspectionDataUniqueID(),
         timelinesInDrawArea: this.stickyTimelines(),
         logBeginTime: this.minQueryLogTimeMS(),
         logEndTime: this.maxQueryLogTimeMS(),

--- a/web/src/app/timeline/timeline-smart.component.html
+++ b/web/src/app/timeline/timeline-smart.component.html
@@ -17,6 +17,7 @@
 <!--This is smart componnt injecting data from services into the dumb component-->
 <!--No other components or elements should be here except a single timeline-frame component-->
 <khi-timeline-frame
+  [inspectionDataUniqueID]="inspectionDataUniqueID()"
   [timelines]="filteredTimelines()"
   [timezoneShiftHours]="timezoneShiftHours()"
   [pixelsPerMs]="pixelsPerMs()"

--- a/web/src/app/timeline/timeline-smart.component.ts
+++ b/web/src/app/timeline/timeline-smart.component.ts
@@ -106,6 +106,18 @@ export class TimelineSmartComponent {
   });
 
   /**
+   * The unique ID of the inspection data.
+   * This is used to detect when the inspection data has changed to refresh timeline renderer cache.
+   */
+  protected readonly inspectionDataUniqueID = computed(() => {
+    const store = this.inspectionData();
+    if (!store) {
+      return '';
+    }
+    return store.uniqueID;
+  });
+
+  /**
    * The current time at the left edge of the viewport.
    */
   protected readonly viewportLeftTimeMs = toSignal(


### PR DESCRIPTION
The timeline renderer may use the cached renderer loaded for previously loaded inspection data when user open another inspection data and contains a resource with same resource path.

This PR also fixes the bug that released GL resources are not actually released.