### PR TITLE
Add TimelineRegistry and TimelinePath

### DIFF
--- a/pkg/model/khifile/v6/timeline_builder.go
+++ b/pkg/model/khifile/v6/timeline_builder.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"cmp"
+	"slices"
+	"sync"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+)
+
+// TimelineBuilder accumulates parsed data (like logs, revisions, and events) for a specific TimelinePath.
+// This struct will be shared across multiple goroutines processing different chunks, so all modifications
+// to its internal state must be protected by its Mutex.
+type TimelineBuilder struct {
+	// Path is the canonical TimelinePath associated with this builder.
+	// If accessed via an alias, this field remains the target path that originally created the builder.
+	Path *TimelinePath
+	// TimelineItemsID is the unique identifier for the accumulated timeline items.
+	TimelineItemsID uint32
+	// internPool is the pool used to intern strings when accumulating data.
+	internPool *InternPool
+	// mu protects the revisions and events slices from concurrent modification.
+	mu sync.Mutex
+	// revisions accumulates the history of resource changes.
+	revisions []*pb.Revision
+	// events accumulates the logs or events associated with the timeline.
+	events []*pb.Event
+}
+
+// AddEvent adds a parsed event to the builder in a thread-safe manner.
+func (b *TimelineBuilder) AddEvent(e *pb.Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = append(b.events, e)
+}
+
+// AddRevision adds a parsed revision to the builder in a thread-safe manner.
+func (b *TimelineBuilder) AddRevision(r *pb.Revision) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.revisions = append(b.revisions, r)
+}
+
+// HasItems returns true if the builder has accumulated any events or revisions.
+func (b *TimelineBuilder) HasItems() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.events) > 0 || len(b.revisions) > 0
+}
+
+// ToProto converts the accumulated data into a TimelineItems protobuf message.
+// It returns nil if there are no events and no revisions.
+func (b *TimelineBuilder) ToProto() *pb.TimelineItems {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if len(b.events) == 0 && len(b.revisions) == 0 {
+		return nil
+	}
+
+	var events []*pb.Event
+	if len(b.events) > 0 {
+		events = slices.Clone(b.events)
+		slices.SortStableFunc(events, func(a, b *pb.Event) int {
+			// TODO: Sort events by time of their associated log after implementing the log registry.
+			return cmp.Compare(a.GetLogId(), b.GetLogId())
+		})
+	}
+
+	var revisions []*pb.Revision
+	if len(b.revisions) > 0 {
+		revisions = slices.Clone(b.revisions)
+		slices.SortStableFunc(revisions, func(a, b *pb.Revision) int {
+			return a.GetChangedTime().AsTime().Compare(b.GetChangedTime().AsTime())
+		})
+	}
+
+	itemsID := b.TimelineItemsID
+	return &pb.TimelineItems{
+		Id:        &itemsID,
+		Events:    events,
+		Revisions: revisions,
+	}
+}

--- a/pkg/model/khifile/v6/timeline_builder_test.go
+++ b/pkg/model/khifile/v6/timeline_builder_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestTimelineBuilder_ToProto_SortsRevisionsByTime(t *testing.T) {
+	builder := &TimelineBuilder{}
+
+	now := time.Now()
+	t1 := timestamppb.New(now.Add(-2 * time.Hour))
+	t2 := timestamppb.New(now.Add(-1 * time.Hour))
+	t3 := timestamppb.New(now)
+
+	id1 := uint32(1)
+	id2 := uint32(2)
+	id3 := uint32(3)
+
+	// Add out of chronological order
+	builder.AddRevision(&pb.Revision{LogId: &id2, ChangedTime: t2})
+	builder.AddRevision(&pb.Revision{LogId: &id3, ChangedTime: t3})
+	builder.AddRevision(&pb.Revision{LogId: &id1, ChangedTime: t1})
+
+	got := builder.ToProto()
+
+	wantRevisions := []*pb.Revision{
+		{LogId: &id1, ChangedTime: t1},
+		{LogId: &id2, ChangedTime: t2},
+		{LogId: &id3, ChangedTime: t3},
+	}
+
+	if diff := cmp.Diff(wantRevisions, got.Revisions, protocmp.Transform()); diff != "" {
+		t.Errorf("Revisions not sorted chronologically (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/model/khifile/v6/timeline_path.go
+++ b/pkg/model/khifile/v6/timeline_path.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"iter"
+	"sync"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"google.golang.org/protobuf/proto"
+)
+
+// TimelinePath represents a single node in the timeline hierarchy tree.
+// Its identity is uniquely managed by TimelinePathPool, so pointer equality (==)
+// guarantees logical equality.
+type TimelinePath struct {
+	// ID is the unique identifier for this timeline path.
+	ID uint32
+	// Parent is a pointer to the parent path. It is nil for root paths.
+	Parent *TimelinePath
+	// Name is a reference to the interned string name of this path segment.
+	Name *InternStringRef
+	// Type is the style definition for this timeline path segment.
+	Type *pb.TimelineType
+}
+
+// PathSegment represents a single level of a timeline path to be appended or retrieved.
+type PathSegment struct {
+	// Name is the string representation of the segment.
+	Name string
+	// Type is the style definition for this segment.
+	Type *pb.TimelineType
+}
+
+// timelinePathKey is used internally as a composite key to deduplicate TimelinePath instances.
+type timelinePathKey struct {
+	// parentID is the ID of the parent TimelinePath, or 0 for root paths.
+	parentID uint32
+	// nameID is the interned string ID.
+	nameID uint32
+	// typeID is the TimelineType ID.
+	typeID uint32
+}
+
+// TimelinePathPool guarantees the uniqueness of TimelinePath instances.
+// It is safe for concurrent use by multiple goroutines.
+type TimelinePathPool struct {
+	// idGen is used to generate unique IDs for new TimelinePath instances.
+	idGen *IDGenerator
+	// stringPool is used to intern string names of path segments to StringRefs.
+	stringPool *InternPool
+	// paths is a concurrent map caching timelinePathKey to *TimelinePath.
+	paths sync.Map // map[timelinePathKey]*TimelinePath
+	// idToPath is a concurrent map caching ID to *TimelinePath.
+	idToPath sync.Map // map[uint32]*TimelinePath
+}
+
+// NewTimelinePathPool creates a new pool for deduplicating TimelinePath instances.
+func NewTimelinePathPool(idGen *IDGenerator, sp *InternPool) *TimelinePathPool {
+	return &TimelinePathPool{
+		idGen:      idGen,
+		stringPool: sp,
+	}
+}
+
+// Get retrieves or creates a multi-level TimelinePath starting from the given parent.
+// If parent is nil, it starts from the root.
+// This method provides a convenient way to build deep paths in a single call.
+func (p *TimelinePathPool) Get(parent *TimelinePath, segments ...PathSegment) *TimelinePath {
+	current := parent
+	for _, seg := range segments {
+		current = p.getOrCreateSingle(current, seg.Name, seg.Type)
+	}
+	return current
+}
+
+// getOrCreateSingle handles the thread-safe retrieval or creation of a single TimelinePath segment.
+func (p *TimelinePathPool) getOrCreateSingle(parent *TimelinePath, name string, t *pb.TimelineType) *TimelinePath {
+	if t == nil || t.Id == nil {
+		panic("TimelineType and its ID must not be nil. TimelineType must be correctly registered to assign the right ID.")
+	}
+
+	nameRef := p.stringPool.InternString(name)
+
+	var parentID uint32
+	if parent != nil {
+		parentID = parent.ID
+	}
+
+	key := timelinePathKey{
+		parentID: parentID,
+		nameID:   nameRef.id,
+		typeID:   *t.Id,
+	}
+
+	// 1. Fast Path: Load from cache.
+	if val, ok := p.paths.Load(key); ok {
+		return val.(*TimelinePath)
+	}
+
+	// 2. Create new path instance with a fresh ID.
+	newID := p.idGen.New(IDTimelinePath)
+	newPath := &TimelinePath{
+		ID:     newID,
+		Parent: parent,
+		Name:   nameRef,
+		Type:   proto.Clone(t).(*pb.TimelineType),
+	}
+	p.idToPath.Store(newID, newPath)
+
+	// 3. Atomic store or retrieve if another goroutine won the race.
+	actual, loaded := p.paths.LoadOrStore(key, newPath)
+	if loaded {
+		p.idToPath.Store(newID, (*TimelinePath)(nil))
+		return actual.(*TimelinePath)
+	}
+	return actual.(*TimelinePath)
+}
+
+// Paths returns an iterator over all TimelinePath instances present in the pool.
+func (p *TimelinePathPool) Paths() iter.Seq[*TimelinePath] {
+	return func(yield func(*TimelinePath) bool) {
+		p.paths.Range(func(key, value any) bool {
+			return yield(value.(*TimelinePath))
+		})
+	}
+}
+
+// ResolvePathFromID returns the TimelinePath corresponding to the given ID.
+// It returns nil if the ID is not found or is an orphaned ID.
+func (p *TimelinePathPool) ResolvePathFromID(id uint32) *TimelinePath {
+	if value, ok := p.idToPath.Load(id); ok {
+		return value.(*TimelinePath)
+	}
+	return nil
+}

--- a/pkg/model/khifile/v6/timeline_path_test.go
+++ b/pkg/model/khifile/v6/timeline_path_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"sync"
+	"testing"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestTimelinePathPool_Get(t *testing.T) {
+	// Set up common dependencies for tests
+	idGen := &IDGenerator{}
+	internPool := NewInternPool(idGen)
+
+	id1 := uint32(1)
+	id2 := uint32(2)
+	typeA := &pb.TimelineType{Id: &id1}
+	typeB := &pb.TimelineType{Id: &id2}
+
+	testCases := []struct {
+		name string
+		test func(t *testing.T, pool *TimelinePathPool)
+	}{
+		{
+			name: "should create and deduplicate root paths",
+			test: func(t *testing.T, pool *TimelinePathPool) {
+				p1 := pool.Get(nil, PathSegment{Name: "root", Type: typeA})
+				p2 := pool.Get(nil, PathSegment{Name: "root", Type: typeA})
+
+				if p1 != p2 {
+					t.Errorf("expected identical pointers for exact same root path")
+				}
+				if p1.Parent != nil {
+					t.Errorf("expected nil parent for root path")
+				}
+				if diff := cmp.Diff("root", p1.Name.Resolve()); diff != "" {
+					t.Errorf("name mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(typeA, p1.Type, protocmp.Transform()); diff != "" {
+					t.Errorf("type mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "should differentiate by name",
+			test: func(t *testing.T, pool *TimelinePathPool) {
+				p1 := pool.Get(nil, PathSegment{Name: "root1", Type: typeA})
+				p2 := pool.Get(nil, PathSegment{Name: "root2", Type: typeA})
+
+				if p1 == p2 {
+					t.Errorf("expected different pointers for different names")
+				}
+			},
+		},
+		{
+			name: "should differentiate by type",
+			test: func(t *testing.T, pool *TimelinePathPool) {
+				p1 := pool.Get(nil, PathSegment{Name: "root", Type: typeA})
+				p2 := pool.Get(nil, PathSegment{Name: "root", Type: typeB})
+
+				if p1 == p2 {
+					t.Errorf("expected different pointers for different types")
+				}
+			},
+		},
+		{
+			name: "should differentiate by parent",
+			test: func(t *testing.T, pool *TimelinePathPool) {
+				parent1 := pool.Get(nil, PathSegment{Name: "parent1", Type: typeA})
+				parent2 := pool.Get(nil, PathSegment{Name: "parent2", Type: typeA})
+
+				child1 := pool.Get(parent1, PathSegment{Name: "child", Type: typeB})
+				child2 := pool.Get(parent2, PathSegment{Name: "child", Type: typeB})
+
+				if child1 == child2 {
+					t.Errorf("expected different pointers for different parents")
+				}
+			},
+		},
+		{
+			name: "should correctly append child paths",
+			test: func(t *testing.T, pool *TimelinePathPool) {
+				parent := pool.Get(nil, PathSegment{Name: "parent", Type: typeA})
+				child := pool.Get(parent, PathSegment{Name: "child", Type: typeB})
+
+				if child.Parent != parent {
+					t.Errorf("expected child path to point to the correct parent")
+				}
+				if diff := cmp.Diff("child", child.Name.Resolve()); diff != "" {
+					t.Errorf("name mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "should build multi-level path identical to sequential build",
+			test: func(t *testing.T, pool *TimelinePathPool) {
+				multi := pool.Get(nil,
+					PathSegment{Name: "root", Type: typeA},
+					PathSegment{Name: "child", Type: typeB},
+				)
+
+				root := pool.Get(nil, PathSegment{Name: "root", Type: typeA})
+				child := pool.Get(root, PathSegment{Name: "child", Type: typeB})
+
+				if multi != child {
+					t.Errorf("expected multi-segment path to match sequential path pointers")
+				}
+			},
+		},
+		{
+			name: "should handle concurrent creation safely without duplicates",
+			test: func(t *testing.T, pool *TimelinePathPool) {
+				const numGoroutines = 100
+				var wg sync.WaitGroup
+				wg.Add(numGoroutines)
+
+				results := make([]*TimelinePath, numGoroutines)
+				for i := 0; i < numGoroutines; i++ {
+					go func(idx int) {
+						defer wg.Done()
+						results[idx] = pool.Get(nil,
+							PathSegment{Name: "concurrent", Type: typeA},
+							PathSegment{Name: "path", Type: typeB},
+						)
+					}(i)
+				}
+				wg.Wait()
+
+				first := results[0]
+				for i := 1; i < numGoroutines; i++ {
+					if results[i] != first {
+						t.Errorf("expected all concurrent calls to return the exact same pointer, mismatch at index %d", i)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use a fresh pool for each test case to avoid cross-test contamination
+			pool := NewTimelinePathPool(idGen, internPool)
+			tc.test(t, pool)
+		})
+	}
+}

--- a/pkg/model/khifile/v6/timeline_registry.go
+++ b/pkg/model/khifile/v6/timeline_registry.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"iter"
+	"sync"
+)
+
+// TimelineRegistry manages the registration and retrieval of TimelineBuilders mapped by their unique TimelinePath.
+// It is safe for concurrent use by multiple goroutines.
+type TimelineRegistry struct {
+	// idGen is used to generate unique IDs for new TimelineBuilder (TimelineItems) instances.
+	idGen *IDGenerator
+	// internPool is passed to new TimelineBuilder instances for string interning.
+	internPool *InternPool
+	// builders is a concurrent map caching *TimelinePath to its *TimelineBuilder.
+	builders sync.Map // map[*TimelinePath]*TimelineBuilder
+	// idToBuilder is a concurrent map caching ID to *TimelineBuilder.
+	idToBuilder sync.Map // map[uint32]*TimelineBuilder
+}
+
+// NewTimelineRegistry creates a new registry for managing TimelineBuilders.
+func NewTimelineRegistry(idGen *IDGenerator, sp *InternPool) *TimelineRegistry {
+	return &TimelineRegistry{
+		idGen:      idGen,
+		internPool: sp,
+	}
+}
+
+// GetBuilder retrieves the TimelineBuilder associated with the given path.
+// Note: The returned TimelineBuilder is a shared instance. Callers must use its Mutex when mutating its state.
+func (r *TimelineRegistry) GetBuilder(path *TimelinePath) *TimelineBuilder {
+	// 1. Fast Path: Load from cache.
+	if val, ok := r.builders.Load(path); ok {
+		return val.(*TimelineBuilder)
+	}
+
+	// 2. Create new builder instance.
+	newID := r.idGen.New(IDTimelineItems)
+	newBuilder := &TimelineBuilder{
+		Path:            path,
+		TimelineItemsID: newID,
+		internPool:      r.internPool,
+	}
+	r.idToBuilder.Store(newID, newBuilder)
+
+	// 3. Atomic store or retrieve if another goroutine won the race.
+	actual, loaded := r.builders.LoadOrStore(path, newBuilder)
+	if loaded {
+		r.idToBuilder.Store(newID, (*TimelineBuilder)(nil))
+		return actual.(*TimelineBuilder)
+	}
+	return actual.(*TimelineBuilder)
+}
+
+// SetAlias configures aliasPath to be an alias of targetPath.
+// Any subsequent request for a builder for aliasPath will return the builder for targetPath.
+// Panics if aliasPath already has a builder attached (i.e., GetBuilder was already called on it).
+func (r *TimelineRegistry) SetAlias(aliasPath, targetPath *TimelinePath) {
+	if aliasPath == targetPath {
+		return
+	}
+
+	targetBuilder := r.GetBuilder(targetPath)
+
+	// Register the alias link.
+	// Fail-fast: if aliasPath already has a builder attached, it's too late to alias it.
+	actual, loaded := r.builders.LoadOrStore(aliasPath, targetBuilder)
+	if loaded && actual != targetBuilder {
+		panic("TimelineRegistry: Cannot set alias on a path that already has a builder attached")
+	}
+}
+
+// Builders returns an iterator over all unique TimelineBuilders present in the registry.
+func (r *TimelineRegistry) Builders() iter.Seq[*TimelineBuilder] {
+	return func(yield func(*TimelineBuilder) bool) {
+		seenBuilders := make(map[*TimelineBuilder]bool)
+		r.builders.Range(func(key, value any) bool {
+			builder := value.(*TimelineBuilder)
+			if seenBuilders[builder] {
+				return true
+			}
+			seenBuilders[builder] = true
+			return yield(builder)
+		})
+	}
+}
+
+// GetBuilderIfExists returns the TimelineBuilder attached to the path,
+// and a boolean indicating whether the builder exists.
+func (r *TimelineRegistry) GetBuilderIfExists(path *TimelinePath) (*TimelineBuilder, bool) {
+	if val, ok := r.builders.Load(path); ok {
+		return val.(*TimelineBuilder), true
+	}
+	return nil, false
+}
+
+// ResolveBuilderFromID returns the TimelineBuilder corresponding to the given ID.
+// It returns nil if the ID is not found or is an orphaned ID.
+func (r *TimelineRegistry) ResolveBuilderFromID(id uint32) *TimelineBuilder {
+	if value, ok := r.idToBuilder.Load(id); ok {
+		return value.(*TimelineBuilder)
+	}
+	return nil
+}

--- a/pkg/model/khifile/v6/timeline_registry_test.go
+++ b/pkg/model/khifile/v6/timeline_registry_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"sync"
+	"testing"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+)
+
+func TestTimelineRegistry_GetBuilder(t *testing.T) {
+	idGen := &IDGenerator{}
+	internPool := NewInternPool(idGen)
+	pool := NewTimelinePathPool(idGen, internPool)
+
+	id := uint32(1)
+	typeA := &pb.TimelineType{Id: &id}
+
+	path1 := pool.Get(nil, PathSegment{Name: "path1", Type: typeA})
+	path2 := pool.Get(nil, PathSegment{Name: "path2", Type: typeA})
+
+	testCases := []struct {
+		name string
+		test func(t *testing.T, registry *TimelineRegistry)
+	}{
+		{
+			name: "should return identical builder for same path",
+			test: func(t *testing.T, registry *TimelineRegistry) {
+				b1 := registry.GetBuilder(path1)
+				b2 := registry.GetBuilder(path1)
+
+				if b1 != b2 {
+					t.Errorf("expected identical builder pointers for same path")
+				}
+				if b1.Path != path1 {
+					t.Errorf("expected builder to hold the correct path")
+				}
+				if b1.TimelineItemsID == 0 {
+					t.Errorf("expected builder to have a valid TimelineItemsID")
+				}
+			},
+		},
+		{
+			name: "should return different builder for different paths",
+			test: func(t *testing.T, registry *TimelineRegistry) {
+				b1 := registry.GetBuilder(path1)
+				b2 := registry.GetBuilder(path2)
+
+				if b1 == b2 {
+					t.Errorf("expected different builder pointers for different paths")
+				}
+			},
+		},
+		{
+			name: "should handle concurrent builder creation safely",
+			test: func(t *testing.T, registry *TimelineRegistry) {
+				const numGoroutines = 100
+				var wg sync.WaitGroup
+				wg.Add(numGoroutines)
+
+				results := make([]*TimelineBuilder, numGoroutines)
+				for i := 0; i < numGoroutines; i++ {
+					go func(idx int) {
+						defer wg.Done()
+						results[idx] = registry.GetBuilder(path1)
+					}(i)
+				}
+				wg.Wait()
+
+				first := results[0]
+				for i := 1; i < numGoroutines; i++ {
+					if results[i] != first {
+						t.Errorf("expected all concurrent calls to return the exact same builder pointer, mismatch at index %d", i)
+					}
+				}
+			},
+		},
+		{
+			name: "should resolve alias to target builder",
+			test: func(t *testing.T, registry *TimelineRegistry) {
+				registry.SetAlias(path1, path2)
+				b1 := registry.GetBuilder(path1)
+				b2 := registry.GetBuilder(path2)
+
+				if b1 != b2 {
+					t.Errorf("expected alias path to resolve to target builder")
+				}
+				if b1.Path != path2 {
+					t.Errorf("expected builder accessed via alias to hold target path, got %v, want %v", b1.Path, path2)
+				}
+			},
+		},
+		{
+			name: "should panic if setting alias on path with attached builder",
+			test: func(t *testing.T, registry *TimelineRegistry) {
+				// Force attaching a builder to path1
+				_ = registry.GetBuilder(path1)
+
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected SetAlias to panic when alias already has a builder")
+					}
+				}()
+				registry.SetAlias(path1, path2)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use a fresh registry for each test case
+			registry := NewTimelineRegistry(idGen, internPool)
+			tc.test(t, registry)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds `TimelinePath`, `TimelinePathPool`, `TimelineRegistry`, `TimelineBuilder`.

* The `TimelinePath` is a linked list data structure representing Timeline location like `Pod(kind) -> default(namespace) -> nginx(resource)`. Each timelines are save with associating them, thus this needs to be singleton in `TimlinePathPool`.
* The `TimelineRegistry` holds `TimelineBuilder` associating them with the `TimelinePath`. Log parsers will get a builder from `TimelineRegistry` with specifying a `TimelinePath` to modify timeline contents. 