### PR TITLE
Change input of style registration not to depend on proto

### DIFF
--- a/pkg/model/khifile/v6/style/timeline.go
+++ b/pkg/model/khifile/v6/style/timeline.go
@@ -20,6 +20,8 @@ import (
 	"slices"
 	"sync"
 
+	"google.golang.org/protobuf/proto"
+
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 )
 
@@ -75,63 +77,110 @@ func reset() {
 	timelineTypes = nil
 }
 
+// Color represents a color with high dynamic range (HDR) capabilities.
+type Color struct {
+	R, G, B, A float32
+}
+
+func (c Color) toProto() *pb.HDRColor4 {
+	return &pb.HDRColor4{
+		R: proto.Float32(c.R),
+		G: proto.Float32(c.G),
+		B: proto.Float32(c.B),
+		A: proto.Float32(c.A),
+	}
+}
+
 // RegisterTimelineType registers a TimelineType, assigns a unique ID to it,
-// mutates the provided pointer by setting its Id field, and returns the same pointer.
-// This allows for global inline initialization in plugins.
-func RegisterTimelineType(t *pb.TimelineType) *pb.TimelineType {
+// and returns the generated pointer. This allows for global inline initialization in plugins.
+func RegisterTimelineType(label string, description string, backgroundColor Color, foregroundColor Color, visible bool, sortPriority int32) *pb.TimelineType {
 	mu.Lock()
 	defer mu.Unlock()
 
 	id := uint32(len(timelineTypes) + 1)
-	t.Id = &id
+	t := &pb.TimelineType{
+		Id:              proto.Uint32(id),
+		Label:           proto.String(label),
+		Description:     proto.String(description),
+		BackgroundColor: backgroundColor.toProto(),
+		ForegroundColor: foregroundColor.toProto(),
+		Visible:         proto.Bool(visible),
+		SortPriority:    proto.Int32(sortPriority),
+	}
 	timelineTypes = append(timelineTypes, t)
 	return t
 }
 
 // RegisterSeverity registers a Severity, assigns a unique ID to it,
-// mutates the provided pointer by setting its Id field, and returns the same pointer.
-func RegisterSeverity(s *pb.Severity) *pb.Severity {
+// and returns the generated pointer.
+func RegisterSeverity(label string, shortLabel string, backgroundColor Color, foregroundColor Color, order int32) *pb.Severity {
 	mu.Lock()
 	defer mu.Unlock()
 
 	id := uint32(len(severities) + 1)
-	s.Id = &id
+	s := &pb.Severity{
+		Id:              proto.Uint32(id),
+		Label:           proto.String(label),
+		ShortLabel:      proto.String(shortLabel),
+		BackgroundColor: backgroundColor.toProto(),
+		ForegroundColor: foregroundColor.toProto(),
+		Order:           proto.Int32(order),
+	}
 	severities = append(severities, s)
 	return s
 }
 
 // RegisterVerb registers a Verb, assigns a unique ID to it,
-// mutates the provided pointer by setting its Id field, and returns the same pointer.
-func RegisterVerb(v *pb.Verb) *pb.Verb {
+// and returns the generated pointer.
+func RegisterVerb(label string, backgroundColor Color, foregroundColor Color, visible bool) *pb.Verb {
 	mu.Lock()
 	defer mu.Unlock()
 
 	id := uint32(len(verbs) + 1)
-	v.Id = &id
+	v := &pb.Verb{
+		Id:              proto.Uint32(id),
+		Label:           proto.String(label),
+		BackgroundColor: backgroundColor.toProto(),
+		ForegroundColor: foregroundColor.toProto(),
+		Visible:         proto.Bool(visible),
+	}
 	verbs = append(verbs, v)
 	return v
 }
 
 // RegisterLogType registers a LogType, assigns a unique ID to it,
-// mutates the provided pointer by setting its Id field, and returns the same pointer.
-func RegisterLogType(l *pb.LogType) *pb.LogType {
+// and returns the generated pointer.
+func RegisterLogType(label string, description string, backgroundColor Color, foregroundColor Color) *pb.LogType {
 	mu.Lock()
 	defer mu.Unlock()
 
 	id := uint32(len(logTypes) + 1)
-	l.Id = &id
+	l := &pb.LogType{
+		Id:              proto.Uint32(id),
+		Label:           proto.String(label),
+		Description:     proto.String(description),
+		BackgroundColor: backgroundColor.toProto(),
+		ForegroundColor: foregroundColor.toProto(),
+	}
 	logTypes = append(logTypes, l)
 	return l
 }
 
 // RegisterRevisionState registers a RevisionState, assigns a unique ID to it,
-// mutates the provided pointer by setting its Id field, and returns the same pointer.
-func RegisterRevisionState(rs *pb.RevisionState) *pb.RevisionState {
+// and returns the generated pointer.
+func RegisterRevisionState(label string, icon string, description string, backgroundColor Color, style pb.RevisionStateStyle) *pb.RevisionState {
 	mu.Lock()
 	defer mu.Unlock()
 
 	id := uint32(len(revisionStates) + 1)
-	rs.Id = &id
+	rs := &pb.RevisionState{
+		Id:              proto.Uint32(id),
+		Label:           proto.String(label),
+		Icon:            proto.String(icon),
+		Description:     proto.String(description),
+		BackgroundColor: backgroundColor.toProto(),
+		Style:           &style,
+	}
 	revisionStates = append(revisionStates, rs)
 	return rs
 }

--- a/pkg/model/khifile/v6/style/timeline_test.go
+++ b/pkg/model/khifile/v6/style/timeline_test.go
@@ -18,31 +18,21 @@ import (
 	"sync"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
-
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 )
 
 func TestRegisterTimelineType(t *testing.T) {
 	reset()
 
-	t1 := &pb.TimelineType{Label: proto.String("Type 1")}
-	t2 := &pb.TimelineType{Label: proto.String("Type 2")}
-
-	res1 := RegisterTimelineType(t1)
-	RegisterTimelineType(t2)
-
-	// Verify the returned pointer is the same as the input
-	if res1 != t1 {
-		t.Errorf("Expected returned pointer to be the same, got different")
-	}
+	res1 := RegisterTimelineType("Type 1", "Desc 1", Color{1, 1, 1, 1}, Color{0, 0, 0, 1}, true, 1)
+	res2 := RegisterTimelineType("Type 2", "Desc 2", Color{1, 1, 1, 1}, Color{0, 0, 0, 1}, true, 2)
 
 	// Verify IDs were assigned starting from 1
-	if t1.Id == nil || *t1.Id != 1 {
-		t.Errorf("Expected ID 1, got %v", t1.Id)
+	if res1.Id == nil || *res1.Id != 1 {
+		t.Errorf("Expected ID 1, got %v", res1.Id)
 	}
-	if t2.Id == nil || *t2.Id != 2 {
-		t.Errorf("Expected ID 2, got %v", t2.Id)
+	if res2.Id == nil || *res2.Id != 2 {
+		t.Errorf("Expected ID 2, got %v", res2.Id)
 	}
 
 	chunk := GenerateChunk()
@@ -64,7 +54,7 @@ func TestRegisterConcurrent(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func(index int) {
 			defer wg.Done()
-			RegisterVerb(&pb.Verb{Label: proto.String("Concurrent Verb")})
+			RegisterVerb("Concurrent Verb", Color{1, 1, 1, 1}, Color{0, 0, 0, 1}, true)
 		}(i)
 	}
 
@@ -95,11 +85,11 @@ func TestRegisterConcurrent(t *testing.T) {
 func TestGenerateChunkHasAllSlices(t *testing.T) {
 	reset()
 
-	RegisterSeverity(&pb.Severity{Label: proto.String("Sev")})
-	RegisterVerb(&pb.Verb{Label: proto.String("Verb")})
-	RegisterLogType(&pb.LogType{Label: proto.String("Log")})
-	RegisterRevisionState(&pb.RevisionState{Label: proto.String("RevState")})
-	RegisterTimelineType(&pb.TimelineType{Label: proto.String("Timeline")})
+	RegisterSeverity("Sev", "S", Color{1, 1, 1, 1}, Color{0, 0, 0, 1}, 1)
+	RegisterVerb("Verb", Color{1, 1, 1, 1}, Color{0, 0, 0, 1}, true)
+	RegisterLogType("Log", "Desc", Color{1, 1, 1, 1}, Color{0, 0, 0, 1})
+	RegisterRevisionState("RevState", "icon", "Desc", Color{1, 1, 1, 1}, pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL)
+	RegisterTimelineType("Timeline", "Desc", Color{1, 1, 1, 1}, Color{0, 0, 0, 1}, true, 1)
 
 	chunk := GenerateChunk()
 


### PR DESCRIPTION
This PR changed the signature of functions `RegisterXXX` defined for style registrations.
It has received the proto types like `pb.RevisionState` directly, but it allows users to omit some fields on the type.
This change made the signature to receive each fields directly on the function to verify these missing fields on the compilation timing.