### PR TITLE
Defined TimelineTypes from the previously defined enum.ParentRelationshipTypes

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/contract/timeline_type.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/timeline_type.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commonlogk8saudit_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeResourceCondition = style.MustRegisterTimelineType(
+		"condition",
+		"Resource conditions from .status.conditions",
+		"conditions",
+		0.6,
+		style.ColorWhite,
+		style.ColorWhite,
+		style.MustForceConvertSRGBHex("#4c29e8"),
+		true,
+		2000,
+	)
+	TimelineTypeEndpointSlice = style.MustRegisterTimelineType(
+		"endpoint",
+		"Pod serving status from EndpointSlice",
+		"line_end_diamond",
+		0.6,
+		style.ColorWhite,
+		style.ColorWhite,
+		style.MustForceConvertSRGBHex("#008000"),
+		true,
+		20000,
+	)
+	TimelineTypeOwnerReference = style.MustRegisterTimelineType(
+		"owns",
+		"Child resource from .metadata.ownerReferences",
+		"link_2",
+		0.6,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#33DD88"),
+		true,
+		7000,
+	)
+	TimelineTypePodPhase = style.MustRegisterTimelineType(
+		"pod",
+		"Pod status on the node from .status.phase",
+		"token",
+		0.6,
+		style.ColorWhite,
+		style.ColorWhite,
+		style.MustForceConvertSRGBHex("#FF8855"),
+		true,
+		8000,
+	)
+)

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/timeline_type.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudclustercomposer_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeAirflowTaskInstance = style.MustRegisterTimelineType(
+		"task",
+		"Airflow Task Instance execution state",
+		"mode_fan",
+		0.6,
+		style.ColorWhite,
+		style.ColorWhite,
+		style.MustForceConvertSRGBHex("#377e22"),
+		true,
+		1501,
+	)
+)

--- a/pkg/task/inspection/googlecloudcommon/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/timeline_type.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeGKE = style.MustRegisterTimelineType(
+		"gke",
+		"GKE Control Plane and lifecycle logs",
+		"cloud",
+		1.0,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#4285F4"),
+		true,
+		40,
+	)
+	TimelineTypeGKENodePool = style.MustRegisterTimelineType(
+		"nodepool",
+		"GKE Nodepool layer",
+		"dns",
+		0.6,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#E0E0E0"),
+		true,
+		45,
+	)
+	TimelineTypeOperation = style.MustRegisterTimelineType(
+		"operation",
+		"GCP operations associated with this resource",
+		"engineering",
+		0.6,
+		style.ColorWhite,
+		style.ColorWhite,
+		style.ColorBlack,
+		true,
+		3000,
+	)
+)

--- a/pkg/task/inspection/googlecloudlogcsm/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/timeline_type.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcsm_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeCSMAccessLog = style.MustRegisterTimelineType(
+		"csm",
+		"CSM Access logs related to this resource",
+		"shuffle",
+		0.6,
+		style.ColorWhite,
+		style.ColorWhite,
+		style.MustForceConvertSRGBHex("#FF8500"),
+		true,
+		5001,
+	)
+)

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/contract/timeline_type.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudloggkeautoscaler_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeManagedInstanceGroup = style.MustRegisterTimelineType(
+		"mig",
+		"MIG logs for the parent node pool",
+		"host",
+		0.6,
+		style.ColorWhite,
+		style.ColorWhite,
+		style.MustForceConvertSRGBHex("#FF5555"),
+		true,
+		10000,
+	)
+)

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/timeline_type.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8scontainer_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeContainer = style.MustRegisterTimelineType(
+		"container",
+		"Container status and logs",
+		"activity_zone",
+		0.6,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#fe9bab"),
+		true,
+		5000,
+	)
+)

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/timeline_type.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8scontrolplane_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeControlPlaneComponent = style.MustRegisterTimelineType(
+		"controlplane",
+		"Control plane component of the cluster",
+		"crown",
+		0.6,
+		style.ColorWhite,
+		style.ColorWhite,
+		style.MustForceConvertSRGBHex("#FF5555"),
+		true,
+		11000,
+	)
+)

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/timeline_type.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8snode_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeNodeComponent = style.MustRegisterTimelineType(
+		"node-component",
+		"Non-containerized component on the node",
+		"code_block",
+		0.6,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#0077CC"),
+		true,
+		6000,
+	)
+)

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/contract/timeline_type.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlognetworkapiaudit_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeNetworkEndpointGroup = style.MustRegisterTimelineType(
+		"neg",
+		"Associated NEG serving status",
+		"network_node",
+		0.6,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#A52A2A"),
+		true,
+		20500,
+	)
+)

--- a/pkg/task/inspection/googlecloudlogserialport/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/timeline_type.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogserialport_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeSerialPort = style.MustRegisterTimelineType(
+		"serialport",
+		"Serial port logs of the node",
+		"usb",
+		0.6,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#333333"),
+		true,
+		1500,
+	)
+)

--- a/pkg/task/inspection/inspectioncore/contract/timeline_type.go
+++ b/pkg/task/inspection/inspectioncore/contract/timeline_type.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectioncore_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+// The following block defines the registered timeline style TimelineTypes.
+// These are registered as package-level variables so they are initialized immediately
+// when this package is imported.
+var (
+	TimelineTypeK8sCluster = style.MustRegisterTimelineType(
+		"k8sCluster",
+		"Kubernetes Cluster layer",
+		"cloud",
+		0.5,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#F5F5F5"),
+		true,
+		50,
+	)
+	TimelineTypeAPIVersion = style.MustRegisterTimelineType(
+		"apiVersion",
+		"Kubernetes API Version layer",
+		"api",
+		0.55,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#EEEEEE"),
+		true,
+		100,
+	)
+	TimelineTypeKind = style.MustRegisterTimelineType(
+		"kind",
+		"Kubernetes API Resource Kind layer",
+		"workspaces",
+		0.55,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#DDDDDD"),
+		true,
+		200,
+	)
+	TimelineTypeNamespace = style.MustRegisterTimelineType(
+		"namespace",
+		"Kubernetes Namespace layer",
+		"folder",
+		0.55,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#D0D0D0"),
+		true,
+		300,
+	)
+	TimelineTypeResource = style.MustRegisterTimelineType(
+		"resource",
+		"General resource lifecycle and logs",
+		"description",
+		1.0,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#CCCCCC"),
+		true,
+		1000,
+	)
+	TimelineTypeSubresource = style.MustRegisterTimelineType(
+		"subresource",
+		"General subresource lifecycle and logs",
+		"page_info",
+		0.6,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#BBBBBB"),
+		true,
+		1200,
+	)
+)


### PR DESCRIPTION
Defined TimelineTypes in task instance packages. These types were from the ParentRelationshipType defined in `pkg/model/enum`. This will replace the enum package eventually after these file scheme migration done.