### PR TITLE
:bug: fix set-input suggestion being wrapped for every lines

### DIFF
--- a/web/src/app/shared/components/set-input/default-chip.component.scss
+++ b/web/src/app/shared/components/set-input/default-chip.component.scss
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+:host {
+  display: inline-flex;
+}
+
 .chip-button {
   border: 0;
   background: none;

--- a/web/src/app/timeline-toolbar/components/set-input-popup.component.scss
+++ b/web/src/app/timeline-toolbar/components/set-input-popup.component.scss
@@ -18,7 +18,8 @@
 @use '../../common.scss' as common;
 
 :host {
-  width: 600px;
+  width: 100%;
+  max-width: 600px;
 }
 
 .popup-container {

--- a/web/src/app/timeline-toolbar/components/set-input-popup.component.scss
+++ b/web/src/app/timeline-toolbar/components/set-input-popup.component.scss
@@ -17,6 +17,10 @@
 @use 'sass:color';
 @use '../../common.scss' as common;
 
+:host {
+  width: 600px;
+}
+
 .popup-container {
   background: white;
   padding: 12px;


### PR DESCRIPTION
This PR fixes the layout of set input popup. It breaks line for every chips inintentionally.

before:
<img width="2748" height="1926" alt="image" src="https://github.com/user-attachments/assets/0d95d524-6c70-428b-832c-e1b999d00569" />

after:
<img width="2748" height="1926" alt="image" src="https://github.com/user-attachments/assets/5ac04ced-a45d-4a44-a204-9be31be47c8c" />
