### PR TITLE
bugfix: automatic scroll to the beginning time of log query when user selected a timeline without point to a log

### DIFF
--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -701,6 +701,10 @@ export class TimelineFrameComponent implements AfterViewInit {
     // Updates the viewportLeftTimeMs property when the curosrTime is updated if that is outside of the viewport.
     effect(() => {
       const cursorTime = this.cursorTimeMS();
+      if (cursorTime === 0) {
+        // Do not scroll when there is no active log selection.
+        return;
+      }
       const viewportLeftTimeMS = untracked(this.viewportLeftTimeMS);
       const viewportWidth = untracked(this.viewportWidth);
       const pixelsPerMs = untracked(this.pixelsPerMs);


### PR DESCRIPTION
When user selected a timeline directly from the timeline chart without clicking events or revisions, KHI automatically select the timeline and deselect currently selected log.
This triggered automatic horizontal scroll on timeline view and user was forcibly scrolled to the left side of query duration.