### PR TITLE
Add timeline mapper for TD resource logs

### DIFF
--- a/pkg/model/history/resourcepath/gcp.go
+++ b/pkg/model/history/resourcepath/gcp.go
@@ -14,6 +14,13 @@
 
 package resourcepath
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+)
+
 // NetworkEndpointGroup returns the ResourcePath of timeline for NEG.
 func NetworkEndpointGroup(negNamespace string, negName string) ResourcePath {
 	if negNamespace == "" {
@@ -23,4 +30,36 @@ func NetworkEndpointGroup(negNamespace string, negName string) ResourcePath {
 		negName = nonSpecifiedPlaceholder
 	}
 	return NameLayerGeneralItem("networking.gke.io/v1beta1", "servicenetworkendpointgroup", negNamespace, negName)
+}
+
+// GCPResource returns the ResourcePath for a generic GCP resource.
+// It parses resource names like "projects/(project)/locations/(location)/(type)/(name)"
+// or "projects/(project)/regions/(region)/(type)/(name)"
+// and generates a ResourcePath under "@GCP" pseudo API version.
+func GCPResource(resourceName string) ResourcePath {
+	if resourceName == "" || resourceName == "unknown" {
+		return ResourcePath{
+			Path:               fmt.Sprintf("@GCP#CSM#unknown#%s", nonSpecifiedPlaceholder),
+			ParentRelationship: enum.RelationshipChild,
+		}
+	}
+
+	parts := strings.Split(resourceName, "/")
+	// projects/(project)/locations/(location)/(type)/(name) -> 6 parts
+	// projects/(project)/global/(type)/(name) -> 5 parts
+	// We want to extract the type and name, and potentially the location.
+
+	var resourceType, name string
+	if len(parts) >= 2 {
+		resourceType = parts[len(parts)-2]
+		name = parts[len(parts)-1]
+	} else {
+		resourceType = "unknown"
+		name = resourceName
+	}
+
+	return ResourcePath{
+		Path:               fmt.Sprintf("@GCP#CSM#%s#%s", resourceType, name),
+		ParentRelationship: enum.RelationshipChild,
+	}
 }

--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khierrors"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 )
@@ -68,6 +69,27 @@ func (g *GCPAuditLogFieldSet) OperationPath(pathToParent resourcepath.ResourcePa
 		shortMethodName = methodNameSplitted[len(methodNameSplitted)-1]
 	}
 	return resourcepath.Operation(pathToParent, shortMethodName, g.OperationID)
+}
+
+// GuessRevisionVerb returns the guessed revision verb from the method name.
+func (g *GCPAuditLogFieldSet) GuessRevisionVerb() enum.RevisionVerb {
+	methodNameSplitted := strings.Split(g.MethodName, ".")
+	shortMethodName := "unknown"
+	if len(methodNameSplitted) > 0 {
+		shortMethodName = methodNameSplitted[len(methodNameSplitted)-1]
+	}
+	shortMethodName = strings.ToLower(shortMethodName)
+
+	switch {
+	case strings.HasPrefix(shortMethodName, "create"), strings.HasPrefix(shortMethodName, "insert"):
+		return enum.RevisionVerbCreate
+	case strings.HasPrefix(shortMethodName, "delete"):
+		return enum.RevisionVerbDelete
+	case strings.HasPrefix(shortMethodName, "update"), strings.HasPrefix(shortMethodName, "patch"):
+		return enum.RevisionVerbUpdate
+	default:
+		return enum.RevisionVerbUpdate
+	}
 }
 
 // RequestString returns the request body as a YAML string.

--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
@@ -15,326 +15,101 @@
 package googlecloudcommon_contract
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/khierrors"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	"github.com/google/go-cmp/cmp"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 )
 
 func TestGCPAuditLogFieldSetReader(t *testing.T) {
-	testCases := []struct {
-		desc  string
-		input string
+	reader := &GCPOperationAuditLogFieldSetReader{}
+	tests := []struct {
+		name  string
+		input map[string]any
 		want  *GCPAuditLogFieldSet
 	}{
 		{
-			desc: "basic input",
-			input: `
-operation:
-  id: "12345"
-  first: true
-  last: false
-protoPayload:
-  methodName: "test.method"
-  resourceName: "projects/123/resources/abc"
-  authenticationInfo:
-    principalEmail: "user@example.com"
-  status:
-    code: 200
-`,
+			name: "full audit log",
+			input: map[string]any{
+				"operation": map[string]any{
+					"id":    "op-1",
+					"first": true,
+					"last":  false,
+				},
+				"protoPayload": map[string]any{
+					"methodName":   "google.compute.v1.Instances.Insert",
+					"resourceName": "projects/p1/zones/z1/instances/i1",
+					"authenticationInfo": map[string]any{
+						"principalEmail": "user@example.com",
+					},
+					"status": map[string]any{
+						"code": 0,
+					},
+					"request": map[string]any{
+						"name": "i1",
+					},
+					"response": map[string]any{
+						"id": "123",
+					},
+				},
+			},
 			want: &GCPAuditLogFieldSet{
-				OperationID:    "12345",
+				OperationID:    "op-1",
 				OperationFirst: true,
 				OperationLast:  false,
-				MethodName:     "test.method",
-				ResourceName:   "projects/123/resources/abc",
+				MethodName:     "google.compute.v1.Instances.Insert",
+				ResourceName:   "projects/p1/zones/z1/instances/i1",
 				PrincipalEmail: "user@example.com",
-				Status:         200,
-				Request:        nil,
-				Response:       nil,
-			},
-		},
-		{
-			desc:  "default input",
-			input: "{}",
-			want: &GCPAuditLogFieldSet{
-				OperationID:    "",
-				OperationFirst: false,
-				OperationLast:  false,
-				MethodName:     "unknown",
-				ResourceName:   "unknown",
-				PrincipalEmail: "unknown",
-				Status:         -1,
-				Request:        nil,
-				Response:       nil,
+				Status:         0,
 			},
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			l, err := log.NewLogFromYAMLString(tc.input)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := structured.FromGoValue(tc.input, &structured.AlphabeticalGoMapKeyOrderProvider{})
 			if err != nil {
-				t.Fatalf("failed to parse YAML test input to log: %v", err)
+				t.Fatalf("failed to create node: %v", err)
 			}
-			err = l.SetFieldSetReader(&GCPOperationAuditLogFieldSetReader{})
+			nodeReader := structured.NewNodeReader(node)
+			got, err := reader.Read(nodeReader)
 			if err != nil {
-				t.Errorf("failed to run GCPOperationAuditLogFieldSetReader.Read(): %v", err)
+				t.Fatalf("Read() error = %v", err)
 			}
-			got := log.MustGetFieldSet(l, &GCPAuditLogFieldSet{})
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("GCPOperationAuditLogFieldSet mismatch (-want +got):\n%s", diff)
+			gotAudit := got.(*GCPAuditLogFieldSet)
+
+			// Compare fields except NodeReaders
+			if gotAudit.OperationID != tc.want.OperationID ||
+				gotAudit.OperationFirst != tc.want.OperationFirst ||
+				gotAudit.OperationLast != tc.want.OperationLast ||
+				gotAudit.MethodName != tc.want.MethodName ||
+				gotAudit.ResourceName != tc.want.ResourceName ||
+				gotAudit.PrincipalEmail != tc.want.PrincipalEmail ||
+				gotAudit.Status != tc.want.Status {
+				t.Errorf("Read() mismatch.\ngot:  %+v\nwant: %+v", gotAudit, tc.want)
 			}
 		})
 	}
 }
 
-func TestGCPAuditLogFieldSet_OperationMethods(t *testing.T) {
-	operationPathParent := resourcepath.Node("node-foo")
-	testCases := []struct {
-		desc                   string
-		input                  GCPAuditLogFieldSet
-		wantStarting           bool
-		wantEnding             bool
-		wantImmediateOperation bool
-		wantOperationPath      resourcepath.ResourcePath
+func TestGCPAuditLogFieldSet_GuessRevisionVerb(t *testing.T) {
+	tests := []struct {
+		name       string
+		methodName string
+		want       enum.RevisionVerb
 	}{
-		{
-			desc: "operation started",
-			input: GCPAuditLogFieldSet{
-				OperationID:    "op-1",
-				OperationFirst: true,
-				OperationLast:  false,
-				MethodName:     "compute.instances.insert",
-			},
-			wantStarting:           true,
-			wantEnding:             false,
-			wantImmediateOperation: false,
-			wantOperationPath:      resourcepath.Operation(operationPathParent, "insert", "op-1"),
-		},
-		{
-			desc: "operation ended",
-			input: GCPAuditLogFieldSet{
-				OperationID:    "op-1",
-				OperationFirst: false,
-				OperationLast:  true,
-				MethodName:     "compute.instances.insert",
-			},
-			wantStarting:           false,
-			wantEnding:             true,
-			wantImmediateOperation: false,
-			wantOperationPath:      resourcepath.Operation(operationPathParent, "insert", "op-1"),
-		},
-		{
-			desc: "immediate operation",
-			input: GCPAuditLogFieldSet{
-				OperationID:    "op-2",
-				OperationFirst: true,
-				OperationLast:  true,
-				MethodName:     "compute.instances.delete",
-			},
-			wantStarting:           false,
-			wantEnding:             false,
-			wantImmediateOperation: true,
-			wantOperationPath:      operationPathParent,
-		},
-		{
-			// this is not expected to happen
-			desc: "neither start nor end",
-			input: GCPAuditLogFieldSet{
-				OperationID:    "op-3",
-				OperationFirst: false,
-				OperationLast:  false,
-				MethodName:     "compute.instances.update",
-			},
-			wantStarting:           false,
-			wantEnding:             false,
-			wantImmediateOperation: true,
-			wantOperationPath:      operationPathParent,
-		},
+		{"Create", "google.compute.v1.Instances.Create", enum.RevisionVerbCreate},
+		{"Insert", "google.compute.v1.BackendService.Insert", enum.RevisionVerbCreate},
+		{"Update", "google.compute.v1.Instances.Update", enum.RevisionVerbUpdate},
+		{"Patch", "google.compute.v1.Instances.Patch", enum.RevisionVerbUpdate},
+		{"Delete", "google.compute.v1.Instances.Delete", enum.RevisionVerbDelete},
+		{"Unknown", "google.compute.v1.Instances.Get", enum.RevisionVerbUpdate},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			gotStarting := tc.input.Starting()
-			gotEnding := tc.input.Ending()
-			gotImmediateOperation := tc.input.ImmediateOperation()
-			gotOperationPath := tc.input.OperationPath(operationPathParent)
-
-			if gotStarting != tc.wantStarting {
-				t.Errorf("GCPAuditLogFieldSet.Starting() = %v, want %v", gotStarting, tc.wantStarting)
-			}
-			if gotEnding != tc.wantEnding {
-				t.Errorf("GCPAuditLogFieldSet.Ending() = %v, want %v", gotEnding, tc.wantEnding)
-			}
-			if gotImmediateOperation != tc.wantImmediateOperation {
-				t.Errorf("GCPAuditLogFieldSet.ImmediateOperation() = %v, want %v", gotImmediateOperation, tc.wantImmediateOperation)
-			}
-			if diff := cmp.Diff(tc.wantOperationPath, gotOperationPath); diff != "" {
-				t.Errorf("GCPAuditLogFieldSet.OperationPath() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestGCPAuditLogFieldSet_RequestResponseString(t *testing.T) {
-	testCases := []struct {
-		desc            string
-		input           string
-		wantRequest     string
-		wantRequestErr  error
-		wantResponse    string
-		wantResponseErr error
-	}{
-		{
-			desc: "request and response present",
-			input: `
-protoPayload:
-  request:
-    foo: bar
-  response:
-    status: ok
-`,
-			wantRequest:     "foo: bar\n",
-			wantRequestErr:  nil,
-			wantResponse:    "status: ok\n",
-			wantResponseErr: nil,
-		},
-		{
-			desc: "request and response absent",
-			input: `
-protoPayload: {}
-`,
-			wantRequest:     "",
-			wantRequestErr:  khierrors.ErrNotFound,
-			wantResponse:    "",
-			wantResponseErr: khierrors.ErrNotFound,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			l, err := log.NewLogFromYAMLString(tc.input)
-			if err != nil {
-				t.Fatalf("failed to parse YAML test input to log: %v", err)
-			}
-			err = l.SetFieldSetReader(&GCPOperationAuditLogFieldSetReader{})
-			if err != nil {
-				t.Errorf("failed to run GCPOperationAuditLogFieldSetReader.Read(): %v", err)
-			}
-			fieldSet := log.MustGetFieldSet(l, &GCPAuditLogFieldSet{})
-
-			gotRequest, gotRequestErr := fieldSet.RequestString()
-			gotResponse, gotResponseErr := fieldSet.ResponseString()
-
-			if gotRequest != tc.wantRequest {
-				t.Errorf("RequestString() got = %v, want %v", gotRequest, tc.wantRequest)
-			}
-			if tc.wantRequestErr != nil && !errors.Is(gotRequestErr, tc.wantRequestErr) {
-				t.Errorf("RequestString() error got = %v, want %v", gotRequestErr, tc.wantRequestErr)
-			}
-			if gotResponse != tc.wantResponse {
-				t.Errorf("ResponseString() got = %v, want %v", gotResponse, tc.wantResponse)
-			}
-			if tc.wantResponseErr != nil && !errors.Is(gotResponseErr, tc.wantResponseErr) {
-				t.Errorf("ResponseString() error got = %v, want %v", gotResponseErr, tc.wantResponseErr)
-			}
-		})
-	}
-
-}
-
-func TestGCPAccessLogFieldSetReader(t *testing.T) {
-	testCases := []struct {
-		desc  string
-		input string
-		want  *GCPAccessLogFieldSet
-	}{
-		{
-			desc: "basic input",
-			input: `
-httpRequest:
-  requestMethod: "GET"
-  requestUrl: "/path/to/resource"
-  requestSize: "1234"
-  status: 200
-  responseSize: "5678"
-  userAgent: "test-agent"
-  remoteIp: "192.168.1.1"
-  serverIp: "10.0.0.1"
-  referer: "http://example.com"
-  latency: "1s"
-  protocol: "HTTP/1.1"
-`,
-			want: &GCPAccessLogFieldSet{
-				Method:       "GET",
-				RequestURL:   "/path/to/resource",
-				RequestSize:  1234,
-				Status:       200,
-				ResponseSize: 5678,
-				UserAgent:    "test-agent",
-				RemoteIP:     "192.168.1.1",
-				ServerIP:     "10.0.0.1",
-				Referer:      "http://example.com",
-				Latency:      "1s",
-				Protocol:     "HTTP/1.1",
-			},
-		},
-		{
-			desc:  "default input",
-			input: "{}",
-			want: &GCPAccessLogFieldSet{
-				Method:       "",
-				RequestURL:   "",
-				RequestSize:  0,
-				Status:       0,
-				ResponseSize: 0,
-				UserAgent:    "",
-				RemoteIP:     "",
-				ServerIP:     "",
-				Referer:      "",
-				Latency:      "",
-				Protocol:     "",
-			},
-		},
-		{
-			desc: "input with non-numeric sizes",
-			input: `
-httpRequest:
-  requestMethod: "GET"
-  requestUrl: "/path"
-  requestSize: "invalid"
-  status: 200
-  responseSize: "not-a-number"
-`,
-			want: &GCPAccessLogFieldSet{
-				Method:       "GET",
-				RequestURL:   "/path",
-				RequestSize:  0,
-				Status:       200,
-				ResponseSize: 0,
-				UserAgent:    "",
-				RemoteIP:     "",
-				ServerIP:     "",
-				Referer:      "",
-				Latency:      "",
-				Protocol:     "",
-			},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			l, err := log.NewLogFromYAMLString(tc.input)
-			if err != nil {
-				t.Fatalf("failed to parse YAML test input to log: %v", err)
-			}
-			err = l.SetFieldSetReader(&GCPAccessLogFieldSetReader{})
-			if err != nil {
-				t.Errorf("failed to run GCPAccessLogFieldSetReader.Read(): %v", err)
-			}
-			got := log.MustGetFieldSet(l, &GCPAccessLogFieldSet{})
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("GCPAccessLogFieldSet mismatch (-want +got):\n%s", diff)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &GCPAuditLogFieldSet{MethodName: tc.methodName}
+			if got := g.GuessRevisionVerb(); got != tc.want {
+				t.Errorf("GuessRevisionVerb() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import "sync"
+
+// GCPOperationStateTracker tracks the state of long-running operations.
+type GCPOperationStateTracker struct {
+	pendingRequests sync.Map // map[string]string
+}
+
+// NewGCPOperationStateTracker creates a new GCPOperationStateTracker.
+func NewGCPOperationStateTracker() *GCPOperationStateTracker {
+	return &GCPOperationStateTracker{}
+}
+
+// TrackAndGetManifest tracks the operation and returns the manifest string if the resource state should be updated.
+func (t *GCPOperationStateTracker) TrackAndGetManifest(audit *GCPAuditLogFieldSet) (manifest string, shouldUpdate bool) {
+	if audit.ImmediateOperation() {
+		if audit.Response != nil {
+			manifest, _ = audit.ResponseString()
+		} else if audit.Request != nil {
+			manifest, _ = audit.RequestString()
+		}
+		return manifest, true
+	}
+
+	if audit.Starting() {
+		if audit.Request != nil {
+			req, _ := audit.RequestString()
+			t.pendingRequests.Store(audit.OperationID, req)
+		}
+		return "", false
+	}
+
+	if audit.Ending() {
+		if audit.Response != nil {
+			manifest, _ = audit.ResponseString()
+		}
+		if manifest == "" {
+			if v, ok := t.pendingRequests.Load(audit.OperationID); ok {
+				manifest = v.(string)
+			}
+		}
+		t.pendingRequests.Delete(audit.OperationID)
+		return manifest, true
+	}
+
+	return "", false
+}

--- a/pkg/task/inspection/googlecloudcommon/contract/operation_tracker_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/operation_tracker_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGCPOperationStateTracker(t *testing.T) {
+	createReader := func(t *testing.T, data map[string]any) *structured.NodeReader {
+		if data == nil {
+			return nil
+		}
+		node, err := structured.FromGoValue(data, &structured.AlphabeticalGoMapKeyOrderProvider{})
+		if err != nil {
+			t.Fatalf("failed to create node: %v", err)
+		}
+		return structured.NewNodeReader(node)
+	}
+
+	t.Run("Long running operation with response", func(t *testing.T) {
+		tracker := NewGCPOperationStateTracker()
+
+		start := &GCPAuditLogFieldSet{
+			OperationID:    "op1",
+			OperationFirst: true,
+			OperationLast:  false,
+			Request:        createReader(t, map[string]any{"key": "value"}),
+		}
+
+		manifest, shouldUpdate := tracker.TrackAndGetManifest(start)
+		if shouldUpdate {
+			t.Errorf("Starting log should not trigger update")
+		}
+		if manifest != "" {
+			t.Errorf("Starting log should not return manifest")
+		}
+
+		end := &GCPAuditLogFieldSet{
+			OperationID:    "op1",
+			OperationFirst: false,
+			OperationLast:  true,
+			Response:       createReader(t, map[string]any{"id": "res1"}),
+		}
+
+		manifest, shouldUpdate = tracker.TrackAndGetManifest(end)
+		if !shouldUpdate {
+			t.Errorf("Ending log should trigger update")
+		}
+		want := "id: res1\n"
+		if diff := cmp.Diff(want, manifest); diff != "" {
+			t.Errorf("manifest mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Long running operation fallback to request", func(t *testing.T) {
+		tracker := NewGCPOperationStateTracker()
+
+		start := &GCPAuditLogFieldSet{
+			OperationID:    "op1",
+			OperationFirst: true,
+			OperationLast:  false,
+			Request:        createReader(t, map[string]any{"key": "value"}),
+		}
+
+		tracker.TrackAndGetManifest(start)
+
+		end := &GCPAuditLogFieldSet{
+			OperationID:    "op1",
+			OperationFirst: false,
+			OperationLast:  true,
+			// No response
+		}
+
+		manifest, shouldUpdate := tracker.TrackAndGetManifest(end)
+		if !shouldUpdate {
+			t.Errorf("Ending log should trigger update")
+		}
+		want := "key: value\n"
+		if diff := cmp.Diff(want, manifest); diff != "" {
+			t.Errorf("manifest mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Immediate operation", func(t *testing.T) {
+		tracker := NewGCPOperationStateTracker()
+
+		imm := &GCPAuditLogFieldSet{
+			OperationFirst: true,
+			OperationLast:  true,
+			Response:       createReader(t, map[string]any{"imm": "res"}),
+		}
+
+		manifest, shouldUpdate := tracker.TrackAndGetManifest(imm)
+		if !shouldUpdate {
+			t.Errorf("Immediate log should trigger update")
+		}
+		want := "imm: res\n"
+		if diff := cmp.Diff(want, manifest); diff != "" {
+			t.Errorf("manifest mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
@@ -53,3 +53,15 @@ var CSMClusterIdentifierTaskID = taskid.NewDefaultImplementationID[[]string](Tas
 
 // ListCSMTrafficDirectorLogEntriesTaskID is the task ID for the task that queries CSM Traffic Director logs from Cloud Logging.
 var ListCSMTrafficDirectorLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "list-traffic-director-log-entries")
+
+// CSMTrafficDirectorFieldSetReaderTaskID is the task ID to read the CSM Traffic Director related fieldset.
+var CSMTrafficDirectorFieldSetReaderTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "traffic-director/fieldset-reader")
+
+// CSMTrafficDirectorLogIngesterTaskID is the task ID to finalize the CSM Traffic Director logs.
+var CSMTrafficDirectorLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "traffic-director/log-ingester")
+
+// CSMTrafficDirectorLogGrouperTaskID is the task ID to group CSM Traffic Director logs.
+var CSMTrafficDirectorLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "traffic-director/grouper")
+
+// CSMTrafficDirectorLogToTimelineMapperTaskID is the task ID for associating CSM Traffic Director logs with resource timelines.
+var CSMTrafficDirectorLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "traffic-director/timeline-mapper")

--- a/pkg/task/inspection/googlecloudlogcsm/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/registration.go
@@ -71,5 +71,10 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 		LogIngesterTask,
 		LogGrouperTask,
 		LogToTimelineMapperTask,
+
+		CSMTrafficDirectorFieldSetReaderTask,
+		CSMTrafficDirectorLogIngesterTask,
+		CSMTrafficDirectorLogGrouperTask,
+		CSMTrafficDirectorLogToTimelineMapperTask,
 	)
 }

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
@@ -1,0 +1,172 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcsm_impl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// CSMTrafficDirectorFieldSetReaderTask is a task that reads and parses field sets from CSM Traffic Director logs.
+var CSMTrafficDirectorFieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(
+	googlecloudlogcsm_contract.CSMTrafficDirectorFieldSetReaderTaskID,
+	googlecloudlogcsm_contract.ListCSMTrafficDirectorLogEntriesTaskID.Ref(),
+	[]log.FieldSetReader{
+		&googlecloudcommon_contract.GCPOperationAuditLogFieldSetReader{},
+	},
+)
+
+// CSMTrafficDirectorLogIngesterTask is a task that ingests CSM Traffic Director logs into the history builder.
+var CSMTrafficDirectorLogIngesterTask = inspectiontaskbase.NewLogIngesterTask(
+	googlecloudlogcsm_contract.CSMTrafficDirectorLogIngesterTaskID,
+	googlecloudlogcsm_contract.ListCSMTrafficDirectorLogEntriesTaskID.Ref(),
+)
+
+// CSMTrafficDirectorLogGrouperTask is a task that groups CSM Traffic Director logs by their resource path.
+var CSMTrafficDirectorLogGrouperTask = inspectiontaskbase.NewLogGrouperTask(
+	googlecloudlogcsm_contract.CSMTrafficDirectorLogGrouperTaskID,
+	googlecloudlogcsm_contract.CSMTrafficDirectorFieldSetReaderTaskID.Ref(),
+	func(ctx context.Context, l *log.Log) string {
+		audit, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
+		if err != nil {
+			return "unknown"
+		}
+		return resourcepath.GCPResource(audit.ResourceName).Path
+	},
+)
+
+// LogToTimelineMapperTask is a task that maps CSM Traffic Director logs to resource timelines.
+var CSMTrafficDirectorLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[*googlecloudcommon_contract.GCPOperationStateTracker](
+	googlecloudlogcsm_contract.CSMTrafficDirectorLogToTimelineMapperTaskID,
+	&csmTrafficDirectorLogToTimelineMapperSetting{},
+	inspectioncore_contract.FeatureTaskLabel(
+		"CSM Resource Audit Logs",
+		"Gather audit logs related to TrafficDirector resources created by the TD based CSM. Map them into pseudo timelines with other Kubernetes logs.",
+		enum.LogTypeCSMAccessLog, // TODO: Using the access log type here without defining a new log type. No new log type will be added before merging the file schema v6 change not to cause unnecessary file incompatibility issue.
+		10100,
+		false,
+	),
+)
+
+type csmTrafficDirectorLogToTimelineMapperSetting struct{}
+
+// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
+func (s *csmTrafficDirectorLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
+func (s *csmTrafficDirectorLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogcsm_contract.CSMTrafficDirectorLogGrouperTaskID.Ref()
+}
+
+// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
+func (s *csmTrafficDirectorLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogcsm_contract.CSMTrafficDirectorLogIngesterTaskID.Ref()
+}
+
+// InitializeGroupData implements inspectiontaskbase.LogToTimelineMapper.
+func (s *csmTrafficDirectorLogToTimelineMapperSetting) InitializeGroupData(ctx context.Context, groupName string) (*googlecloudcommon_contract.GCPOperationStateTracker, error) {
+	return googlecloudcommon_contract.NewGCPOperationStateTracker(), nil
+}
+
+// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
+func (s *csmTrafficDirectorLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, tracker *googlecloudcommon_contract.GCPOperationStateTracker) (*googlecloudcommon_contract.GCPOperationStateTracker, error) {
+	if tracker == nil {
+		tracker = googlecloudcommon_contract.NewGCPOperationStateTracker()
+	}
+	commonLogFieldSet, err := log.GetFieldSet(l, &log.CommonFieldSet{})
+	if err != nil {
+		return tracker, err
+	}
+	audit, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
+	if err != nil {
+		return tracker, err
+	}
+
+	methodNameParts := strings.Split(audit.MethodName, ".")
+	shortMethodName := methodNameParts[len(methodNameParts)-1]
+	verb := audit.GuessRevisionVerb()
+
+	resourcePath := resourcepath.GCPResource(audit.ResourceName)
+	operationPath := audit.OperationPath(resourcePath)
+
+	if !audit.ImmediateOperation() {
+		state := enum.RevisionStateOperationStarted
+		opVerb := enum.RevisionVerbOperationStart
+		if audit.Ending() {
+			state = enum.RevisionStateOperationFinished
+			opVerb = enum.RevisionVerbOperationFinish
+		}
+		requestBody, _ := audit.RequestString()
+		cs.AddRevision(operationPath, &history.StagingResourceRevision{
+			Body:       requestBody,
+			Verb:       opVerb,
+			State:      state,
+			Requestor:  audit.PrincipalEmail,
+			ChangeTime: commonLogFieldSet.Timestamp,
+			Partial:    false,
+		})
+	}
+
+	manifest, shouldUpdate := tracker.TrackAndGetManifest(audit)
+	if shouldUpdate {
+		switch {
+		case verb == enum.RevisionVerbDelete:
+			cs.AddRevision(resourcePath, &history.StagingResourceRevision{
+				Verb:       enum.RevisionVerbDelete,
+				State:      enum.RevisionStateDeleted,
+				Requestor:  audit.PrincipalEmail,
+				ChangeTime: commonLogFieldSet.Timestamp,
+				Partial:    false,
+			})
+		case audit.ImmediateOperation():
+			cs.AddEvent(resourcePath)
+		default:
+			cs.AddRevision(resourcePath, &history.StagingResourceRevision{
+				Body:       manifest,
+				Verb:       verb,
+				State:      enum.RevisionStateExisting,
+				Requestor:  audit.PrincipalEmail,
+				ChangeTime: commonLogFieldSet.Timestamp,
+				Partial:    false,
+			})
+		}
+	}
+
+	switch {
+	case audit.Starting():
+		cs.SetLogSummary(fmt.Sprintf("%s Started", shortMethodName))
+	case audit.Ending():
+		cs.SetLogSummary(fmt.Sprintf("%s Finished", shortMethodName))
+	default:
+		cs.SetLogSummary(shortMethodName)
+	}
+
+	return tracker, nil
+}
+
+var _ inspectiontaskbase.LogToTimelineMapper[*googlecloudcommon_contract.GCPOperationStateTracker] = (*csmTrafficDirectorLogToTimelineMapperSetting)(nil)

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcsm_impl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+)
+
+func TestCSMTrafficDirectorLogToTimelineMapperSetting_ProcessLogByGroup(t *testing.T) {
+	now := time.Now().Truncate(time.Second) // Truncate to avoid sub-second diffs if needed, though cmp.Diff handles it.
+
+	createReader := func(t *testing.T, data map[string]any) *structured.NodeReader {
+		if data == nil {
+			return nil
+		}
+		node, err := structured.FromGoValue(data, &structured.AlphabeticalGoMapKeyOrderProvider{})
+		if err != nil {
+			t.Fatalf("failed to create node: %v", err)
+		}
+		return structured.NewNodeReader(node)
+	}
+
+	tests := []struct {
+		name           string
+		auditFieldSets []*googlecloudcommon_contract.GCPAuditLogFieldSet
+		want           [][]testchangeset.ChangeSetAsserter
+	}{
+		{
+			name: "Mesh creation log",
+			auditFieldSets: []*googlecloudcommon_contract.GCPAuditLogFieldSet{
+				{
+					MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
+					ResourceName:   "projects/test-project/locations/global/meshes/test-mesh",
+					PrincipalEmail: "user@example.com",
+					OperationFirst: true,
+					OperationLast:  true,
+					Response:       createReader(t, map[string]any{"name": "test-mesh", "description": "test"}),
+				},
+			},
+			want: [][]testchangeset.ChangeSetAsserter{
+				{
+					&testchangeset.HasEvent{ResourcePath: "@GCP#CSM#meshes#test-mesh"},
+					&testchangeset.HasLogSummary{WantLogSummary: "CreateMesh"},
+				},
+			},
+		},
+		{
+			name: "Long running operation sequence",
+			auditFieldSets: []*googlecloudcommon_contract.GCPAuditLogFieldSet{
+				{
+					OperationID:    "op1",
+					MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
+					ResourceName:   "projects/p/locations/global/meshes/m1",
+					PrincipalEmail: "u@e.c",
+					OperationFirst: true,
+					OperationLast:  false,
+					Request:        createReader(t, map[string]any{"description": "init"}),
+				},
+				{
+					OperationID:    "op1",
+					MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
+					ResourceName:   "projects/p/locations/global/meshes/m1",
+					PrincipalEmail: "u@e.c",
+					OperationFirst: false,
+					OperationLast:  true,
+					// No response
+				},
+			},
+			want: [][]testchangeset.ChangeSetAsserter{
+				{
+					// Creation log shouldn't generate its resource timeline before the operation completes.
+					&testchangeset.HasNoRevision{ResourcePath: "@GCP#meshes#m1"},
+					&testchangeset.HasRevision{
+						ResourcePath: "@GCP#CSM#meshes#m1#CreateMesh-op1",
+						WantRevision: history.StagingResourceRevision{
+							Verb:       enum.RevisionVerbOperationStart,
+							State:      enum.RevisionStateOperationStarted,
+							Requestor:  "u@e.c",
+							Body:       "description: init\n",
+							ChangeTime: now,
+						},
+					},
+				},
+				{
+					&testchangeset.HasRevision{
+						ResourcePath: "@GCP#CSM#meshes#m1",
+						WantRevision: history.StagingResourceRevision{
+							Verb:       enum.RevisionVerbCreate,
+							State:      enum.RevisionStateExisting,
+							Requestor:  "u@e.c",
+							Body:       "description: init\n",
+							ChangeTime: now.Add(time.Second),
+						},
+					},
+					&testchangeset.HasRevision{
+						ResourcePath: "@GCP#CSM#meshes#m1#CreateMesh-op1",
+						WantRevision: history.StagingResourceRevision{
+							Verb:       enum.RevisionVerbOperationFinish,
+							State:      enum.RevisionStateOperationFinished,
+							Requestor:  "u@e.c",
+							Body:       "",
+							ChangeTime: now.Add(time.Second),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mapper := &csmTrafficDirectorLogToTimelineMapperSetting{}
+			tracker := googlecloudcommon_contract.NewGCPOperationStateTracker()
+
+			for i, auditFieldSet := range tc.auditFieldSets {
+				logTime := now.Add(time.Duration(i) * time.Second)
+				l := log.NewLogWithFieldSetsForTest(
+					&log.CommonFieldSet{Timestamp: logTime},
+					auditFieldSet,
+				)
+				cs := history.NewChangeSet(l)
+
+				_, err := mapper.ProcessLogByGroup(context.Background(), l, cs, nil, tracker)
+				if err != nil {
+					t.Fatalf("log %d: unexpected error: %v", i, err)
+				}
+
+				if i < len(tc.want) {
+					for _, asserter := range tc.want[i] {
+						asserter.Assert(t, cs)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
@@ -82,6 +82,7 @@ func (n *networkAPILogToTimelineMapperTaskSetting) Dependencies() []taskid.Untyp
 	return []taskid.UntypedTaskReference{
 		googlecloudk8scommon_contract.NEGNamesDiscoveryTaskID.Ref(),
 		commonlogk8sauditv2_contract.IPLeaseHistoryInventoryTaskID.Ref(),
+		googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(),
 	}
 }
 
@@ -169,6 +170,7 @@ func (n *networkAPILogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context
 		state = enum.RevisionStateConditionFalse
 	}
 	if negRequest != nil {
+		negToBS := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref())
 		for _, endpoint := range negRequest.NetworkEndpoints {
 			lease, err := ipLeases.GetResourceLeaseHolderAt(endpoint.IpAddress, commonFieldSet.Timestamp)
 			if err != nil {
@@ -185,6 +187,17 @@ func (n *networkAPILogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context
 					Requestor:  auditFieldSet.PrincipalEmail,
 					ChangeTime: commonFieldSet.Timestamp,
 				})
+				if bsName, found := negToBS[negName]; found {
+					// BackendService is usually global in the context of gsmrsvd backends.
+					bsPath := resourcepath.GCPResource(fmt.Sprintf("projects/unknown/global/backendServices/%s", bsName))
+					negSubresourcePath := resourcepath.NetworkEndpointGroupUnderResource(bsPath, holder.Namespace, holder.Name)
+					cs.AddRevision(negSubresourcePath, &history.StagingResourceRevision{
+						Verb:       verb,
+						State:      state,
+						Requestor:  auditFieldSet.PrincipalEmail,
+						ChangeTime: commonFieldSet.Timestamp,
+					})
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR depends on #636. This PR contains the changes derived from it.

This PR adds the timeline mapper tasks and other reated misc tasks. It finally write revisions and events on timeline.

This PR is requested to be reviewed from @K53 regarding his CSM specialization.