### PR TITLE
Add Inventory/Discovery tasks for parsing the map from NEG name to BS name

### DIFF
--- a/pkg/task/inspection/googlecloudk8scommon/contract/inventory.go
+++ b/pkg/task/inspection/googlecloudk8scommon/contract/inventory.go
@@ -15,6 +15,8 @@
 package googlecloudk8scommon_contract
 
 import (
+	"regexp"
+
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	commonlogk8sauditv2_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8sauditv2/contract"
@@ -25,3 +27,23 @@ type NEGNameToResourceIdentityMap = map[string]commonlogk8sauditv2_contract.Reso
 var NEGNamesInventoryTaskID = taskid.NewDefaultImplementationID[NEGNameToResourceIdentityMap](GoogleCloudCommonK8STaskIDPrefix + "neg-names-inventory")
 
 var NEGNamesInventoryTaskBuilder = inspectiontaskbase.NewInventoryTaskBuilder(NEGNamesInventoryTaskID)
+
+// NEGToBackendServiceMap is a map from NEG name to BackendService name.
+type NEGToBackendServiceMap = map[string]string
+
+// NEGToBackendServiceInventoryTaskID is the task ID for the inventory task that provides NEG to BackendService mappings.
+var NEGToBackendServiceInventoryTaskID = taskid.NewDefaultImplementationID[NEGToBackendServiceMap](GoogleCloudCommonK8STaskIDPrefix + "neg-to-backend-service-inventory")
+
+// NEGToBackendServiceInventoryBuilder is the inventory task builder for NEG to BackendService mappings.
+var NEGToBackendServiceInventoryBuilder = inspectiontaskbase.NewInventoryTaskBuilder(NEGToBackendServiceInventoryTaskID)
+
+var negToBackendServiceRegex = regexp.MustCompile(`NEG "Key\{\\"([^"]+)\\"[^}]*\}" attached to BackendService "Key\{\\"([^"]+)\\"\}"`)
+
+// ExtractNEGToBackendService extracts the NEG name and BackendService name from a given message.
+func ExtractNEGToBackendService(message string) (negName string, backendServiceName string) {
+	matches := negToBackendServiceRegex.FindStringSubmatch(message)
+	if len(matches) == 3 {
+		return matches[1], matches[2]
+	}
+	return "", ""
+}

--- a/pkg/task/inspection/googlecloudk8scommon/impl/negtobackendservice_inventory.go
+++ b/pkg/task/inspection/googlecloudk8scommon/impl/negtobackendservice_inventory.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudk8scommon_impl
+
+import (
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+)
+
+// NEGToBackendServiceMergeStrategy is the merge strategy for the NEG to BackendService inventory.
+type NEGToBackendServiceMergeStrategy struct{}
+
+var _ inspectiontaskbase.InventoryMergerStrategy[googlecloudk8scommon_contract.NEGToBackendServiceMap] = (*NEGToBackendServiceMergeStrategy)(nil)
+
+func (s *NEGToBackendServiceMergeStrategy) Merge(maps []googlecloudk8scommon_contract.NEGToBackendServiceMap) (googlecloudk8scommon_contract.NEGToBackendServiceMap, error) {
+	result := make(googlecloudk8scommon_contract.NEGToBackendServiceMap)
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result, nil
+}
+
+// NEGToBackendServiceInventoryTask is the inventory task that provides aggregated NEG to BackendService mappings.
+var NEGToBackendServiceInventoryTask = googlecloudk8scommon_contract.NEGToBackendServiceInventoryBuilder.InventoryTask(
+	&NEGToBackendServiceMergeStrategy{},
+)

--- a/pkg/task/inspection/googlecloudk8scommon/impl/registration.go
+++ b/pkg/task/inspection/googlecloudk8scommon/impl/registration.go
@@ -46,5 +46,6 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 		InputNodeNameFilterTask,
 		NEGNamesInventoryTask,
 		NEGNamesDiscoveryTask,
+		NEGToBackendServiceInventoryTask,
 	)
 }

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/taskid.go
@@ -18,6 +18,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8sauditv2_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8sauditv2/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 )
 
 // TaskIDPrefix is the prefix for all task IDs in the googlecloudlogk8saudit package.
@@ -28,3 +29,6 @@ var GCPK8sAuditLogListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*lo
 var GCPK8sAuditLogCommonFieldSetReaderTaskID = taskid.NewImplementationID(commonlogk8sauditv2_contract.K8sAuditLogProviderRef, "gcp")
 
 var GCPK8sAuditLogParserTailTaskID = taskid.NewImplementationID(commonlogk8sauditv2_contract.K8sAuditLogParserTailRef, "gcp")
+
+// NEGToBackendServiceDiscoveryTaskID is the task ID for the discovery task that extracts NEG to BackendService mappings from Kubernetes Audit logs.
+var NEGToBackendServiceDiscoveryTaskID = taskid.NewDefaultImplementationID[googlecloudk8scommon_contract.NEGToBackendServiceMap](TaskIDPrefix + "neg-discovery")

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/neg_discovery_task.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/neg_discovery_task.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8saudit_impl
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	commonlogk8sauditv2_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8sauditv2/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8saudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// AuditLogNEGDiscoveryTask is the discovery task that extracts NEG to BackendService mappings from Kubernetes Audit logs.
+var AuditLogNEGDiscoveryTask = googlecloudk8scommon_contract.NEGToBackendServiceInventoryBuilder.DiscoveryTask(
+	googlecloudlogk8saudit_contract.NEGToBackendServiceDiscoveryTaskID,
+	[]taskid.UntypedTaskReference{commonlogk8sauditv2_contract.ManifestGeneratorTaskID.Ref()},
+	func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (googlecloudk8scommon_contract.NEGToBackendServiceMap, error) {
+		if taskMode != inspectioncore_contract.TaskModeRun {
+			return nil, nil
+		}
+
+		groups := coretask.GetTaskResult(ctx, commonlogk8sauditv2_contract.ManifestGeneratorTaskID.Ref())
+		result := make(googlecloudk8scommon_contract.NEGToBackendServiceMap)
+
+		for _, group := range groups {
+			if group.Resource == nil || group.Resource.Kind != "Pod" {
+				continue
+			}
+			for _, mLog := range group.Logs {
+				if mLog.ResourceBodyReader == nil {
+					continue
+				}
+				conditionsReader, err := mLog.ResourceBodyReader.GetReader("status.conditions")
+				if err == nil {
+					conditionsReader.Children()(func(_ structured.NodeChildrenKey, conditionReader structured.NodeReader) bool {
+						message := conditionReader.ReadStringOrDefault("message", "")
+						neg, bs := googlecloudk8scommon_contract.ExtractNEGToBackendService(message)
+						if neg != "" && bs != "" {
+							result[neg] = bs
+						}
+						return true
+					})
+				}
+			}
+		}
+		return result, nil
+	},
+)

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/neg_discovery_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/neg_discovery_task_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8saudit_impl
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	commonlogk8sauditv2_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8sauditv2/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+func TestAuditLogNEGDiscoveryTask(t *testing.T) {
+	createNode := func(t *testing.T, message string) *structured.NodeReader {
+		node, err := structured.FromGoValue(map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"message": message,
+					},
+				},
+			},
+		}, &structured.AlphabeticalGoMapKeyOrderProvider{})
+		if err != nil {
+			t.Fatalf("failed to create node: %v", err)
+		}
+		return structured.NewNodeReader(node)
+	}
+
+	tests := []struct {
+		name     string
+		groupMap commonlogk8sauditv2_contract.ResourceManifestLogGroupMap
+		taskMode inspectioncore_contract.InspectionTaskModeType
+		want     googlecloudk8scommon_contract.NEGToBackendServiceMap
+	}{
+		{
+			name: "valid audit log",
+			groupMap: commonlogk8sauditv2_contract.ResourceManifestLogGroupMap{
+				"group1": {
+					Resource: &commonlogk8sauditv2_contract.ResourceIdentity{
+						Kind: "Pod",
+					},
+					Logs: []*commonlogk8sauditv2_contract.ResourceManifestLog{
+						{
+							ResourceBodyReader: createNode(t, `Pod has become Healthy in NEG "Key{\"k8s1-audit\", zone: \"asia-northeast1-b\"}" attached to BackendService "Key{\"bs-audit\"}". Marking condition "cloud.google.com/load-balancer-neg-ready" to True.`),
+						},
+					},
+				},
+			},
+			taskMode: inspectioncore_contract.TaskModeRun,
+			want: googlecloudk8scommon_contract.NEGToBackendServiceMap{
+				"k8s1-audit": "bs-audit",
+			},
+		},
+		{
+			name: "not a pod",
+			groupMap: commonlogk8sauditv2_contract.ResourceManifestLogGroupMap{
+				"group1": {
+					Resource: &commonlogk8sauditv2_contract.ResourceIdentity{
+						Kind: "Deployment",
+					},
+					Logs: []*commonlogk8sauditv2_contract.ResourceManifestLog{
+						{
+							ResourceBodyReader: createNode(t, `Pod has become Healthy in NEG "Key{\"k8s1-audit\", zone: \"asia-northeast1-b\"}" attached to BackendService "Key{\"bs-audit\"}". Marking condition "cloud.google.com/load-balancer-neg-ready" to True.`),
+						},
+					},
+				},
+			},
+			taskMode: inspectioncore_contract.TaskModeRun,
+			want:     googlecloudk8scommon_contract.NEGToBackendServiceMap{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+			result, _, err := inspectiontest.RunInspectionTask(ctx, AuditLogNEGDiscoveryTask, tc.taskMode, map[string]any{},
+				tasktest.NewTaskDependencyValuePair(commonlogk8sauditv2_contract.ManifestGeneratorTaskID.Ref(), tc.groupMap),
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, result); diff != "" {
+				t.Errorf("result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/parser.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/parser.go
@@ -54,6 +54,7 @@ var GCPK8sAuditLogParserTailTask = inspectiontaskbase.NewInspectionTask(
 		commonlogk8sauditv2_contract.ContainerIDDiscoveryTaskID.Ref(),
 		commonlogk8sauditv2_contract.IPLeaseHistoryDiscoveryTaskID.Ref(),
 		googlecloudk8scommon_contract.NEGNamesDiscoveryTaskID.Ref(),
+		googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(),
 	},
 	func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) (struct{}, error) {
 		return struct{}{}, nil

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/registration.go
@@ -45,5 +45,6 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 	return coretask.RegisterTasks(scoped,
 		GCPK8sAuditLogCommonFieldSetReaderTask,
 		GCPK8sAuditLogParserTailTask,
+		AuditLogNEGDiscoveryTask,
 	)
 }

--- a/pkg/task/inspection/googlecloudlogk8sevent/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/contract/taskid.go
@@ -41,3 +41,6 @@ var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogG
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
 var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](GKEK8sEventLogTaskIDPrefix + "timeline-mapper")
+
+// NEGToBackendServiceDiscoveryTaskID is the task ID for the discovery task that extracts NEG to BackendService mappings from Kubernetes Event logs.
+var NEGToBackendServiceDiscoveryTaskID = taskid.NewDefaultImplementationID[googlecloudk8scommon_contract.NEGToBackendServiceMap](GKEK8sEventLogTaskIDPrefix + "neg-discovery")

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/neg_discovery_task.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/neg_discovery_task.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8sevent_impl
+
+import (
+	"context"
+
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogk8sevent_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8sevent/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// EventLogNEGDiscoveryTask is the discovery task that extracts NEG to BackendService mappings from Kubernetes Event logs.
+var EventLogNEGDiscoveryTask = googlecloudk8scommon_contract.NEGToBackendServiceInventoryBuilder.DiscoveryTask(
+	googlecloudlogk8sevent_contract.NEGToBackendServiceDiscoveryTaskID,
+	[]taskid.UntypedTaskReference{googlecloudlogk8sevent_contract.FieldSetReaderTaskID.Ref()},
+	func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (googlecloudk8scommon_contract.NEGToBackendServiceMap, error) {
+		if taskMode != inspectioncore_contract.TaskModeRun {
+			return nil, nil
+		}
+
+		logs := coretask.GetTaskResult(ctx, googlecloudlogk8sevent_contract.FieldSetReaderTaskID.Ref())
+		result := make(googlecloudk8scommon_contract.NEGToBackendServiceMap)
+
+		for _, l := range logs {
+			fs, err := log.GetFieldSet(l, &googlecloudlogk8sevent_contract.KubernetesEventFieldSet{})
+			if err == nil {
+				neg, bs := googlecloudk8scommon_contract.ExtractNEGToBackendService(fs.Message)
+				if neg != "" && bs != "" {
+					result[neg] = bs
+				}
+			}
+		}
+		return result, nil
+	},
+)

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/neg_discovery_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/neg_discovery_task_test.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8sevent_impl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogk8sevent_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8sevent/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+func TestEventLogNEGDiscoveryTask(t *testing.T) {
+	tests := []struct {
+		name     string
+		logs     []*log.Log
+		taskMode inspectioncore_contract.InspectionTaskModeType
+		want     googlecloudk8scommon_contract.NEGToBackendServiceMap
+	}{
+		{
+			name: "valid event log",
+			logs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(&log.CommonFieldSet{Timestamp: time.Now()}, &googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+					Message: `Pod has become Healthy in NEG "Key{\"k8s1-event\", zone: \"asia-northeast1-b\"}" attached to BackendService "Key{\"bs-event\"}". Marking condition "cloud.google.com/load-balancer-neg-ready" to True.`,
+				}),
+				log.NewLogWithFieldSetsForTest(&log.CommonFieldSet{Timestamp: time.Now()}), // no fieldset
+			},
+			taskMode: inspectioncore_contract.TaskModeRun,
+			want: googlecloudk8scommon_contract.NEGToBackendServiceMap{
+				"k8s1-event": "bs-event",
+			},
+		},
+		{
+			name: "dry run mode",
+			logs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(&log.CommonFieldSet{Timestamp: time.Now()}, &googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+					Message: `Pod has become Healthy in NEG "Key{\"k8s1-event\", zone: \"asia-northeast1-b\"}" attached to BackendService "Key{\"bs-event\"}". Marking condition "cloud.google.com/load-balancer-neg-ready" to True.`,
+				}),
+			},
+			taskMode: inspectioncore_contract.TaskModeDryRun,
+			want:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+			result, _, err := inspectiontest.RunInspectionTask(ctx, EventLogNEGDiscoveryTask, tc.taskMode, map[string]any{},
+				tasktest.NewTaskDependencyValuePair(googlecloudlogk8sevent_contract.FieldSetReaderTaskID.Ref(), tc.logs),
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, result); diff != "" {
+				t.Errorf("result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/registration.go
@@ -46,5 +46,6 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 		LogGrouperTask,
 		LogIngesterTask,
 		LogToTimelineMapperTask,
+		EventLogNEGDiscoveryTask,
 	)
 }


### PR DESCRIPTION
This PR adds the `Inventory`- `Discovery` tasks for getting the relationships of NEG and BS names from audit logs or event logs.

The name of BS name created by TD CSM controlplan is not directly searchable from cluster name or some other well-known identifier. Thus, CSM parser will use the backend service name appeared on audit logs or event logs to generate its log filter.

ref: https://github.com/GoogleCloudPlatform/khi/blob/main/docs/en/khi-task-system-concept.md#task-utilities-to-discover-information-from-logs

This review is requested to @K53  regarding his CSM specialization.