### PR TITLE
fixed minor issues on Makefile

### DIFF
--- a/.agents/rules/markdown-coding-rule.md
+++ b/.agents/rules/markdown-coding-rule.md
@@ -5,7 +5,7 @@ globs: **/*.md
 
 # KHI Markdown Standards
 
-- Run `make lint-markdown` to check style and formatting.
+- Run `make format-md` and `make lint-md` to check style and formatting.
 
 ## 2. Language and Style
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -14,6 +14,8 @@ All the following `make` commands must be run from the root folder:
 * `make build-go`, `make build-web`: Builds the backend and frontend source code respectively.
 * `make test-go`, `make test-web`: Runs the backend and frontend tests respectively.
 * `make lint-go`, `make lint-web`: Runs the backend and frontend linters respectively.
+* `make format-go`, `make format-web`: Runs the backend and frontend formatters respectively.
+* Run `make pre-commit` before finalizing a task. It runs formatter for every file.
 
 ## Technical stack
 

--- a/docs/en/development-contribution/development-guide.md
+++ b/docs/en/development-contribution/development-guide.md
@@ -104,13 +104,13 @@ npm install
 To lint Markdown files, run:
 
 ```bash
-make lint-markdown
+make lint-md
 ```
 
 To automatically fix markdownlint issues:
 
 ```bash
-make lint-markdown-fix
+make format-md
 ```
 
 ## Releasing container image

--- a/docs/ja/development-contribution/development-guide.md
+++ b/docs/ja/development-contribution/development-guide.md
@@ -103,13 +103,13 @@ npm install
 下記のコマンドでリンターが実行されます:
 
 ```bash
-make lint-markdown
+make lint-md
 ```
 
 マークダウンを自動的に修正するには下記を実行します:
 
 ```bash
-make lint-markdown-fix
+make format-md
 ```
 
 ## コンテナイメージのリリース

--- a/scripts/make/build.mk
+++ b/scripts/make/build.mk
@@ -26,7 +26,7 @@ watch-karma: $(GENERATE_FRONTEND_DUMMY) ## Run karma test server
 	cd web && npm run test
 
 khi: $(GENERATE_BACKEND_DUMMY) $(FRONTEND_ARTIFACT_FILES_DUMMY) $(BACKEND_SRCS)
-	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X github.com/GoogleCloudPlatform/khi/pkg/common/constants.VERSION=$(shell cat ./VERSION)" -o ./khi ./cmd/kubernetes-history-inspector/...
+	CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/GoogleCloudPlatform/khi/pkg/common/constants.VERSION=$(shell cat ./VERSION)" -o ./khi ./cmd/kubernetes-history-inspector/...
 
 .PHONY: build-go
 build-go: khi ## Build backend for production

--- a/scripts/make/hooks.mk
+++ b/scripts/make/hooks.mk
@@ -1,23 +1,23 @@
 
 .PHONY: pre-commit
 pre-commit: ## Run pre-commit checks (internal)
-	@if jj root >/dev/null 2>&1 && [ -z "$$(git diff --cached --name-only 2>/dev/null)" ]; then \
-		scripts_files=$$(jj diff --name-only | while IFS= read -r f; do [ -e "$$f" ] && echo "$$f"; done | sed 's| |\\ |g'); \
-		if [ -n "$$scripts_files" ]; then \
-			$(MAKE) add-licenses && \
-			$(MAKE) format && \
-			$(MAKE) lint && \
-			$(MAKE) lint-markdown-fix && \
-			$(MAKE) lint-markdown; \
-		fi \
-	else \
+	@if git rev-parse --is-inside-work-tree >/dev/null 2>&1 && [ -n "$$(git diff --cached --name-only 2>/dev/null)" ]; then \
 		scripts_files=$$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g'); \
 		if [ -n "$$scripts_files" ]; then \
 			$(MAKE) add-licenses && \
 			$(MAKE) format && \
 			$(MAKE) lint && \
-			$(MAKE) lint-markdown-fix && \
-			$(MAKE) lint-markdown && \
+			$(MAKE) format-md && \
+			$(MAKE) lint-md && \
 			echo "$$scripts_files" | xargs git add; \
+		fi \
+	elif jj root >/dev/null 2>&1; then \
+		scripts_files=$$(jj diff --name-only | while IFS= read -r f; do [ -e "$$f" ] && echo "$$f"; done | sed 's| |\\ |g'); \
+		if [ -n "$$scripts_files" ]; then \
+			$(MAKE) add-licenses && \
+			$(MAKE) format && \
+			$(MAKE) lint && \
+			$(MAKE) format-md && \
+			$(MAKE) lint-md; \
 		fi \
 	fi

--- a/scripts/make/lint.mk
+++ b/scripts/make/lint.mk
@@ -53,10 +53,10 @@ check-format-go: ## Check backend source code format
 check-format-web: $(GENERATE_FRONTEND_DUMMY) ## Check frontend source code format
 	cd web && npx prettier --ignore-path .gitignore --check "./**/*.+(ts|json|html|scss)"
 
-.PHONY: lint-markdown
-lint-markdown: ## Run markdown linter
+.PHONY: lint-md
+lint-md: ## Run markdown linter
 	npx markdownlint-cli2
 
-.PHONY: lint-markdown-fix
-lint-markdown-fix: ## Fix markdown linter errors
+.PHONY: format-md
+format-md: ## Fix markdown linter errors
 	npx markdownlint-cli2 --fix

--- a/scripts/make/testing.mk
+++ b/scripts/make/testing.mk
@@ -3,11 +3,11 @@
 
 .PHONY: test-web
 test-web: $(GENERATE_FRONTEND_DUMMY) $(FRONTEND_SOURCE_FILES)## Run frontend tests
-	cd web && npx ng test --watch=false
+	cd web && npx ng test --browsers ChromeHeadlessNoSandbox --watch=false
 
-.PHONY: test-web-headless
-test-web-headless: $(GENERATE_FRONTEND_DUMMY) ## Run frontend tests and generate coverage report
-	cd web && npx ng test --browsers ChromeHeadlessNoSandbox --watch false
+.PHONY: watch-test-web
+watch-test-web: $(GENERATE_FRONTEND_DUMMY) ## Run frontend tests in watch mode
+	cd web && npx ng test
 
 .PHONY: test-go
 test-go: $(GENERATE_BACKEND_DUMMY) $(BACKEND_TEST_SRCS) $(FRONTEND_ARTIFACT_FILES_DUMMY) ## Run backend tests


### PR DESCRIPTION
Fixed several minor issues of Makefile:

* `make pre-commit` may fail when user run it on a folder with jj workspace without colocating git
* `make lint-markdown-fix` wasn't aligned with the naming convention of target names
* `make test-web` runs Chrome with headless mode by default to allow agents easier to test them by them own
* `make build-go` generated the linux ELF even if it ran from Mac