### PR TITLE
Add core timeline domain models and timeline store

### DIFF
--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  TimelineStore,
+  TimelineDTO,
+  RevisionDTO,
+  EventDTO,
+} from 'src/app/store/domain/timeline-store';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { LogStore } from 'src/app/store/domain/log-store';
+
+describe('TimelineStore', () => {
+  let internPool: InternPoolStore;
+  let styleStore: StyleStore;
+  let logStore: LogStore;
+  let store: TimelineStore;
+
+  const mockColor = { r: 0, g: 0, b: 0, a: 1 };
+
+  beforeEach(() => {
+    internPool = new InternPoolStore();
+    styleStore = new StyleStore();
+    logStore = new LogStore(internPool, styleStore);
+    store = new TimelineStore(internPool, styleStore, logStore);
+
+    styleStore.addTimelineTypes([
+      {
+        id: 1,
+        label: 'type-a',
+        description: 'desc',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        visible: true,
+        sortPriority: 0,
+      },
+    ]);
+
+    styleStore.addSeverities([
+      {
+        id: 1,
+        label: 'S1',
+        shortLabel: 'S1',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 0,
+      },
+    ]);
+
+    styleStore.addLogTypes([
+      {
+        id: 1,
+        label: 'L1',
+        description: '',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      },
+    ]);
+
+    styleStore.addVerbs([
+      {
+        id: 1,
+        label: 'V1',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        visible: true,
+      },
+    ]);
+
+    styleStore.addRevisionStates([
+      {
+        id: 1,
+        label: 'normal',
+        icon: '',
+        description: '',
+        backgroundColor: mockColor,
+        style: 0,
+      },
+    ]);
+  });
+
+  it('should successfully populate internal states on initialize', () => {
+    internPool.addStrings([
+      { id: 1, value: 'timeline-x' },
+      { id: 2, value: 'principal-y' },
+    ]);
+
+    const rawTimelines: TimelineDTO[] = [
+      {
+        id: 10,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [100],
+        eventIds: [200],
+      },
+    ];
+
+    const rawRevisions: RevisionDTO[] = [
+      {
+        id: 100,
+        logId: 1,
+        changedTime: 123456n,
+        principalStringId: 2,
+        verbTypeId: 1,
+        stateTypeId: 1,
+      },
+    ];
+
+    const rawEvents: EventDTO[] = [
+      {
+        id: 200,
+        logId: 1,
+      },
+    ];
+
+    expect(() =>
+      store.initialize(rawTimelines, 1, rawRevisions, 1, rawEvents, 1),
+    ).not.toThrow();
+
+    const t = store.getTimeline(10);
+    expect(t.id).toBe(10);
+    expect(t.name).toBe('timeline-x');
+
+    const all = store.timelines;
+    expect(all.length).toBe(1);
+    expect(all[0].id).toBe(10);
+  });
+
+  it('should correctly decode timeline traversal path', () => {
+    internPool.addStrings([
+      { id: 1, value: 'root' },
+      { id: 2, value: 'child' },
+    ]);
+
+    const rawTimelines: TimelineDTO[] = [
+      {
+        id: 1,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [],
+      },
+      {
+        id: 2,
+        timelineTypeId: 1,
+        nameStringId: 2,
+        parentTimelineId: 1,
+        revisionIds: [],
+        eventIds: [],
+      },
+    ];
+
+    store.initialize(rawTimelines, 2, [], 0, [], 0);
+
+    const timeline = store.getTimeline(2);
+    const computedPath = timeline.path;
+
+    expect(computedPath.length).toBe(2);
+    expect(computedPath[0].label).toBe('root');
+    expect(computedPath[1].label).toBe('child');
+  });
+
+  it('should error when reading invalid timeline ID', () => {
+    expect(() => store.getTimeline(999)).toThrowError(
+      'Timeline ID 999 not found',
+    );
+  });
+});

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -1,0 +1,385 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Event,
+  TimelinePathNode,
+  Revision,
+  Timeline,
+} from 'src/app/store/domain/timeline';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { InternedStructDecoder } from 'src/app/store/domain/struct-decoder';
+import { InternedStruct } from 'src/app/generated/khifile/shared_pb';
+import { RevisionState, TimelineType, Verb } from 'src/app/store/domain/style';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+
+/**
+ * Raw timeline object interface from the assembler.
+ */
+export interface TimelineDTO {
+  readonly id: number;
+  readonly timelineTypeId: number;
+  readonly nameStringId: number;
+  readonly parentTimelineId: number;
+  readonly revisionIds: readonly number[];
+  readonly eventIds: readonly number[];
+}
+
+/**
+ * Raw revision object interface from the assembler.
+ */
+export interface RevisionDTO {
+  readonly id: number;
+  readonly logId: number;
+  readonly changedTime: bigint;
+  readonly principalStringId: number;
+  readonly verbTypeId: number;
+  readonly stateTypeId: number;
+  readonly body?: InternedStruct;
+}
+
+/**
+ * Raw event object interface from the assembler.
+ */
+export interface EventDTO {
+  readonly id: number;
+  readonly logId: number;
+}
+
+/**
+ * Store for managing and retrieving timelines, revisions, and events efficiently.
+ */
+export class TimelineStore {
+  // Timeline metadata
+  private timelineIds = new Uint32Array(0);
+  private timelineTypeIds = new Uint32Array(0);
+  private timelineNameStringIds = new Uint32Array(0);
+  private timelineParentIds = new Uint32Array(0);
+  private readonly timelineRevisionIds: Uint32Array[] = [];
+  private readonly timelineEventIds: Uint32Array[] = [];
+  private timelineIdToIndex: { [tid: number]: number } = {};
+  private readonly timelinesList: ReadonlyDomainElement<Timeline>[] = [];
+
+  // Revision metadata stored in packed arrays
+  private revisionIds = new Uint32Array(0);
+  private revisionLogIds = new Uint32Array(0);
+  private revisionChangedTimes = new BigUint64Array(0);
+  private revisionPrincipalStringIds = new Uint32Array(0);
+  private revisionVerbTypeIds = new Uint32Array(0);
+  private revisionStateTypeIds = new Uint32Array(0);
+  private readonly revisionBodies: InternedStruct[] = [];
+  private revisionIdToIndex: { [rid: number]: number } = {};
+
+  // Event metadata
+  private eventIds = new Uint32Array(0);
+  private eventLogIds = new Uint32Array(0);
+  private eventIdToIndex: { [eid: number]: number } = {};
+
+  private readonly decoder: InternedStructDecoder;
+
+  constructor(
+    private readonly internPool: InternPoolStore,
+    private readonly styleStore: StyleStore,
+    public readonly logStore: LogStore,
+  ) {
+    this.decoder = new InternedStructDecoder(this.internPool);
+  }
+
+  /**
+   * Initializes the store with the raw timelines, revisions, and events.
+   * @param timelines Iterable of raw timelines.
+   * @param timelineCount Total number of timelines.
+   * @param revisions Iterable of raw revisions.
+   * @param revisionCount Total number of revisions.
+   * @param events Iterable of raw events.
+   * @param eventCount Total number of events.
+   */
+  public initialize(
+    timelines: Iterable<TimelineDTO>,
+    timelineCount: number,
+    revisions: Iterable<RevisionDTO>,
+    revisionCount: number,
+    events: Iterable<EventDTO>,
+    eventCount: number,
+  ): void {
+    this.timelineIds = new Uint32Array(timelineCount);
+    this.timelineTypeIds = new Uint32Array(timelineCount);
+    this.timelineNameStringIds = new Uint32Array(timelineCount);
+    this.timelineParentIds = new Uint32Array(timelineCount);
+
+    this.timelineRevisionIds.length = 0;
+    this.timelineEventIds.length = 0;
+    this.revisionBodies.length = 0;
+    this.timelinesList.length = 0;
+    this.timelineIdToIndex = {};
+    this.revisionIdToIndex = {};
+    this.eventIdToIndex = {};
+
+    // Load timelines
+    let tIndex = 0;
+    for (const t of timelines) {
+      this.timelineIds[tIndex] = t.id;
+      this.timelineTypeIds[tIndex] = t.timelineTypeId;
+      this.timelineNameStringIds[tIndex] = t.nameStringId;
+      this.timelineParentIds[tIndex] = t.parentTimelineId;
+
+      this.timelineRevisionIds[tIndex] = new Uint32Array(t.revisionIds);
+      this.timelineEventIds[tIndex] = new Uint32Array(t.eventIds);
+
+      this.timelineIdToIndex[t.id] = tIndex;
+      this.timelinesList.push(new Timeline(t.id, this));
+      tIndex++;
+    }
+
+    this.revisionIds = new Uint32Array(revisionCount);
+    this.revisionLogIds = new Uint32Array(revisionCount);
+    this.revisionChangedTimes = new BigUint64Array(revisionCount);
+    this.revisionPrincipalStringIds = new Uint32Array(revisionCount);
+    this.revisionVerbTypeIds = new Uint32Array(revisionCount);
+    this.revisionStateTypeIds = new Uint32Array(revisionCount);
+
+    // Load revisions
+    let rIndex = 0;
+    for (const r of revisions) {
+      this.revisionIds[rIndex] = r.id;
+      this.revisionLogIds[rIndex] = r.logId;
+      this.revisionChangedTimes[rIndex] = r.changedTime;
+      this.revisionPrincipalStringIds[rIndex] = r.principalStringId;
+      this.revisionVerbTypeIds[rIndex] = r.verbTypeId;
+      this.revisionStateTypeIds[rIndex] = r.stateTypeId;
+
+      if (r.body !== undefined) {
+        this.revisionBodies[rIndex] = r.body;
+      }
+      this.revisionIdToIndex[r.id] = rIndex;
+      rIndex++;
+    }
+
+    // load events
+    this.eventIds = new Uint32Array(eventCount);
+    this.eventLogIds = new Uint32Array(eventCount);
+    let eIndex = 0;
+    for (const e of events) {
+      this.eventIds[eIndex] = e.id;
+      this.eventLogIds[eIndex] = e.logId;
+      this.eventIdToIndex[e.id] = eIndex;
+      eIndex++;
+    }
+  }
+
+  // --- Timeline Accessors ---
+
+  /**
+   * Retrieves a specific timeline domain adapter by its ID.
+   * @param id The unique timeline identifier.
+   * @returns The readonly domain element adapter for the timeline.
+   * @throws Error if the specified timeline ID is not found in the store.
+   */
+  public getTimeline(id: number): ReadonlyDomainElement<Timeline> {
+    return this.timelinesList[this.getTimelineIndex(id)];
+  }
+
+  /**
+   * Gets a readonly list of all timeline domain adapters in the store.
+   */
+  public get timelines(): readonly ReadonlyDomainElement<Timeline>[] {
+    return this.timelinesList;
+  }
+
+  /**
+   * Gets the name of a timeline by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Timeline} domain adapter.
+   */
+  public _getTimelineName(id: number): string {
+    return this.internPool.getString(
+      this.timelineNameStringIds[this.getTimelineIndex(id)],
+    );
+  }
+
+  /**
+   * Gets the categorization style classification of a timeline by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Timeline} domain adapter.
+   */
+  public _getTimelineType(id: number): ReadonlyDomainElement<TimelineType> {
+    return this.styleStore.getTimelineType(
+      this.timelineTypeIds[this.getTimelineIndex(id)],
+    );
+  }
+
+  /**
+   * Gets the parent timeline identification associated to the specified entity.
+   * @note Intended solely for internal retrieval inside the {@link Timeline} domain adapter.
+   */
+  public _getTimelineParentId(id: number): number {
+    return this.timelineParentIds[this.getTimelineIndex(id)];
+  }
+
+  /**
+   * Evaluates nodes path from root timeline.
+   * @note Intended solely for internal retrieval inside the {@link Timeline} domain adapter.
+   */
+  public _computeTimelinePath(
+    id: number,
+  ): ReadonlyDomainElement<TimelinePathNode[]> {
+    const path: TimelinePathNode[] = [];
+    let currentId: number | null = id;
+
+    while (currentId && currentId !== 0) {
+      const idx = this.getTimelineIndex(currentId);
+      path.push({
+        id: currentId,
+        type: this.styleStore.getTimelineType(this.timelineTypeIds[idx]),
+        label: this.internPool.getString(this.timelineNameStringIds[idx]),
+      });
+      currentId = this.timelineParentIds[idx];
+    }
+    return path.reverse();
+  }
+
+  /**
+   * Retrieves child revision adapters of a specific timeline.
+   * @note Intended solely for internal retrieval inside the {@link Timeline} domain adapter.
+   */
+  public _getRevisionsForTimeline(
+    id: number,
+  ): ReadonlyDomainElement<Revision[]> {
+    const revIds = this.timelineRevisionIds[this.getTimelineIndex(id)];
+    if (!revIds) {
+      return [];
+    }
+
+    const revisions: Revision[] = [];
+    for (let i = 0; i < revIds.length; i++) {
+      revisions.push(new Revision(revIds[i], id, this, i));
+    }
+    revisions.sort((r1, r2) => Number(r1.changedTime - r2.changedTime));
+    return revisions;
+  }
+
+  /**
+   * Retrieves child events of a specific timeline.
+   * @note Intended solely for internal retrieval inside the {@link Timeline} domain adapter.
+   */
+  public _getEventsForTimeline(id: number): ReadonlyDomainElement<Event[]> {
+    const eventIds = this.timelineEventIds[this.getTimelineIndex(id)];
+    if (!eventIds) {
+      return [];
+    }
+
+    const events: Event[] = [];
+    for (let i = 0; i < eventIds.length; i++) {
+      events.push(new Event(eventIds[i], id, this));
+    }
+    events.sort((e1, e2) => e1.logIndex - e2.logIndex);
+    return events;
+  }
+
+  private getTimelineIndex(id: number): number {
+    const index = this.timelineIdToIndex[id];
+    if (index === undefined) {
+      throw new Error(`Timeline ID ${id} not found`);
+    }
+    return index;
+  }
+
+  // --- Revision Accessors ---
+
+  /**
+   * Gets state timestamp evaluation for a revision by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Revision} domain adapter.
+   */
+  public _getRevisionChangedTime(id: number): bigint {
+    return this.revisionChangedTimes[this.getRevisionIndex(id)];
+  }
+
+  /**
+   * Gets state principal execution user string for a revision by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Revision} domain adapter.
+   */
+  public _getRevisionPrincipal(id: number): string {
+    return this.internPool.getString(
+      this.revisionPrincipalStringIds[this.getRevisionIndex(id)],
+    );
+  }
+
+  /**
+   * Gets revision verb execution data from store by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Revision} domain adapter.
+   */
+  public _getRevisionVerb(id: number): ReadonlyDomainElement<Verb> {
+    return this.styleStore.getVerb(
+      this.revisionVerbTypeIds[this.getRevisionIndex(id)],
+    );
+  }
+
+  /**
+   * Gets revision presentation state categorization details by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Revision} domain adapter.
+   */
+  public _getRevisionState(id: number): ReadonlyDomainElement<RevisionState> {
+    return this.styleStore.getRevisionState(
+      this.revisionStateTypeIds[this.getRevisionIndex(id)],
+    );
+  }
+
+  /**
+   * Gets revision source log element ID reference.
+   * @note Intended solely for internal retrieval inside the {@link Revision} domain adapter.
+   */
+  public _getRevisionLogId(id: number): number {
+    return this.revisionLogIds[this.getRevisionIndex(id)];
+  }
+
+  /**
+   * Decodes encapsulated revision properties from its structural domain interface.
+   * @note Intended solely for internal retrieval inside the {@link Revision} domain adapter.
+   */
+  public _decodeRevisionBody(
+    id: number,
+  ): ReadonlyDomainElement<Record<string, unknown>> | null {
+    const struct = this.revisionBodies[this.getRevisionIndex(id)];
+    if (!struct) return null;
+    return this.decoder.decode(struct);
+  }
+
+  private getRevisionIndex(id: number): number {
+    const index = this.revisionIdToIndex[id];
+    if (index === undefined) {
+      throw new Error(`Revision ID ${id} not found`);
+    }
+    return index;
+  }
+
+  // --- Event Accessors ---
+
+  /**
+   * Gets underlying data log ID for resource event by its ID.
+   * @note Intended solely for internal retrieval inside the {@link Event} domain adapter.
+   */
+  public _getEventLogId(id: number): number {
+    return this.eventLogIds[this.getEventIndex(id)];
+  }
+
+  private getEventIndex(id: number): number {
+    const index = this.eventIdToIndex[id];
+    if (index === undefined) {
+      throw new Error(`Event ID ${id} not found`);
+    }
+    return index;
+  }
+}

--- a/web/src/app/store/domain/timeline.spec.ts
+++ b/web/src/app/store/domain/timeline.spec.ts
@@ -1,0 +1,571 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  TimelineStore,
+  TimelineDTO,
+  RevisionDTO,
+  EventDTO,
+} from 'src/app/store/domain/timeline-store';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { LogStore, LogDTO } from 'src/app/store/domain/log-store';
+import { create } from '@bufbuild/protobuf';
+import {
+  InternedStructSchema,
+  InternedValueSchema,
+} from 'src/app/generated/khifile/shared_pb';
+
+describe('Timeline', () => {
+  let internPool: InternPoolStore;
+  let styleStore: StyleStore;
+  let logStore: LogStore;
+  let timelineStore: TimelineStore;
+
+  const mockColor = { r: 0, g: 0, b: 0, a: 1 };
+
+  beforeEach(() => {
+    internPool = new InternPoolStore();
+    styleStore = new StyleStore();
+    logStore = new LogStore(internPool, styleStore);
+    timelineStore = new TimelineStore(internPool, styleStore, logStore);
+
+    styleStore.addTimelineTypes([
+      {
+        id: 1,
+        label: 'type-a',
+        description: 'desc',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        visible: true,
+        sortPriority: 0,
+      },
+    ]);
+
+    styleStore.addSeverities([
+      {
+        id: 1,
+        label: 'S1',
+        shortLabel: 'S1',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 0,
+      },
+    ]);
+
+    styleStore.addLogTypes([
+      {
+        id: 1,
+        label: 'L1',
+        description: '',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+      },
+    ]);
+
+    styleStore.addVerbs([
+      {
+        id: 1,
+        label: 'V1',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        visible: true,
+      },
+    ]);
+
+    styleStore.addRevisionStates([
+      {
+        id: 1,
+        label: 'normal',
+        icon: '',
+        description: '',
+        backgroundColor: mockColor,
+        style: 0,
+      },
+    ]);
+  });
+
+  describe('id', () => {
+    it('should return the correct ID', () => {
+      internPool.addStrings([{ id: 1, value: 'timeline-label' }]);
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
+      ];
+      timelineStore.initialize(rawTimelines, 1, [], 0, [], 0);
+      const timeline = timelineStore.getTimeline(10);
+      expect(timeline.id).toBe(10);
+    });
+  });
+
+  describe('name', () => {
+    it('should return the correct string value from the intern pool', () => {
+      internPool.addStrings([{ id: 1, value: 'timeline-label' }]);
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
+      ];
+      timelineStore.initialize(rawTimelines, 1, [], 0, [], 0);
+      const timeline = timelineStore.getTimeline(10);
+      expect(timeline.name).toBe('timeline-label');
+    });
+  });
+
+  describe('revisions', () => {
+    it('should yield populated Revision lazy data', () => {
+      internPool.addStrings([
+        { id: 1, value: 'timeline-label' },
+        { id: 2, value: 'user-name' },
+        { id: 3, value: 'log-summary' },
+      ]);
+
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [100],
+          eventIds: [],
+        },
+      ];
+
+      const rawRevisions: RevisionDTO[] = [
+        {
+          id: 100,
+          logId: 1,
+          changedTime: 1234567890n,
+          principalStringId: 2,
+          verbTypeId: 1,
+          stateTypeId: 1,
+        },
+      ];
+
+      const rawLogs: LogDTO[] = [
+        {
+          id: 1,
+          ts: 100n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+      ];
+
+      logStore.initialize(rawLogs, 1);
+      timelineStore.initialize(rawTimelines, 1, rawRevisions, 1, [], 0);
+
+      const timeline = timelineStore.getTimeline(10);
+      const revs = timeline.revisions;
+      expect(revs.length).toBe(1);
+      expect(revs[0].id).toBe(100);
+      expect(revs[0].changedTime).toBe(1234567890n);
+      expect(revs[0].legacyChangedTimeMs).toBe(1234.56789);
+      expect(revs[0].principal).toBe('user-name');
+      expect(revs[0].log.id).toBe(1);
+      expect(revs[0].log.timestamp).toBe(100n);
+      expect(revs[0].log.legacyTimestampMs).toBe(0.0001);
+    });
+  });
+
+  describe('events', () => {
+    it('should yield populated Event lazy data', () => {
+      internPool.addStrings([
+        { id: 1, value: 'timeline-label' },
+        { id: 3, value: 'log-summary' },
+      ]);
+
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [200],
+        },
+      ];
+
+      const rawEvents: EventDTO[] = [
+        {
+          id: 200,
+          logId: 2,
+        },
+      ];
+
+      const rawLogs: LogDTO[] = [
+        {
+          id: 2,
+          ts: 200n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+      ];
+
+      logStore.initialize(rawLogs, 1);
+      timelineStore.initialize(rawTimelines, 1, [], 0, rawEvents, 1);
+
+      const timeline = timelineStore.getTimeline(10);
+      const events = timeline.events;
+      expect(events.length).toBe(1);
+      expect(events[0].id).toBe(200);
+      expect(events[0].log.id).toBe(2);
+      expect(events[0].log.timestamp).toBe(200n);
+      expect(events[0].log.legacyTimestampMs).toBe(0.0002);
+    });
+  });
+
+  describe('layer', () => {
+    it('should return correct layer depth based on lineage', () => {
+      internPool.addStrings([
+        { id: 1, value: 'parent-tl' },
+        { id: 2, value: 'child-tl' },
+        { id: 3, value: 'grandchild-tl' },
+      ]);
+
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
+        {
+          id: 20,
+          timelineTypeId: 1,
+          nameStringId: 2,
+          parentTimelineId: 10,
+          revisionIds: [],
+          eventIds: [],
+        },
+        {
+          id: 30,
+          timelineTypeId: 1,
+          nameStringId: 3,
+          parentTimelineId: 20,
+          revisionIds: [],
+          eventIds: [],
+        },
+      ];
+
+      timelineStore.initialize(rawTimelines, 3, [], 0, [], 0);
+
+      const parent = timelineStore.getTimeline(10);
+      const child = timelineStore.getTimeline(20);
+      const grandchild = timelineStore.getTimeline(30);
+
+      expect(parent.layer).toBe(0);
+      expect(child.layer).toBe(1);
+      expect(grandchild.layer).toBe(2);
+    });
+  });
+
+  describe('type', () => {
+    it('should return correct type configuration', () => {
+      internPool.addStrings([{ id: 1, value: 'parent' }]);
+
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
+      ];
+
+      timelineStore.initialize(rawTimelines, 1, [], 0, [], 0);
+
+      const parent = timelineStore.getTimeline(10);
+      expect(parent.type.id).toBe(1);
+    });
+  });
+
+  describe('debugPathText', () => {
+    it('should return correct slash-separated hierarchical debug path', () => {
+      internPool.addStrings([
+        { id: 1, value: 'parent' },
+        { id: 2, value: 'child' },
+      ]);
+
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
+        {
+          id: 20,
+          timelineTypeId: 1,
+          nameStringId: 2,
+          parentTimelineId: 10,
+          revisionIds: [],
+          eventIds: [],
+        },
+      ];
+
+      timelineStore.initialize(rawTimelines, 2, [], 0, [], 0);
+
+      const child = timelineStore.getTimeline(20);
+      expect(child.debugPathText).toBe('parent/child');
+    });
+  });
+
+  describe('Revision', () => {
+    describe('body and bodyYAML', () => {
+      it('should decode revision body and bodyYAML correctly', () => {
+        internPool.addStrings([
+          { id: 1, value: 'timeline-label' },
+          { id: 2, value: 'user-name' },
+          { id: 3, value: 'log-summary' },
+          { id: 10, value: 'user' },
+          { id: 11, value: 'status' },
+          { id: 12, value: 'alice' },
+        ]);
+
+        internPool.addFieldPathSets([{ id: 1, fieldPathStringIds: [10, 11] }]);
+
+        const struct = create(InternedStructSchema, {
+          fieldPathSetId: 1,
+          values: [
+            create(InternedValueSchema, {
+              kind: { case: 'stringValue', value: 12 },
+            }),
+            create(InternedValueSchema, {
+              kind: { case: 'int64Value', value: 42n },
+            }),
+          ],
+        });
+
+        const rawTimelines: TimelineDTO[] = [
+          {
+            id: 10,
+            timelineTypeId: 1,
+            nameStringId: 1,
+            parentTimelineId: 0,
+            revisionIds: [100, 101],
+            eventIds: [],
+          },
+        ];
+
+        const rawRevisions: RevisionDTO[] = [
+          {
+            id: 100,
+            logId: 1,
+            changedTime: 1234567890n,
+            principalStringId: 2,
+            verbTypeId: 1,
+            stateTypeId: 1,
+            body: struct,
+          },
+          {
+            id: 101,
+            logId: 2,
+            changedTime: 1234567890n,
+            principalStringId: 2,
+            verbTypeId: 1,
+            stateTypeId: 1,
+          },
+        ];
+
+        const rawLogs: LogDTO[] = [
+          {
+            id: 1,
+            ts: 100n,
+            logTypeId: 1,
+            severityTypeId: 1,
+            summaryStringId: 3,
+          },
+          {
+            id: 2,
+            ts: 200n,
+            logTypeId: 1,
+            severityTypeId: 1,
+            summaryStringId: 3,
+          },
+        ];
+
+        logStore.initialize(rawLogs, 2);
+        timelineStore.initialize(rawTimelines, 1, rawRevisions, 2, [], 0);
+
+        const timeline = timelineStore.getTimeline(10);
+        const revs = timeline.revisions;
+
+        expect(revs[0].body).toEqual({
+          user: 'alice',
+          status: 42,
+        });
+        expect(revs[0].bodyYAML).toContain('user: alice');
+        expect(revs[0].bodyYAML).toContain('status: 42');
+
+        expect(revs[1].body).toBeNull();
+        expect(revs[1].bodyYAML).toBe('');
+      });
+    });
+
+    describe('properties', () => {
+      it('should return correct adjacent revisions, end times, verb, state, and parent timeline', () => {
+        internPool.addStrings([
+          { id: 1, value: 'timeline-label' },
+          { id: 2, value: 'user-name' },
+          { id: 3, value: 'log-summary' },
+        ]);
+
+        const rawTimelines: TimelineDTO[] = [
+          {
+            id: 10,
+            timelineTypeId: 1,
+            nameStringId: 1,
+            parentTimelineId: 0,
+            revisionIds: [100, 101],
+            eventIds: [],
+          },
+        ];
+
+        const rawRevisions: RevisionDTO[] = [
+          {
+            id: 100,
+            logId: 1,
+            changedTime: 100n,
+            principalStringId: 2,
+            verbTypeId: 1,
+            stateTypeId: 1,
+          },
+          {
+            id: 101,
+            logId: 2,
+            changedTime: 200n,
+            principalStringId: 2,
+            verbTypeId: 1,
+            stateTypeId: 1,
+          },
+        ];
+
+        const rawLogs: LogDTO[] = [
+          {
+            id: 1,
+            ts: 100n,
+            logTypeId: 1,
+            severityTypeId: 1,
+            summaryStringId: 3,
+          },
+          {
+            id: 2,
+            ts: 200n,
+            logTypeId: 1,
+            severityTypeId: 1,
+            summaryStringId: 3,
+          },
+        ];
+
+        logStore.initialize(rawLogs, 2);
+        timelineStore.initialize(rawTimelines, 1, rawRevisions, 2, [], 0);
+
+        const timeline = timelineStore.getTimeline(10);
+        const revs = timeline.revisions;
+
+        expect(revs.length).toBe(2);
+
+        // Test: timeline reference
+        expect(revs[0].timeline.id).toBe(timeline.id);
+
+        // Test: next / prev
+        expect(revs[0].prev).toBeNull();
+        expect(revs[0].next?.id).toBe(revs[1].id);
+        expect(revs[1].prev?.id).toBe(revs[0].id);
+        expect(revs[1].next).toBeNull();
+
+        // Test: getEndNs() & legacyGetEndMs()
+        expect(revs[0].getEndNs()).toBe(200n);
+        expect(revs[0].legacyGetEndMs()).toBe(0.0002);
+        expect(revs[1].getEndNs()).toBeNull();
+        expect(revs[1].legacyGetEndMs()).toBeNull();
+
+        // Test: verb and state
+        expect(revs[0].verb.id).toBe(1);
+        expect(revs[0].state.id).toBe(1);
+      });
+    });
+  });
+
+  describe('Event', () => {
+    describe('properties', () => {
+      it('should return correct parent timeline reference, logIndex, and timestamps', () => {
+        internPool.addStrings([
+          { id: 1, value: 'timeline-label' },
+          { id: 3, value: 'log-summary' },
+        ]);
+
+        const rawTimelines: TimelineDTO[] = [
+          {
+            id: 10,
+            timelineTypeId: 1,
+            nameStringId: 1,
+            parentTimelineId: 0,
+            revisionIds: [],
+            eventIds: [200],
+          },
+        ];
+
+        const rawEvents: EventDTO[] = [
+          {
+            id: 200,
+            logId: 1,
+          },
+        ];
+
+        const rawLogs: LogDTO[] = [
+          {
+            id: 1,
+            ts: 100n,
+            logTypeId: 1,
+            severityTypeId: 1,
+            summaryStringId: 3,
+          },
+        ];
+
+        logStore.initialize(rawLogs, 1);
+        timelineStore.initialize(rawTimelines, 1, [], 0, rawEvents, 1);
+
+        const timeline = timelineStore.getTimeline(10);
+        const ev = timeline.events[0];
+
+        expect(ev.timeline.id).toBe(timeline.id);
+        expect(ev.logIndex).toBe(0);
+        expect(ev.timestamp).toBe(100n);
+        expect(ev.legacyTimestamp).toBe(0.0001);
+      });
+    });
+  });
+});

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -1,0 +1,288 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RevisionState, TimelineType, Verb } from 'src/app/store/domain/style';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import * as yaml from 'js-yaml';
+
+import { Log } from 'src/app/store/domain/log';
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import { BigIntTimeUtil } from 'src/app/utils/bigint-time-util';
+
+/**
+ * Represents a node in the path from the root timeline.
+ */
+export interface TimelinePathNode {
+  readonly id: number;
+  readonly type: TimelineType;
+  readonly label: string;
+}
+
+/**
+ * Lazy adapter for a resource revision.
+ */
+export class Revision {
+  private _body?: ReadonlyDomainElement<Record<string, unknown>> | null;
+  private _log?: ReadonlyDomainElement<Log>;
+
+  constructor(
+    public readonly id: number,
+    public readonly timelineId: number,
+    private readonly timelineStore: TimelineStore,
+    public readonly index: number,
+  ) {}
+
+  /**
+   * Gets the next revision in chronological order on this timeline, or null if this is the latest.
+   */
+  get next(): ReadonlyDomainElement<Revision> | null {
+    const revisions = this.timeline.revisions;
+    return this.index < revisions.length - 1 ? revisions[this.index + 1] : null;
+  }
+
+  /**
+   * Gets the previous revision in chronological order on this timeline, or null if this is the first.
+   */
+  get prev(): ReadonlyDomainElement<Revision> | null {
+    const revisions = this.timeline.revisions;
+    return this.index > 0 ? revisions[this.index - 1] : null;
+  }
+
+  /**
+   * Gets the end time of this revision in nanoseconds.
+   * If there is a subsequent revision, returns the start time of that revision.
+   * Otherwise, returns null.
+   */
+  public getEndNs(): bigint | null {
+    const n = this.next;
+    return n ? n.changedTime : null;
+  }
+
+  /**
+   * Gets the end time of this revision in milliseconds.
+   * @deprecated Use {@link getEndNs} instead.
+   */
+  public legacyGetEndMs(): number | null {
+    const n = this.next;
+    return n ? n.legacyChangedTimeMs : null;
+  }
+
+  /**
+   * Gets the timeline this revision belongs to.
+   */
+  get timeline(): ReadonlyDomainElement<Timeline> {
+    return this.timelineStore.getTimeline(this.timelineId);
+  }
+
+  /**
+   * Gets the Unix timestamp (in nanoseconds) when the state changed.
+   */
+  get changedTime(): bigint {
+    return this.timelineStore._getRevisionChangedTime(this.id);
+  }
+
+  /**
+   * Gets the Unix timestamp (in milliseconds) when the state changed.
+   * @deprecated Use {@link changedTime} instead, which returns the timestamp in nanoseconds.
+   */
+  get legacyChangedTimeMs(): number {
+    return BigIntTimeUtil.NsToNumberMs(this.changedTime);
+  }
+
+  /**
+   * Gets the user identity or agent who initiated the state change.
+   */
+  get principal(): string {
+    return this.timelineStore._getRevisionPrincipal(this.id);
+  }
+
+  /**
+   * Gets the associated audit verb metadata.
+   */
+  get verb(): ReadonlyDomainElement<Verb> {
+    return this.timelineStore._getRevisionVerb(this.id);
+  }
+
+  /**
+   * Gets the visual state presentation category metadata.
+   */
+  get state(): ReadonlyDomainElement<RevisionState> {
+    return this.timelineStore._getRevisionState(this.id);
+  }
+
+  /**
+   * Gets the underlying log record for the specific state revision.
+   */
+  get log(): ReadonlyDomainElement<Log> {
+    if (!this._log) {
+      this._log = this.timelineStore.logStore.getLog(
+        this.timelineStore._getRevisionLogId(this.id),
+      );
+    }
+    return this._log;
+  }
+
+  /**
+   * Gets the optional structured resource manifest parameters at the snapshot moment.
+   */
+  get body(): ReadonlyDomainElement<Record<string, unknown>> | null {
+    if (this._body === undefined) {
+      this._body = this.timelineStore._decodeRevisionBody(this.id);
+    }
+    return this._body;
+  }
+
+  /**
+   * Gets the YAML string representation of the resource manifest.
+   */
+  get bodyYAML(): string {
+    return this.body ? yaml.dump(this.body, { lineWidth: -1 }) : '';
+  }
+
+  /**
+   * Gets the chronological index of the underlying log.
+   */
+  get logIndex(): number {
+    return this.log.logIndex;
+  }
+}
+
+/**
+ * Lazy adapter for an event on a timeline.
+ */
+export class Event {
+  private _log?: ReadonlyDomainElement<Log>;
+
+  constructor(
+    public readonly id: number,
+    public readonly timelineId: number,
+    private readonly timelineStore: TimelineStore,
+  ) {}
+
+  /**
+   * Gets the timeline this event belongs to.
+   */
+  get timeline(): ReadonlyDomainElement<Timeline> {
+    return this.timelineStore.getTimeline(this.timelineId);
+  }
+
+  /**
+   * Gets the underlying log record for this specific resource event.
+   */
+  get log(): ReadonlyDomainElement<Log> {
+    if (!this._log) {
+      this._log = this.timelineStore.logStore.getLog(
+        this.timelineStore._getEventLogId(this.id),
+      );
+    }
+    return this._log;
+  }
+
+  /**
+   * Gets the chronological index of the underlying log.
+   */
+  get logIndex(): number {
+    return this.log.logIndex;
+  }
+
+  /**
+   * Gets the timestamp of the log in nanoseconds.
+   */
+  get timestamp(): bigint {
+    return this.log.timestamp;
+  }
+
+  /**
+   * Gets the timestamp in milliseconds.
+   * @deprecated Use log.timestamp.
+   */
+  get legacyTimestamp(): number {
+    return this.log.legacyTimestampMs;
+  }
+}
+
+/**
+ * Lazy adapter for a timeline.
+ */
+export class Timeline {
+  private _path?: ReadonlyDomainElement<TimelinePathNode[]>;
+  private _revisions?: ReadonlyDomainElement<Revision[]>;
+  private _events?: ReadonlyDomainElement<Event[]>;
+
+  constructor(
+    public readonly id: number,
+    private readonly timelineStore: TimelineStore,
+  ) {}
+
+  /**
+   * Gets the localized string name label for the timeline.
+   */
+  get name(): string {
+    return this.timelineStore._getTimelineName(this.id);
+  }
+
+  /**
+   * Gets the classification presentation styling applied to this timeline tracking instance.
+   */
+  get type(): ReadonlyDomainElement<TimelineType> {
+    return this.timelineStore._getTimelineType(this.id);
+  }
+
+  /**
+   * Gets the calculated structural path node trace.
+   */
+  get path(): ReadonlyDomainElement<TimelinePathNode[]> {
+    if (this._path === undefined) {
+      this._path = this.timelineStore._computeTimelinePath(this.id);
+    }
+    return this._path;
+  }
+
+  /**
+   * Returns the debug representation of the timeline's path from its parent.
+   */
+  get debugPathText(): string {
+    return this.path.map((n) => n.label).join('/');
+  }
+
+  /**
+   * Gets the depth layer of this timeline in the hierarchy.
+   * Returns 0 if the timeline has no parent, 1 if there is one parent, and so on.
+   */
+  get layer(): number {
+    return this.path.length - 1;
+  }
+
+  /**
+   * Gets the sequence array of status changes associated with this timeline.
+   */
+  get revisions(): ReadonlyDomainElement<Revision[]> {
+    if (this._revisions === undefined) {
+      this._revisions = this.timelineStore._getRevisionsForTimeline(this.id);
+    }
+    return this._revisions;
+  }
+
+  /**
+   * Gets the list events associated with this timeline tracking stream.
+   */
+  get events(): ReadonlyDomainElement<Event[]> {
+    if (this._events === undefined) {
+      this._events = this.timelineStore._getEventsForTimeline(this.id);
+    }
+    return this._events;
+  }
+}


### PR DESCRIPTION
Added timeline domain store. It holds the entire timeline structure information on frontend side.
TimelineStore keep all timeline information with TypedArray as the central datastore. This helps reducing the memory consumption when it loads a huge timeline data, and it easier for WebGL renderer to handle these data especially in timestamps.
And Timeline, Revision,Event are used as the accessor classes.

This mainly provides following functionalities:

* TimelineStore
  * timelines getter: returns all Timeline array
  * getTimeline: find a Timeline instance from ID

* Timeline
  * accessors for its properties. But the actual data is stored in TimelineStore's array.
  * `legacyXXXX` getters for time related properties. The new format stores time in biguint nano second format. But almost all of the codes used in frontend expects number in ms unix seconds. To migrate them gradually, this domain store provides similar function but produce the value in Ms UnixTime