### PR TITLE
bugfix: ignore changing selected timeline when user clicked a log from log list

### DIFF
--- a/web/src/app/services/selection-manager.service.ts
+++ b/web/src/app/services/selection-manager.service.ts
@@ -349,6 +349,7 @@ export class SelectionManagerService {
               targetTimeline,
               relatedRevision,
               true,
+              true,
             );
             return;
           }
@@ -359,6 +360,7 @@ export class SelectionManagerService {
             this.changeSelectionByEventInternal(
               targetTimeline,
               relatedEvent,
+              true,
               true,
             );
             return;
@@ -371,8 +373,11 @@ export class SelectionManagerService {
     timeline: ResourceTimeline,
     event: ResourceEvent,
     ignoreLogSelect: boolean,
+    ignoreTimelineSelect: boolean = false,
   ) {
-    this.selectedTimelineSubject.next(timeline);
+    if (!ignoreTimelineSelect) {
+      this.selectedTimelineSubject.next(timeline);
+    }
 
     if (!ignoreLogSelect)
       this.changeSelectionByLogInternal(event.logIndex, true);
@@ -382,9 +387,12 @@ export class SelectionManagerService {
     timeline: ResourceTimeline,
     revision: ResourceRevision,
     ignoreLogSelect: boolean,
+    ignoreTimelineSelect: boolean = false,
   ) {
     this.selectedRevisionSubject.next(revision);
-    this.selectedTimelineSubject.next(timeline);
+    if (!ignoreTimelineSelect) {
+      this.selectedTimelineSubject.next(timeline);
+    }
 
     if (!ignoreLogSelect)
       this.changeSelectionByLogInternal(revision.logIndex, true);

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -332,6 +332,25 @@ export class TimelineFrameComponent implements AfterViewInit {
   });
 
   /**
+   * Returns the actual timeline that contains the currently selected log.
+   */
+  protected readonly selectedLogTimeline = computed(() => {
+    const logIndexStr = this.selectedLogIndex();
+    if (logIndexStr === null) {
+      return null;
+    }
+    const logIndex = Number(logIndexStr);
+    const timelines = this.timelines();
+    return (
+      timelines.find(
+        (timeline) =>
+          timeline.events.some((e) => e.logIndex === logIndex) ||
+          timeline.revisions.some((r) => r.logIndex === logIndex),
+      ) ?? null
+    );
+  });
+
+  /**
    * current cursor position time in milliseconds.
    */
   readonly cursorTimeMS = input<number>(0);
@@ -726,7 +745,8 @@ export class TimelineFrameComponent implements AfterViewInit {
     });
     effect(() => {
       this.selectedLogIndex(); // Just for triggering the effect when the selected log index is changed.
-      const selectedTimeline = this.selectedTimeline();
+      const logTimeline = this.selectedLogTimeline();
+      const selectedTimeline = logTimeline ?? this.selectedTimeline();
       if (!selectedTimeline) {
         return;
       }


### PR DESCRIPTION
KHI previously changed the selected timeline to child timeline if user selected a log from the log list.
But this behavior easily make user lost where they are looking at.

This change disables auto timeline selection behavior on the timing.