### PR TITLE
Removed redundant v from the version string

### DIFF
--- a/web/src/app/header/components/header.component.html
+++ b/web/src/app/header/components/header.component.html
@@ -18,7 +18,7 @@
   <div class="title-section">
     <img src="assets/icons/khi.svg" alt="Khi Logo" />
     <h1 class="app-title">Kubernetes History Inspector</h1>
-    <span class="version-badge">v{{ version() }}</span>
+    <span class="version-badge">{{ version() }}</span>
     @if (sessionId()) {
       <span
         class="session-badge"

--- a/web/src/app/header/components/header.component.spec.ts
+++ b/web/src/app/header/components/header.component.spec.ts
@@ -46,7 +46,7 @@ describe('HeaderComponent', () => {
   });
 
   it('should render version badge', () => {
-    fixture.componentRef.setInput('version', '1.2.3');
+    fixture.componentRef.setInput('version', 'v1.2.3');
     fixture.detectChanges();
 
     const badgeEl = fixture.debugElement.query(By.css('.version-badge'));


### PR DESCRIPTION
The character `v` used in the prefix of KHI versions is expected to be included in the version string itself.
But it is already put in the UI code as well and it results in the duplicated prefixes.