### PR TITLE
build(makefile): optimize variable evaluation and directory traversal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .DEFAULT_GOAL := help
 
-VERSION=$(shell cat ./VERSION)
-GIT_SHORT_HASH=$(shell git rev-parse --short HEAD)
-GIT_TAG_NAME="release-"$(VERSION)
+VERSION := $(shell cat ./VERSION)
+GIT_SHORT_HASH := $(shell git rev-parse --short HEAD)
+GIT_TAG_NAME := "release-"$(VERSION)
 
 DUMMY_DIR := scripts/make
 GENERATE_FRONTEND_DUMMY := $(DUMMY_DIR)/generate-frontend.done
@@ -10,14 +10,14 @@ GENERATE_BACKEND_DUMMY := $(DUMMY_DIR)/generate-backend.done
 FRONTEND_GENERATED_ASSETS_DUMMY := $(DUMMY_DIR)/generate-font-atlas.done
 MSDF_SETUP_DUMMY := $(DUMMY_DIR)/msdf-setup.done
 
-BACKEND_TEST_SRCS = $(shell find . -name "*_test.go" -not -path "web/*" -not -path "zzz_*.go")
-BACKEND_SRCS = $(shell find . -name "*.go" -not -path "web/*" -not -path "zzz_*.go" -not -path "*_test.go")
+BACKEND_TEST_SRCS := $(shell find . -path "./web" -prune -o -path "./.git" -prune -o -name "*_test.go" -not -name "zzz_*.go" -print)
+BACKEND_SRCS := $(shell find . -path "./web" -prune -o -path "./.git" -prune -o -name "*.go" -not -name "zzz_*.go" -not -name "*_test.go" -print)
 ENUM_GO_ALL_FILES := $(wildcard pkg/model/enum/*.go)
 ENUM_GO_FILES := $(filter-out %_test.go,$(ENUM_GO_ALL_FILES))
 
 FRONTEND_CODEGEN_DIR := scripts/frontend-codegen
 FRONTEND_CODEGEN_DEPS := $(wildcard $(FRONTEND_CODEGEN_DIR)/*.go $(FRONTEND_CODEGEN_DIR)/templates/*)
-FRONTEND_SOURCE_FILES = $(shell find web -not -path "*/node_modules/*" -not -path "*/.angular/*" -not -path "web/src/assets/*" -not -path "web/src/environments/version.*.ts" -not -path "*/zzz-generated.*" -not -path "web/angular.json")
+FRONTEND_SOURCE_FILES := $(shell find ./web \( -name "node_modules" -o -name ".angular" -o -path "./web/src/assets" \) -prune -o -not -path "./web/src/environments/version.*.ts" -not -path "*/zzz-generated.*" -not -path "./web/angular.json" -print)
 FRONTEND_GENERATED_SRCS = web/src/app/zzz-generated.scss web/src/app/zzz-generated.ts web/angular.json
 FRONTEND_ARTIFACT_FILES_DUMMY = pkg/server/dist/browser/build-web.done
 


### PR DESCRIPTION
Change variable assignments for VERSION, GIT_SHORT_HASH, GIT_TAG_NAME, and source file lists from recursively expanded (`=`) to simply expanded (`:=`) to prevent redundant shell command execution. Update `find` commands to use `-prune` for skipping .git, web, node_modules, and .angular directories to improve file searching performance.

These took `20-40sec` for any Make targets before. But now it just take less than a second.