### PR TITLE
Added timeline mapper base task type

### DIFF
--- a/pkg/core/inspection/taskbase/mapper_task_v2.go
+++ b/pkg/core/inspection/taskbase/mapper_task_v2.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectiontaskbase
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/progressutil"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// LogToTimelineMapperV2 defines the interface for mapping logs to timeline elements (events or revisions) in KHI file v6 format.
+type LogToTimelineMapperV2[T any] interface {
+	// LogIngesterTask is one of prerequisite task of LogToTimelineMapperV2 ingesting logs before processing with this mapper.
+	LogIngesterTask() taskid.TaskReference[[]*log.Log]
+	// Dependencies are the additional references used in timeline mapper.
+	Dependencies() []taskid.UntypedTaskReference
+	// GroupedLogTask returns a reference to the task that provides the grouped logs.
+	GroupedLogTask() taskid.TaskReference[LogGroupMap]
+	// PassCount returns the number of pre-processing passes to perform on each group.
+	PassCount() int
+	// PreProcessLogByGroup is called during a pre-processing pass for each log in a group.
+	// The passIndex is 0-indexed and ranges from 0 to PassCount()-1.
+	PreProcessLogByGroup(ctx context.Context, passIndex int, l *log.Log, prevGroupData T) (T, error)
+	// ProcessLogByGroup is called for each log entry to stage mutations via TimelineChangeSet.
+	// The prevGroupData is the returned value from the last processed log in the same group.
+	ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData T) (*khifilev6.TimelineChangeSet, T, error)
+}
+
+// SinglePassMapperBase provides a base implementation of LogToTimelineMapperV2
+// for mappers that only require a single pass over the logs.
+type SinglePassMapperBase[T any] struct{}
+
+// PassCount returns 0 as no pre-processing pass is required.
+func (SinglePassMapperBase[T]) PassCount() int {
+	return 0
+}
+
+// PreProcessLogByGroup is a no-op pre-processor that returns the state as-is.
+func (SinglePassMapperBase[T]) PreProcessLogByGroup(ctx context.Context, passIndex int, l *log.Log, prevGroupData T) (T, error) {
+	return prevGroupData, nil
+}
+
+// StatelessMapperBase provides a base implementation of LogToTimelineMapperV2
+// for mappers that are both stateless and only require a single pass.
+type StatelessMapperBase struct{}
+
+// PassCount returns 0 as no pre-processing pass is required.
+func (StatelessMapperBase) PassCount() int {
+	return 0
+}
+
+// PreProcessLogByGroup is a no-op pre-processor that returns an empty struct.
+func (StatelessMapperBase) PreProcessLogByGroup(ctx context.Context, passIndex int, l *log.Log, prevGroupData struct{}) (struct{}, error) {
+	return struct{}{}, nil
+}
+
+// NewLogToTimelineMapperTaskV2 creates a task that modifies the KHI v6 TimelineRegistry based on grouped logs.
+// It processes logs in parallel and applies the logic from the provided LogToTimelineMapperV2.
+func NewLogToTimelineMapperTaskV2[T any](tid taskid.TaskImplementationID[struct{}], mapper LogToTimelineMapperV2[T], labels ...coretask.LabelOpt) coretask.Task[struct{}] {
+	groupedLogTaskID := mapper.GroupedLogTask()
+	dependencies := append([]taskid.UntypedTaskReference{mapper.LogIngesterTask(), mapper.GroupedLogTask()}, mapper.Dependencies()...)
+	return NewProgressReportableInspectionTask(tid, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, tp *inspectionmetadata.TaskProgressMetadata) (struct{}, error) {
+		if taskMode == inspectioncore_contract.TaskModeDryRun {
+			slog.DebugContext(ctx, "Skipping task because this is dry run mode")
+			return struct{}{}, nil
+		}
+
+		builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+		groupedLogs := coretask.GetTaskResult(ctx, groupedLogTaskID)
+
+		totalLogCount := 0
+		var processedLogCount atomic.Uint32
+		var skippedLogCount atomic.Uint32
+		for _, group := range groupedLogs {
+			totalLogCount += len(group.Logs)
+		}
+
+		passCount := mapper.PassCount()
+		totalSteps := totalLogCount * (passCount + 1)
+
+		updator := progressutil.NewProgressUpdator(tp, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
+			current := processedLogCount.Load()
+			if totalSteps > 0 {
+				tp.Percentage = float32(current) / float32(totalSteps)
+			}
+			tp.Message = fmt.Sprintf("%d/%d", current, totalSteps)
+		})
+		updator.Start(ctx)
+
+		processedLogCount.Store(0)
+
+		var sharedErr error
+		var errMu sync.Mutex
+
+		setErr := func(err error) {
+			errMu.Lock()
+			defer errMu.Unlock()
+			if sharedErr == nil {
+				sharedErr = err
+			}
+		}
+
+		hasErr := func() bool {
+			if ctx.Err() != nil {
+				return true
+			}
+			errMu.Lock()
+			defer errMu.Unlock()
+			return sharedErr != nil
+		}
+
+		pool := worker.NewPool(runtime.GOMAXPROCS(0))
+		for _, group := range groupedLogs {
+			if ctx.Err() != nil {
+				break
+			}
+			pool.Run(func() {
+				if hasErr() {
+					return
+				}
+				var groupData T
+
+				// 1. Pre-processing passes
+				passCount := mapper.PassCount()
+				for passIdx := 0; passIdx < passCount; passIdx++ {
+					for _, l := range group.Logs {
+						if hasErr() {
+							return
+						}
+						nextGroupData, err := mapper.PreProcessLogByGroup(ctx, passIdx, l, groupData)
+						processedLogCount.Add(1)
+						if err != nil {
+							logTaskError(ctx, fmt.Sprintf("pre-processor ended with an error at passIndex %d", passIdx), err, l)
+							setErr(err)
+							return
+						}
+						groupData = nextGroupData
+					}
+				}
+
+				// 2. Final processing pass
+				for _, l := range group.Logs {
+					if hasErr() {
+						return
+					}
+					cs, nextGroupData, err := mapper.ProcessLogByGroup(ctx, l, groupData)
+					processedLogCount.Add(1)
+					if err != nil {
+						logTaskError(ctx, "parser ended with an error", err, l)
+						setErr(err)
+						return
+					}
+					groupData = nextGroupData
+
+					if cs != nil {
+						err := cs.Flush(builder.TimelineAccumulator)
+						if err != nil {
+							logTaskError(ctx, "failed to flush the changeset to timeline registry", err, l)
+							setErr(err)
+							return
+						}
+					} else {
+						skippedLogCount.Add(1)
+					}
+				}
+			})
+		}
+		pool.Wait()
+		updator.Done()
+
+		if ctx.Err() != nil {
+			return struct{}{}, ctx.Err()
+		}
+		if sharedErr != nil {
+			return struct{}{}, sharedErr
+		}
+
+		slog.DebugContext(ctx, fmt.Sprintf("LogToTimelineMapperTaskV2 %s finished: processed %d logs (skipped %d logs)", tid.String(), totalLogCount, skippedLogCount.Load()))
+
+		tracingActive, _ := khictx.GetValue(ctx, inspectioncore_contract.TracingActive)
+		if tracingActive {
+			trace.SpanFromContext(ctx).SetAttributes(
+				attribute.String("log_count", fmt.Sprintf("%d", totalLogCount)),
+			)
+		}
+
+		return struct{}{}, nil
+	}, append([]coretask.LabelOpt{
+		// Tasks modifying history must be dependent from SerializerTask.
+		coretask.NewSubsequentTaskRefsTaskLabel(inspectioncore_contract.SerializerTaskID.Ref())}, labels...)...)
+}

--- a/pkg/core/inspection/taskbase/mapper_task_v2_test.go
+++ b/pkg/core/inspection/taskbase/mapper_task_v2_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectiontaskbase
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+var mockLogToTimelineMapperV2PrevTaskID = taskid.NewDefaultImplementationID[LogGroupMap]("mock-timeline-mapper-v2-prev")
+var mockLogSerializerV2PrevTaskID = taskid.NewDefaultImplementationID[[]*log.Log]("mock-timeline-mapper-v2-prev-log-serializer")
+
+type mockLogToTimelineMapperV2GroupData struct {
+	ProcessedLogs int
+}
+
+type mockLogToTimelineMapperV2 struct {
+	passCount int
+	path      *khifilev6.TimelinePath
+}
+
+func (m *mockLogToTimelineMapperV2) GroupedLogTask() taskid.TaskReference[LogGroupMap] {
+	return mockLogToTimelineMapperV2PrevTaskID.Ref()
+}
+
+func (m *mockLogToTimelineMapperV2) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return mockLogSerializerV2PrevTaskID.Ref()
+}
+
+func (m *mockLogToTimelineMapperV2) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+func (m *mockLogToTimelineMapperV2) PassCount() int {
+	return m.passCount
+}
+
+func (m *mockLogToTimelineMapperV2) PreProcessLogByGroup(ctx context.Context, passIndex int, l *log.Log, prevGroupData mockLogToTimelineMapperV2GroupData) (mockLogToTimelineMapperV2GroupData, error) {
+	return mockLogToTimelineMapperV2GroupData{
+		ProcessedLogs: prevGroupData.ProcessedLogs + 1,
+	}, nil
+}
+
+func (m *mockLogToTimelineMapperV2) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData mockLogToTimelineMapperV2GroupData) (*khifilev6.TimelineChangeSet, mockLogToTimelineMapperV2GroupData, error) {
+	shouldErr := l.ReadBoolOrDefault("error", false)
+	if shouldErr {
+		return nil, prevGroupData, fmt.Errorf("test error")
+	}
+	shouldSkip := l.ReadBoolOrDefault("skip", false)
+	if shouldSkip {
+		return nil, mockLogToTimelineMapperV2GroupData{
+			ProcessedLogs: prevGroupData.ProcessedLogs + 1,
+		}, nil
+	}
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+	cs.AddEvent(m.path)
+
+	return cs, mockLogToTimelineMapperV2GroupData{
+		ProcessedLogs: prevGroupData.ProcessedLogs + 1,
+	}, nil
+}
+
+var _ LogToTimelineMapperV2[mockLogToTimelineMapperV2GroupData] = (*mockLogToTimelineMapperV2)(nil)
+
+func TestLogToTimelineMapperV2Task(t *testing.T) {
+	type testLog struct {
+		yaml         string
+		shouldIngest bool
+	}
+
+	type testGroup struct {
+		group string
+		logs  []testLog
+	}
+
+	testCases := []struct {
+		desc            string
+		taskMode        inspectioncore_contract.InspectionTaskModeType
+		prevLogGroupMap []testGroup
+		passCount       int
+		cancelContext   bool
+		wantError       bool
+	}{
+		{
+			desc:     "DryRun mode",
+			taskMode: inspectioncore_contract.TaskModeDryRun,
+			prevLogGroupMap: []testGroup{
+				{
+					group: "group1",
+					logs: []testLog{
+						{
+							yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`,
+							shouldIngest: false,
+						},
+					},
+				},
+			},
+			passCount: 1,
+			wantError: false,
+		},
+		{
+			desc:     "Normal execution with some skipped logs and 2 passes",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			prevLogGroupMap: []testGroup{
+				{
+					group: "group1",
+					logs: []testLog{
+						{
+							yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`,
+							shouldIngest: true,
+						},
+						{
+							yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-2", "skip": true}`,
+							shouldIngest: false,
+						},
+					},
+				},
+			},
+			passCount: 2,
+			wantError: false,
+		},
+		{
+			desc:     "Execution with error in one log",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			prevLogGroupMap: []testGroup{
+				{
+					group: "group1",
+					logs: []testLog{
+						{
+							yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`,
+							shouldIngest: false,
+						},
+						{
+							yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-2", "error": true}`,
+							shouldIngest: false,
+						},
+					},
+				},
+			},
+			passCount: 0,
+			wantError: true,
+		},
+		{
+			desc:     "Execution with context cancelled",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			prevLogGroupMap: []testGroup{
+				{
+					group: "group1",
+					logs: []testLog{
+						{
+							yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`,
+							shouldIngest: false,
+						},
+					},
+				},
+			},
+			passCount:     0,
+			cancelContext: true,
+			wantError:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tid := taskid.NewDefaultImplementationID[struct{}]("mock-timeline-mapper-v2")
+
+			ctx := context.Background()
+			ctx = inspectiontest.WithDefaultTestInspectionTaskContext(ctx)
+
+			builder := khifilev6.NewBuilder()
+			ctx = khictx.WithValue(ctx, inspectioncore_contract.Builder, builder)
+
+			prevGroupMap := make(LogGroupMap)
+			var shouldHaveItems bool
+
+			for _, tg := range tc.prevLogGroupMap {
+				var logs []*log.Log
+				for _, tl := range tg.logs {
+					l := mustNewLogFromYAML(t, tl.yaml)
+					logs = append(logs, l)
+					if tl.shouldIngest {
+						shouldHaveItems = true
+					}
+
+					// Populate log accumulator with log metadata before mapping
+					severityID := uint32(1)
+					logTypeID := uint32(2)
+					_ = builder.LogAccumulator.AddLog(&khifilev6.StagingLog{
+						Log:       l,
+						Summary:   "test",
+						Timestamp: time.Now(),
+						Severity:  &pb.Severity{Id: &severityID},
+						LogType:   &pb.LogType{Id: &logTypeID},
+					})
+				}
+				prevGroupMap[tg.group] = &LogGroup{
+					Group: tg.group,
+					Logs:  logs,
+				}
+			}
+
+			idGen := &khifilev6.IDGenerator{}
+			pool := khifilev6.NewInternPool(idGen)
+			pathPool := khifilev6.NewTimelinePathPool(idGen, pool)
+			timelineTypeID := uint32(3)
+			timelineType := &pb.TimelineType{Id: &timelineTypeID}
+			path := pathPool.Get(nil, khifilev6.PathSegment{Name: "test-path", Type: timelineType})
+
+			mapper := &mockLogToTimelineMapperV2{
+				passCount: tc.passCount,
+				path:      path,
+			}
+			task := NewLogToTimelineMapperTaskV2(tid, mapper)
+
+			if tc.cancelContext {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			_, _, err := inspectiontest.RunInspectionTask(ctx, task, tc.taskMode, map[string]any{}, tasktest.NewTaskDependencyValuePair(mockLogToTimelineMapperV2PrevTaskID.Ref(), prevGroupMap))
+			if (err != nil) != tc.wantError {
+				t.Fatalf("RunInspectionTask() error = %v, wantError %v", err, tc.wantError)
+			}
+
+			if tc.cancelContext {
+				var expectedErr = context.Canceled
+				if err == nil || err.Error() != expectedErr.Error() {
+					t.Errorf("RunInspectionTask() error = %v, want %v", err, expectedErr)
+				}
+			}
+
+			if !tc.wantError {
+				// Verify timeline items inside the accumulator registry
+				timelineBuilder := builder.TimelineAccumulator.GetBuilder(path)
+				hasItems := timelineBuilder.HasItems()
+
+				if shouldHaveItems {
+					if !hasItems {
+						t.Error("expected timeline builder to have items successfully flushed, but had none")
+					}
+				} else {
+					if hasItems {
+						t.Error("expected timeline builder to remain empty, but items were found")
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/core/inspection/taskbase/utils.go
+++ b/pkg/core/inspection/taskbase/utils.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectiontaskbase
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+)
+
+// logTaskError logs an error message using slog.ErrorContext with raw log content.
+func logTaskError(ctx context.Context, message string, err error, l *log.Log) {
+	var yaml string
+	if l != nil {
+		yamlBytes, err2 := l.Serialize("", &structured.YAMLNodeSerializer{})
+		if err2 != nil {
+			yaml = "ERROR!! failed to dump in yaml"
+		} else {
+			yaml = string(yamlBytes)
+		}
+	} else {
+		yaml = "nil log"
+	}
+
+	// TODO(#705): Use slog's attr after improving KHI's logger.
+	slog.ErrorContext(ctx, fmt.Sprintf("%s\nerror: %v\nlogContent:\n%s", message, err, yaml))
+}


### PR DESCRIPTION
This PR implements a new base type using `LogToTimelineMapperV2` interface.
It's a base task utility used for mapping a logs onto timelines.