### PR TITLE
Removing unused CORS code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,6 @@ require (
 	cloud.google.com/go/compute v1.57.0
 	cloud.google.com/go/errorreporting v0.4.0
 	cloud.google.com/go/profiler v0.4.3
-	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/gin-contrib/static v1.1.5
 	github.com/gin-gonic/gin v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
-github.com/gin-contrib/cors v1.7.6 h1:3gQ8GMzs1Ylpf70y8bMw4fVpycXIeX1ZemuSQIsnQQY=
-github.com/gin-contrib/cors v1.7.6/go.mod h1:Ulcl+xN4jel9t1Ry8vqph23a60FwH9xVLd+3ykmTjOk=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-contrib/static v1.1.5 h1:bAPqT4KTZN+4uDY1b90eSrD1t8iNzod7Jj8njwmnzz4=

--- a/pkg/core/init/default/defaultextension.go
+++ b/pkg/core/init/default/defaultextension.go
@@ -163,7 +163,6 @@ func (d *DefaultInitExtension) ConfigureInspectionTaskServer(taskServer *coreins
 func (d *DefaultInitExtension) ConfigureKHIWebServerFactory(serverFactory *server.ServerFactory) error {
 	serverFactory.AddOptions(option.Required())
 
-
 	if *parameters.Debug.Verbose {
 		serverFactory.AddOptions(
 			option.AccessLog("/api/v3/inspection", "/api/v3/popup"), // ignoreing noisy paths
@@ -180,7 +179,5 @@ func (d *DefaultInitExtension) ConfigureKHIWebServerFactory(serverFactory *serve
 func (d *DefaultInitExtension) BeforeTerminate() error {
 	return nil
 }
-
-
 
 var _ coreinit.InitExtension = (*DefaultInitExtension)(nil)

--- a/pkg/core/init/default/defaultextension.go
+++ b/pkg/core/init/default/defaultextension.go
@@ -34,7 +34,6 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/server"
 	"github.com/GoogleCloudPlatform/khi/pkg/server/option"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
-	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 
 	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
@@ -164,9 +163,7 @@ func (d *DefaultInitExtension) ConfigureInspectionTaskServer(taskServer *coreins
 func (d *DefaultInitExtension) ConfigureKHIWebServerFactory(serverFactory *server.ServerFactory) error {
 	serverFactory.AddOptions(option.Required())
 
-	corsConfig := cors.DefaultConfig()
-	corsConfig.AllowAllOrigins = true
-	serverFactory.AddOptions(option.CORS(corsConfig))
+
 	if *parameters.Debug.Verbose {
 		serverFactory.AddOptions(
 			option.AccessLog("/api/v3/inspection", "/api/v3/popup"), // ignoreing noisy paths
@@ -183,5 +180,7 @@ func (d *DefaultInitExtension) ConfigureKHIWebServerFactory(serverFactory *serve
 func (d *DefaultInitExtension) BeforeTerminate() error {
 	return nil
 }
+
+
 
 var _ coreinit.InitExtension = (*DefaultInitExtension)(nil)

--- a/pkg/server/option/option.go
+++ b/pkg/server/option/option.go
@@ -17,7 +17,6 @@ package option
 import (
 	"slices"
 
-	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -69,32 +68,6 @@ func (s *requiredOption) Apply(engine *gin.Engine) error {
 
 var _ Option = (*requiredOption)(nil)
 
-// corsOption is an Option implementation for enabling CORS.
-type corsOption struct {
-	corsConfig cors.Config
-}
-
-// CORS creates a new Option to enable CORS.
-func CORS(config cors.Config) Option {
-	return &corsOption{config}
-}
-
-func (c *corsOption) ID() string {
-	return "cors"
-}
-
-// Order returns the application order for the CORS option.
-func (c *corsOption) Order() int {
-	return 1
-}
-
-// Apply configures the Gin engine to use the gin-contrib/cors middleware with all origins allowed.
-func (c *corsOption) Apply(engine *gin.Engine) error {
-	engine.Use(cors.New(c.corsConfig))
-	return nil
-}
-
-var _ Option = (*corsOption)(nil)
 
 type accessLogOption struct {
 	ignoredPath []string

--- a/pkg/server/option/option.go
+++ b/pkg/server/option/option.go
@@ -68,7 +68,6 @@ func (s *requiredOption) Apply(engine *gin.Engine) error {
 
 var _ Option = (*requiredOption)(nil)
 
-
 type accessLogOption struct {
 	ignoredPath []string
 }

--- a/pkg/server/option/option_test.go
+++ b/pkg/server/option/option_test.go
@@ -121,4 +121,3 @@ func TestApplyOptions(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/server/option/option_test.go
+++ b/pkg/server/option/option_test.go
@@ -17,10 +17,8 @@ package option
 import (
 	"errors"
 	"fmt"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -124,40 +122,3 @@ func TestApplyOptions(t *testing.T) {
 	}
 }
 
-func TestCorsOption(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	config := cors.Config{
-		AllowOrigins: []string{"http://localhost:4200"},
-	}
-
-	opt := CORS(config)
-	engine := gin.New()
-
-	if err := opt.Apply(engine); err != nil {
-		t.Fatalf("Apply() failed: %v", err)
-	}
-
-	// Check ID and Order
-	if opt.ID() != "cors" {
-		t.Errorf("ID() got = %q, want = \"cors\"", opt.ID())
-	}
-	if opt.Order() != 1 {
-		t.Errorf("Order() got = %d, want = 1", opt.Order())
-	}
-
-	// Check if CORS header is present by making a request
-	engine.GET("/test", func(c *gin.Context) {
-		c.String(200, "ok")
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	req.Header.Set("Origin", "http://localhost:4200")
-	w := httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
-
-	gotHeader := w.Header().Get("Access-Control-Allow-Origin")
-	if gotHeader != "http://localhost:4200" {
-		t.Errorf("Access-Control-Allow-Origin header not set correctly. got=%q, want=%q", gotHeader, "http://localhost:4200")
-	}
-}


### PR DESCRIPTION
The current frontend code is proxied by the Angular dev server proxy during the development.
We no longer need the CORS configuration in the Go server.