### PR TITLE
Add fleet PJ form task and query task to gather CSM TD audit logs

### DIFF
--- a/pkg/task/inspection/googlecloudlogcsm/README.md
+++ b/pkg/task/inspection/googlecloudlogcsm/README.md
@@ -1,0 +1,61 @@
+# Cloud Service Mesh (CSM) Inspection Tasks
+
+This package (`googlecloudlogcsm`) contains tasks for inspecting Cloud Service Mesh (CSM) access logs. It handles querying logs, parsing Envoy-related fields, and mapping them to KHI timeline events.
+
+## Task Overview
+
+The CSM inspection pipeline handles the following:
+
+1. **Inputs**: Capturing user-specified filters such as Envoy response flags.
+2. **Log Fetching**: Querying Cloud Logging for CSM access logs.
+3. **Inventory**: Extracting mappings between NEGs (Network Endpoint Groups) and BackendServices from Kubernetes Event logs and Audit logs.
+4. **Parsing & Mapping**: Reading log fields and mapping them to resource timelines.
+
+### Inventory Tasks
+
+These tasks are used to discover associations that are not directly present in the access logs but are required for proper resource mapping. They are provided by shared Google Cloud components and log provider packages.
+
+- **`EventLogNEGDiscoveryTask`** (in `googlecloudlogk8sevent`): Discovers NEG to BackendService mappings by parsing Kubernetes Event logs.
+- **`AuditLogNEGDiscoveryTask`** (in `googlecloudlogk8saudit`): Discovers NEG to BackendService mappings by parsing Kubernetes Audit logs (via resource manifests).
+- **`NEGToBackendServiceInventoryTask`** (in `googlecloudk8scommon`): Aggregates the discovery results into a single consolidated inventory map.
+
+### CSM Access Log Pipeline
+
+- **`InputCSMResponseFlagsTask`**: Form input for filtering logs by Envoy response flags.
+- **`ListLogEntriesTask`**: Fetches CSM access logs from Cloud Logging.
+- **`FieldSetReaderTask`**: Parses raw logs into `CSMFieldSet` to extract structured fields.
+- **`LogIngesterTask`**: Ingests the logs into the final KHI history.
+- **`LogGrouperTask`**: Groups logs by the reporter pod.
+- **`LogToTimelineMapperTask`**: Maps CSM access log events to resource timelines, utilizing the NEG inventory for accurate service association.
+
+## Task Relationship Diagram
+
+```mermaid
+graph TD
+    classDef input fill:#e0f7fa,stroke:#006064,stroke-width:2px;
+    classDef query fill:#fff3e0,stroke:#e65100,stroke-width:2px;
+    classDef pipeline fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px;
+    classDef inventory fill:#fff9c4,stroke:#fbc02d,stroke-width:2px;
+
+    classDef external fill:#f5f5f5,stroke:#9e9e9e,stroke-width:2px,stroke-dasharray: 5 5;
+
+    %% External Tasks
+    EventFieldSet[Event FieldSet Reader]:::external
+    ManifestGen[Manifest Generator]:::external
+
+    %% Inventory
+    EventFieldSet --> EventDiscovery[EventLogNEGDiscoveryTask]:::inventory
+    ManifestGen --> AuditDiscovery[AuditLogNEGDiscoveryTask]:::inventory
+    EventDiscovery --> Inventory[NEGToBackendServiceInventoryTask]:::inventory
+    AuditDiscovery --> Inventory
+
+    %% CSM Access Log Pipeline
+    FlagsInput[InputCSMResponseFlagsTask]:::input
+    FlagsInput --> ListLogs[ListLogEntriesTask]:::query
+    ListLogs --> FieldSetRead[FieldSetReaderTask]:::query
+    ListLogs --> Ingester[LogIngesterTask]:::pipeline
+    FieldSetRead --> Grouper[LogGrouperTask]:::pipeline
+    Grouper --> Mapper[LogToTimelineMapperTask]:::pipeline
+    Ingester --> Mapper
+    Inventory --> Mapper
+```

--- a/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
@@ -44,3 +44,12 @@ var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogG
 
 // LogToTimelineMapperTaskID is the task ID for associating CSM access log events with resource timelines.
 var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "timeline-mapper")
+
+// InputFleetProjectIDTaskID is the task ID for the form input that specifies the Fleet Project ID where CSM control plane logs are stored.
+var InputFleetProjectIDTaskID = taskid.NewDefaultImplementationID[string](TaskIDPrefix + "input/fleet-project-id")
+
+// CSMClusterIdentifierTaskID is the task ID for the unique cluster identifier(s) extracted from BackendService names.
+var CSMClusterIdentifierTaskID = taskid.NewDefaultImplementationID[[]string](TaskIDPrefix + "cluster-identifier")
+
+// ListCSMTrafficDirectorLogEntriesTaskID is the task ID for the task that queries CSM Traffic Director logs from Cloud Logging.
+var ListCSMTrafficDirectorLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "list-traffic-director-log-entries")

--- a/pkg/task/inspection/googlecloudlogcsm/impl/cluster_identifier_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/cluster_identifier_task.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcsm_impl
+
+import (
+	"context"
+	"strings"
+
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
+)
+
+// CSMClusterIdentifierTask extracts the unique cluster identifier(s) from BackendService names.
+// CSM BackendService names follow the pattern: gsmrsvd-(cluster-identifier)-(neg-id).
+var CSMClusterIdentifierTask = coretask.NewTask(
+	googlecloudlogcsm_contract.CSMClusterIdentifierTaskID,
+	[]taskid.UntypedTaskReference{googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref()},
+	func(ctx context.Context) ([]string, error) {
+		inventory := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref())
+
+		uniqueIds := make(map[string]struct{})
+
+		for _, bsName := range inventory {
+			if strings.HasPrefix(bsName, "gsmrsvd-") {
+				// gsmrsvd-<cluster-id>-<neg-id>
+				parts := strings.Split(bsName, "-")
+				if len(parts) >= 3 {
+					uniqueIds[parts[1]] = struct{}{}
+				}
+			}
+		}
+
+		result := make([]string, 0, len(uniqueIds))
+		for id := range uniqueIds {
+			result = append(result, id)
+		}
+		return result, nil
+	},
+)

--- a/pkg/task/inspection/googlecloudlogcsm/impl/cluster_identifier_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/cluster_identifier_task_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcsm_impl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+)
+
+func TestCSMClusterIdentifierTask(t *testing.T) {
+	tests := []struct {
+		name      string
+		inventory googlecloudk8scommon_contract.NEGToBackendServiceMap
+		want      []string
+	}{
+		{
+			name: "single backend",
+			inventory: googlecloudk8scommon_contract.NEGToBackendServiceMap{
+				"neg1": "gsmrsvd-cluster1-neg1",
+			},
+			want: []string{"cluster1"},
+		},
+		{
+			name: "multiple backends same cluster",
+			inventory: googlecloudk8scommon_contract.NEGToBackendServiceMap{
+				"neg1": "gsmrsvd-cluster1-neg1",
+				"neg2": "gsmrsvd-cluster1-neg2",
+			},
+			want: []string{"cluster1"},
+		},
+		{
+			name: "multiple clusters",
+			inventory: googlecloudk8scommon_contract.NEGToBackendServiceMap{
+				"neg1": "gsmrsvd-cluster1-neg1",
+				"neg2": "gsmrsvd-cluster2-neg2",
+			},
+			want: []string{"cluster1", "cluster2"},
+		},
+		{
+			name: "no gsmrsvd backends",
+			inventory: googlecloudk8scommon_contract.NEGToBackendServiceMap{
+				"neg1": "other-backend",
+			},
+			want: []string{},
+		},
+		{
+			name: "malformed name",
+			inventory: googlecloudk8scommon_contract.NEGToBackendServiceMap{
+				"neg1": "gsmrsvd-clusteronly",
+			},
+			want: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			result, err := tasktest.RunTask(ctx, CSMClusterIdentifierTask,
+				tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), tc.inventory),
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, result, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogcsm/impl/form_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/form_task.go
@@ -24,11 +24,27 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/formtask"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
 )
 
 const priorityForCSMGroup = googlecloudcommon_contract.FormBasePriority + 10000
+
+var InputFleetProjectIDTask = formtask.NewTextFormTaskBuilder(googlecloudlogcsm_contract.InputFleetProjectIDTaskID, priorityForCSMGroup+500, "Fleet project ID").
+	WithDependencies([]taskid.UntypedTaskReference{
+		googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(),
+	}).
+	WithDescription("The project ID where the Fleet is hosted and CSM control plane logs are stored. Default is the cluster's project ID.").
+	WithDefaultValueFunc(func(ctx context.Context, previousValues []string) (string, error) {
+		if len(previousValues) > 0 {
+			return previousValues[0], nil
+		}
+		cluster := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref())
+		return cluster.ProjectID, nil
+	}).
+	Build()
 
 var inputCSMAliasMap gcpqueryutil.SetFilterAliasToItemsMap = map[string][]string{}
 

--- a/pkg/task/inspection/googlecloudlogcsm/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/registration.go
@@ -64,6 +64,9 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 		ClusterIdentityAliasTask,
 
 		InputCSMResponseFlagsTask,
+		InputFleetProjectIDTask,
+		CSMClusterIdentifierTask,
+		ListCSMTrafficDirectorLogEntriesTask,
 		FieldSetReaderTask,
 		LogIngesterTask,
 		LogGrouperTask,

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_query_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_query_task.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcsm_impl
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+type CSMTrafficDirectorListLogEntryTaskSetting struct{}
+
+// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+func (s *CSMTrafficDirectorListLogEntryTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
+	fleetProjectID := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref())
+	return []string{fmt.Sprintf("projects/%s", fleetProjectID)}, nil
+}
+
+// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+func (s *CSMTrafficDirectorListLogEntryTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{
+		googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref(),
+		googlecloudlogcsm_contract.CSMClusterIdentifierTaskID.Ref(),
+	}
+}
+
+// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+func (s *CSMTrafficDirectorListLogEntryTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
+	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
+		DefaultLogType: enum.LogTypeAudit,
+		QueryName:      "CSM Traffic Director logs",
+		ExampleQuery: `(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+  protoPayload.resourceName: "gsmrsvd-XXXX" -- XXXX part will be generated from other log parsing result
+  resource.labels.project_id="fleet-project"`,
+	}
+}
+
+// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+func (s *CSMTrafficDirectorListLogEntryTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+	fleetProjectID := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref())
+	clusterIdentifiers := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.CSMClusterIdentifierTaskID.Ref())
+
+	dryRunComment := ""
+	if taskMode == inspectioncore_contract.TaskModeDryRun {
+		clusterIdentifiers = []string{"dummy"}
+		dryRunComment = " -- The actual resource name selector will be generated from other logs in the middle of the pipeline."
+	} else if len(clusterIdentifiers) == 0 {
+		slog.InfoContext(ctx, "No CSM BackendServices found in inventory. Skipping Traffic Director log query.")
+		return nil, nil
+	}
+
+	resourceNameFilter := ""
+	if len(clusterIdentifiers) == 1 {
+		resourceNameFilter = fmt.Sprintf(`protoPayload.resourceName:"gsmrsvd-%s"`, clusterIdentifiers[0])
+	} else {
+		quotedIdentifiers := make([]string, len(clusterIdentifiers))
+		for i, id := range clusterIdentifiers {
+			quotedIdentifiers[i] = fmt.Sprintf(`"gsmrsvd-%s"`, id)
+		}
+		resourceNameFilter = fmt.Sprintf(`protoPayload.resourceName:(%s)`, strings.Join(quotedIdentifiers, " OR "))
+	}
+
+	query := fmt.Sprintf(`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+%s%s
+resource.labels.project_id="%s"`, resourceNameFilter, dryRunComment, fleetProjectID)
+
+	return []string{query}, nil
+}
+
+// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+func (s *CSMTrafficDirectorListLogEntryTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
+	return googlecloudlogcsm_contract.ListCSMTrafficDirectorLogEntriesTaskID
+}
+
+// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+func (s *CSMTrafficDirectorListLogEntryTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
+	return 1, nil
+}
+
+var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*CSMTrafficDirectorListLogEntryTaskSetting)(nil)
+
+var ListCSMTrafficDirectorLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&CSMTrafficDirectorListLogEntryTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_query_task_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcsm_impl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+func TestCSMTrafficDirectorListLogEntryTaskSetting_LogFilters(t *testing.T) {
+	tests := []struct {
+		name               string
+		fleetProjectID     string
+		clusterIdentifiers []string
+		taskMode           inspectioncore_contract.InspectionTaskModeType
+		want               []string
+	}{
+		{
+			name:               "single identifier",
+			fleetProjectID:     "fleet-project",
+			clusterIdentifiers: []string{"cluster1"},
+			taskMode:           inspectioncore_contract.TaskModeRun,
+			want: []string{
+				`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"gsmrsvd-cluster1"
+resource.labels.project_id="fleet-project"`,
+			},
+		},
+		{
+			name:               "multiple identifiers",
+			fleetProjectID:     "fleet-project",
+			clusterIdentifiers: []string{"cluster1", "cluster2"},
+			taskMode:           inspectioncore_contract.TaskModeRun,
+			want: []string{
+				`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:("gsmrsvd-cluster1" OR "gsmrsvd-cluster2")
+resource.labels.project_id="fleet-project"`,
+			},
+		},
+		{
+			name:               "no identifiers",
+			fleetProjectID:     "fleet-project",
+			clusterIdentifiers: []string{},
+			taskMode:           inspectioncore_contract.TaskModeRun,
+			want:               nil,
+		},
+		{
+			name:               "dry run",
+			fleetProjectID:     "fleet-project",
+			clusterIdentifiers: []string{"cluster1"}, // Should be ignored in dry run
+			taskMode:           inspectioncore_contract.TaskModeDryRun,
+			want: []string{
+				`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"gsmrsvd-dummy" -- The actual resource name selector will be generated from other logs in the middle of the pipeline.
+resource.labels.project_id="fleet-project"`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			setting := &CSMTrafficDirectorListLogEntryTaskSetting{}
+
+			// Mocking dependencies by providing them in the context
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref(), tc.fleetProjectID)
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogcsm_contract.CSMClusterIdentifierTaskID.Ref(), tc.clusterIdentifiers)
+
+			got, err := setting.LogFilters(ctx, tc.taskMode)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("LogFilters() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Note: This PR is depending on #635, thus the diff contains the things to be merged on #635.

This change introduced a new text input field to receive the fleet project ID. CSM TD creates NEG, BS, HttpRoutes in the fleet project.
The resources created by the CSM is prefixed by `gsmrsvd-(random id defined by a cluster)`. The query task depending on a task to read the random ID from found NEG-BS mapping added in #635.

This review is requested to @K53  regarding his CSM specialization.
