### PR TITLE
fix: confirm refresh when backend disconnects

### DIFF
--- a/web/src/app/root.component.spec.ts
+++ b/web/src/app/root.component.spec.ts
@@ -72,20 +72,21 @@ describe('RootComponent', () => {
     expect(event.returnValue).toBe('');
   });
 
-  it('should remove confirmation before unload when backend reconnects', () => {
+  it('should skip confirmation before unload when backend is connected', () => {
     const fixture = TestBed.createComponent(RootComponent);
-    fixture.detectChanges();
-    connectionStatus.set(BackendConnectionStatus.Disconnected);
     fixture.detectChanges();
     const handler = getBeforeUnloadHandler(addEventListenerSpy);
 
     connectionStatus.set(BackendConnectionStatus.Connected);
     fixture.detectChanges();
+    const event = {
+      preventDefault: jasmine.createSpy('preventDefault'),
+      returnValue: 'initial',
+    } as unknown as BeforeUnloadEvent;
+    handler(event);
 
-    expect(removeEventListenerSpy).toHaveBeenCalledWith(
-      'beforeunload',
-      handler,
-    );
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.returnValue).toBe('initial');
   });
 
   it('should remove confirmation before unload when destroyed', () => {

--- a/web/src/app/root.component.spec.ts
+++ b/web/src/app/root.component.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { signal, WritableSignal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { BACKEND_SYNC } from './services/api/backend-sync.service';
+import {
+  BackendConnectionStatus,
+  BackendSyncService,
+} from './services/api/backend-sync-interface';
+import { RootComponent } from './root.component';
+
+describe('RootComponent', () => {
+  let connectionStatus: WritableSignal<BackendConnectionStatus>;
+  let addEventListenerSpy: jasmine.Spy<typeof window.addEventListener>;
+  let removeEventListenerSpy: jasmine.Spy<typeof window.removeEventListener>;
+
+  beforeEach(async () => {
+    connectionStatus = signal(BackendConnectionStatus.Connecting);
+    addEventListenerSpy = spyOn(window, 'addEventListener');
+    removeEventListenerSpy = spyOn(window, 'removeEventListener');
+
+    await TestBed.configureTestingModule({
+      imports: [RootComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: BACKEND_SYNC,
+          useValue: {
+            connectionStatus: connectionStatus.asReadonly(),
+          } as unknown as BackendSyncService,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('should create the app root', () => {
+    const fixture = TestBed.createComponent(RootComponent);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should request confirmation before unload when backend is disconnected', () => {
+    const fixture = TestBed.createComponent(RootComponent);
+    fixture.detectChanges();
+
+    connectionStatus.set(BackendConnectionStatus.Disconnected);
+    fixture.detectChanges();
+
+    const handler = getBeforeUnloadHandler(addEventListenerSpy);
+    const event = {
+      preventDefault: jasmine.createSpy('preventDefault'),
+      returnValue: 'initial',
+    } as unknown as BeforeUnloadEvent;
+    handler(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toBe('');
+  });
+
+  it('should remove confirmation before unload when backend reconnects', () => {
+    const fixture = TestBed.createComponent(RootComponent);
+    fixture.detectChanges();
+    connectionStatus.set(BackendConnectionStatus.Disconnected);
+    fixture.detectChanges();
+    const handler = getBeforeUnloadHandler(addEventListenerSpy);
+
+    connectionStatus.set(BackendConnectionStatus.Connected);
+    fixture.detectChanges();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      handler,
+    );
+  });
+
+  it('should remove confirmation before unload when destroyed', () => {
+    const fixture = TestBed.createComponent(RootComponent);
+    fixture.detectChanges();
+    connectionStatus.set(BackendConnectionStatus.Disconnected);
+    fixture.detectChanges();
+    const handler = getBeforeUnloadHandler(addEventListenerSpy);
+
+    fixture.destroy();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      handler,
+    );
+  });
+});
+
+function getBeforeUnloadHandler(
+  addEventListenerSpy: jasmine.Spy<typeof window.addEventListener>,
+): (event: BeforeUnloadEvent) => void {
+  const call = addEventListenerSpy.calls
+    .all()
+    .find((call) => call.args[0] === 'beforeunload');
+  expect(call).toBeDefined();
+  return call!.args[1] as (event: BeforeUnloadEvent) => void;
+}

--- a/web/src/app/root.component.spec.ts
+++ b/web/src/app/root.component.spec.ts
@@ -17,12 +17,12 @@
 import { signal, WritableSignal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { BACKEND_SYNC } from './services/api/backend-sync.service';
+import { BACKEND_SYNC } from 'src/app/services/api/backend-sync.service';
 import {
   BackendConnectionStatus,
   BackendSyncService,
-} from './services/api/backend-sync-interface';
-import { RootComponent } from './root.component';
+} from 'src/app/services/api/backend-sync-interface';
+import { RootComponent } from 'src/app/root.component';
 
 describe('RootComponent', () => {
   let connectionStatus: WritableSignal<BackendConnectionStatus>;

--- a/web/src/app/root.component.ts
+++ b/web/src/app/root.component.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, effect, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { BACKEND_SYNC } from './services/api/backend-sync.service';
+import { BackendConnectionStatus } from './services/api/backend-sync-interface';
 
 @Component({
   selector: 'khi-root',
@@ -22,4 +24,27 @@ import { RouterOutlet } from '@angular/router';
   styleUrls: ['./root.component.scss'],
   imports: [RouterOutlet],
 })
-export class RootComponent {}
+export class RootComponent {
+  private readonly backendSync = inject(BACKEND_SYNC);
+
+  private readonly beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+    event.preventDefault();
+    event.returnValue = '';
+  };
+
+  constructor() {
+    effect((onCleanup) => {
+      if (
+        this.backendSync.connectionStatus() !==
+        BackendConnectionStatus.Disconnected
+      ) {
+        return;
+      }
+
+      window.addEventListener('beforeunload', this.beforeUnloadHandler);
+      onCleanup(() => {
+        window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+      });
+    });
+  }
+}

--- a/web/src/app/root.component.ts
+++ b/web/src/app/root.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, effect, inject } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { BACKEND_SYNC } from 'src/app/services/api/backend-sync.service';
 import { BackendConnectionStatus } from 'src/app/services/api/backend-sync-interface';
@@ -24,27 +24,26 @@ import { BackendConnectionStatus } from 'src/app/services/api/backend-sync-inter
   styleUrls: ['./root.component.scss'],
   imports: [RouterOutlet],
 })
-export class RootComponent {
+export class RootComponent implements OnDestroy {
   private readonly backendSync = inject(BACKEND_SYNC);
 
   private readonly beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+    if (
+      this.backendSync.connectionStatus() !==
+      BackendConnectionStatus.Disconnected
+    ) {
+      return;
+    }
+
     event.preventDefault();
     event.returnValue = '';
   };
 
   constructor() {
-    effect((onCleanup) => {
-      if (
-        this.backendSync.connectionStatus() !==
-        BackendConnectionStatus.Disconnected
-      ) {
-        return;
-      }
+    window.addEventListener('beforeunload', this.beforeUnloadHandler);
+  }
 
-      window.addEventListener('beforeunload', this.beforeUnloadHandler);
-      onCleanup(() => {
-        window.removeEventListener('beforeunload', this.beforeUnloadHandler);
-      });
-    });
+  ngOnDestroy() {
+    window.removeEventListener('beforeunload', this.beforeUnloadHandler);
   }
 }

--- a/web/src/app/root.component.ts
+++ b/web/src/app/root.component.ts
@@ -15,8 +15,8 @@
  */
 import { Component, effect, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { BACKEND_SYNC } from './services/api/backend-sync.service';
-import { BackendConnectionStatus } from './services/api/backend-sync-interface';
+import { BACKEND_SYNC } from 'src/app/services/api/backend-sync.service';
+import { BackendConnectionStatus } from 'src/app/services/api/backend-sync-interface';
 
 @Component({
   selector: 'khi-root',


### PR DESCRIPTION
## Summary
- Listen to the existing backend connection status in the root component.
- Register the browser native `beforeunload` confirmation only while the backend is disconnected.
- Remove the handler when the backend reconnects or the root component is destroyed.

Fixes #179

## Tests
- `npx ng run frontend:test --browsers=ChromeHeadlessNoSandbox --watch=false --include=src/app/root.component.spec.ts`
- `npm run lint`
- `npx ng run frontend:build:dev`
- `git diff --check`