### PR TITLE
Add the new ChangeSet utility

### DIFF
--- a/pkg/model/khifile/v6/builder.go
+++ b/pkg/model/khifile/v6/builder.go
@@ -37,12 +37,13 @@ type Builder struct {
 func NewBuilder() *Builder {
 	gen := &IDGenerator{}
 	internPool := NewInternPool(gen)
+	logAcc := NewLogAccumulator(internPool, gen)
 
 	return &Builder{
 		idGenerator:         gen,
 		internPool:          internPool,
-		TimelineAccumulator: NewTimelineAccumulator(gen, internPool),
-		LogAccumulator:      NewLogAccumulator(internPool, gen),
+		TimelineAccumulator: NewTimelineAccumulator(gen, internPool, logAcc),
+		LogAccumulator:      logAcc,
 		MetadataAccumulator: NewMetadataAccumulator(),
 	}
 }

--- a/pkg/model/khifile/v6/changeset.go
+++ b/pkg/model/khifile/v6/changeset.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	khifile "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// StagingRevision represents a resource revision in parser-side domain model before serialization.
+// It holds the raw information about resource change to be processed and interned later during serialization.
+type StagingRevision struct {
+	// ChangedTime is the time of the resource modification.
+	ChangedTime time.Time
+	// ResourceBody represents the resource content at this revision.
+	ResourceBody structured.Node
+	// Principal is the requestor of the modification.
+	Principal string
+	// VerbType is the styled representation of the change verb.
+	VerbType *pb.Verb
+	// StateType is the styled representation of the revision state.
+	StateType *pb.RevisionState
+}
+
+// LogChangeSet accumulates metadata updates for a specific log during parsing.
+// It decouples the parsing logic from serialization details and provides thread-safe accumulation.
+type LogChangeSet struct {
+	// Log holds the reference to the parser-side log model.
+	Log *log.Log
+	// Summary stores the accumulated log summary.
+	Summary string
+	// Timestamp represents the log timestamp.
+	Timestamp time.Time
+	// LogType represents the styled log type.
+	LogType *pb.LogType
+	// Severity represents the styled severity.
+	Severity *pb.Severity
+}
+
+// NewLogChangeSet creates a new LogChangeSet for staging mutations on the given log.
+func NewLogChangeSet(l *log.Log) (*LogChangeSet, error) {
+	if l == nil {
+		return nil, fmt.Errorf("log cannot be nil")
+	}
+	return &LogChangeSet{
+		Log: l,
+	}, nil
+}
+
+// SetSummary updates the staged summary string.
+func (cs *LogChangeSet) SetSummary(summary string) {
+	cs.Summary = summary
+}
+
+// SetTimestamp updates the staged timestamp.
+func (cs *LogChangeSet) SetTimestamp(t time.Time) {
+	cs.Timestamp = t
+}
+
+// SetLogType updates the staged log type style.
+func (cs *LogChangeSet) SetLogType(lt *pb.LogType) {
+	cs.LogType = lt
+}
+
+// SetSeverity updates the staged severity style.
+func (cs *LogChangeSet) SetSeverity(sev *pb.Severity) {
+	cs.Severity = sev
+}
+
+// Flush writes the staged log metadata into the provided LogAccumulator.
+func (cs *LogChangeSet) Flush(logAcc *LogAccumulator) error {
+	return logAcc.AddLog(&StagingLog{
+		Log:       cs.Log,
+		Summary:   cs.Summary,
+		Timestamp: cs.Timestamp,
+		LogType:   cs.LogType,
+		Severity:  cs.Severity,
+	})
+}
+
+// TimelineChangeSet stages events and revisions for multiple timeline paths.
+// It acts as a localized buffer during the parsing phase of a single log.
+type TimelineChangeSet struct {
+	// Log holds the reference to the parser-side log model.
+	Log *log.Log
+	// Events tracks which paths should have an event associated with this log.
+	Events map[*TimelinePath]bool
+	// Revisions tracks staging revisions to be appended to specific paths.
+	Revisions map[*TimelinePath][]*StagingRevision
+	// Aliases tracks structural path aliases to be registered. The key is the alias path and the value is the target path.
+	Aliases map[*TimelinePath]*TimelinePath
+}
+
+// NewTimelineChangeSet creates a new TimelineChangeSet to stage timeline mutations.
+func NewTimelineChangeSet(l *log.Log) *TimelineChangeSet {
+	return &TimelineChangeSet{
+		Log:       l,
+		Events:    make(map[*TimelinePath]bool),
+		Revisions: make(map[*TimelinePath][]*StagingRevision),
+		Aliases:   make(map[*TimelinePath]*TimelinePath),
+	}
+}
+
+// AddEvent stages a timeline event on the specified path for the log associated with this changeset.
+func (cs *TimelineChangeSet) AddEvent(path *TimelinePath) {
+	cs.Events[path] = true
+}
+
+// AddRevision stages a resource revision on the specified path.
+func (cs *TimelineChangeSet) AddRevision(path *TimelinePath, revision *StagingRevision) {
+	cs.Revisions[path] = append(cs.Revisions[path], revision)
+}
+
+// AddAlias stages an alias mapping from the alias path to the target path.
+func (cs *TimelineChangeSet) AddAlias(aliasPath, targetPath *TimelinePath) {
+	cs.Aliases[aliasPath] = targetPath
+}
+
+// Flush converts staging events, revisions, and aliases to serialized types and writes them to the TimelineAccumulator.
+func (cs *TimelineChangeSet) Flush(accumulator *TimelineAccumulator) error {
+	registry := accumulator.registry
+	pool := registry.internPool
+	logAcc := registry.logAcc
+
+	resolvedLogID, ok := logAcc.ResolveLogID(cs.Log.ID)
+	if !ok {
+		return fmt.Errorf("failed to resolve log ID for parser log %q", cs.Log.ID)
+	}
+
+	for aliasPath, targetPath := range cs.Aliases {
+		if err := accumulator.SetAlias(aliasPath, targetPath); err != nil {
+			return fmt.Errorf("failed to set timeline alias: %w", err)
+		}
+	}
+
+	for path := range cs.Events {
+		builder := registry.GetBuilder(path)
+		builder.AddEvent(&pb.Event{
+			LogId: &resolvedLogID,
+		})
+	}
+
+	for path, revisions := range cs.Revisions {
+		builder := registry.GetBuilder(path)
+		for _, r := range revisions {
+			var bodyRef *khifile.InternedStruct
+			if r.ResourceBody != nil {
+				var err error
+				bodyRef, err = ToInternedStruct(r.ResourceBody, pool)
+				if err != nil {
+					return fmt.Errorf("failed to intern resource body for revision: %w", err)
+				}
+			}
+
+			var principalID *uint32
+			if r.Principal != "" {
+				ref := pool.InternString(r.Principal)
+				principalID = &ref.id
+			}
+
+			var verbID *uint32
+			if r.VerbType != nil {
+				verbID = r.VerbType.Id
+			}
+
+			var stateID *uint32
+			if r.StateType != nil {
+				stateID = r.StateType.Id
+			}
+
+			var changedTime *timestamppb.Timestamp
+			if !r.ChangedTime.IsZero() {
+				changedTime = timestamppb.New(r.ChangedTime)
+			}
+
+			builder.AddRevision(&pb.Revision{
+				LogId:             &resolvedLogID,
+				ChangedTime:       changedTime,
+				ResourceBody:      bodyRef,
+				PrincipalStringId: principalID,
+				VerbType:          verbID,
+				StateType:         stateID,
+			})
+		}
+	}
+	return nil
+}

--- a/pkg/model/khifile/v6/changeset_test.go
+++ b/pkg/model/khifile/v6/changeset_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+)
+
+func TestLogChangeSet_Flush(t *testing.T) {
+	idGen := &khifilev6.IDGenerator{}
+	pool := khifilev6.NewInternPool(idGen)
+	logAcc := khifilev6.NewLogAccumulator(pool, idGen)
+
+	node := structured.NewStandardMap(nil, nil)
+	l := log.NewLog(structured.NewNodeReader(node))
+	l.ID = "test-log-id"
+
+	severityID := uint32(1)
+	logTypeID := uint32(2)
+	severity := &pb.Severity{Id: &severityID}
+	logType := &pb.LogType{Id: &logTypeID}
+
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		t.Fatalf("NewLogChangeSet() returned unexpected error: %v", err)
+	}
+
+	cs.SetSummary("test summary")
+	cs.SetTimestamp(time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC))
+	cs.SetSeverity(severity)
+	cs.SetLogType(logType)
+
+	// Verify fluent assertions work as expected.
+	testchangeset.AssertLog(t, cs).
+		HasSummary("test summary").
+		HasSeverity(severity).
+		HasLogType(logType)
+
+	// Flush to accumulator.
+	if err := cs.Flush(logAcc); err != nil {
+		t.Fatalf("Flush() returned unexpected error: %v", err)
+	}
+
+	// Verify that the log is resolved to its serialized ID.
+	resolvedID, ok := logAcc.ResolveLogID("test-log-id")
+	if !ok {
+		t.Fatal("expected log to be resolved in LogAccumulator")
+	}
+	if resolvedID != 1 {
+		t.Errorf("expected resolved log ID to be 1, got %d", resolvedID)
+	}
+}
+
+func TestTimelineChangeSet_Flush(t *testing.T) {
+	idGen := &khifilev6.IDGenerator{}
+	pool := khifilev6.NewInternPool(idGen)
+	logAcc := khifilev6.NewLogAccumulator(pool, idGen)
+	accumulator := khifilev6.NewTimelineAccumulator(idGen, pool, logAcc)
+
+	node := structured.NewStandardMap(nil, nil)
+	l := log.NewLog(structured.NewNodeReader(node))
+	l.ID = "test-log-id"
+
+	severityID := uint32(1)
+	logTypeID := uint32(2)
+	_ = logAcc.AddLog(&khifilev6.StagingLog{
+		Log:       l,
+		Summary:   "test summary",
+		Timestamp: time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC),
+		Severity:  &pb.Severity{Id: &severityID},
+		LogType:   &pb.LogType{Id: &logTypeID},
+	})
+
+	pathPool := khifilev6.NewTimelinePathPool(idGen, pool)
+	timelineTypeID := uint32(3)
+	timelineType := &pb.TimelineType{Id: &timelineTypeID}
+	path := pathPool.Get(nil, khifilev6.PathSegment{Name: "test-path", Type: timelineType})
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+	cs.AddEvent(path)
+
+	stagingRev := &khifilev6.StagingRevision{
+		ChangedTime: time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC),
+	}
+	cs.AddRevision(path, stagingRev)
+
+	// Verify fluent assertions work.
+	testchangeset.AssertTimeline(t, cs).
+		HasEvent(path).
+		HasRevision(path, stagingRev)
+
+	// Flush to accumulator.
+	if err := cs.Flush(accumulator); err != nil {
+		t.Fatalf("Flush() returned unexpected error: %v", err)
+	}
+
+	builder := accumulator.GetBuilder(path)
+	if !builder.HasItems() {
+		t.Error("expected TimelineBuilder to have items")
+	}
+}

--- a/pkg/model/khifile/v6/log_accumulator.go
+++ b/pkg/model/khifile/v6/log_accumulator.go
@@ -37,18 +37,20 @@ type StagingLog struct {
 // by interning their structured data using an InternPool.
 // It is safe for concurrent use by multiple goroutines.
 type LogAccumulator struct {
-	pool  *InternPool
-	idGen *IDGenerator
-	logs  []*pb.Log
-	mu    sync.RWMutex
+	pool         *InternPool
+	idGen        *IDGenerator
+	logs         []*pb.Log
+	parserIDToID map[string]uint32
+	mu           sync.RWMutex
 }
 
 // NewLogAccumulator creates a new LogAccumulator with the provided InternPool and IDGenerator.
 func NewLogAccumulator(pool *InternPool, idGen *IDGenerator) *LogAccumulator {
 	return &LogAccumulator{
-		pool:  pool,
-		idGen: idGen,
-		logs:  make([]*pb.Log, 0),
+		pool:         pool,
+		idGen:        idGen,
+		logs:         make([]*pb.Log, 0),
+		parserIDToID: make(map[string]uint32),
 	}
 }
 
@@ -87,9 +89,21 @@ func (a *LogAccumulator) AddLog(s *StagingLog) error {
 		a.logs = append(a.logs, make([]*pb.Log, needed)...)
 	}
 	a.logs[id-1] = pbLog
+	a.parserIDToID[s.Log.ID] = id
 	a.mu.Unlock()
 
 	return nil
+}
+
+// ResolveLogID returns the serialized log ID (uint32) for a given parser-side log ID (string).
+// It returns false if the log ID is not found.
+// TODO: For the historical reason, KHI's log.Log generates ID in the form of string.
+// We should improve this and use the parser ID directly to reduce this logic in future.
+func (a *LogAccumulator) ResolveLogID(parserID string) (uint32, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	id, ok := a.parserIDToID[parserID]
+	return id, ok
 }
 
 // GetLog returns a log by its ID. Returns nil if the log is not found.

--- a/pkg/model/khifile/v6/log_accumulator.go
+++ b/pkg/model/khifile/v6/log_accumulator.go
@@ -97,7 +97,7 @@ func (a *LogAccumulator) AddLog(s *StagingLog) error {
 
 // ResolveLogID returns the serialized log ID (uint32) for a given parser-side log ID (string).
 // It returns false if the log ID is not found.
-// TODO: For the historical reason, KHI's log.Log generates ID in the form of string.
+// TODO(#699): For the historical reason, KHI's log.Log generates ID in the form of string.
 // We should improve this and use the parser ID directly to reduce this logic in future.
 func (a *LogAccumulator) ResolveLogID(parserID string) (uint32, bool) {
 	a.mu.RLock()

--- a/pkg/model/khifile/v6/timeline_accumulator.go
+++ b/pkg/model/khifile/v6/timeline_accumulator.go
@@ -24,9 +24,9 @@ type TimelineAccumulator struct {
 }
 
 // NewTimelineAccumulator creates a new TimelineAccumulator facade.
-func NewTimelineAccumulator(idGen *IDGenerator, internPool *InternPool) *TimelineAccumulator {
+func NewTimelineAccumulator(idGen *IDGenerator, internPool *InternPool, logAcc *LogAccumulator) *TimelineAccumulator {
 	pathPool := NewTimelinePathPool(idGen, internPool)
-	registry := NewTimelineRegistry(idGen, internPool)
+	registry := NewTimelineRegistry(idGen, internPool, logAcc)
 	return &TimelineAccumulator{
 		pathPool: pathPool,
 		registry: registry,

--- a/pkg/model/khifile/v6/timeline_accumulator.go
+++ b/pkg/model/khifile/v6/timeline_accumulator.go
@@ -43,6 +43,12 @@ func (a *TimelineAccumulator) GetBuilder(path *TimelinePath) *TimelineBuilder {
 	return a.registry.GetBuilder(path)
 }
 
+// SetAlias configures aliasPath to be an alias of targetPath.
+// Returns an error if aliasPath already has a builder attached (i.e., GetBuilder was already called on it).
+func (a *TimelineAccumulator) SetAlias(aliasPath, targetPath *TimelinePath) error {
+	return a.registry.SetAlias(aliasPath, targetPath)
+}
+
 // Accumulate extracts the arrays of Timeline and TimelineItems protobuf messages.
 func (a *TimelineAccumulator) Accumulate() ([]*pb.Timeline, []*pb.TimelineItems) {
 	return ExtractTimelinesAndItemsChunkSource(a.pathPool, a.registry)

--- a/pkg/model/khifile/v6/timeline_registry.go
+++ b/pkg/model/khifile/v6/timeline_registry.go
@@ -15,6 +15,7 @@
 package khifilev6
 
 import (
+	"errors"
 	"iter"
 	"sync"
 )
@@ -67,10 +68,10 @@ func (r *TimelineRegistry) GetBuilder(path *TimelinePath) *TimelineBuilder {
 
 // SetAlias configures aliasPath to be an alias of targetPath.
 // Any subsequent request for a builder for aliasPath will return the builder for targetPath.
-// Panics if aliasPath already has a builder attached (i.e., GetBuilder was already called on it).
-func (r *TimelineRegistry) SetAlias(aliasPath, targetPath *TimelinePath) {
+// Returns an error if aliasPath already has a builder attached (i.e., GetBuilder was already called on it).
+func (r *TimelineRegistry) SetAlias(aliasPath, targetPath *TimelinePath) error {
 	if aliasPath == targetPath {
-		return
+		return nil
 	}
 
 	targetBuilder := r.GetBuilder(targetPath)
@@ -79,8 +80,9 @@ func (r *TimelineRegistry) SetAlias(aliasPath, targetPath *TimelinePath) {
 	// Fail-fast: if aliasPath already has a builder attached, it's too late to alias it.
 	actual, loaded := r.builders.LoadOrStore(aliasPath, targetBuilder)
 	if loaded && actual != targetBuilder {
-		panic("TimelineRegistry: Cannot set alias on a path that already has a builder attached")
+		return errors.New("timeline registry: cannot set alias on a path that already has a builder attached")
 	}
+	return nil
 }
 
 // Builders returns an iterator over all unique TimelineBuilders present in the registry.

--- a/pkg/model/khifile/v6/timeline_registry.go
+++ b/pkg/model/khifile/v6/timeline_registry.go
@@ -27,6 +27,8 @@ type TimelineRegistry struct {
 	idGen *IDGenerator
 	// internPool is passed to new TimelineBuilder instances for string interning.
 	internPool *InternPool
+	// logAcc is the LogAccumulator reference used to resolve log IDs.
+	logAcc *LogAccumulator
 	// builders is a concurrent map caching *TimelinePath to its *TimelineBuilder.
 	builders sync.Map // map[*TimelinePath]*TimelineBuilder
 	// idToBuilder is a concurrent map caching ID to *TimelineBuilder.
@@ -34,10 +36,11 @@ type TimelineRegistry struct {
 }
 
 // NewTimelineRegistry creates a new registry for managing TimelineBuilders.
-func NewTimelineRegistry(idGen *IDGenerator, sp *InternPool) *TimelineRegistry {
+func NewTimelineRegistry(idGen *IDGenerator, sp *InternPool, logAcc *LogAccumulator) *TimelineRegistry {
 	return &TimelineRegistry{
 		idGen:      idGen,
 		internPool: sp,
+		logAcc:     logAcc,
 	}
 }
 

--- a/pkg/model/khifile/v6/timeline_registry_test.go
+++ b/pkg/model/khifile/v6/timeline_registry_test.go
@@ -91,7 +91,9 @@ func TestTimelineRegistry_GetBuilder(t *testing.T) {
 		{
 			name: "should resolve alias to target builder",
 			test: func(t *testing.T, registry *TimelineRegistry) {
-				registry.SetAlias(path1, path2)
+				if err := registry.SetAlias(path1, path2); err != nil {
+					t.Fatalf("failed to set alias: %v", err)
+				}
 				b1 := registry.GetBuilder(path1)
 				b2 := registry.GetBuilder(path2)
 
@@ -104,17 +106,15 @@ func TestTimelineRegistry_GetBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "should panic if setting alias on path with attached builder",
+			name: "should return error if setting alias on path with attached builder",
 			test: func(t *testing.T, registry *TimelineRegistry) {
 				// Force attaching a builder to path1
 				_ = registry.GetBuilder(path1)
 
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf("expected SetAlias to panic when alias already has a builder")
-					}
-				}()
-				registry.SetAlias(path1, path2)
+				err := registry.SetAlias(path1, path2)
+				if err == nil {
+					t.Errorf("expected SetAlias to return an error when alias already has a builder")
+				}
 			},
 		},
 	}

--- a/pkg/model/khifile/v6/timeline_registry_test.go
+++ b/pkg/model/khifile/v6/timeline_registry_test.go
@@ -122,7 +122,8 @@ func TestTimelineRegistry_GetBuilder(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Use a fresh registry for each test case
-			registry := NewTimelineRegistry(idGen, internPool)
+			logAcc := NewLogAccumulator(internPool, idGen)
+			registry := NewTimelineRegistry(idGen, internPool, logAcc)
 			tc.test(t, registry)
 		})
 	}

--- a/pkg/model/khifile/v6/timeline_serializer_test.go
+++ b/pkg/model/khifile/v6/timeline_serializer_test.go
@@ -170,7 +170,9 @@ func TestExtractTimelinesAndItemsChunkSource(t *testing.T) {
 				pathMap[def.id] = path
 
 				if def.aliasOf != "" {
-					registry.SetAlias(path, pathMap[def.aliasOf])
+					if err := registry.SetAlias(path, pathMap[def.aliasOf]); err != nil {
+						t.Fatalf("failed to set alias: %v", err)
+					}
 					continue
 				}
 

--- a/pkg/model/khifile/v6/timeline_serializer_test.go
+++ b/pkg/model/khifile/v6/timeline_serializer_test.go
@@ -155,7 +155,8 @@ func TestExtractTimelinesAndItemsChunkSource(t *testing.T) {
 			idGen := &IDGenerator{}
 			internPool := NewInternPool(idGen)
 			pathPool := NewTimelinePathPool(idGen, internPool)
-			registry := NewTimelineRegistry(idGen, internPool)
+			logAcc := NewLogAccumulator(internPool, idGen)
+			registry := NewTimelineRegistry(idGen, internPool, logAcc)
 
 			pathMap := make(map[string]*TimelinePath)
 

--- a/pkg/testutil/testchangeset/changeset_asserter.go
+++ b/pkg/testutil/testchangeset/changeset_asserter.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testchangeset
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+// LogChangeSetAsserter provides fluent, chainable assertions for LogChangeSet.
+type LogChangeSetAsserter struct {
+	t  *testing.T
+	cs *khifilev6.LogChangeSet
+}
+
+// AssertLog starts a fluent assertion chain for the given LogChangeSet.
+func AssertLog(t *testing.T, cs *khifilev6.LogChangeSet) *LogChangeSetAsserter {
+	t.Helper()
+	return &LogChangeSetAsserter{t: t, cs: cs}
+}
+
+// HasSummary asserts that the LogChangeSet has the expected summary.
+func (a *LogChangeSetAsserter) HasSummary(wantSummary string) *LogChangeSetAsserter {
+	a.t.Helper()
+	if a.cs.Summary != wantSummary {
+		a.t.Errorf("LogChangeSet summary mismatch: want %q, got %q", wantSummary, a.cs.Summary)
+	}
+	return a
+}
+
+// HasSeverity asserts that the LogChangeSet has the expected severity type.
+func (a *LogChangeSetAsserter) HasSeverity(want *pb.Severity) *LogChangeSetAsserter {
+	a.t.Helper()
+	if diff := cmp.Diff(want, a.cs.Severity, protocmp.Transform()); diff != "" {
+		a.t.Errorf("LogChangeSet severity mismatch (-want +got):\n%s", diff)
+	}
+	return a
+}
+
+// HasLogType asserts that the LogChangeSet has the expected log type.
+func (a *LogChangeSetAsserter) HasLogType(want *pb.LogType) *LogChangeSetAsserter {
+	a.t.Helper()
+	if diff := cmp.Diff(want, a.cs.LogType, protocmp.Transform()); diff != "" {
+		a.t.Errorf("LogChangeSet log type mismatch (-want +got):\n%s", diff)
+	}
+	return a
+}
+
+// HasTimestamp asserts that the LogChangeSet has the expected timestamp.
+func (a *LogChangeSetAsserter) HasTimestamp(want time.Time) *LogChangeSetAsserter {
+	a.t.Helper()
+	if !a.cs.Timestamp.Equal(want) {
+		a.t.Errorf("LogChangeSet timestamp mismatch: want %v, got %v", want, a.cs.Timestamp)
+	}
+	return a
+}
+
+// TimelineChangeSetAsserter provides fluent, chainable assertions for TimelineChangeSet.
+type TimelineChangeSetAsserter struct {
+	t  *testing.T
+	cs *khifilev6.TimelineChangeSet
+}
+
+// AssertTimeline starts a fluent assertion chain for the given TimelineChangeSet.
+func AssertTimeline(t *testing.T, cs *khifilev6.TimelineChangeSet) *TimelineChangeSetAsserter {
+	t.Helper()
+	return &TimelineChangeSetAsserter{t: t, cs: cs}
+}
+
+// HasEvent asserts that an event was staged on the expected path.
+func (a *TimelineChangeSetAsserter) HasEvent(wantPath *khifilev6.TimelinePath) *TimelineChangeSetAsserter {
+	a.t.Helper()
+	if !a.cs.Events[wantPath] {
+		a.t.Errorf("TimelineChangeSet: expected event staged on path %v, but not found", wantPath)
+	}
+	return a
+}
+
+// HasNoEvent asserts that no event was staged on the path.
+func (a *TimelineChangeSetAsserter) HasNoEvent(path *khifilev6.TimelinePath) *TimelineChangeSetAsserter {
+	a.t.Helper()
+	if a.cs.Events[path] {
+		a.t.Errorf("TimelineChangeSet: expected no event staged on path %v, but found one", path)
+	}
+	return a
+}
+
+// HasRevision asserts that a matching StagingRevision was staged on the expected path.
+func (a *TimelineChangeSetAsserter) HasRevision(wantPath *khifilev6.TimelinePath, wantRevision *khifilev6.StagingRevision, cmpOpts ...cmp.Option) *TimelineChangeSetAsserter {
+	a.t.Helper()
+	revisions, exist := a.cs.Revisions[wantPath]
+	if !exist || len(revisions) == 0 {
+		a.t.Errorf("TimelineChangeSet: no revisions found for path %v", wantPath)
+		return a
+	}
+
+	for _, rev := range revisions {
+		if rev.ChangedTime.Equal(wantRevision.ChangedTime) &&
+			rev.Principal == wantRevision.Principal &&
+			rev.VerbType == wantRevision.VerbType &&
+			rev.StateType == wantRevision.StateType {
+
+			if diff := cmp.Diff(wantRevision.ResourceBody, rev.ResourceBody, cmpOpts...); diff == "" {
+				return a
+			}
+		}
+	}
+
+	a.t.Errorf("TimelineChangeSet: revision matching %+v not found on path %v. Staged revisions count: %d", wantRevision, wantPath, len(revisions))
+	return a
+}
+
+// HasNoRevision asserts that no revision was staged on the path.
+func (a *TimelineChangeSetAsserter) HasNoRevision(path *khifilev6.TimelinePath) *TimelineChangeSetAsserter {
+	a.t.Helper()
+	revisions, exist := a.cs.Revisions[path]
+	if exist && len(revisions) > 0 {
+		a.t.Errorf("TimelineChangeSet: expected no revisions staged on path %v, but found %d", path, len(revisions))
+	}
+	return a
+}
+
+// HasAlias asserts that an alias mapping from the alias path to the target path was staged.
+func (a *TimelineChangeSetAsserter) HasAlias(wantAliasPath, wantTargetPath *khifilev6.TimelinePath) *TimelineChangeSetAsserter {
+	a.t.Helper()
+	targetPath, exist := a.cs.Aliases[wantAliasPath]
+	if !exist {
+		a.t.Errorf("TimelineChangeSet: alias from path %v not found", wantAliasPath)
+		return a
+	}
+	if targetPath != wantTargetPath {
+		a.t.Errorf("TimelineChangeSet: alias target mismatch for %v: want %v, got %v", wantAliasPath, wantTargetPath, targetPath)
+	}
+	return a
+}
+
+// HasNoAlias asserts that no alias was staged for the given alias path.
+func (a *TimelineChangeSetAsserter) HasNoAlias(aliasPath *khifilev6.TimelinePath) *TimelineChangeSetAsserter {
+	a.t.Helper()
+	targetPath, exist := a.cs.Aliases[aliasPath]
+	if exist {
+		a.t.Errorf("TimelineChangeSet: expected no alias staged for path %v, but found one pointing to %v", aliasPath, targetPath)
+	}
+	return a
+}


### PR DESCRIPTION

Introduces LogChangeSet and TimelineChangeSet utilities to stage log metadata modifications and timeline events/revisions during parsing. This pattern decouples the parsing logic from the underlying serialization details (such as string interning, ID resolution, and lock management) and significantly improves the testability of parsers.

# Key Changes
* ChangeSet Utilities (changeset.go): Added LogChangeSet to accumulate metadata updates for a log, and TimelineChangeSet to stage events and revisions for multiple timeline paths. Both structures provide a Flush method to apply accumulated changes safely.
* Test Asserters (changeset_asserter.go): Added TimelineChangeSetAsserter and LogChangeSetAsserter to allow highly readable, chainable assertions on accumulated ChangeSet data in parser tests.
* Log ID Resolution (log_accumulator.go): Updated LogAccumulator to maintain a mapping between parser-side log IDs and serialized log IDs, enabling dynamic ID resolution during timeline item construction.
* Encapsulated Timeline Building (timeline_builder.go, timeline_registry.go): Modified TimelineBuilder methods to accept parser-side domain models (log.Log and StagingRevision) rather than raw protobuf messages, encapsulating string interning and ID resolution logic within the builder.

# Mock code

```golang
// ParseLog parses the given log and returns the sets of mutations for the log metadata and timeline items.
// This is the extension side parser. By just returning changeset types, we can easily use asserters to verify them.
func ParseLog(l *log.Log) (*khifilev6.LogChangeSet, *khifilev6.TimelineChangeSet, error) {
	logCS, err := khifilev6.NewLogChangeSet(l)
	if err != nil {
		return nil, nil, err
	}
	logCS.SetSummary("Parsed summary content")
	timelineCS := khifilev6.NewTimelineChangeSet(l)
	targetPath := khifilev6.NewTimelinePath("target-resource")
	// Accumulate an event to the changeset
	timelineCS.AddEvent(targetPath)
	return logCS, timelineCS, nil
}
// ProcessLog is an example of the caller side (e.g., a pipeline runner) flushing the changes. This should be wrapped by base task type side.
func ProcessLog(l *log.Log, logAcc *khifilev6.LogAccumulator, timelineReg *khifilev6.TimelineRegistry) error {
	logCS, timelineCS, err := ParseLog(l)
	if err != nil {
		return err
	}
	// Flush accumulated changes safely to the actual storage
	if err := logCS.Flush(logAcc); err != nil {
		return err
	}
	if err := timelineCS.Flush(timelineReg); err != nil {
		return err
	}
	return nil
}

---
package myparser_test
import (
	"testing"
	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
	"github.com/myproject/myparser" // replace with actual package path
	"google.golang.org/protobuf/proto"
)
func TestParseLog(t *testing.T) {
	// Initialize common pools required for resolving paths
	idGen := khifilev6.NewIDGenerator()
	internPool := khifilev6.NewInternPool(idGen)
	pathPool := khifilev6.NewTimelinePathPool(idGen, internPool)
	// Pre-resolve expected path using the same pool definition
	expectedSegment := khifilev6.PathSegment{
		Name: "target-resource",
		Type: &pb.TimelineType{Id: proto.Uint32(1)},
	}
	expectedPath := pathPool.Get(nil, expectedSegment)
	testCases := []struct {
		name        string
		inputLog    *log.Log
		wantSummary string
		wantEventOn *khifilev6.TimelinePath
	}{
		{
			name:        "successfully parses log and returns changesets",
			inputLog:    &log.Log{ID: "test-log-id"},
			wantSummary: "Parsed summary content",
			wantEventOn: expectedPath,
		},
	}
	for _, tc := range testCases {
		t.Run(tc.name, func(t *testing.T) {
			// Pass pathPool to the parser
			logCS, timelineCS, err := myparser.ParseLog(tc.inputLog, pathPool)
			if err != nil {
				t.Fatalf("ParseLog() returned unexpected error: %v", err)
			}
			// Verify LogChangeSet fluently
			testchangeset.AssertLog(t, logCS).
				HasSummary(tc.wantSummary)
			// Verify TimelineChangeSet fluently
			if tc.wantEventOn != nil {
				testchangeset.AssertTimeline(t, timelineCS).
					HasEvent(tc.wantEventOn)
			}
		})
	}
}