### PR TITLE
Add lookup methods to Timeline and their unit tests

### DIFF
--- a/web/src/app/common/misc-util.ts
+++ b/web/src/app/common/misc-util.ts
@@ -55,7 +55,7 @@ export const defaultNumberComparator = (
  * to maintain the sorted order.
  */
 export function bisectLeft<T, U>(
-  arr: T[],
+  arr: readonly T[],
   target: U,
   comparator: (item: T, target: U) => number,
   lo = 0,
@@ -78,7 +78,7 @@ export function bisectLeft<T, U>(
  * to maintain the sorted order.
  */
 export function bisectRight<T, U>(
-  arr: T[],
+  arr: readonly T[],
   target: U,
   comparator: (item: T, target: U) => number,
   lo = 0,

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -267,7 +267,7 @@ export class TimelineStore {
     for (let i = 0; i < revIds.length; i++) {
       revisions.push(new Revision(revIds[i], id, this, i));
     }
-    revisions.sort((r1, r2) => Number(r1.changedTime - r2.changedTime));
+    revisions.sort((r1, r2) => r1.logIndex - r2.logIndex);
     return revisions;
   }
 

--- a/web/src/app/store/domain/timeline.spec.ts
+++ b/web/src/app/store/domain/timeline.spec.ts
@@ -290,6 +290,210 @@ describe('Timeline', () => {
     });
   });
 
+  describe('lookupRevisionFromLog and lookupEventFromLog', () => {
+    it('should lookup events and revisions from logIndex using binary search', () => {
+      internPool.addStrings([
+        { id: 1, value: 'timeline-label' },
+        { id: 2, value: 'user-name' },
+        { id: 3, value: 'log-summary' },
+      ]);
+
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [100, 101],
+          eventIds: [200, 201],
+        },
+      ];
+
+      const rawRevisions: RevisionDTO[] = [
+        {
+          id: 100,
+          logId: 1,
+          changedTime: 100n,
+          principalStringId: 2,
+          verbTypeId: 1,
+          stateTypeId: 1,
+        },
+        {
+          id: 101,
+          logId: 3,
+          changedTime: 300n,
+          principalStringId: 2,
+          verbTypeId: 1,
+          stateTypeId: 1,
+        },
+      ];
+
+      const rawEvents: EventDTO[] = [
+        {
+          id: 200,
+          logId: 2,
+        },
+        {
+          id: 201,
+          logId: 4,
+        },
+      ];
+
+      const rawLogs: LogDTO[] = [
+        {
+          id: 1,
+          ts: 100n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+        {
+          id: 2,
+          ts: 200n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+        {
+          id: 3,
+          ts: 300n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+        {
+          id: 4,
+          ts: 400n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+      ];
+
+      logStore.initialize(rawLogs, 4);
+      timelineStore.initialize(rawTimelines, 1, rawRevisions, 2, rawEvents, 2);
+
+      const timeline = timelineStore.getTimeline(10);
+
+      const log1 = logStore.getLog(1);
+      const log2 = logStore.getLog(2);
+      const log3 = logStore.getLog(3);
+      const log4 = logStore.getLog(4);
+
+      // Test lookups for revisions
+      expect(timeline.lookupRevisionFromLog(log1)).not.toBeNull();
+      expect(timeline.lookupRevisionFromLog(log1)!.id).toBe(100);
+      expect(timeline.lookupRevisionFromLog(log3)).not.toBeNull();
+      expect(timeline.lookupRevisionFromLog(log3)!.id).toBe(101);
+      expect(timeline.lookupRevisionFromLog(log2)).toBeNull();
+      expect(timeline.lookupRevisionFromLog(null)).toBeNull();
+
+      // Test lookups for events
+      expect(timeline.lookupEventFromLog(log2)).not.toBeNull();
+      expect(timeline.lookupEventFromLog(log2)!.id).toBe(200);
+      expect(timeline.lookupEventFromLog(log4)).not.toBeNull();
+      expect(timeline.lookupEventFromLog(log4)!.id).toBe(201);
+      expect(timeline.lookupEventFromLog(log1)).toBeNull();
+      expect(timeline.lookupEventFromLog(null)).toBeNull();
+    });
+  });
+
+  describe('lookupRevisionAtNs', () => {
+    it('should lookup active revisions at given times', () => {
+      internPool.addStrings([
+        { id: 1, value: 'timeline-label' },
+        { id: 2, value: 'user-name' },
+        { id: 3, value: 'log-summary' },
+      ]);
+
+      const rawTimelines: TimelineDTO[] = [
+        {
+          id: 10,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [100, 101],
+          eventIds: [],
+        },
+        {
+          id: 20,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
+      ];
+
+      const rawRevisions: RevisionDTO[] = [
+        {
+          id: 100,
+          logId: 1,
+          changedTime: 100n,
+          principalStringId: 2,
+          verbTypeId: 1,
+          stateTypeId: 1,
+        },
+        {
+          id: 101,
+          logId: 2,
+          changedTime: 200n,
+          principalStringId: 2,
+          verbTypeId: 1,
+          stateTypeId: 1,
+        },
+      ];
+
+      const rawLogs: LogDTO[] = [
+        {
+          id: 1,
+          ts: 100n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+        {
+          id: 2,
+          ts: 200n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+      ];
+
+      logStore.initialize(rawLogs, 2);
+      timelineStore.initialize(rawTimelines, 2, rawRevisions, 2, [], 0);
+
+      const timeline = timelineStore.getTimeline(10);
+      const emptyTimeline = timelineStore.getTimeline(20);
+
+      // 1. Before any revision starts
+      expect(timeline.lookupRevisionAtNs(50n)).toBeNull();
+
+      // 2. Exactly at first revision start
+      expect(timeline.lookupRevisionAtNs(100n)).not.toBeNull();
+      expect(timeline.lookupRevisionAtNs(100n)!.id).toBe(100);
+
+      // 3. Exactly at first revision start with exclusive = true
+      expect(timeline.lookupRevisionAtNs(100n, true)).toBeNull();
+
+      // 4. Between first and second revision
+      expect(timeline.lookupRevisionAtNs(150n)).not.toBeNull();
+      expect(timeline.lookupRevisionAtNs(150n)!.id).toBe(100);
+      expect(timeline.lookupRevisionAtNs(150n, true)!.id).toBe(100);
+
+      // 5. Exactly at second revision
+      expect(timeline.lookupRevisionAtNs(200n)!.id).toBe(101);
+      expect(timeline.lookupRevisionAtNs(200n, true)!.id).toBe(100);
+
+      // 6. After second revision
+      expect(timeline.lookupRevisionAtNs(250n)!.id).toBe(101);
+
+      // 7. Empty timeline
+      expect(emptyTimeline.lookupRevisionAtNs(150n)).toBeNull();
+    });
+  });
+
   describe('type', () => {
     it('should return correct type configuration', () => {
       internPool.addStrings([{ id: 1, value: 'parent' }]);

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -338,8 +338,12 @@ export class Timeline {
     const startIdx = bisectLeft(arr, beginTimeNs, (item, target) =>
       item.timestamp < target ? -1 : item.timestamp > target ? 1 : 0,
     );
-    const endIdx = bisectLeft(arr, endTimeNs, (item, target) =>
-      item.timestamp < target ? -1 : item.timestamp > target ? 1 : 0,
+    const endIdx = bisectLeft(
+      arr,
+      endTimeNs,
+      (item, target) =>
+        item.timestamp < target ? -1 : item.timestamp > target ? 1 : 0,
+      startIdx,
     );
     return arr.slice(startIdx, endIdx);
   }

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -21,6 +21,7 @@ import * as yaml from 'js-yaml';
 import { Log } from 'src/app/store/domain/log';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { BigIntTimeUtil } from 'src/app/utils/bigint-time-util';
+import { bisectLeft } from 'src/app/common/misc-util';
 
 /**
  * Represents a node in the path from the root timeline.
@@ -284,5 +285,112 @@ export class Timeline {
       this._events = this.timelineStore._getEventsForTimeline(this.id);
     }
     return this._events;
+  }
+
+  /**
+   * Looks up an event on this timeline by its associated log using binary search.
+   * Returns the event if found, otherwise null.
+   */
+  public lookupEventFromLog(
+    log: ReadonlyDomainElement<Log> | null,
+  ): ReadonlyDomainElement<Event> | null {
+    if (!log) return null;
+    const arr = this.events;
+    const idx = bisectLeft(
+      arr,
+      log.logIndex,
+      (item, target) => item.logIndex - target,
+    );
+    if (idx < arr.length && arr[idx].logIndex === log.logIndex) {
+      return arr[idx];
+    }
+    return null;
+  }
+
+  /**
+   * Looks up a revision on this timeline by its associated log using binary search.
+   * Returns the revision if found, otherwise null.
+   */
+  public lookupRevisionFromLog(
+    log: ReadonlyDomainElement<Log> | null,
+  ): ReadonlyDomainElement<Revision> | null {
+    if (!log) return null;
+    const arr = this.revisions;
+    const idx = bisectLeft(
+      arr,
+      log.logIndex,
+      (item, target) => item.logIndex - target,
+    );
+    if (idx < arr.length && arr[idx].logIndex === log.logIndex) {
+      return arr[idx];
+    }
+    return null;
+  }
+
+  /**
+   * Looks up events on this timeline within a nanosecond time range [beginTimeNs, endTimeNs).
+   */
+  public lookupEventsInRangeNs(
+    beginTimeNs: bigint,
+    endTimeNs: bigint,
+  ): ReadonlyDomainElement<Event>[] {
+    const arr = this.events;
+    const startIdx = bisectLeft(arr, beginTimeNs, (item, target) =>
+      item.timestamp < target ? -1 : item.timestamp > target ? 1 : 0,
+    );
+    const endIdx = bisectLeft(arr, endTimeNs, (item, target) =>
+      item.timestamp < target ? -1 : item.timestamp > target ? 1 : 0,
+    );
+    return arr.slice(startIdx, endIdx);
+  }
+
+  /**
+   * Looks up revisions on this timeline that overlap with a nanosecond time range [beginTimeNs, endTimeNs).
+   */
+  public lookupRevisionsInRangeNs(
+    beginTimeNs: bigint,
+    endTimeNs: bigint,
+  ): ReadonlyDomainElement<Revision>[] {
+    const arr = this.revisions;
+    let startIdx = bisectLeft(arr, beginTimeNs, (item, target) =>
+      item.changedTime < target ? -1 : item.changedTime > target ? 1 : 0,
+    );
+    if (startIdx > 0) {
+      // Adjust the starting index to include the preceding revision if it overlaps with the query range.
+      // Since revisions form a contiguous sequence of intervals:
+      // - If startIdx reaches the end of the array, it means beginTimeNs is after the last revision's start time.
+      //   Since the last revision has no end time (it lasts indefinitely), it always overlaps with the range.
+      // - Otherwise, if the revision starting at startIdx begins after beginTimeNs, the preceding revision at
+      //   startIdx - 1 must end at arr[startIdx].changedTime, which is strictly after beginTimeNs. Thus,
+      //   the preceding revision overlaps with the range and must be included.
+      if (startIdx === arr.length || arr[startIdx].changedTime > beginTimeNs) {
+        startIdx--;
+      }
+    }
+    const endIdx = bisectLeft(
+      arr,
+      endTimeNs,
+      (item, target) =>
+        item.changedTime < target ? -1 : item.changedTime > target ? 1 : 0,
+      startIdx,
+    );
+    return arr.slice(startIdx, endIdx);
+  }
+
+  /**
+   * Returns the active revision at a given nanosecond time.
+   */
+  public lookupRevisionAtNs(
+    timeNs: bigint,
+    exclusive = false,
+  ): ReadonlyDomainElement<Revision> | null {
+    const arr = this.revisions;
+    const idx = bisectLeft(arr, timeNs, (item, target) =>
+      item.changedTime < target ? -1 : item.changedTime > target ? 1 : 0,
+    );
+    if (idx < arr.length && arr[idx].changedTime === timeNs && !exclusive) {
+      return arr[idx];
+    }
+    return idx > 0 ? arr[idx - 1] : null;
   }
 }


### PR DESCRIPTION
Adding several lookup methods on Timeline class. These methods provide fast search operation for looking up elements of a Timeline.
These operations are frequently used in KHI's frontend. And the type provides `O(logN)` speed for these operations.