### PR TITLE
Add LogAccumulator storing all logs before serializing them into the khifile

### DIFF
--- a/pkg/model/khifile/v6/README.md
+++ b/pkg/model/khifile/v6/README.md
@@ -1,0 +1,63 @@
+# KHI File v6 Serializer Architecture
+
+This directory (`pkg/model/khifile/v6`) contains the core serialization logic for generating the `khifile v6` binary format. The design strictly isolates the internal KHI data models from the generated Protobuf schema, ensuring type safety, high concurrency, and minimal memory footprint.
+
+## Processing Flow
+
+```text
++-------------------------------------------------------------+
+|                     Inspection Tasks                        |
+| (Concurrent generation of Logs, Timelines, Metadata, etc.)  |
++-------------------------------------------------------------+
+          |                      |                      |
+          v                      v                      v
++------------------+   +-------------------+  +-------------------+
+|  LogAccumulator  |   |MetadataAccumulator|  |TimelineAccumulator|
+|  (sync.RWMutex)  |   |  (sync.RWMutex)   |  | (Facade wrapper)  |
++------------------+   +-------------------+  +-------------------+
+          |                      |                      |
+          |                      v                      |
+          |            [Type Switch & Fallback]         |
+          v                                             v
++-------------------------------------------------------------+
+|                 InternPool & IDGenerator                    |
+| (Thread-safe ID assignment, Structural/String Deduplication)|
++-------------------------------------------------------------+
+          |                      |                      |
+          |  [Convert to pb.*]   | [Convert to pb.*]    |
+          v                      v                      v
++------------------+   +-------------------+  +-------------------+
+|    []*pb.Log     |   | []*pb.MetadataItem|  | []*pb.Timeline... |
++------------------+   +-------------------+  +-------------------+
+          |                      |                      |
+          +----------------------+----------------------+
+                                 |
+                                 v
+                 +-------------------------------+
+                 |       File Generator          |
+                 | (Writes Protobuf Binary Chunks|
+                 +-------------------------------+
+```
+
+## Core Components
+
+### 1. Accumulators (`LogAccumulator`, `MetadataAccumulator`, `TimelineAccumulator`)
+
+These act as thread-safe builders that gather data produced concurrently by multiple inspection tasks.
+
+- **Concurrency Optimization:** They use synchronization primitives (`sync.RWMutex` or `sync.Mutex`) combined with dynamically expanding slices to guarantee efficient insertions and fast lookups. We intentionally avoid `sync.Map` to prevent severe GC overhead from interface boxing (`any`) and to avoid expensive `O(N log N)` sorting phases at the end of the run.
+- **Responsibility:** They are responsible for taking an internal domain model (e.g., `log.Log`, `inspectionmetadata.Metadata`), converting it to its corresponding Protobuf message (e.g., `pb.Log`), and storing it safely until the final file generation phase. The `TimelineAccumulator` acts as a unified facade, internally orchestrating a `TimelineRegistry` and `TimelinePathPool` to properly manage aliasing and deep hierarchical paths.
+
+### 2. `InternPool` and `IDGenerator`
+
+To minimize the file size and memory footprint during serialization, structural data (like JSON trees in logs) and repeating strings are deduplicated using the `InternPool`.
+
+- **`IDGenerator`:** Provides atomic, strictly sequential `uint32` IDs across different namespaces (`IDLog`, `IDString`, `IDFieldSet`). Because IDs are guaranteed to be sequential starting from 1, Accumulators can use ultra-fast slice indexing (`slice[id-1]`) instead of hash maps.
+- **`InternPool`:** Reduces duplicated complex data structures (`structured.Node`) into `pb.InternedStruct` by mapping identical field structures and strings to shared `uint32` reference IDs.
+
+### 3. Metadata Filtering and Fallback
+
+The `MetadataAccumulator` utilizes Go's type-switching alongside the `oneof` feature in Protobuf to balance type safety and extensibility.
+
+- **Label Filtering:** Only internal metadata flagged with `IncludeInResultBinary()` is processed and serialized into the file.
+- **Strong Typing vs. Extensibility:** Known metadata types (e.g., `HeaderMetadata`, `QueryMetadata`) are strictly mapped to their dedicated Protobuf messages. If an unknown metadata type is received (e.g., from an experimental or third-party task), it safely falls back to standard JSON serialization and is stored in a generic `json_payload` string field. This ensures backward compatibility, prevents crashes, and allows the frontend to easily parse and display unrecognized metadata.

--- a/pkg/model/khifile/v6/ids.go
+++ b/pkg/model/khifile/v6/ids.go
@@ -28,6 +28,12 @@ const (
 	IDString IDNamespace = iota
 	// IDFieldSet is the namespace for field set IDs.
 	IDFieldSet
+	// IDTimelinePath is the namespace for timeline path IDs.
+	IDTimelinePath
+	// IDTimelineItems is the namespace for timeline items IDs.
+	IDTimelineItems
+	// IDLog is the namespace for log IDs.
+	IDLog
 
 	// idNamespaceMax is the sentinel value for the maximum number of namespaces.
 	idNamespaceMax

--- a/pkg/model/khifile/v6/log_accumulator.go
+++ b/pkg/model/khifile/v6/log_accumulator.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// StagingLog represents a log entry and its associated metadata to be added to LogAccumulator.
+type StagingLog struct {
+	Log       *log.Log
+	Summary   string
+	Timestamp time.Time
+	LogType   *pb.LogType
+	Severity  *pb.Severity
+}
+
+// LogAccumulator facilitates the construction of a list of Log proto messages
+// by interning their structured data using an InternPool.
+// It is safe for concurrent use by multiple goroutines.
+type LogAccumulator struct {
+	pool  *InternPool
+	idGen *IDGenerator
+	logs  []*pb.Log
+	mu    sync.RWMutex
+}
+
+// NewLogAccumulator creates a new LogAccumulator with the provided InternPool and IDGenerator.
+func NewLogAccumulator(pool *InternPool, idGen *IDGenerator) *LogAccumulator {
+	return &LogAccumulator{
+		pool:  pool,
+		idGen: idGen,
+		logs:  make([]*pb.Log, 0),
+	}
+}
+
+// AddLog converts a StagingLog into a khifilev6.Log proto and adds it to the accumulator.
+// It interns the log body to optimize storage.
+func (a *LogAccumulator) AddLog(s *StagingLog) error {
+	if s.Severity == nil || s.Severity.Id == nil {
+		return fmt.Errorf("severity or its ID is missing")
+	}
+	if s.LogType == nil || s.LogType.Id == nil {
+		return fmt.Errorf("log type or its ID is missing")
+	}
+
+	internedBody, err := ToInternedStruct(s.Log.Node, a.pool)
+	if err != nil {
+		return fmt.Errorf("failed to intern log body: %w", err)
+	}
+
+	id := a.idGen.New(IDLog)
+	pbLog := &pb.Log{
+		Id:   &id,
+		Body: internedBody,
+	}
+
+	pbLog.Ts = timestamppb.New(s.Timestamp)
+	pbLog.SeverityTypeId = s.Severity.Id
+
+	summaryStrRef := a.pool.InternString(s.Summary)
+	pbLog.SummaryStringId = &summaryStrRef.id
+
+	pbLog.LogTypeId = s.LogType.Id
+
+	a.mu.Lock()
+	if needed := int(id) - len(a.logs); needed > 0 {
+		// Note: Go compiler optimizes append(slice, make([]T, n)...) to avoid temporary allocation.
+		a.logs = append(a.logs, make([]*pb.Log, needed)...)
+	}
+	a.logs[id-1] = pbLog
+	a.mu.Unlock()
+
+	return nil
+}
+
+// GetLog returns a log by its ID. Returns nil if the log is not found.
+func (a *LogAccumulator) GetLog(id uint32) *pb.Log {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if id == 0 || int(id) > len(a.logs) {
+		return nil
+	}
+	return a.logs[id-1]
+}
+
+// Accumulate returns the accumulated list of Log proto messages.
+// The returned list is naturally sorted by log ID.
+func (a *LogAccumulator) Accumulate() []*pb.Log {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	result := make([]*pb.Log, 0, len(a.logs))
+	for _, l := range a.logs {
+		if l != nil {
+			result = append(result, l)
+		}
+	}
+	return result
+}

--- a/pkg/model/khifile/v6/log_accumulator_test.go
+++ b/pkg/model/khifile/v6/log_accumulator_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestLogAccumulator(t *testing.T) {
+	node1 := structured.NewStandardMap(
+		[]string{"message", "level"},
+		[]structured.Node{
+			structured.NewStandardScalarNode("test message 1"),
+			structured.NewStandardScalarNode("info"),
+		},
+	)
+	node2 := structured.NewStandardMap(
+		[]string{"message", "level"},
+		[]structured.Node{
+			structured.NewStandardScalarNode("test message 1"), // Same structure and content
+			structured.NewStandardScalarNode("info"),
+		},
+	)
+	node3 := structured.NewStandardMap(
+		[]string{"error_code"},
+		[]structured.Node{
+			structured.NewStandardScalarNode(500),
+		},
+	)
+
+	testSeverityID := uint32(1)
+	testLogTypeID := uint32(2)
+	testSeverity := &pb.Severity{Id: &testSeverityID}
+	testLogType := &pb.LogType{Id: &testLogTypeID}
+
+	testCases := []struct {
+		name         string
+		logsToAdd    []*StagingLog
+		wantErr      bool
+		wantLogCount int
+		validate     func(t *testing.T, acc *LogAccumulator)
+	}{
+		{
+			name:         "empty accumulator",
+			logsToAdd:    []*StagingLog{},
+			wantErr:      false,
+			wantLogCount: 0,
+			validate: func(t *testing.T, acc *LogAccumulator) {
+				if gotLog := acc.GetLog(1); gotLog != nil {
+					t.Errorf("GetLog(1) returned a log on empty accumulator instead of nil")
+				}
+			},
+		},
+		{
+			name: "single log",
+			logsToAdd: []*StagingLog{
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node1)),
+					Summary:   "test summary",
+					Timestamp: time.Date(2026, 4, 29, 8, 0, 0, 0, time.UTC),
+					LogType:   testLogType,
+					Severity:  testSeverity,
+				},
+			},
+			wantErr:      false,
+			wantLogCount: 1,
+			validate: func(t *testing.T, acc *LogAccumulator) {
+				logs := acc.Accumulate()
+				if logs[0].GetId() != 1 {
+					t.Errorf("expected ID 1, got %d", logs[0].GetId())
+				}
+				if logs[0].Body == nil {
+					t.Errorf("expected non-nil Body")
+				}
+				if logs[0].GetSeverityTypeId() != testSeverityID {
+					t.Errorf("expected severity %d, got %d", testSeverityID, logs[0].GetSeverityTypeId())
+				}
+				if logs[0].GetLogTypeId() != testLogTypeID {
+					t.Errorf("expected log type %d, got %d", testLogTypeID, logs[0].GetLogTypeId())
+				}
+
+				// Verify GetLog
+				if gotLog := acc.GetLog(1); gotLog == nil || gotLog.GetId() != 1 {
+					t.Errorf("GetLog(1) failed to return the correct log")
+				}
+				if gotLog := acc.GetLog(999); gotLog != nil {
+					t.Errorf("GetLog(999) returned a log instead of nil")
+				}
+			},
+		},
+		{
+			name: "multiple logs with deduplication",
+			logsToAdd: []*StagingLog{
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node1)),
+					Summary:   "test summary 1",
+					Timestamp: time.Now(),
+					LogType:   testLogType,
+					Severity:  testSeverity,
+				},
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node2)), // Same structure
+					Summary:   "test summary 2",
+					Timestamp: time.Now(),
+					LogType:   testLogType,
+					Severity:  testSeverity,
+				},
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node3)), // Different structure
+					Summary:   "test summary 3",
+					Timestamp: time.Now(),
+					LogType:   testLogType,
+					Severity:  testSeverity,
+				},
+			},
+			wantErr:      false,
+			wantLogCount: 3,
+			validate: func(t *testing.T, acc *LogAccumulator) {
+				logs := acc.Accumulate()
+				if logs[0].GetId() != 1 {
+					t.Errorf("expected ID 1, got %d", logs[0].GetId())
+				}
+				if logs[1].GetId() != 2 {
+					t.Errorf("expected ID 2, got %d", logs[1].GetId())
+				}
+				if logs[2].GetId() != 3 {
+					t.Errorf("expected ID 3, got %d", logs[2].GetId())
+				}
+
+				// The first two logs should have exactly the same interned structure
+				if diff := cmp.Diff(logs[0].Body, logs[1].Body, protocmp.Transform()); diff != "" {
+					t.Errorf("log bodies should be identical due to interning (-want +got):\n%s", diff)
+				}
+
+				// Verify GetLog
+				if gotLog := acc.GetLog(2); gotLog == nil || gotLog.GetId() != 2 {
+					t.Errorf("GetLog(2) failed to return the correct log")
+				}
+			},
+		},
+		{
+			name: "missing severity error",
+			logsToAdd: []*StagingLog{
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node1)),
+					Summary:   "test summary",
+					Timestamp: time.Now(),
+					LogType:   testLogType,
+					Severity:  nil,
+				},
+			},
+			wantErr:      true,
+			wantLogCount: 0,
+		},
+		{
+			name: "missing log type error",
+			logsToAdd: []*StagingLog{
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node1)),
+					Summary:   "test summary",
+					Timestamp: time.Now(),
+					LogType:   nil,
+					Severity:  testSeverity,
+				},
+			},
+			wantErr:      true,
+			wantLogCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			idGen := &IDGenerator{}
+			pool := NewInternPool(idGen)
+			acc := NewLogAccumulator(pool, idGen)
+
+			for _, l := range tc.logsToAdd {
+				err := acc.AddLog(l)
+				if (err != nil) != tc.wantErr {
+					t.Fatalf("AddLog() error = %v, wantErr %v", err, tc.wantErr)
+				}
+			}
+
+			logs := acc.Accumulate()
+			if len(logs) != tc.wantLogCount {
+				t.Fatalf("expected %d logs, got %d", tc.wantLogCount, len(logs))
+			}
+
+			if tc.validate != nil {
+				tc.validate(t, acc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adding `LogAccumulator`.

This type receives logs that will be serialized into the KHI file from parsers and returns the list when the file generator needed it.