### PR TITLE
Replace the serializer task to use the new file format serializer

### DIFF
--- a/pkg/core/inspection/runner.go
+++ b/pkg/core/inspection/runner.go
@@ -34,6 +34,7 @@ import (
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/lifecycle"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/parameters"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
@@ -105,8 +106,12 @@ func (i *InspectionTaskRunner) addDefaultRunContextOptions() {
 		RunContextOptionFromValue(inspectioncore_contract.InspectionSharedMap, i.inspectionSharedMap),
 		RunContextOptionFromValue(inspectioncore_contract.GlobalSharedMap, inspectionRunnerGlobalSharedMap),
 		RunContextOptionFromValue(inspectioncore_contract.CurrentIOConfig, i.ioconfig),
+		// TODO: remove history builder injection. After KHI file format migration is done.
 		RunContextOptionFromFunc(inspectioncore_contract.CurrentHistoryBuilder, func(ctx context.Context, mode inspectioncore_contract.InspectionTaskModeType) (*history.Builder, error) {
 			return history.NewBuilder(i.ioconfig.TemporaryFolder), nil
+		}),
+		RunContextOptionFromFunc(inspectioncore_contract.Builder, func(ctx context.Context, mode inspectioncore_contract.InspectionTaskModeType) (*khifilev6.Builder, error) {
+			return khifilev6.NewBuilder(), nil
 		}),
 	}
 

--- a/pkg/core/inspection/test/testutil.go
+++ b/pkg/core/inspection/test/testutil.go
@@ -58,7 +58,7 @@ func WithDefaultTestInspectionTaskContext(baseContext context.Context) context.C
 		panic("Failed to create test IOConfig: " + err.Error())
 	}
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.CurrentIOConfig, ioConfig)
-	// TODO: remove history builder injection. After KHI file format migration is done.
+	// TODO(#425): remove history builder injection. After KHI file format migration is done.
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.CurrentHistoryBuilder, history.NewBuilder(ioConfig.TemporaryFolder))
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.Builder, khifilev6.NewBuilder())
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.InspectionRunMetadata, generateTestMetadata())

--- a/pkg/core/inspection/test/testutil.go
+++ b/pkg/core/inspection/test/testutil.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
@@ -57,7 +58,9 @@ func WithDefaultTestInspectionTaskContext(baseContext context.Context) context.C
 		panic("Failed to create test IOConfig: " + err.Error())
 	}
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.CurrentIOConfig, ioConfig)
+	// TODO: remove history builder injection. After KHI file format migration is done.
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.CurrentHistoryBuilder, history.NewBuilder(ioConfig.TemporaryFolder))
+	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.Builder, khifilev6.NewBuilder())
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.InspectionRunMetadata, generateTestMetadata())
 	return taskCtx
 }

--- a/pkg/model/khifile/v6/builder.go
+++ b/pkg/model/khifile/v6/builder.go
@@ -24,6 +24,12 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
 )
 
+// BuilderProgressReporter is an interface to report progress during KHI file generation.
+type BuilderProgressReporter interface {
+	// ReportProgress reports the current progress with a percentage (0.0 to 1.0) and status message.
+	ReportProgress(progress float32, status string)
+}
+
 // Builder orchestrates the accumulators, pools, and final file generation for KHI v6 format.
 type Builder struct {
 	idGenerator         *IDGenerator
@@ -48,18 +54,27 @@ func NewBuilder() *Builder {
 }
 
 // Build writes the accumulated data to the provided io.Writer in KHI v6 format.
-func (b *Builder) Build(w io.Writer) error {
+func (b *Builder) Build(w io.Writer, reporter BuilderProgressReporter) error {
+	report := func(progress float32, status string) {
+		if reporter != nil {
+			reporter.ReportProgress(progress, status)
+		}
+	}
+
+	report(0.0, "Initializing KHI writer")
 	writer, err := NewWriter(w)
 	if err != nil {
 		return fmt.Errorf("failed to create writer: %w", err)
 	}
 
+	report(0.1, "Writing timeline style chunk")
 	// 1. Write TimelineStyleChunk directly (no generator needed since it's a single chunk)
 	styleChunk := style.GenerateChunk()
 	if err := writer.WriteChunk(ChunkTypeTimelineStyle, styleChunk); err != nil {
 		return fmt.Errorf("failed to write timeline style chunk: %w", err)
 	}
 
+	report(0.2, "Writing metadata chunk")
 	// 2. Write MetadataChunk
 	metadataList := b.MetadataAccumulator.Accumulate()
 	if len(metadataList) > 0 {
@@ -70,6 +85,7 @@ func (b *Builder) Build(w io.Writer) error {
 		}
 	}
 
+	report(0.4, "Writing log chunks")
 	// 3. Write LogChunks
 	logs := b.LogAccumulator.Accumulate()
 	if len(logs) > 0 {
@@ -80,6 +96,7 @@ func (b *Builder) Build(w io.Writer) error {
 		}
 	}
 
+	report(0.6, "Writing timeline chunks")
 	// 4. Write TimelineChunks
 	timelines, timelineItems := b.TimelineAccumulator.Accumulate()
 
@@ -99,6 +116,7 @@ func (b *Builder) Build(w io.Writer) error {
 		}
 	}
 
+	report(0.8, "Writing intern pool chunks")
 	// 5. Write InternPoolChunk (Strings and FieldPathSets)
 	stringSeq := mapSeq(b.internPool.SortedStringRefs(), func(ref *InternStringRef) *pb.InternString {
 		return ref.ToProto()
@@ -116,6 +134,7 @@ func (b *Builder) Build(w io.Writer) error {
 		return fmt.Errorf("failed to write intern field path set chunks: %w", err)
 	}
 
+	report(1.0, "Done")
 	return nil
 }
 

--- a/pkg/model/khifile/v6/builder_test.go
+++ b/pkg/model/khifile/v6/builder_test.go
@@ -240,7 +240,7 @@ func TestBuilder_Build(t *testing.T) {
 			tc.setup(b)
 
 			var buf bytes.Buffer
-			if err := b.Build(&buf); err != nil {
+			if err := b.Build(&buf, nil); err != nil {
 				t.Fatalf("Build() failed: %v.", err)
 			}
 

--- a/pkg/task/inspection/inspectioncore/contract/contextkey.go
+++ b/pkg/task/inspection/inspectioncore/contract/contextkey.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 )
 
 // InspectionTaskMode is the context key to access the execution mode of the inspection task.
@@ -62,6 +63,9 @@ var CurrentIOConfig = typedmap.NewTypedKey[*IOConfig]("khi.google.com/inspection
 // CurrentHistoryBuilder is the context key to access the history builder instance
 // used for constructing timeline data during inspection execution.
 var CurrentHistoryBuilder = typedmap.NewTypedKey[*history.Builder]("khi.google.com/inspection/current-history-builder")
+
+// Builder is the context key to access the KHI file builder instance.
+var Builder = typedmap.NewTypedKey[*khifilev6.Builder]("khi.google.com/inspection/builder")
 
 // TaskRunner is the context key to access the task runner instance
 // used for executing tasks during inspection execution.

--- a/pkg/task/inspection/inspectioncore/impl/serializer.go
+++ b/pkg/task/inspection/inspectioncore/impl/serializer.go
@@ -16,10 +16,10 @@ package inspectioncore_impl
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/filter"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
@@ -28,6 +28,16 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
+type taskProgressReporter struct {
+	progress *inspectionmetadata.TaskProgressMetadata
+}
+
+func (t *taskProgressReporter) ReportProgress(percentage float32, status string) {
+	t.progress.Update(percentage, status)
+}
+
+// SerializeTask is a subsequent task that must be included in the task graph after tasks like TimelineMapper and LogIngester.
+// It retrieves the Builder instance populated by its preceding tasks and serializes its accumulated contents into the final KHI file.
 var SerializeTask = inspectiontaskbase.NewProgressReportableInspectionTask(inspectioncore_contract.SerializerTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (*inspectioncore_contract.FileSystemStore, error) {
 	if taskMode == inspectioncore_contract.TaskModeDryRun {
 		slog.DebugContext(ctx, "Skipping because this is in dryrun mode")
@@ -36,22 +46,42 @@ var SerializeTask = inspectiontaskbase.NewProgressReportableInspectionTask(inspe
 	inspectionID := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionTaskInspectionID)
 	metadataSet := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
 	ioConfig := khictx.MustGetValue(ctx, inspectioncore_contract.CurrentIOConfig)
-	builder := khictx.MustGetValue(ctx, inspectioncore_contract.CurrentHistoryBuilder)
-	store := inspectioncore_contract.NewFileSystemInspectionResultRepository(filepath.Join(ioConfig.DataDestination, inspectionID+".khi"))
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
 
+	// 1. Collect metadata to the v6 builder
+	for _, key := range metadataSet.Keys() {
+		metadata, found := typedmap.Get(metadataSet, inspectionmetadata.NewMetadataLabelsKey[inspectionmetadata.Metadata](key))
+		if !found {
+			return nil, fmt.Errorf("expected metadata not found: %s", key)
+		}
+		if err := builder.MetadataAccumulator.AddMetadata(metadata); err != nil {
+			return nil, err
+		}
+	}
+
+	// 2. Prepare Output File Store
+	store := inspectioncore_contract.NewFileSystemInspectionResultRepository(filepath.Join(ioConfig.DataDestination, inspectionID+".khi"))
 	writer, err := store.GetWriter()
 	if err != nil {
 		return nil, err
 	}
-	defer writer.Close()
-	resultMetadata, err := inspectionmetadata.GetSerializableSubsetMapFromMetadataSet(metadataSet, filter.NewEqualFilter(inspectionmetadata.LabelKeyIncludedInResultBinaryFlag, true, false))
+
+	// 3. Build KHI v6 format and write
+	if err := builder.Build(writer, &taskProgressReporter{progress: progress}); err != nil {
+		writer.Close()
+		return nil, err
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	// 4. Update final file size in metadata
+	fileSize, err := store.GetInspectionResultSizeInBytes()
 	if err != nil {
 		return nil, err
 	}
-	fileSize, err := builder.Finalize(ctx, resultMetadata, writer, progress)
-	if err != nil {
-		return nil, err
-	}
+
 	header, found := typedmap.Get(metadataSet, inspectionmetadata.HeaderMetadataKey)
 	if found {
 		header.FileSize = fileSize

--- a/pkg/task/inspection/inspectioncore/impl/serializer_test.go
+++ b/pkg/task/inspection/inspectioncore/impl/serializer_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectioncore_impl
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestSerializeTask verifies that SerializeTask successfully converts accumulated
+// builder contents into the v6 protobuf chunk format.
+func TestSerializeTask(t *testing.T) {
+	testCases := []struct {
+		name     string
+		setup    func(ctx context.Context, b *khifilev6.Builder)
+		verify   func(t *testing.T, store *inspectioncore_contract.FileSystemStore)
+		wantErr  bool
+		taskMode inspectioncore_contract.InspectionTaskModeType
+	}{
+		{
+			name: "successfully serializes v6 format containing metadata chunks",
+			setup: func(ctx context.Context, b *khifilev6.Builder) {
+				// Add a dummy header metadata.
+				_ = b.MetadataAccumulator.AddMetadata(&inspectionmetadata.HeaderMetadata{
+					InspectionType: "test-type",
+					InspectionName: "test-name",
+				})
+			},
+			verify: func(t *testing.T, store *inspectioncore_contract.FileSystemStore) {
+				if store == nil {
+					t.Fatal("Store should not be nil.")
+				}
+
+				reader, err := store.GetReader()
+				if err != nil {
+					t.Fatalf("Failed to get reader: %v.", err)
+				}
+				defer reader.Close()
+
+				khiReader, err := khifilev6.NewReader(reader)
+				if err != nil {
+					t.Fatalf("Failed to initialize KHI reader: %v.", err)
+				}
+
+				foundMetadata := false
+				foundTestHeader := false
+
+				for {
+					chunk, err := khiReader.NextChunk()
+					if errors.Is(err, io.EOF) {
+						break
+					}
+					if err != nil {
+						t.Fatalf("Failed to read next chunk: %v.", err)
+					}
+
+					if chunk.Type == khifilev6.ChunkTypeMetadata {
+						foundMetadata = true
+						var metadataChunk pb.MetadataChunk
+						if err := proto.Unmarshal(chunk.Data, &metadataChunk); err != nil {
+							t.Fatalf("Failed to unmarshal metadata chunk: %v.", err)
+						}
+						for _, item := range metadataChunk.Metadata {
+							if header := item.GetHeader(); header != nil {
+								if header.GetInspectionType() == "test-type" && header.GetInspectionName() == "test-name" {
+									foundTestHeader = true
+									break
+								}
+							}
+						}
+					}
+				}
+
+				if !foundMetadata {
+					t.Error("Expected MetadataChunk, but it was not found in the output file.")
+				}
+				if !foundTestHeader {
+					t.Error("Could not find the expected header metadata with type 'test-type' and name 'test-name' inside the MetadataChunk.")
+				}
+			},
+			wantErr:  false,
+			taskMode: inspectioncore_contract.TaskModeRun,
+		},
+		{
+			name: "skips serialization and returns nil store in DryRun mode",
+			setup: func(ctx context.Context, b *khifilev6.Builder) {
+				_ = b.MetadataAccumulator.AddMetadata(&inspectionmetadata.HeaderMetadata{
+					InspectionType: "test-type",
+					InspectionName: "test-name",
+				})
+			},
+			verify: func(t *testing.T, store *inspectioncore_contract.FileSystemStore) {
+				if store != nil {
+					t.Errorf("Expected nil store in DryRun mode, got %v.", store)
+				}
+			},
+			wantErr:  false,
+			taskMode: inspectioncore_contract.TaskModeDryRun,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			taskCtx := inspectiontest.WithDefaultTestInspectionTaskContext(ctx)
+
+			// Obtain the builder from task context.
+			builder := khictx.MustGetValue(taskCtx, inspectioncore_contract.Builder)
+
+			if tc.setup != nil {
+				tc.setup(taskCtx, builder)
+			}
+
+			mode := tc.taskMode
+			store, _, err := inspectiontest.RunInspectionTask(taskCtx, SerializeTask, mode, nil)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("SerializeTask error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if !tc.wantErr {
+				tc.verify(t, store)
+				// Cleanup the generated file.
+				if store != nil {
+					reader, err := store.GetReader()
+					if err == nil {
+						if file, ok := reader.(*os.File); ok {
+							path := file.Name()
+							_ = file.Close()
+							_ = os.Remove(path)
+						} else {
+							_ = reader.Close()
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is the first change to replace all the builder related codes used in parser tasks into the code using new format builder.

Because the current builder haven't implemented the progress reporting feature, added simple mechanism to report progresses. 