### PR TITLE
Add listing methods in style-store

### DIFF
--- a/web/src/app/store/domain/style-store.spec.ts
+++ b/web/src/app/store/domain/style-store.spec.ts
@@ -115,6 +115,105 @@ describe('StyleStore', () => {
     );
   });
 
+  describe('Array-returning getters', () => {
+    it('should return all added elements, filtering out undefined slots', () => {
+      const severity1 = {
+        id: 2,
+        label: 'WARNING',
+        shortLabel: 'W',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 2,
+      };
+      const severity2 = {
+        id: 5,
+        label: 'ERROR',
+        shortLabel: 'E',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 3,
+      };
+      store.addSeverities([severity1, severity2]);
+      expect(store.severities).toEqual([severity1, severity2]);
+
+      const logType1 = {
+        id: 1,
+        label: 'API Server',
+        description: 'Kubernetes API Server logs',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      };
+      const logType2 = {
+        id: 3,
+        label: 'Controller Manager',
+        description: 'Kubernetes Controller Manager logs',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      };
+      store.addLogTypes([logType1, logType2]);
+      expect(store.logTypes).toEqual([logType1, logType2]);
+
+      const verb1 = {
+        id: 0,
+        label: 'Get',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        visible: true,
+      };
+      const verb2 = {
+        id: 2,
+        label: 'Create',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        visible: true,
+      };
+      store.addVerbs([verb1, verb2]);
+      expect(store.verbs).toEqual([verb1, verb2]);
+
+      const revisionState1 = {
+        id: 1,
+        label: 'Running',
+        icon: 'play_arrow',
+        description: 'Resource is running',
+        backgroundColor: mockColor,
+        style: RevisionStateStyle.NORMAL,
+      };
+      const revisionState2 = {
+        id: 4,
+        label: 'Failed',
+        icon: 'error',
+        description: 'Resource failed',
+        backgroundColor: mockColor,
+        style: RevisionStateStyle.NORMAL,
+      };
+      store.addRevisionStates([revisionState1, revisionState2]);
+      expect(store.revisionStates).toEqual([revisionState1, revisionState2]);
+
+      const timelineType1 = {
+        id: 2,
+        label: 'Pod',
+        description: 'Pod lifecycle timeline',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        typeChipBackgroundColor: mockColor,
+        visible: true,
+        sortPriority: 10,
+      };
+      const timelineType2 = {
+        id: 5,
+        label: 'Node',
+        description: 'Node lifecycle timeline',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        typeChipBackgroundColor: mockColor,
+        visible: true,
+        sortPriority: 20,
+      };
+      store.addTimelineTypes([timelineType1, timelineType2]);
+      expect(store.timelineTypes).toEqual([timelineType1, timelineType2]);
+    });
+  });
+
   describe('IconAtlas', () => {
     it('should throw an error if getIconAtlas is called before setIconAtlas', () => {
       expect(() => store.getIconAtlas()).toThrowError(

--- a/web/src/app/store/domain/style-store.ts
+++ b/web/src/app/store/domain/style-store.ts
@@ -69,11 +69,11 @@ export interface IconAtlasDTO {
  * Manages the style-related definitions for the UI.
  */
 export class StyleStore {
-  private readonly severities: Severity[] = [];
-  private readonly logTypes: LogType[] = [];
-  private readonly verbs: Verb[] = [];
-  private readonly revisionStates: RevisionState[] = [];
-  private readonly timelineTypes: TimelineType[] = [];
+  private readonly _severities: Severity[] = [];
+  private readonly _logTypes: LogType[] = [];
+  private readonly _verbs: Verb[] = [];
+  private readonly _revisionStates: RevisionState[] = [];
+  private readonly _timelineTypes: TimelineType[] = [];
 
   private iconAtlas: IconAtlas | undefined;
 
@@ -83,7 +83,7 @@ export class StyleStore {
    */
   public addSeverities(items: Iterable<SeverityDTO>): void {
     for (const item of items) {
-      this.severities[item.id] = item;
+      this._severities[item.id] = item;
     }
   }
 
@@ -93,7 +93,7 @@ export class StyleStore {
    */
   public addLogTypes(items: Iterable<LogTypeDTO>): void {
     for (const item of items) {
-      this.logTypes[item.id] = item;
+      this._logTypes[item.id] = item;
     }
   }
 
@@ -103,7 +103,7 @@ export class StyleStore {
    */
   public addVerbs(items: Iterable<VerbDTO>): void {
     for (const item of items) {
-      this.verbs[item.id] = item;
+      this._verbs[item.id] = item;
     }
   }
 
@@ -113,7 +113,7 @@ export class StyleStore {
    */
   public addRevisionStates(items: Iterable<RevisionStateDTO>): void {
     for (const item of items) {
-      this.revisionStates[item.id] = item;
+      this._revisionStates[item.id] = item;
     }
   }
 
@@ -123,7 +123,7 @@ export class StyleStore {
    */
   public addTimelineTypes(items: Iterable<TimelineTypeDTO>): void {
     for (const item of items) {
-      this.timelineTypes[item.id] = item;
+      this._timelineTypes[item.id] = item;
     }
   }
 
@@ -164,8 +164,8 @@ export class StyleStore {
    * @param id The ID of the severity.
    * @returns The resolved severity.
    */
-  public getSeverity(id: number): ReadonlyDomainElement<SeverityDTO> {
-    const item = this.severities[id];
+  public getSeverity(id: number): ReadonlyDomainElement<Severity> {
+    const item = this._severities[id];
     if (!item) {
       throw new Error(`Severity ID ${id} not found`);
     }
@@ -177,8 +177,8 @@ export class StyleStore {
    * @param id The ID of the log type.
    * @returns The resolved log type.
    */
-  public getLogType(id: number): ReadonlyDomainElement<LogTypeDTO> {
-    const item = this.logTypes[id];
+  public getLogType(id: number): ReadonlyDomainElement<LogType> {
+    const item = this._logTypes[id];
     if (!item) {
       throw new Error(`LogType ID ${id} not found`);
     }
@@ -190,8 +190,8 @@ export class StyleStore {
    * @param id The ID of the verb.
    * @returns The resolved verb.
    */
-  public getVerb(id: number): ReadonlyDomainElement<VerbDTO> {
-    const item = this.verbs[id];
+  public getVerb(id: number): ReadonlyDomainElement<Verb> {
+    const item = this._verbs[id];
     if (!item) {
       throw new Error(`Verb ID ${id} not found`);
     }
@@ -203,8 +203,8 @@ export class StyleStore {
    * @param id The ID of the revision state.
    * @returns The resolved revision state.
    */
-  public getRevisionState(id: number): ReadonlyDomainElement<RevisionStateDTO> {
-    const item = this.revisionStates[id];
+  public getRevisionState(id: number): ReadonlyDomainElement<RevisionState> {
+    const item = this._revisionStates[id];
     if (!item) {
       throw new Error(`RevisionState ID ${id} not found`);
     }
@@ -216,12 +216,53 @@ export class StyleStore {
    * @param id The ID of the timeline type.
    * @returns The resolved timeline type.
    */
-  public getTimelineType(id: number): ReadonlyDomainElement<TimelineTypeDTO> {
-    const item = this.timelineTypes[id];
+  public getTimelineType(id: number): ReadonlyDomainElement<TimelineType> {
+    const item = this._timelineTypes[id];
     if (!item) {
       throw new Error(`TimelineType ID ${id} not found`);
     }
     return item;
+  }
+
+  /**
+   * Returns all severities defined in the store.
+   */
+  public get severities(): ReadonlyDomainElement<Severity[]> {
+    return this._severities.filter(
+      (item): item is Severity => item !== undefined,
+    );
+  }
+
+  /**
+   * Returns all log types defined in the store.
+   */
+  public get logTypes(): ReadonlyDomainElement<LogType[]> {
+    return this._logTypes.filter((item): item is LogType => item !== undefined);
+  }
+
+  /**
+   * Returns all verbs defined in the store.
+   */
+  public get verbs(): ReadonlyDomainElement<Verb[]> {
+    return this._verbs.filter((item): item is Verb => item !== undefined);
+  }
+
+  /**
+   * Returns all revision states defined in the store.
+   */
+  public get revisionStates(): ReadonlyDomainElement<RevisionState[]> {
+    return this._revisionStates.filter(
+      (item): item is RevisionState => item !== undefined,
+    );
+  }
+
+  /**
+   * Returns all timeline types defined in the store.
+   */
+  public get timelineTypes(): ReadonlyDomainElement<TimelineType[]> {
+    return this._timelineTypes.filter(
+      (item): item is TimelineType => item !== undefined,
+    );
   }
 
   /**


### PR DESCRIPTION
Exposed all registered style definitions (Severity, LogType, Verb, RevisionState, and TimelineType) as read-only arrays from StyleStore (filtering out any undefined slots).

This allows UI components to easily retrieve all registered styles at once—making it much simpler to dynamically render UI legends, filter dropdowns, or option lists—rather than being restricted to querying individual elements by ID. Corresponding unit tests have been added to verify the array-retrieval behavior.