### PR TITLE
Adding log store domain layer

### DIFF
--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LogStore, LogDTO } from 'src/app/store/domain/log-store';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { create } from '@bufbuild/protobuf';
+import {
+  InternedStructSchema,
+  InternedValueSchema,
+} from 'src/app/generated/khifile/shared_pb';
+
+describe('LogStore', () => {
+  let internPool: InternPoolStore;
+  let styleStore: StyleStore;
+  let store: LogStore;
+
+  const mockColor = { r: 0, g: 0, b: 0, a: 1 };
+
+  beforeEach(() => {
+    internPool = new InternPoolStore();
+    styleStore = new StyleStore();
+    store = new LogStore(internPool, styleStore);
+
+    // Avoid errors of missing keys in basic tests
+    styleStore.addSeverities([
+      {
+        id: 1,
+        label: 'S1',
+        shortLabel: 'S1',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 0,
+      },
+      {
+        id: 2,
+        label: 'S2',
+        shortLabel: 'S2',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 0,
+      },
+      {
+        id: 3,
+        label: 'S3',
+        shortLabel: 'S3',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 0,
+      },
+      {
+        id: 4,
+        label: 'S4',
+        shortLabel: 'S4',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 0,
+      },
+    ]);
+
+    styleStore.addLogTypes([
+      {
+        id: 1,
+        label: 'L1',
+        description: '',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      },
+      {
+        id: 2,
+        label: 'L2',
+        description: '',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      },
+      {
+        id: 3,
+        label: 'L3',
+        description: '',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      },
+      {
+        id: 4,
+        label: 'L4',
+        description: '',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      },
+    ]);
+  });
+
+  it('should succeed with correctly ordered timestamps', () => {
+    const logs: LogDTO[] = [
+      { id: 1, ts: 1000n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+      { id: 2, ts: 1005n, logTypeId: 2, severityTypeId: 2, summaryStringId: 2 },
+      { id: 3, ts: 1005n, logTypeId: 3, severityTypeId: 3, summaryStringId: 3 },
+      { id: 4, ts: 1010n, logTypeId: 4, severityTypeId: 4, summaryStringId: 4 },
+    ];
+
+    expect(() => store.initialize(logs, 4)).not.toThrow();
+  });
+
+  it('should throw error if logs are out of timestamp order', () => {
+    const logs: LogDTO[] = [
+      { id: 1, ts: 1000n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+      { id: 2, ts: 999n, logTypeId: 2, severityTypeId: 2, summaryStringId: 2 },
+    ];
+
+    expect(() => store.initialize(logs, 2)).toThrowError(
+      /Logs are not sorted by timestamp/,
+    );
+  });
+
+  it('should fetch log entries and handle incorrect id lookups', () => {
+    internPool.addStrings([
+      { id: 1, value: 'first_summary' },
+      { id: 2, value: 'second_summary' },
+    ]);
+
+    styleStore.addSeverities([
+      {
+        id: 10,
+        label: 'INFO',
+        shortLabel: 'I',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 0,
+      },
+    ]);
+
+    styleStore.addLogTypes([
+      {
+        id: 100,
+        label: 'audit',
+        description: 'audit desc',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      },
+    ]);
+
+    const logs: LogDTO[] = [
+      {
+        id: 55,
+        ts: 10n,
+        logTypeId: 100,
+        severityTypeId: 10,
+        summaryStringId: 1,
+      },
+      {
+        id: 56,
+        ts: 20n,
+        logTypeId: 100,
+        severityTypeId: 10,
+        summaryStringId: 2,
+      },
+    ];
+
+    store.initialize(logs, 2);
+
+    const logObj = store.getLog(55);
+    expect(logObj.id).toBe(55);
+    expect(logObj.timestamp).toBe(10n);
+    expect(logObj.summary).toBe('first_summary');
+    expect(logObj.severity.label).toBe('INFO');
+    expect(logObj.logType.label).toBe('audit');
+    expect(logObj.logIndex).toBe(0);
+
+    expect(store.getIndex(55)).toBe(0);
+    expect(store.getIndex(56)).toBe(1);
+    expect(() => store.getIndex(99)).toThrowError('Log ID 99 not found');
+
+    expect(() => store.getLog(99)).toThrowError('Log ID 99 not found');
+  });
+
+  it('should return decoded log body correctly', () => {
+    internPool.addStrings([
+      { id: 10, value: 'user' },
+      { id: 11, value: 'status' },
+      { id: 12, value: 'alice' },
+    ]);
+
+    internPool.addFieldPathSets([{ id: 1, fieldPathStringIds: [10, 11] }]);
+
+    const struct = create(InternedStructSchema, {
+      fieldPathSetId: 1,
+      values: [
+        create(InternedValueSchema, {
+          kind: { case: 'stringValue', value: 12 },
+        }),
+        create(InternedValueSchema, {
+          kind: { case: 'int64Value', value: 42n },
+        }),
+      ],
+    });
+
+    const logs: LogDTO[] = [
+      {
+        id: 1,
+        ts: 10n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+        body: struct,
+      },
+      { id: 2, ts: 20n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+    ];
+
+    store.initialize(logs, 2);
+
+    expect(store.getLog(1).body).toEqual({
+      user: 'alice',
+      status: 42,
+    });
+    expect(store.getLog(1).bodyYAML).toBe('user: alice\nstatus: 42\n');
+    expect(store.getLog(2).body).toBeNull();
+    expect(store.getLog(2).bodyYAML).toBe('');
+    expect(() => store.getLog(99)).toThrowError('Log ID 99 not found');
+  });
+
+  it('should return count and iterator correctly', () => {
+    const logs: LogDTO[] = [
+      { id: 1, ts: 1000n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+      { id: 2, ts: 1005n, logTypeId: 2, severityTypeId: 2, summaryStringId: 2 },
+    ];
+
+    store.initialize(logs, 2);
+
+    expect(store.count).toBe(2);
+
+    const iteratedLogs = Array.from(store.logs());
+    expect(iteratedLogs.length).toBe(2);
+    expect(iteratedLogs[0].id).toBe(1);
+    expect(iteratedLogs[1].id).toBe(2);
+  });
+});

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Log } from 'src/app/store/domain/log';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { InternedStructDecoder } from 'src/app/store/domain/struct-decoder';
+import { InternedStruct } from 'src/app/generated/khifile/shared_pb';
+import { LogType, Severity } from 'src/app/store/domain/style';
+import { ReadonlyDomainElement, Undefinable } from 'src/app/store/domain/types';
+
+/**
+ * Raw Log object interface from the assembler.
+ *
+ * This type is used because domain layer stores must not receive proto type
+ * directly to decouple file version difference with domain stores.
+ */
+export interface LogDTO {
+  readonly id: number;
+  readonly ts: bigint;
+  readonly logTypeId: number;
+  readonly severityTypeId: number;
+  readonly summaryStringId: number;
+  readonly body?: InternedStruct;
+}
+
+/**
+ * Store for managing and retrieving logs efficiently.
+ */
+export class LogStore {
+  private ids = new Uint32Array(0);
+  private timestamps = new BigUint64Array(0);
+  private logTypeIds = new Uint32Array(0);
+  private severityIds = new Uint32Array(0);
+  private summaryStringIds = new Uint32Array(0);
+
+  private bodies: Undefinable<InternedStruct>[] = [];
+  private idToIndex: Undefinable<number>[] = [];
+  private readonly decoder: InternedStructDecoder;
+
+  constructor(
+    private readonly internPool: InternPoolStore,
+    private readonly styleStore: StyleStore,
+  ) {
+    this.decoder = new InternedStructDecoder(this.internPool);
+  }
+
+  /**
+   * Initializes the store with the raw logs.
+   * Assumes logs are already sorted by timestamp.
+   * @param logs The iterable of raw logs.
+   * @param count The total number of logs.
+   */
+  public initialize(logs: Iterable<LogDTO>, count: number): void {
+    this.ids = new Uint32Array(count);
+    this.timestamps = new BigUint64Array(count);
+    this.logTypeIds = new Uint32Array(count);
+    this.severityIds = new Uint32Array(count);
+    this.summaryStringIds = new Uint32Array(count);
+
+    this.bodies = new Array<Undefinable<InternedStruct>>(count);
+    this.idToIndex = [];
+
+    let index = 0;
+    let prevTs = 0n;
+    for (const log of logs) {
+      if (index > 0 && log.ts < prevTs) {
+        throw new Error(
+          `Logs are not sorted by timestamp at index ${index}: timestamp ${log.ts} < ${prevTs}`,
+        );
+      }
+      prevTs = log.ts;
+
+      this.ids[index] = log.id;
+      this.timestamps[index] = log.ts;
+      this.logTypeIds[index] = log.logTypeId;
+      this.severityIds[index] = log.severityTypeId;
+      this.summaryStringIds[index] = log.summaryStringId;
+      this.bodies[index] = log.body;
+      this.idToIndex[log.id] = index;
+      index++;
+    }
+  }
+
+  /**
+   * Gets a log entry adapter by its ID.
+   * @param id The ID of the log.
+   * @returns The log entry adapter.
+   */
+  public getLog(id: number): ReadonlyDomainElement<Log> {
+    const index = this.idToIndex[id];
+    if (index === undefined) {
+      throw new Error(`Log ID ${id} not found`);
+    }
+
+    return new Log(id, this);
+  }
+
+  /**
+   * Gets the total number of logs.
+   */
+  public get count(): number {
+    return this.ids.length;
+  }
+
+  /**
+   * Returns an iterator for all logs in the store.
+   */
+  public *logs(): IterableIterator<ReadonlyDomainElement<Log>> {
+    for (let i = 0; i < this.ids.length; i++) {
+      yield new Log(this.ids[i], this);
+    }
+  }
+
+  // --- Internal getters for Log adapter ---
+
+  /**
+   * Gets the timestamp of a log by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Log} domain adapter.
+   */
+  public _getTimestamp(id: number): bigint {
+    return this.timestamps[this.getIndex(id)];
+  }
+
+  /**
+   * Gets the summary value of a log by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Log} domain adapter.
+   */
+  public _getSummary(id: number): string {
+    return this.internPool.getString(this.summaryStringIds[this.getIndex(id)]);
+  }
+
+  /**
+   * Gets the log type metadata of a log by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Log} domain adapter.
+   */
+  public _getLogType(id: number): ReadonlyDomainElement<LogType> {
+    return this.styleStore.getLogType(this.logTypeIds[this.getIndex(id)]);
+  }
+
+  /**
+   * Gets the severity metadata of a log by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Log} domain adapter.
+   */
+  public _getSeverity(id: number): ReadonlyDomainElement<Severity> {
+    return this.styleStore.getSeverity(this.severityIds[this.getIndex(id)]);
+  }
+
+  /**
+   * Decodes the nested properties of a log by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Log} domain adapter.
+   */
+  public _decodeBody(
+    id: number,
+  ): ReadonlyDomainElement<Record<string, unknown>> | null {
+    const index = this.getIndex(id);
+    const struct = this.bodies[index];
+    if (!struct) return null;
+    return this.decoder.decode(struct);
+  }
+
+  /**
+   * Gets the index of a log in the store by its ID.
+   * @param id The ID of the log.
+   * @returns The index of the log.
+   */
+  public getIndex(id: number): number {
+    const index = this.idToIndex[id];
+    if (index === undefined) {
+      throw new Error(`Log ID ${id} not found`);
+    }
+    return index;
+  }
+}

--- a/web/src/app/store/domain/log.ts
+++ b/web/src/app/store/domain/log.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yaml from 'js-yaml';
+import { LogType, Severity } from 'src/app/store/domain/style';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import { BigIntTimeUtil } from 'src/app/utils/bigint-time-util';
+
+/**
+ * Lazy adapter for a Log entry.
+ * Evaluates fields on demand and ensures deep immutability.
+ */
+export class Log {
+  private _body?: ReadonlyDomainElement<Record<string, unknown>> | null;
+
+  constructor(
+    public readonly id: number,
+    private readonly store: LogStore,
+  ) {}
+
+  /**
+   * Gets the chronological index of this log in the store.
+   */
+  get logIndex(): number {
+    return this.store.getIndex(this.id);
+  }
+
+  /**
+   * Gets the timestamp of the log entry.
+   */
+  get timestamp(): bigint {
+    return this.store._getTimestamp(this.id);
+  }
+
+  /**
+   * Gets the timestamp (in milliseconds) of the log entry.
+   * @deprecated Use {@link timestamp} instead, which returns the timestamp in nanoseconds.
+   */
+  get legacyTimestampMs(): number {
+    return BigIntTimeUtil.NsToNumberMs(this.timestamp);
+  }
+
+  /**
+   * Gets the human-readable summary of the log.
+   */
+  get summary(): string {
+    return this.store._getSummary(this.id);
+  }
+
+  /**
+   * Gets the associated log source category.
+   */
+  get logType(): ReadonlyDomainElement<LogType> {
+    return this.store._getLogType(this.id);
+  }
+
+  /**
+   * Gets the severity priority of the log.
+   */
+  get severity(): ReadonlyDomainElement<Severity> {
+    return this.store._getSeverity(this.id);
+  }
+
+  /**
+   * Gets the structured log attributes decoded from Intern pool data stores.
+   */
+  get body(): ReadonlyDomainElement<Record<string, unknown>> | null {
+    if (this._body === undefined) {
+      this._body = this.store._decodeBody(this.id) as ReadonlyDomainElement<
+        Record<string, unknown>
+      > | null;
+    }
+    return this._body;
+  }
+
+  /**
+   * Gets the YAML string representation of the structured log attributes.
+   */
+  get bodyYAML(): string {
+    return this.body ? yaml.dump(this.body, { lineWidth: -1 }) : '';
+  }
+}

--- a/web/src/app/utils/bigint-time-util.spec.ts
+++ b/web/src/app/utils/bigint-time-util.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BigIntTimeUtil } from './bigint-time-util';
+
+describe('BigIntTimeUtil', () => {
+  describe('NsToNumberMs', () => {
+    it('should convert nanoseconds to milliseconds', () => {
+      expect(BigIntTimeUtil.NsToNumberMs(0n)).toBe(0);
+      expect(BigIntTimeUtil.NsToNumberMs(1000000n)).toBe(1);
+      expect(BigIntTimeUtil.NsToNumberMs(1500000n)).toBe(1.5);
+      expect(BigIntTimeUtil.NsToNumberMs(1234567890n)).toBe(1234.56789);
+      expect(BigIntTimeUtil.NsToNumberMs(500n)).toBe(0.0005);
+    });
+  });
+});

--- a/web/src/app/utils/bigint-time-util.ts
+++ b/web/src/app/utils/bigint-time-util.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility class for converting time represented as BigInt.
+ */
+export class BigIntTimeUtil {
+  /**
+   * Converts nanoseconds in BigInt to milliseconds in number, maintaining sub-millisecond precision.
+   * @param ns The nanoseconds in BigInt.
+   * @returns The milliseconds in number.
+   */
+  public static NsToNumberMs(ns: bigint): number {
+    return Number(ns / 1000000n) + Number(ns % 1000000n) / 1000000;
+  }
+}


### PR DESCRIPTION
This PR adds log store in the domain layer. 

These domain types receives values converted from proto types, store them in memory efficient method because store needs to keep them in memory even user is not currently seeing the data on the screen, and provides efficient methods to access data.

Any views will access to Log data or the Style data from these domain layer. 