### PR TITLE
feat: Adding TimelineStyleRegistry

### DIFF
--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -47,12 +47,18 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version-file: './go.mod'
+    - name: Install jq
+      run: sudo apt-get update && sudo apt-get install -y jq
+    # Building frontend artifacts because that is used in embed.fs in Go.
+    - name: npm install
+      working-directory: ./web
+      run: npm ci
+    - name: Build web
+      run: make build-web
+
     - name: Backend Test
       run: |
         make generate-backend
-        mkdir -p pkg/server/dist/browser/session
-        # A placeholder frontend code read from backend test
-        echo '<!--INJECT GENERATED CODE HERE FROM BACKEND-->' > ./pkg/server/dist/browser/index.html
         go test ./... -args -skip-cloud-logging=true
     - name: Backend Format and Lint Check
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ zzz_*.json
 # Vendor folders
 scripts/msdf-generator/vendor/
 scripts/make/*.done
+
+# Go embedded assets for icons
+pkg/model/khifile/v6/style/assets/

--- a/pkg/model/khifile/v6/style/timeline.go
+++ b/pkg/model/khifile/v6/style/timeline.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package style
+
+import (
+	_ "embed"
+	"encoding/json"
+	"slices"
+	"sync"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+)
+
+//go:embed assets/zzz-icon-codepoints.json
+var iconCodepointsBytes []byte
+
+//go:embed assets/zzz-material-icons-msdf.json
+var materialIconsMSDFJSONBytes []byte
+
+//go:embed assets/zzz-material-icons-msdf.png
+var materialIconsMSDFPNGBytes []byte
+
+var (
+	iconAtlasOnce   sync.Once
+	cachedIconAtlas *pb.IconAtlas
+)
+
+// GetIconAtlas returns the embedded IconAtlas instance cached globally.
+func GetIconAtlas() *pb.IconAtlas {
+	iconAtlasOnce.Do(func() {
+		var codepoints map[string]string
+		if err := json.Unmarshal(iconCodepointsBytes, &codepoints); err != nil {
+			panic("failed to unmarshal embedded zzz-icon-codepoints.json: " + err.Error())
+		}
+
+		cachedIconAtlas = &pb.IconAtlas{
+			MsdfIconImage:    [][]byte{materialIconsMSDFPNGBytes},
+			BmfontJson:       materialIconsMSDFJSONBytes,
+			NameToCodepoints: codepoints,
+		}
+	})
+	return cachedIconAtlas
+}
+
+var (
+	mu             sync.RWMutex
+	severities     []*pb.Severity
+	verbs          []*pb.Verb
+	logTypes       []*pb.LogType
+	revisionStates []*pb.RevisionState
+	timelineTypes  []*pb.TimelineType
+)
+
+// reset clears the registry. This is primarily intended for testing to avoid test pollution
+// across different packages testing plugin loading.
+func reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	severities = nil
+	verbs = nil
+	logTypes = nil
+	revisionStates = nil
+	timelineTypes = nil
+}
+
+// RegisterTimelineType registers a TimelineType, assigns a unique ID to it,
+// mutates the provided pointer by setting its Id field, and returns the same pointer.
+// This allows for global inline initialization in plugins.
+func RegisterTimelineType(t *pb.TimelineType) *pb.TimelineType {
+	mu.Lock()
+	defer mu.Unlock()
+
+	id := uint32(len(timelineTypes) + 1)
+	t.Id = &id
+	timelineTypes = append(timelineTypes, t)
+	return t
+}
+
+// RegisterSeverity registers a Severity, assigns a unique ID to it,
+// mutates the provided pointer by setting its Id field, and returns the same pointer.
+func RegisterSeverity(s *pb.Severity) *pb.Severity {
+	mu.Lock()
+	defer mu.Unlock()
+
+	id := uint32(len(severities) + 1)
+	s.Id = &id
+	severities = append(severities, s)
+	return s
+}
+
+// RegisterVerb registers a Verb, assigns a unique ID to it,
+// mutates the provided pointer by setting its Id field, and returns the same pointer.
+func RegisterVerb(v *pb.Verb) *pb.Verb {
+	mu.Lock()
+	defer mu.Unlock()
+
+	id := uint32(len(verbs) + 1)
+	v.Id = &id
+	verbs = append(verbs, v)
+	return v
+}
+
+// RegisterLogType registers a LogType, assigns a unique ID to it,
+// mutates the provided pointer by setting its Id field, and returns the same pointer.
+func RegisterLogType(l *pb.LogType) *pb.LogType {
+	mu.Lock()
+	defer mu.Unlock()
+
+	id := uint32(len(logTypes) + 1)
+	l.Id = &id
+	logTypes = append(logTypes, l)
+	return l
+}
+
+// RegisterRevisionState registers a RevisionState, assigns a unique ID to it,
+// mutates the provided pointer by setting its Id field, and returns the same pointer.
+func RegisterRevisionState(rs *pb.RevisionState) *pb.RevisionState {
+	mu.Lock()
+	defer mu.Unlock()
+
+	id := uint32(len(revisionStates) + 1)
+	rs.Id = &id
+	revisionStates = append(revisionStates, rs)
+	return rs
+}
+
+// GenerateChunk generates the final TimelineStyleChunk containing all registered styles.
+func GenerateChunk() *pb.TimelineStyleChunk {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	// Create shallow copies of the slices to avoid concurrent modification issues
+	// if someone decides to append while another is iterating over the chunk.
+	return &pb.TimelineStyleChunk{
+		Severities:     slices.Clone(severities),
+		Verbs:          slices.Clone(verbs),
+		LogTypes:       slices.Clone(logTypes),
+		RevisionStates: slices.Clone(revisionStates),
+		TimelineTypes:  slices.Clone(timelineTypes),
+		IconAtlas:      GetIconAtlas(),
+	}
+}

--- a/pkg/model/khifile/v6/style/timeline_test.go
+++ b/pkg/model/khifile/v6/style/timeline_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package style
+
+import (
+	"sync"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+)
+
+func TestRegisterTimelineType(t *testing.T) {
+	reset()
+
+	t1 := &pb.TimelineType{Label: proto.String("Type 1")}
+	t2 := &pb.TimelineType{Label: proto.String("Type 2")}
+
+	res1 := RegisterTimelineType(t1)
+	RegisterTimelineType(t2)
+
+	// Verify the returned pointer is the same as the input
+	if res1 != t1 {
+		t.Errorf("Expected returned pointer to be the same, got different")
+	}
+
+	// Verify IDs were assigned starting from 1
+	if t1.Id == nil || *t1.Id != 1 {
+		t.Errorf("Expected ID 1, got %v", t1.Id)
+	}
+	if t2.Id == nil || *t2.Id != 2 {
+		t.Errorf("Expected ID 2, got %v", t2.Id)
+	}
+
+	chunk := GenerateChunk()
+	if len(chunk.TimelineTypes) != 2 {
+		t.Fatalf("Expected 2 TimelineTypes in chunk, got %d", len(chunk.TimelineTypes))
+	}
+	if *chunk.TimelineTypes[0].Id != 1 {
+		t.Errorf("Expected first chunk TimelineType ID to be 1")
+	}
+}
+
+func TestRegisterConcurrent(t *testing.T) {
+	reset()
+
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(index int) {
+			defer wg.Done()
+			RegisterVerb(&pb.Verb{Label: proto.String("Concurrent Verb")})
+		}(i)
+	}
+
+	wg.Wait()
+
+	chunk := GenerateChunk()
+	if len(chunk.Verbs) != numGoroutines {
+		t.Fatalf("Expected %d Verbs registered, got %d", numGoroutines, len(chunk.Verbs))
+	}
+
+	// Verify all IDs from 1 to numGoroutines exist exactly once
+	idMap := make(map[uint32]bool)
+	for _, v := range chunk.Verbs {
+		if v.Id == nil {
+			t.Fatalf("Verb ID is nil")
+		}
+		if idMap[*v.Id] {
+			t.Errorf("Duplicate ID found: %d", *v.Id)
+		}
+		idMap[*v.Id] = true
+	}
+
+	if len(idMap) != numGoroutines {
+		t.Errorf("Expected %d unique IDs, got %d", numGoroutines, len(idMap))
+	}
+}
+
+func TestGenerateChunkHasAllSlices(t *testing.T) {
+	reset()
+
+	RegisterSeverity(&pb.Severity{Label: proto.String("Sev")})
+	RegisterVerb(&pb.Verb{Label: proto.String("Verb")})
+	RegisterLogType(&pb.LogType{Label: proto.String("Log")})
+	RegisterRevisionState(&pb.RevisionState{Label: proto.String("RevState")})
+	RegisterTimelineType(&pb.TimelineType{Label: proto.String("Timeline")})
+
+	chunk := GenerateChunk()
+
+	if len(chunk.Severities) != 1 {
+		t.Errorf("Expected 1 Severity, got %d", len(chunk.Severities))
+	}
+	if len(chunk.Verbs) != 1 {
+		t.Errorf("Expected 1 Verb, got %d", len(chunk.Verbs))
+	}
+	if len(chunk.LogTypes) != 1 {
+		t.Errorf("Expected 1 LogType, got %d", len(chunk.LogTypes))
+	}
+	if len(chunk.RevisionStates) != 1 {
+		t.Errorf("Expected 1 RevisionState, got %d", len(chunk.RevisionStates))
+	}
+	if len(chunk.TimelineTypes) != 1 {
+		t.Errorf("Expected 1 TimelineType, got %d", len(chunk.TimelineTypes))
+	}
+}
+
+func TestGenerateChunkHasIconAtlas(t *testing.T) {
+	reset()
+
+	chunk := GenerateChunk()
+	if chunk.IconAtlas == nil {
+		t.Fatal("Expected IconAtlas not to be nil in TimelineStyleChunk")
+	}
+
+	if len(chunk.IconAtlas.MsdfIconImage) == 0 || len(chunk.IconAtlas.MsdfIconImage[0]) == 0 {
+		t.Error("Expected non-empty embedded PNG bytes in MsdfIconImage")
+	}
+
+	if len(chunk.IconAtlas.BmfontJson) == 0 {
+		t.Error("Expected non-empty embedded BMFont configuration JSON")
+	}
+
+	if len(chunk.IconAtlas.NameToCodepoints) == 0 {
+		t.Error("Expected populated mapping in NameToCodepoints")
+	}
+}

--- a/scripts/make/codegen.mk
+++ b/scripts/make/codegen.mk
@@ -23,8 +23,13 @@ $(GENERATE_BACKEND_DUMMY): ## Generate backend source code
 .PHONY: generate-backend
  generate-backend: $(GENERATE_BACKEND_DUMMY) ## Generate backend source code
 
+# TODO: eventually the following cp commands are not needed after we removed icon image dependency directly from the frontend.
 $(FRONTEND_GENERATED_ASSETS_DUMMY): scripts/msdf-generator/index.js scripts/msdf-generator/zzz_generated_used_icons.json $(MSDF_SETUP_DUMMY)## Generate font atlas
 	cd scripts/msdf-generator && node index.js
+	mkdir -p pkg/model/khifile/v6/style/assets
+	cp web/src/assets/zzz-icon-codepoints.json pkg/model/khifile/v6/style/assets/
+	cp web/src/assets/zzz-material-icons-msdf.json pkg/model/khifile/v6/style/assets/
+	cp web/src/assets/zzz-material-icons-msdf.png pkg/model/khifile/v6/style/assets/
 	touch $(FRONTEND_GENERATED_ASSETS_DUMMY)
 
 generate-frontend-assets: $(FRONTEND_GENERATED_ASSETS_DUMMY) ## Generate font atlas


### PR DESCRIPTION
This PR adds TimelineStyleRegistry which stores all the style information registered from each task packages.
Previously these styles are defined with enum values and it resulsts in the incompatibility of a file if the file was generated from other KHI containing another task.
From KHI file schema v6, these style information will be generated one time per a binary and embedded into the KHI file directly. This enable KHI be extended without considering the shared style part.