### PR TITLE
Adding KHI file schema v6 namespaced ID generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=

--- a/pkg/model/khifile/v6/ids.go
+++ b/pkg/model/khifile/v6/ids.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"sync/atomic"
+
+	"golang.org/x/sys/cpu"
+)
+
+// IDNamespace represents a namespace for generating unique IDs.
+type IDNamespace uint32
+
+const (
+	// IDString is the namespace for string IDs.
+	IDString IDNamespace = iota
+	// IDFieldSet is the namespace for field set IDs.
+	IDFieldSet
+
+	// idNamespaceMax is the sentinel value for the maximum number of namespaces.
+	idNamespaceMax
+)
+
+type nsCounter struct {
+	value atomic.Uint32
+	_     cpu.CacheLinePad
+}
+
+// IDGenerator generates unique IDs for different namespaces.
+// It is safe for concurrent use.
+// Note: This generates uint32 IDs instead of string IDs used in pkg/common/idgenerator
+// to save memory and disk space in the file format.
+type IDGenerator struct {
+	counters [idNamespaceMax]nsCounter
+}
+
+// New allocates a fresh uint32 ID in the given namespace.
+// IDs start from 1.
+// Note: This method panics if the namespace is invalid.
+func (g *IDGenerator) New(ns IDNamespace) uint32 {
+	if ns >= idNamespaceMax {
+		panic("invalid namespace")
+	}
+	return g.counters[ns].value.Add(1)
+}
+
+// Set sets the current value of the ID counter for the given namespace.
+// Note: This method is safe from data races, but the outcome is non-deterministic
+// if called concurrently with New. It is intended for initialization or single-threaded setup.
+func (g *IDGenerator) Set(ns IDNamespace, value uint32) {
+	if ns >= idNamespaceMax {
+		panic("invalid namespace")
+	}
+	g.counters[ns].value.Store(value)
+}

--- a/pkg/model/khifile/v6/ids_test.go
+++ b/pkg/model/khifile/v6/ids_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestIDGenerator(t *testing.T) {
+	t.Run("sequential new", func(t *testing.T) {
+		g := &IDGenerator{}
+
+		steps := []struct {
+			name string
+			ns   IDNamespace
+			want uint32
+		}{
+			{"first string", IDString, 1},
+			{"second string", IDString, 2},
+			{"first fieldset", IDFieldSet, 1},
+		}
+
+		for _, step := range steps {
+			t.Run(step.name, func(t *testing.T) {
+				got := g.New(step.ns)
+				if got != step.want {
+					t.Errorf("New(%v) = %d, want %d", step.ns, got, step.want)
+				}
+			})
+		}
+	})
+
+	t.Run("set and new", func(t *testing.T) {
+		g := &IDGenerator{}
+		g.Set(IDString, 5)
+
+		steps := []struct {
+			name string
+			ns   IDNamespace
+			want uint32
+		}{
+			{"after set 5", IDString, 6},
+			{"after set 6", IDString, 7},
+		}
+
+		for _, step := range steps {
+			t.Run(step.name, func(t *testing.T) {
+				got := g.New(step.ns)
+				if got != step.want {
+					t.Errorf("New(%v) = %d, want %d", step.ns, got, step.want)
+				}
+			})
+		}
+	})
+
+	t.Run("concurrent new", func(t *testing.T) {
+		g := &IDGenerator{}
+		const (
+			numGoroutines = 10
+			numIncrements = 100
+		)
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		ids := make(map[uint32]bool)
+		var mu sync.Mutex
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < numIncrements; j++ {
+					id := g.New(IDString)
+					mu.Lock()
+					if ids[id] {
+						t.Errorf("duplicate ID generated: %d", id)
+					}
+					ids[id] = true
+					mu.Unlock()
+				}
+			}()
+		}
+		wg.Wait()
+
+		expectedTotal := numGoroutines * numIncrements
+		if len(ids) != expectedTotal {
+			t.Errorf("total unique IDs = %d, want %d", len(ids), expectedTotal)
+		}
+	})
+}


### PR DESCRIPTION
This PR adds new IDGenerator type which produces unique ID thread-safely. This type is used for serializing the new KHI file format v6.