### PR TITLE
enforce @typescript-eslint/array-type ESlint rule

### DIFF
--- a/scripts/make/lint.mk
+++ b/scripts/make/lint.mk
@@ -42,7 +42,7 @@ format-go: ## Format backend source code
 
 .PHONY: format-web
 format-web: $(GENERATE_FRONTEND_DUMMY) ## Format frontend source code
-	cd web && npx prettier --ignore-path .gitignore --write "./**/*.+(ts|json|html|scss)"
+	cd web && npx prettier --ignore-path .gitignore --write "./**/*.+(ts|json|html|scss|mjs)"
 	cd web && npx stylelint "src/**/*.scss" --fix
 
 .PHONY: check-format-go
@@ -51,7 +51,7 @@ check-format-go: ## Check backend source code format
 
 .PHONY: check-format-web
 check-format-web: $(GENERATE_FRONTEND_DUMMY) ## Check frontend source code format
-	cd web && npx prettier --ignore-path .gitignore --check "./**/*.+(ts|json|html|scss)"
+	cd web && npx prettier --ignore-path .gitignore --check "./**/*.+(ts|json|html|scss|mjs)"
 
 .PHONY: lint-md
 lint-md: ## Run markdown linter

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -64,6 +64,7 @@ export default defineConfig([globalIgnores(["src/app/generated/**/*"]), {
 
         "@typescript-eslint/no-unused-vars": "error",
         "@typescript-eslint/no-explicit-any": "error",
+        "@typescript-eslint/array-type": ["error", { default: "array" }],
     },
 }, {
     files: ["**/*.html"],

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -23,51 +23,62 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
 });
 
-export default defineConfig([globalIgnores(["src/app/generated/**/*"]), {
+export default defineConfig([
+  globalIgnores(["src/app/generated/**/*"]),
+  {
     extends: compat.extends("plugin:storybook/recommended"),
-}, {
+  },
+  {
     files: ["**/*.ts"],
 
     extends: compat.extends(
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@angular-eslint/recommended",
-        "plugin:@angular-eslint/template/process-inline-templates",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:@angular-eslint/recommended",
+      "plugin:@angular-eslint/template/process-inline-templates",
     ),
 
     languageOptions: {
-        ecmaVersion: 5,
-        sourceType: "script",
+      ecmaVersion: 5,
+      sourceType: "script",
 
-        parserOptions: {
-            project: ["tsconfig.json"],
-            createDefaultProgram: true,
-        },
+      parserOptions: {
+        project: ["tsconfig.json"],
+        createDefaultProgram: true,
+      },
     },
 
     rules: {
-        "@angular-eslint/directive-selector": ["error", {
-            type: "attribute",
-            prefix: ["graph", "khi"],
-            style: "camelCase",
-        }],
+      "@angular-eslint/directive-selector": [
+        "error",
+        {
+          type: "attribute",
+          prefix: ["graph", "khi"],
+          style: "camelCase",
+        },
+      ],
 
-        "@angular-eslint/component-selector": ["error", {
-            type: "element",
-            prefix: ["graph", "khi"],
-            style: "kebab-case",
-        }],
+      "@angular-eslint/component-selector": [
+        "error",
+        {
+          type: "element",
+          prefix: ["graph", "khi"],
+          style: "kebab-case",
+        },
+      ],
 
-        "@typescript-eslint/no-unused-vars": "error",
-        "@typescript-eslint/no-explicit-any": "error",
-        "@typescript-eslint/array-type": ["error", { default: "array" }],
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/array-type": ["error", { default: "array" }],
     },
-}, {
+  },
+  {
     files: ["**/*.html"],
     extends: compat.extends("plugin:@angular-eslint/template/recommended"),
     rules: {},
-}]);
+  },
+]);

--- a/web/proxy.conf.mjs
+++ b/web/proxy.conf.mjs
@@ -16,16 +16,16 @@
 
 /**
  * Angular Proxy Configuration
- * 
+ *
  * This file defines the proxy configuration for the Angular development server.
  * During development, requests to the /api/ path are forwarded to localhost:8080.
  */
 
 export default {
-  '/api': {
-    target: 'http://localhost:8080',
+  "/api": {
+    target: "http://localhost:8080",
     secure: false,
     changeOrigin: true,
-    logLevel: 'debug'
-  }
+    logLevel: "debug",
+  },
 };

--- a/web/src/app/store/domain/types.ts
+++ b/web/src/app/store/domain/types.ts
@@ -20,8 +20,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export type ReadonlyDomainElement<T> = T extends Function
   ? T
-  : T extends ReadonlyArray<infer U>
-    ? ReadonlyArray<ReadonlyDomainElement<U>>
+  : T extends readonly (infer U)[]
+    ? readonly ReadonlyDomainElement<U>[]
     : T extends object
       ? { readonly [K in keyof T]: ReadonlyDomainElement<T[K]> }
       : T;


### PR DESCRIPTION
As I discussed in the PR review comment below, we would be better to enable the `@typescript-eslint/array-type` ESlint rule to have more consistent code.
https://github.com/GoogleCloudPlatform/khi/pull/686#discussion_r3295784541

In addition to this, I enabled prettier for these configuration files because it was unintentionally ignored.