### PR TITLE
Make storybook works with BigInt

### DIFF
--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -30,4 +30,10 @@ const preview: Preview = {
   },
 };
 
+// Workaround to use BigInt in Storybook.
+// Ref: https://github.com/storybookjs/storybook/issues/22452#issuecomment-1538474857
+(window.BigInt.prototype as any).toJSON = function () {
+  return this.toString();
+};
+
 export default preview;


### PR DESCRIPTION
KHI uses bigint in its domain layer but it can't work with Storybook simply. This PR adds a hack for the script only loaded on Storybook to serialize bigint forcibly.