### PR TITLE
bugfix: scaling around right edge of query duration may be clipped to jump to other timing

### DIFF
--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -649,7 +649,7 @@ export class TimelineFrameComponent implements AfterViewInit {
    * The current action that is being performed.
    * This is defined not to move and scale at the same frame.
    */
-  private currrentAction: 'moving' | 'scaling' | 'none' = 'none';
+  private currentAction: 'moving' | 'scaling' | 'none' = 'none';
 
   /**
    * The source of truth for the horizontal scroll position.
@@ -659,6 +659,12 @@ export class TimelineFrameComponent implements AfterViewInit {
    * This property is usually kept as "property" but changed to "scroll" only when users triggers scrolling animation.
    */
   private horizontalScrollSourceOfTruth: 'scroll' | 'property' = 'property';
+
+  /**
+   * A scroll may register an event handler and it must be ignored on the next frame.
+   * This is the current event ID to let the even handler to know if the handler is obsolete.
+   */
+  private currentScrollEventID = 0;
 
   constructor() {
     // Updates the scrollLeft property of the container element when the viewportLeftTimeMS changes.
@@ -677,10 +683,28 @@ export class TimelineFrameComponent implements AfterViewInit {
       if (this.horizontalScrollSourceOfTruth === 'scroll') {
         return;
       }
-      container.nativeElement.scrollLeft = calculator.timeMSToOffsetLeft(
-        vpLT,
-        pixelsPerMs,
-      );
+      const targetScrollLeft = calculator.timeMSToOffsetLeft(vpLT, pixelsPerMs);
+      // The scroll target may take few frames to complete its resize.
+      // If the element is smaller than the expected size, wait a frame to apply. If it failed on the next frame, it'll retry the next frame and so on.
+      this.currentScrollEventID++;
+      const scrollEventID = this.currentScrollEventID;
+      const moveToTargetScroll = () => {
+        container.nativeElement.scrollLeft = targetScrollLeft;
+        if (scrollEventID === this.currentScrollEventID) {
+          if (
+            Math.abs(container.nativeElement.scrollLeft - targetScrollLeft) < 1
+          ) {
+            // scroll position is matching with the target. Finish the scaling behavior.
+            this.currentAction = 'none';
+          } else {
+            // scroll position is not matching with the target. Retry on the next frame.
+            this.renderingLoopManager.registerOnceBeforeRenderHandler(
+              moveToTargetScroll,
+            );
+          }
+        }
+      };
+      moveToTargetScroll();
     });
     // Updates the viewportLeftTimeMS property and pxielsPerMs when the loaded inspection data is updated.
     effect(() => {
@@ -869,7 +893,7 @@ export class TimelineFrameComponent implements AfterViewInit {
       });
 
       const onContainerScroll = () => {
-        if (this.shiftStatus() || this.currrentAction !== 'none') {
+        if (this.shiftStatus() || this.currentAction !== 'none') {
           return;
         }
         this.onScrollForMove();
@@ -923,9 +947,9 @@ export class TimelineFrameComponent implements AfterViewInit {
       throw new Error('failed to lookup container');
     }
     const horizontalScrollCalculator = this.horizontalScrollCalculator();
-    this.currrentAction = 'moving';
+    this.currentAction = 'moving';
     this.renderingLoopManager.registerOnceBeforeRenderHandler(() => {
-      this.currrentAction = 'none';
+      this.currentAction = 'none';
       const pixelsPerMS = this.pixelsPerMs();
       const maxScrollLeft = horizontalScrollCalculator.maxScrollLeft(
         pixelsPerMS,
@@ -946,13 +970,13 @@ export class TimelineFrameComponent implements AfterViewInit {
   }
 
   onWheelForScaling(event: WheelEvent) {
-    if (this.currrentAction !== 'none') return;
-    this.currrentAction = 'scaling';
+    if (this.currentAction !== 'none') return;
+    this.currentAction = 'scaling';
     this.renderingLoopManager.registerOnceBeforeRenderHandler(() => {
       const container = this.container();
       const indexArea = this.indexSplitArea();
       if (!container || !indexArea) {
-        this.currrentAction = 'none';
+        this.currentAction = 'none';
         return;
       }
       const containerBox = container.nativeElement.getBoundingClientRect();
@@ -962,7 +986,7 @@ export class TimelineFrameComponent implements AfterViewInit {
         containerBox.left -
         indexAreaBox.width -
         this.GUTTER_WIDTH;
-      this.currrentAction = 'none';
+      this.currentAction = 'none';
       const calculator = this.horizontalScrollCalculator();
 
       const currentPixelsPerMs = this.pixelsPerMs();


### PR DESCRIPTION
When user scale timeline around the right edge of timeline, KHI scale the virtual scroll element itself and change scroll amount to keep the mouse center timing is consistent.
 But browsers may take few frames to reflect the resizing request and it may clamp the amount for the scaling. Introduced a new logic to wait scaling before moving the scrolling location.