### PR TITLE
bugfix: automatic log scroll is not matching to the actual element

### DIFF
--- a/web/src/app/log/components/log-list.component.ts
+++ b/web/src/app/log/components/log-list.component.ts
@@ -39,7 +39,8 @@ import { bisectLeft } from '../../common/misc-util';
 
 class LogListScrollingStrategy extends FixedSizeVirtualScrollStrategy {
   constructor() {
-    super(14.5, 500, 1000);
+    // heght:12px + border-bottom: 0.2px
+    super(12.2, 500, 1000);
   }
 }
 


### PR DESCRIPTION
The constant value given for virtual scroll strategy was wrong. This make the auto scroll feature to scroll to another element on the log view. This was very inconvenient. 