### PR TITLE
Adding the InspectionDataBuilder to build the domain layer

### DIFF
--- a/web/src/app/parser/core/builder.spec.ts
+++ b/web/src/app/parser/core/builder.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InspectionDataBuilder } from 'src/app/parser/core/builder';
+import { LogDTO } from 'src/app/store/domain/log-store';
+import {
+  TimelineDTO,
+  RevisionDTO,
+  EventDTO,
+} from 'src/app/store/domain/timeline-store';
+import {
+  Severity,
+  LogType,
+  Verb,
+  RevisionState,
+  TimelineType,
+  RevisionStateStyle,
+} from 'src/app/store/domain/style';
+
+describe('InspectionDataBuilder (Core)', () => {
+  let builder: InspectionDataBuilder;
+
+  const mockColor = { r: 0.1, g: 0.2, b: 0.3, a: 1.0 };
+
+  beforeEach(() => {
+    builder = new InspectionDataBuilder();
+  });
+
+  it('should accumulate stores and construct domain instances correctly', () => {
+    const rawLogs: LogDTO[] = [
+      {
+        id: 100,
+        ts: 1234n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+      },
+    ];
+
+    const rawTimelines: TimelineDTO[] = [
+      {
+        id: 10,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [100],
+        eventIds: [200],
+      },
+    ];
+
+    const rawRevisions: RevisionDTO[] = [
+      {
+        id: 100,
+        logId: 100,
+        changedTime: 1234n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+      },
+    ];
+
+    const rawEvents: EventDTO[] = [
+      {
+        id: 200,
+        logId: 100,
+      },
+    ];
+
+    const rawSeverity: Severity = {
+      id: 1,
+      label: 'INFO',
+      shortLabel: 'I',
+      backgroundColor: mockColor,
+      foregroundColor: mockColor,
+      order: 0,
+    };
+
+    const rawLogType: LogType = {
+      id: 1,
+      label: 'type-label',
+      description: '',
+      backgroundColor: mockColor,
+      foregroundColor: mockColor,
+    };
+
+    const rawVerb: Verb = {
+      id: 1,
+      label: 'VERB',
+      backgroundColor: mockColor,
+      foregroundColor: mockColor,
+      visible: true,
+    };
+
+    const rawRevisionState: RevisionState = {
+      id: 1,
+      label: 'normal',
+      icon: '',
+      description: '',
+      backgroundColor: mockColor,
+      style: RevisionStateStyle.NORMAL,
+    };
+
+    const rawTimelineType: TimelineType = {
+      id: 1,
+      label: 'tl-type',
+      description: '',
+      icon: '',
+      backgroundColor: mockColor,
+      foregroundColor: mockColor,
+      typeChipBackgroundColor: mockColor,
+      visible: true,
+      sortPriority: 0,
+      height: 1,
+    };
+
+    const result = builder
+      .addStrings([{ id: 1, value: 'summary_value' }])
+      .addFieldPathSets([{ id: 10, fieldPathStringIds: [1] }])
+      .addLogs(rawLogs)
+      .addTimelines(rawTimelines)
+      .addRevisions(rawRevisions)
+      .addEvents(rawEvents)
+      .addSeverities([rawSeverity])
+      .addLogTypes([rawLogType])
+      .addVerbs([rawVerb])
+      .addRevisionStates([rawRevisionState])
+      .addTimelineTypes([rawTimelineType])
+      .build();
+
+    expect(result.internPool.getString(1)).toBe('summary_value');
+    expect(result.styleStore.getLogType(1).label).toBe('type-label');
+
+    const l = result.logStore.getLog(100);
+    expect(l.id).toBe(100);
+    expect(l.timestamp).toBe(1234n);
+  });
+});

--- a/web/src/app/parser/core/builder.ts
+++ b/web/src/app/parser/core/builder.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InspectionDataV2 } from 'src/app/store/domain/inspection-data';
+import { LogStore, LogDTO } from 'src/app/store/domain/log-store';
+import {
+  InternPoolStore,
+  StringEntryDTO,
+  FieldPathSetEntryDTO,
+} from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import {
+  TimelineStore,
+  RevisionDTO,
+  TimelineDTO,
+  EventDTO,
+} from 'src/app/store/domain/timeline-store';
+import {
+  LogType,
+  RevisionState,
+  Severity,
+  TimelineType,
+  Verb,
+} from 'src/app/store/domain/style';
+
+/**
+ * Core InspectionDataBuilder for compiling raw store inputs.
+ * Collects components in a version-decoupled form.
+ */
+export class InspectionDataBuilder {
+  private readonly internPool = new InternPoolStore();
+  private readonly styleStore = new StyleStore();
+  private readonly logStore: LogStore;
+  private readonly timelineStore: TimelineStore;
+
+  private readonly rawLogs: LogDTO[] = [];
+  private readonly rawTimelines: TimelineDTO[] = [];
+  private readonly rawRevisions: RevisionDTO[] = [];
+  private readonly rawEvents: EventDTO[] = [];
+
+  constructor() {
+    this.logStore = new LogStore(this.internPool, this.styleStore);
+    this.timelineStore = new TimelineStore(
+      this.internPool,
+      this.styleStore,
+      this.logStore,
+    );
+  }
+
+  /**
+   * Adds interned strings to the pool.
+   */
+  public addStrings(strings: Iterable<StringEntryDTO>): this {
+    this.internPool.addStrings(strings);
+    return this;
+  }
+
+  /**
+   * Adds field path sets to the pool.
+   */
+  public addFieldPathSets(sets: Iterable<FieldPathSetEntryDTO>): this {
+    this.internPool.addFieldPathSets(sets);
+    return this;
+  }
+
+  /**
+   * Adds domain raw logs.
+   */
+  public addLogs(logs: Iterable<LogDTO>): this {
+    for (const log of logs) {
+      this.rawLogs.push(log);
+    }
+    return this;
+  }
+
+  /**
+   * Adds domain raw timelines.
+   */
+  public addTimelines(timelines: Iterable<TimelineDTO>): this {
+    for (const timeline of timelines) {
+      this.rawTimelines.push(timeline);
+    }
+    return this;
+  }
+
+  /**
+   * Adds domain raw revisions.
+   */
+  public addRevisions(revisions: Iterable<RevisionDTO>): this {
+    for (const revision of revisions) {
+      this.rawRevisions.push(revision);
+    }
+    return this;
+  }
+
+  /**
+   * Adds domain raw events.
+   */
+  public addEvents(events: Iterable<EventDTO>): this {
+    for (const event of events) {
+      this.rawEvents.push(event);
+    }
+    return this;
+  }
+
+  /**
+   * Registers styling metadata: severity rules.
+   */
+  public addSeverities(items: Iterable<Severity>): this {
+    this.styleStore.addSeverities(items);
+    return this;
+  }
+
+  /**
+   * Registers styling metadata: logging types.
+   */
+  public addLogTypes(items: Iterable<LogType>): this {
+    this.styleStore.addLogTypes(items);
+    return this;
+  }
+
+  /**
+   * Registers styling metadata: verb classifications.
+   */
+  public addVerbs(items: Iterable<Verb>): this {
+    this.styleStore.addVerbs(items);
+    return this;
+  }
+
+  /**
+   * Registers styling metadata: revision tracking states.
+   */
+  public addRevisionStates(items: Iterable<RevisionState>): this {
+    this.styleStore.addRevisionStates(items);
+    return this;
+  }
+
+  /**
+   * Registers styling metadata: classification types.
+   */
+  public addTimelineTypes(items: Iterable<TimelineType>): this {
+    this.styleStore.addTimelineTypes(items);
+    return this;
+  }
+
+  /**
+   * Instantiates data store contexts returning root inspection model.
+   */
+  public build(): InspectionDataV2 {
+    this.logStore.initialize(this.rawLogs, this.rawLogs.length);
+    this.timelineStore.initialize(
+      this.rawTimelines,
+      this.rawTimelines.length,
+      this.rawRevisions,
+      this.rawRevisions.length,
+      this.rawEvents,
+      this.rawEvents.length,
+    );
+
+    return {
+      internPool: this.internPool,
+      styleStore: this.styleStore,
+      logStore: this.logStore,
+      timelineStore: this.timelineStore,
+    };
+  }
+}

--- a/web/src/app/store/domain/inspection-data.ts
+++ b/web/src/app/store/domain/inspection-data.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LogStore } from 'src/app/store/domain/log-store';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+
+/**
+ * Represents the complete domain model for v6 file format or later.
+ *
+ * This model is accessed by views after being converted from Protobuf types.
+ * It provides efficient memory layouts and high-speed in-memory searches on the frontend,
+ * while absorbing differences in the Protobuf side.
+ *
+ * TODO: Remove "V2" suffix once this completely replaces the existing InspectionData.
+ */
+export interface InspectionDataV2 {
+  /**
+   * Interned storage provider providing efficient memory layout.
+   */
+  readonly internPool: InternPoolStore;
+
+  /**
+   * Provides visual style definitions used in the inspection data.
+   */
+  readonly styleStore: StyleStore;
+
+  /**
+   * Log store provides efficient access for log data.
+   */
+  readonly logStore: LogStore;
+
+  /**
+   * Timeline store provides efficient access for timeline data.
+   */
+  readonly timelineStore: TimelineStore;
+}

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -43,10 +43,13 @@ describe('TimelineStore', () => {
         id: 1,
         label: 'type-a',
         description: 'desc',
+        icon: '',
         backgroundColor: mockColor,
         foregroundColor: mockColor,
+        typeChipBackgroundColor: mockColor,
         visible: true,
         sortPriority: 0,
+        height: 1,
       },
     ]);
 

--- a/web/src/app/store/domain/timeline.spec.ts
+++ b/web/src/app/store/domain/timeline.spec.ts
@@ -48,10 +48,13 @@ describe('Timeline', () => {
         id: 1,
         label: 'type-a',
         description: 'desc',
+        icon: '',
         backgroundColor: mockColor,
         foregroundColor: mockColor,
+        typeChipBackgroundColor: mockColor,
         visible: true,
         sortPriority: 0,
+        height: 1,
       },
     ]);
 


### PR DESCRIPTION
This PR introduces a new InspectionDataBuilder type which is a type given to assembler during the parsing phase.
Assembler parses its version specific chunked proto file structure and insert them to the InspectionDataBuilder to get the InspectionData eventually.

The InspectionDataBuilder type must not depend on any proto types and these version differences are expected to be absorbed in the assembler.

ContainerReader--[Read header and compressed chunked protos]--> VersionSpeicficBluePrint --[Accumulate proto data grouped by its type] --InspectionDataBuilder --> InspectionData(domain model)

Please check the interface.ts included in #630.