### PR TITLE
Adding make clean command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,24 @@ include scripts/make/*.mk
 #  Development commands
 # ====================================================================================
 
+## Clean
+.PHONY: clean
+clean: ## Clean build artifacts and generated files
+	@echo "Cleaning Go binaries..."
+	rm -rf ./bin ./khi ./khi-debug
+	@echo "Cleaning frontend artifacts..."
+	rm -rf ./pkg/server/dist/* web/.angular web/coverage
+	@echo "Cleaning test and coverage reports..."
+	rm -rf go-cover.html go-cover.output result.json
+	@echo "Cleaning intermediate generated files..."
+	rm -rf pkg/generated/*.go zzz_*.go zzz_*.json
+	rm -rf web/src/app/zzz-generated.scss web/src/app/zzz-generated.ts web/angular.json
+	rm -rf scripts/msdf-generator/zzz_generated_used_icons.json
+	@echo "Cleaning make dummy files..."
+	rm -rf scripts/make/*.done
+
+
+
 ## Test
 .PHONY: test
 test: test-web test-go ## Run all tests

--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,15 @@ clean: ## Clean build artifacts and generated files
 	@echo "Cleaning Go binaries..."
 	rm -rf ./bin ./khi ./khi-debug
 	@echo "Cleaning frontend artifacts..."
-	rm -rf ./pkg/server/dist/* web/.angular web/coverage
+	rm -rf ./pkg/server/dist web/.angular web/coverage
 	@echo "Cleaning test and coverage reports..."
 	rm -rf go-cover.html go-cover.output result.json
 	@echo "Cleaning intermediate generated files..."
-	rm -rf pkg/generated/*.go zzz_*.go zzz_*.json
-	rm -rf web/src/app/zzz-generated.scss web/src/app/zzz-generated.ts web/angular.json
-	rm -rf scripts/msdf-generator/zzz_generated_used_icons.json
+	find . -path "./web" -prune -o -path "./.git" -prune -o -type f -name "zzz_*.go" -exec rm -f {} + -o -type f -name "zzz_*.json" -exec rm -f {} +
+	rm -rf pkg/generated
+	rm -rf web/src/app/zzz-generated.scss web/src/app/zzz-generated.ts web/angular.json web/src/environments/version.*.ts
 	@echo "Cleaning make dummy files..."
 	rm -rf scripts/make/*.done
-
-
 
 ## Test
 .PHONY: test

--- a/scripts/backend-codegen/main.go
+++ b/scripts/backend-codegen/main.go
@@ -83,6 +83,10 @@ func generateInspectionRegistration() error {
 		return fmt.Errorf("failed to format generated code: %w", err)
 	}
 
+	if err := os.MkdirAll(filepath.Dir(inspectionRegistrationOutputPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for generated file: %w", err)
+	}
+
 	if err := os.WriteFile(inspectionRegistrationOutputPath, formattedSource, 0644); err != nil {
 		return fmt.Errorf("failed to write generated file: %w", err)
 	}


### PR DESCRIPTION
Adding `make clean` target. This makes our life easier to switch workspace and rebuild it again on another commit.