### PR TITLE
feat(khifile): implement v6 chunk container writer and reader

### DIFF
--- a/pkg/model/khifile/v6/container.go
+++ b/pkg/model/khifile/v6/container.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	// MagicBytes are the first 3 bytes of a KHI file ("KHI").
+	MagicBytes = []byte{'K', 'H', 'I'}
+	// Version is the supported version of the KHI file format.
+	Version = byte(0x06)
+
+	ErrInvalidMagicBytes  = errors.New("invalid magic bytes")
+	ErrUnsupportedVersion = errors.New("unsupported version")
+)
+
+// ChunkType represents the type of a chunk in the KHI file.
+type ChunkType uint32
+
+const (
+	ChunkTypeMetadata      ChunkType = 1
+	ChunkTypeInternPool    ChunkType = 2
+	ChunkTypeLog           ChunkType = 3
+	ChunkTypeTimelineStyle ChunkType = 4
+	ChunkTypeTimeline      ChunkType = 5
+)
+
+// Writer writes chunks to a KHI v6 file.
+type Writer struct {
+	w io.Writer
+}
+
+// NewWriter creates a new Writer and writes the magic bytes and version.
+func NewWriter(w io.Writer) (*Writer, error) {
+	header := []byte{MagicBytes[0], MagicBytes[1], MagicBytes[2], Version}
+	if _, err := w.Write(header); err != nil {
+		return nil, fmt.Errorf("failed to write header: %w", err)
+	}
+	return &Writer{w: w}, nil
+}
+
+// WriteChunk serializes the given protobuf message, gzips it, and writes the chunk header and payload.
+func (w *Writer) WriteChunk(chunkType ChunkType, message proto.Message) error {
+	// 1. Serialize proto message
+	b, err := proto.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("failed to marshal proto message: %w", err)
+	}
+
+	// 2. Compress payload with gzip
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(b); err != nil {
+		return fmt.Errorf("failed to compress payload: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	payload := buf.Bytes()
+	const maxChunkSize = 64 * 1024 * 1024 // 64MB hard limit based on Protobuf constraints
+	if len(payload) > maxChunkSize {
+		return fmt.Errorf("payload size %d exceeds maximum allowed chunk size (64MB)", len(payload))
+	}
+	size := uint32(len(payload))
+
+	// 3. Write chunk header (Size, Type)
+	var header [8]byte
+	binary.LittleEndian.PutUint32(header[0:4], size)
+	binary.LittleEndian.PutUint32(header[4:8], uint32(chunkType))
+
+	if _, err := w.w.Write(header[:]); err != nil {
+		return fmt.Errorf("failed to write chunk header: %w", err)
+	}
+
+	// 4. Write payload
+	if _, err := w.w.Write(payload); err != nil {
+		return fmt.Errorf("failed to write chunk payload: %w", err)
+	}
+
+	return nil
+}
+
+// WriteGenerator consumes the ChunkGenerator and writes all generated chunks sequentially.
+func (w *Writer) WriteGenerator(gen ChunkGenerator) error {
+	defer gen.Close()
+	chunkType := gen.ChunkType()
+	for {
+		msg, err := gen.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("generator error for type %d: %w", chunkType, err)
+		}
+		if err := w.WriteChunk(chunkType, msg); err != nil {
+			return err
+		}
+	}
+}
+
+// Chunk represents a parsed chunk from a KHI v6 file.
+type Chunk struct {
+	Type ChunkType
+	Data []byte // Uncompressed protobuf binary data
+}
+
+// Reader reads chunks from a KHI v6 file.
+type Reader struct {
+	r io.Reader
+}
+
+// NewReader reads and validates the file header.
+func NewReader(r io.Reader) (*Reader, error) {
+	var header [4]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, fmt.Errorf("failed to read header: %w", err)
+	}
+
+	if header[0] != MagicBytes[0] || header[1] != MagicBytes[1] || header[2] != MagicBytes[2] {
+		return nil, ErrInvalidMagicBytes
+	}
+
+	if header[3] != Version {
+		return nil, ErrUnsupportedVersion
+	}
+
+	return &Reader{r: r}, nil
+}
+
+// NextChunk reads the next chunk size and type, decompresses the payload, and returns it.
+// Returns io.EOF if no more chunks are available.
+func (r *Reader) NextChunk() (*Chunk, error) {
+	// 1. Read chunk header (Size, Type)
+	var header [8]byte
+	if _, err := io.ReadFull(r.r, header[:]); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, err // Return native EOF/UnexpectedEOF for natural termination/truncation
+		}
+		return nil, fmt.Errorf("failed to read chunk header: %w", err)
+	}
+
+	size := binary.LittleEndian.Uint32(header[0:4])
+	chunkType := ChunkType(binary.LittleEndian.Uint32(header[4:8]))
+
+	// 2. Read compressed payload
+	const maxChunkSize = 64 * 1024 * 1024 // 64MB hard limit based on Protobuf constraints
+	if size > maxChunkSize {
+		return nil, fmt.Errorf("chunk size %d exceeds safety limit (64MB)", size)
+	}
+	payload := make([]byte, size)
+	if _, err := io.ReadFull(r.r, payload); err != nil {
+		return nil, fmt.Errorf("failed to read chunk payload: %w", err)
+	}
+
+	// 3. Decompress payload
+	gr, err := gzip.NewReader(bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gr.Close()
+
+	const maxUncompressedSize = 64 * 1024 * 1024 // 64MB limit to match Protobuf parser limits
+	uncompressed, err := io.ReadAll(io.LimitReader(gr, maxUncompressedSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress payload: %w", err)
+	}
+
+	return &Chunk{
+		Type: chunkType,
+		Data: uncompressed,
+	}, nil
+}

--- a/pkg/model/khifile/v6/container_test.go
+++ b/pkg/model/khifile/v6/container_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestWriter_Header(t *testing.T) {
+	var buf bytes.Buffer
+	_, err := NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+
+	expected := []byte{'K', 'H', 'I', 0x06}
+	if !bytes.Equal(buf.Bytes(), expected) {
+		t.Errorf("Header mismatch, got: %v, want: %v", buf.Bytes(), expected)
+	}
+}
+
+func TestReader_ValidHeader(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{'K', 'H', 'I', 0x06})
+	_, err := NewReader(buf)
+	if err != nil {
+		t.Errorf("NewReader returned unexpected error: %v", err)
+	}
+}
+
+func TestReader_InvalidMagicBytes(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{'K', 'H', 'A', 0x06})
+	_, err := NewReader(buf)
+	if !errors.Is(err, ErrInvalidMagicBytes) {
+		t.Errorf("Expected ErrInvalidMagicBytes, got: %v", err)
+	}
+}
+
+func TestReader_UnsupportedVersion(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{'K', 'H', 'I', 0x07})
+	_, err := NewReader(buf)
+	if !errors.Is(err, ErrUnsupportedVersion) {
+		t.Errorf("Expected ErrUnsupportedVersion, got: %v", err)
+	}
+}
+
+func TestWriter_WriteChunk_Format(t *testing.T) {
+	var buf bytes.Buffer
+	w, err := NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+
+	msg := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"test": {Kind: &structpb.Value_StringValue{StringValue: "value"}},
+		},
+	}
+	err = w.WriteChunk(ChunkTypeMetadata, msg)
+	if err != nil {
+		t.Fatalf("WriteChunk returned error: %v", err)
+	}
+
+	b := buf.Bytes()
+	if len(b) < 12 {
+		t.Fatalf("Buffer too short")
+	}
+
+	// First 4 bytes are header
+	// Next 4 bytes are size
+	size := binary.LittleEndian.Uint32(b[4:8])
+	if int(size) != len(b)-12 {
+		t.Errorf("Size mismatch. Expected %d, got %d", len(b)-12, size)
+	}
+
+	// Next 4 bytes are type
+	chunkType := binary.LittleEndian.Uint32(b[8:12])
+	if chunkType != uint32(ChunkTypeMetadata) {
+		t.Errorf("ChunkType mismatch. Expected %d, got %d", ChunkTypeMetadata, chunkType)
+	}
+
+	// Verify it's a valid gzip stream
+	payload := b[12:]
+	gr, err := gzip.NewReader(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Failed to create gzip reader for payload: %v", err)
+	}
+	defer gr.Close()
+
+	uncompressed, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("Failed to decompress payload: %v", err)
+	}
+
+	var parsed structpb.Struct
+	if err := proto.Unmarshal(uncompressed, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal decompressed payload: %v", err)
+	}
+
+	if diff := cmp.Diff(msg, &parsed, protocmp.Transform()); diff != "" {
+		t.Errorf("Unmarshaled proto differs from original (-want +got):\n%s", diff)
+	}
+}
+
+func TestReader_EOF(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{'K', 'H', 'I', 0x06})
+	r, _ := NewReader(buf)
+	_, err := r.NextChunk()
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("Expected io.EOF, got %v", err)
+	}
+}
+
+func TestReader_IncompleteChunk(t *testing.T) {
+	// Provide valid header + chunk size 10 + chunk type 1 + only 2 bytes payload
+	buf := bytes.NewBuffer([]byte{'K', 'H', 'I', 0x06, 10, 0, 0, 0, 1, 0, 0, 0, 0, 0})
+	r, _ := NewReader(buf)
+	_, err := r.NextChunk()
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("Expected io.ErrUnexpectedEOF, got %v", err)
+	}
+}
+
+func TestContainer_WriteAndRead_E2E(t *testing.T) {
+	var buf bytes.Buffer
+	w, err := NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+
+	chunks := []struct {
+		ctype ChunkType
+		msg   proto.Message
+	}{
+		{
+			ctype: ChunkTypeMetadata,
+			msg: &structpb.Struct{
+				Fields: map[string]*structpb.Value{"id": {Kind: &structpb.Value_NumberValue{NumberValue: 1}}},
+			},
+		},
+		{
+			ctype: ChunkTypeLog,
+			msg: &structpb.Struct{
+				Fields: map[string]*structpb.Value{"log": {Kind: &structpb.Value_StringValue{StringValue: "hello"}}},
+			},
+		},
+	}
+
+	for _, c := range chunks {
+		if err := w.WriteChunk(c.ctype, c.msg); err != nil {
+			t.Fatalf("WriteChunk failed: %v", err)
+		}
+	}
+
+	r, err := NewReader(&buf)
+	if err != nil {
+		t.Fatalf("NewReader returned error: %v", err)
+	}
+
+	for i, c := range chunks {
+		parsed, err := r.NextChunk()
+		if err != nil {
+			t.Fatalf("NextChunk #%d returned error: %v", i, err)
+		}
+
+		if parsed.Type != c.ctype {
+			t.Errorf("Chunk #%d Type mismatch. got %d, want %d", i, parsed.Type, c.ctype)
+		}
+
+		var parsedMsg structpb.Struct
+		if err := proto.Unmarshal(parsed.Data, &parsedMsg); err != nil {
+			t.Fatalf("Chunk #%d Unmarshal failed: %v", i, err)
+		}
+
+		if diff := cmp.Diff(c.msg, &parsedMsg, protocmp.Transform()); diff != "" {
+			t.Errorf("Chunk #%d payload differs (-want +got):\n%s", i, diff)
+		}
+	}
+
+	// Should EOF now
+	_, err = r.NextChunk()
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("Expected EOF at the end, got: %v", err)
+	}
+}

--- a/pkg/model/khifile/v6/generator.go
+++ b/pkg/model/khifile/v6/generator.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"io"
+	"iter"
+
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+)
+
+// DefaultChunkSizeLimit is the recommended maximum byte size for a single chunk payload.
+// It is set to 60MB to safely stay under the typical 64MB Protobuf parser limit.
+const DefaultChunkSizeLimit = 60 * 1024 * 1024
+
+// ChunkGenerator is an interface for generating chunks sequentially.
+// Implementations must ensure that the size of the generated messages respects
+// the KHI file chunk limit (typically ~64MB).
+type ChunkGenerator interface {
+	ChunkType() ChunkType
+	// Next returns the next chunk. It returns io.EOF when done.
+	Next() (proto.Message, error)
+	// Close releases any resources (like goroutines from iterators) associated with the generator.
+	Close() error
+}
+
+type splittingGenerator[T proto.Message, C proto.Message] struct {
+	chunkType ChunkType
+	next      func() (T, bool)
+	stop      func()
+	sizeLimit int
+	wrapper   func([]T) C
+
+	pendingItem T
+	hasPending  bool
+}
+
+// NewSplittingGenerator creates a highly generic ChunkGenerator that splits an iterator
+// of Protobuf messages into multiple chunks based on an exact byte limit.
+//
+// It uses `proto.Size()` to accurately measure each element. When the accumulated size
+// exceeds `sizeLimit`, it invokes the `wrapper` function to build the final Chunk message.
+//
+// Type Parameters:
+//   - T: The element type yielded by the iterator (e.g., *pb.Log)
+//   - C: The chunk message type that holds the elements (e.g., *pb.LogChunk)
+func NewSplittingGenerator[T proto.Message, C proto.Message](
+	chunkType ChunkType,
+	seq iter.Seq[T],
+	sizeLimit int,
+	wrapper func([]T) C,
+) ChunkGenerator {
+	next, stop := iter.Pull(seq)
+	return &splittingGenerator[T, C]{
+		chunkType: chunkType,
+		next:      next,
+		stop:      stop,
+		sizeLimit: sizeLimit,
+		wrapper:   wrapper,
+	}
+}
+
+func (g *splittingGenerator[T, C]) ChunkType() ChunkType {
+	return g.chunkType
+}
+
+func (g *splittingGenerator[T, C]) Next() (proto.Message, error) {
+	var batch []T
+	currentSize := 0
+
+	for {
+		var item T
+		var valid bool
+
+		if g.hasPending {
+			item = g.pendingItem
+			valid = true
+			g.hasPending = false
+		} else {
+			item, valid = g.next()
+		}
+
+		if !valid {
+			if len(batch) == 0 {
+				return nil, io.EOF
+			}
+			return g.wrapper(batch), nil
+		}
+
+		// proto.Size gives the exact byte size of the serialized message.
+		// We add 8 bytes as a conservative estimate for the Protobuf length-delimited field tag
+		// and length prefix overhead.
+		itemSize := proto.Size(item) + 8
+
+		// If adding this item exceeds the limit AND we already have items in the batch,
+		// we hold this item for the next chunk and return the current batch.
+		// (If the batch is empty, we must add it anyway to avoid an infinite loop
+		// in the case where a single item is larger than the limit).
+		if currentSize+itemSize > g.sizeLimit && len(batch) > 0 {
+			g.pendingItem = item
+			g.hasPending = true
+			return g.wrapper(batch), nil
+		}
+
+		batch = append(batch, item)
+		currentSize += itemSize
+	}
+}
+
+func (g *splittingGenerator[T, C]) Close() error {
+	if g.stop != nil {
+		g.stop()
+	}
+	return nil
+}
+
+// NewInternPoolGenerator creates a SplittingGenerator for InternPool chunks.
+// It groups pb.InternString messages into pb.InterningPoolChunk respecting the size limit.
+func NewInternPoolGenerator(seq iter.Seq[*pb.InternString]) ChunkGenerator {
+	wrapper := func(batch []*pb.InternString) *pb.InterningPoolChunk {
+		return &pb.InterningPoolChunk{Strings: batch}
+	}
+	return NewSplittingGenerator(ChunkTypeInternPool, seq, DefaultChunkSizeLimit, wrapper)
+}
+
+// NewInternFieldPathSetGenerator creates a SplittingGenerator for InternPool chunks containing field path sets.
+// It groups pb.InternFieldPathSet messages into pb.InterningPoolChunk respecting the size limit.
+func NewInternFieldPathSetGenerator(seq iter.Seq[*pb.InternFieldPathSet]) ChunkGenerator {
+	wrapper := func(batch []*pb.InternFieldPathSet) *pb.InterningPoolChunk {
+		return &pb.InterningPoolChunk{FieldPathSets: batch}
+	}
+	return NewSplittingGenerator(ChunkTypeInternPool, seq, DefaultChunkSizeLimit, wrapper)
+}
+
+// NewLogGenerator creates a SplittingGenerator for Log chunks.
+// It groups pb.Log messages into pb.LogChunk respecting the size limit.
+func NewLogGenerator(seq iter.Seq[*pb.Log]) ChunkGenerator {
+	wrapper := func(batch []*pb.Log) *pb.LogChunk {
+		return &pb.LogChunk{Logs: batch}
+	}
+	return NewSplittingGenerator(ChunkTypeLog, seq, DefaultChunkSizeLimit, wrapper)
+}
+
+// NewTimelineGenerator creates a SplittingGenerator for Timeline chunks.
+// It groups pb.Timeline messages into pb.TimelineChunk respecting the size limit.
+func NewTimelineGenerator(seq iter.Seq[*pb.Timeline]) ChunkGenerator {
+	wrapper := func(batch []*pb.Timeline) *pb.TimelineChunk {
+		return &pb.TimelineChunk{Timelines: batch}
+	}
+	return NewSplittingGenerator(ChunkTypeTimeline, seq, DefaultChunkSizeLimit, wrapper)
+}
+
+// NewTimelineItemsGenerator creates a SplittingGenerator for Timeline chunks containing timeline items.
+// It groups pb.TimelineItems messages into pb.TimelineChunk respecting the size limit.
+func NewTimelineItemsGenerator(seq iter.Seq[*pb.TimelineItems]) ChunkGenerator {
+	wrapper := func(batch []*pb.TimelineItems) *pb.TimelineChunk {
+		return &pb.TimelineChunk{TimelineItems: batch}
+	}
+	return NewSplittingGenerator(ChunkTypeTimeline, seq, DefaultChunkSizeLimit, wrapper)
+}

--- a/pkg/model/khifile/v6/generator_test.go
+++ b/pkg/model/khifile/v6/generator_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"io"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+)
+
+func TestSplittingGenerator(t *testing.T) {
+	// Create a sequence of 5 string messages.
+	// Each StringValue("test") is about 6 bytes serialized.
+	seq := func(yield func(*wrapperspb.StringValue) bool) {
+		for i := 0; i < 5; i++ {
+			if !yield(wrapperspb.String("test")) {
+				return
+			}
+		}
+	}
+
+	// Wrapper to group them into MetadataChunk (reusing for test).
+	// Although MetadataChunk expects Any, we just use MetadataChunk for the structure and cast it below.
+	wrapper := func(batch []*wrapperspb.StringValue) *pb.MetadataChunk {
+		// Mock implementation just for checking chunk boundaries
+		return &pb.MetadataChunk{}
+	}
+
+	// Case 1: Limit is large enough for all items.
+	gen1 := NewSplittingGenerator(ChunkTypeMetadata, seq, 1000, wrapper)
+	defer gen1.Close()
+
+	if gen1.ChunkType() != ChunkTypeMetadata {
+		t.Errorf("Expected chunk type %d, got %d", ChunkTypeMetadata, gen1.ChunkType())
+	}
+
+	_, err := gen1.Next()
+	if err != nil {
+		t.Fatalf("Expected 1 chunk, got error: %v", err)
+	}
+
+	_, err = gen1.Next()
+	if err != io.EOF {
+		t.Fatalf("Expected EOF, got: %v", err)
+	}
+
+	// Case 2: Limit is very small (10 bytes), each item is ~8 bytes.
+	// So each item should get its own chunk.
+	gen2 := NewSplittingGenerator(ChunkTypeMetadata, seq, 10, wrapper)
+	defer gen2.Close()
+
+	count := 0
+	for {
+		_, err := gen2.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count++
+	}
+	if count != 5 {
+		t.Errorf("Expected 5 chunks, got %d", count)
+	}
+}
+
+func TestSplittingGenerator_IntegrationWithWriter(t *testing.T) {
+	seq := func(yield func(*pb.InternString) bool) {
+		for i := 0; i < 3; i++ {
+			id := uint32(i)
+			val := "a"
+			if !yield(&pb.InternString{Id: &id, Value: &val}) {
+				return
+			}
+		}
+	}
+
+	wrapper := func(batch []*pb.InternString) *pb.InterningPoolChunk {
+		return &pb.InterningPoolChunk{Strings: batch}
+	}
+
+	// Set limit to 30 bytes. A single InternString is ~5 bytes + 8 overhead = 13 bytes.
+	// It should fit 2 strings in the first chunk (26 bytes), and 1 in the second.
+	gen := NewSplittingGenerator(ChunkTypeInternPool, seq, 30, wrapper)
+
+	var w DummyWriter
+	err := w.WriteGenerator(gen)
+	if err != nil {
+		t.Fatalf("WriteGenerator failed: %v", err)
+	}
+
+	if len(w.chunks) != 2 {
+		t.Fatalf("Expected 2 chunks to be written, got %d", len(w.chunks))
+	}
+
+	chunk1 := w.chunks[0].(*pb.InterningPoolChunk)
+	if len(chunk1.Strings) != 2 {
+		t.Errorf("Expected 2 strings in chunk 1, got %d", len(chunk1.Strings))
+	}
+
+	chunk2 := w.chunks[1].(*pb.InterningPoolChunk)
+	if len(chunk2.Strings) != 1 {
+		t.Errorf("Expected 1 string in chunk 2, got %d", len(chunk2.Strings))
+	}
+}
+
+// DummyWriter simulates the real Writer to test WriteGenerator.
+type DummyWriter struct {
+	chunks []proto.Message
+}
+
+func (w *DummyWriter) WriteChunk(t ChunkType, msg proto.Message) error {
+	w.chunks = append(w.chunks, msg)
+	return nil
+}
+
+func (w *DummyWriter) WriteGenerator(gen ChunkGenerator) error {
+	defer gen.Close()
+	chunkType := gen.ChunkType()
+	for {
+		msg, err := gen.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := w.WriteChunk(chunkType, msg); err != nil {
+			return err
+		}
+	}
+}


### PR DESCRIPTION
## Overview
This PR implements the foundational backend container for the next-generation KHI file format (implemented under the `v6` package path). It introduces a chunk-based binary writer/reader and a memory-efficient generator to handle massive Protobuf datasets, moving us away from the restrictive JSON format.

## Key Changes

### 1. Binary Chunk Container (`container.go`)
- Implemented `Writer` and `Reader` for the new KHI binary format.
- Handles the file header validation (Magic bytes `KHI` + Version `0x06`).
- Implements the chunking specification: `[Size: uint32] + [Type: uint32] + [Gzipped Protobuf Payload]`.
- This format allows the frontend to stream and decompress individual chunks without loading the entire file into memory at once.

### 2. Generic Splitting Generator (`generator.go`)
- To respect the ~64MB size limit of Protobuf parsers, introduced a `ChunkGenerator` interface and a highly generic `SplittingGenerator`.
- Leverages Go 1.23 `iter.Seq` and `proto.Size()` to accurately measure and slice continuous streams of Protobuf messages into multiple chunks based on a strict byte limit (`DefaultChunkSizeLimit = 60MB`).
- Integrated with `Writer.WriteGenerator()` to automatically consume iterators, split them at boundaries, and write gzipped chunks to the file.
- Added specific factory wrappers for chunk types: `NewInternPoolGenerator`, `NewInternFieldPathSetGenerator`, `NewLogGenerator`, `NewTimelineGenerator`, and `NewTimelineItemsGenerator`.

## Testing
- Added comprehensive unit tests for `container_test.go` covering format precision, valid/invalid headers, compression/decompression, and truncated file handling.
- Added unit tests for `generator_test.go` to verify correct boundary splitting under specific size limits, including edge cases where single items approach the limit.
- All tests pass successfully.
