### PR TITLE
 Added log ingester base task types

### DIFF
--- a/pkg/core/inspection/taskbase/grouped_logingester_task_v2.go
+++ b/pkg/core/inspection/taskbase/grouped_logingester_task_v2.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectiontaskbase
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/progressutil"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// GroupedLogIngesterV2 defines the interface for ingesting log metadata into KHI v6 format using group-sequential processing.
+type GroupedLogIngesterV2[T any] interface {
+	// RawLogTask returns the task reference that provides the raw logs to ingest.
+	RawLogTask() taskid.TaskReference[[]*log.Log]
+	// GroupedLogTask returns a reference to the task that provides the grouped logs.
+	GroupedLogTask() taskid.TaskReference[LogGroupMap]
+	// Dependencies returns additional task dependencies of the ingester.
+	Dependencies() []taskid.UntypedTaskReference
+	// PassCount returns the number of pre-processing passes to perform on each group.
+	PassCount() int
+	// PreProcessLogByGroup is called during a pre-processing pass for each log in a group.
+	// The passIndex is 0-indexed and ranges from 0 to PassCount()-1.
+	PreProcessLogByGroup(ctx context.Context, passIndex int, l *log.Log, prevGroupData T) (T, error)
+	// ProcessLogByGroup is called for each log entry in a group to customize log metadata.
+	// The prevGroupData is the returned value from the last processed log in the same group.
+	ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData T) (*khifilev6.LogChangeSet, T, error)
+}
+
+// SinglePassGroupedIngesterBase provides a base implementation of GroupedLogIngesterV2
+// for ingesters that only require a single pass over the logs.
+type SinglePassGroupedIngesterBase[T any] struct{}
+
+// PassCount returns 0 as no pre-processing pass is required.
+func (SinglePassGroupedIngesterBase[T]) PassCount() int {
+	return 0
+}
+
+// PreProcessLogByGroup is a no-op pre-processor that returns the state as-is.
+func (SinglePassGroupedIngesterBase[T]) PreProcessLogByGroup(ctx context.Context, passIndex int, l *log.Log, prevGroupData T) (T, error) {
+	return prevGroupData, nil
+}
+
+// NewGroupedLogIngesterTaskV2 returns a task that ingests log metadata into the KHI v6 builder using group-sequential processing.
+func NewGroupedLogIngesterTaskV2[T any](taskID taskid.TaskImplementationID[[]*log.Log], ingester GroupedLogIngesterV2[T], labels ...coretask.LabelOpt) coretask.Task[[]*log.Log] {
+	rawLogTaskID := ingester.RawLogTask()
+	groupedLogTaskID := ingester.GroupedLogTask()
+	dependencies := append([]taskid.UntypedTaskReference{rawLogTaskID, groupedLogTaskID}, ingester.Dependencies()...)
+	return NewProgressReportableInspectionTask(taskID, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*log.Log, error) {
+		if taskMode == inspectioncore_contract.TaskModeDryRun {
+			return []*log.Log{}, nil
+		}
+		logs := coretask.GetTaskResult(ctx, rawLogTaskID)
+		groupedLogs := coretask.GetTaskResult(ctx, groupedLogTaskID)
+		builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+
+		totalLogCount := 0
+		var processedLogCount atomic.Uint32
+		var skippedLogCount atomic.Uint32
+		for _, group := range groupedLogs {
+			totalLogCount += len(group.Logs)
+		}
+
+		passCount := ingester.PassCount()
+		totalSteps := totalLogCount * (passCount + 1)
+
+		progressUpdator := progressutil.NewProgressUpdator(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
+			current := processedLogCount.Load()
+			if totalSteps > 0 {
+				tp.Percentage = float32(current) / float32(totalSteps)
+			}
+			tp.Message = fmt.Sprintf("%d/%d", current, totalSteps)
+		})
+		progressUpdator.Start(ctx)
+
+		var sharedErr error
+		var errMu sync.Mutex
+
+		setErr := func(err error) {
+			errMu.Lock()
+			defer errMu.Unlock()
+			if sharedErr == nil {
+				sharedErr = err
+			}
+		}
+
+		hasErr := func() bool {
+			if ctx.Err() != nil {
+				return true
+			}
+			errMu.Lock()
+			defer errMu.Unlock()
+			return sharedErr != nil
+		}
+
+		pool := worker.NewPool(runtime.GOMAXPROCS(0))
+		for _, group := range groupedLogs {
+			if ctx.Err() != nil {
+				break
+			}
+			pool.Run(func() {
+				if hasErr() {
+					return
+				}
+				var groupData T
+
+				// 1. Pre-processing passes
+				passCount := ingester.PassCount()
+				for passIdx := 0; passIdx < passCount; passIdx++ {
+					for _, l := range group.Logs {
+						if hasErr() {
+							return
+						}
+						nextGroupData, err := ingester.PreProcessLogByGroup(ctx, passIdx, l, groupData)
+						processedLogCount.Add(1)
+						if err != nil {
+							logTaskError(ctx, fmt.Sprintf("pre-processor ended with an error at passIndex %d", passIdx), err, l)
+							setErr(err)
+							return
+						}
+						groupData = nextGroupData
+					}
+				}
+
+				// 2. Final processing pass
+				for _, l := range group.Logs {
+					if hasErr() {
+						return
+					}
+					cs, nextGroupData, err := ingester.ProcessLogByGroup(ctx, l, groupData)
+					processedLogCount.Add(1)
+					if err != nil {
+						logTaskError(ctx, "parser ended with an error", err, l)
+						setErr(err)
+						return
+					}
+					groupData = nextGroupData
+
+					if cs != nil {
+						err = cs.Flush(builder.LogAccumulator)
+						if err != nil {
+							logTaskError(ctx, "failed to flush log changeset in V2 ingester", err, l)
+							setErr(err)
+							return
+						}
+					} else {
+						skippedLogCount.Add(1)
+					}
+				}
+			})
+		}
+
+		pool.Wait()
+		progressUpdator.Done()
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if sharedErr != nil {
+			return nil, sharedErr
+		}
+
+		slog.DebugContext(ctx, fmt.Sprintf("GroupedLogIngesterTaskV2 %s finished: processed %d logs (skipped %d logs)", taskID.String(), totalLogCount, skippedLogCount.Load()))
+
+		tracingActive, _ := khictx.GetValue(ctx, inspectioncore_contract.TracingActive)
+		if tracingActive {
+			trace.SpanFromContext(ctx).SetAttributes(
+				attribute.String("log_count", fmt.Sprintf("%d", totalLogCount)),
+			)
+		}
+		return logs, nil
+	}, append([]coretask.LabelOpt{
+		// Tasks modifying history must be dependent from SerializerTask.
+		coretask.NewSubsequentTaskRefsTaskLabel(inspectioncore_contract.SerializerTaskID.Ref())}, labels...)...)
+}

--- a/pkg/core/inspection/taskbase/grouped_logingester_task_v2_test.go
+++ b/pkg/core/inspection/taskbase/grouped_logingester_task_v2_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectiontaskbase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/google/go-cmp/cmp"
+)
+
+var mockGroupedRawTaskID = taskid.NewDefaultImplementationID[[]*log.Log]("mock-grouped-raw")
+var mockGroupedLogTaskID = taskid.NewDefaultImplementationID[LogGroupMap]("mock-grouped-log")
+
+type testState struct {
+	Prefix string
+}
+
+type mockGroupedLogIngester struct {
+	SinglePassGroupedIngesterBase[testState]
+	rawTask   taskid.TaskReference[[]*log.Log]
+	groupTask taskid.TaskReference[LogGroupMap]
+	processFn func(ctx context.Context, l *log.Log, state testState) (*khifilev6.LogChangeSet, testState, error)
+}
+
+func (m *mockGroupedLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return m.rawTask
+}
+
+func (m *mockGroupedLogIngester) GroupedLogTask() taskid.TaskReference[LogGroupMap] {
+	return m.groupTask
+}
+
+func (m *mockGroupedLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return nil
+}
+
+func (m *mockGroupedLogIngester) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData testState) (*khifilev6.LogChangeSet, testState, error) {
+	if m.processFn != nil {
+		return m.processFn(ctx, l, prevGroupData)
+	}
+	return nil, prevGroupData, nil
+}
+
+var _ GroupedLogIngesterV2[testState] = (*mockGroupedLogIngester)(nil)
+
+func TestNewGroupedLogIngesterTaskV2(t *testing.T) {
+	testCases := []struct {
+		name          string
+		rawLogs       []*log.Log
+		groups        LogGroupMap
+		setup         func(t *testing.T, rawLogs []*log.Log) (func(ctx context.Context, l *log.Log, state testState) (*khifilev6.LogChangeSet, testState, error), func(t *testing.T))
+		cancelContext bool
+		wantErr       bool
+		wantErrMsg    string
+	}{
+		{
+			name: "successfully processes logs with state",
+			rawLogs: []*log.Log{
+				mustNewLogFromYAML(t, `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`),
+				mustNewLogFromYAML(t, `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-2"}`),
+			},
+			groups: LogGroupMap{
+				"group1": {
+					Group: "group1",
+					Logs: []*log.Log{
+						mustNewLogFromYAML(t, `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`),
+						mustNewLogFromYAML(t, `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-2"}`),
+					},
+				},
+			},
+			setup: func(t *testing.T, rawLogs []*log.Log) (func(ctx context.Context, l *log.Log, state testState) (*khifilev6.LogChangeSet, testState, error), func(t *testing.T)) {
+				processedStates := make(map[string]string)
+				processFn := func(ctx context.Context, l *log.Log, state testState) (*khifilev6.LogChangeSet, testState, error) {
+					newState := testState{Prefix: state.Prefix + "a"}
+					processedStates[l.ID] = newState.Prefix
+					cs, err := khifilev6.NewLogChangeSet(l)
+					if err != nil {
+						return nil, state, err
+					}
+					cs.SetSummary(newState.Prefix)
+					severityID := uint32(1)
+					logTypeID := uint32(2)
+					cs.SetSeverity(&pb.Severity{Id: &severityID})
+					cs.SetLogType(&pb.LogType{Id: &logTypeID})
+					return cs, newState, nil
+				}
+				verifyFn := func(t *testing.T) {
+					if diff := cmp.Diff("a", processedStates[rawLogs[0].ID]); diff != "" {
+						t.Errorf("rawLogs[0] state mismatch (-want +got):\n%s", diff)
+					}
+					if diff := cmp.Diff("aa", processedStates[rawLogs[1].ID]); diff != "" {
+						t.Errorf("rawLogs[1] state mismatch (-want +got):\n%s", diff)
+					}
+				}
+				return processFn, verifyFn
+			},
+		},
+		{
+			name: "context cancelled",
+			rawLogs: []*log.Log{
+				mustNewLogFromYAML(t, `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`),
+			},
+			groups: LogGroupMap{
+				"group1": {
+					Group: "group1",
+					Logs: []*log.Log{
+						mustNewLogFromYAML(t, `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`),
+					},
+				},
+			},
+			cancelContext: true,
+			wantErr:       true,
+			wantErrMsg:    "context canceled",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, group := range tc.groups {
+				for i := range group.Logs {
+					if i < len(tc.rawLogs) {
+						group.Logs[i] = tc.rawLogs[i]
+					}
+				}
+			}
+
+			var processFn func(ctx context.Context, l *log.Log, state testState) (*khifilev6.LogChangeSet, testState, error)
+			var verifyFn func(t *testing.T)
+			if tc.setup != nil {
+				processFn, verifyFn = tc.setup(t, tc.rawLogs)
+			}
+
+			ingester := &mockGroupedLogIngester{
+				rawTask:   mockGroupedRawTaskID.Ref(),
+				groupTask: mockGroupedLogTaskID.Ref(),
+				processFn: processFn,
+			}
+
+			tid := taskid.NewDefaultImplementationID[[]*log.Log]("test-grouped-ingester")
+			task := NewGroupedLogIngesterTaskV2(tid, ingester)
+
+			ctx := context.Background()
+			ctx = inspectiontest.WithDefaultTestInspectionTaskContext(ctx)
+			builder := khifilev6.NewBuilder()
+			ctx = khictx.WithValue(ctx, inspectioncore_contract.Builder, builder)
+
+			if tc.cancelContext {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			result, _, err := inspectiontest.RunInspectionTask(
+				ctx,
+				task,
+				inspectioncore_contract.TaskModeRun,
+				map[string]any{},
+				tasktest.NewTaskDependencyValuePair(mockGroupedRawTaskID.Ref(), tc.rawLogs),
+				tasktest.NewTaskDependencyValuePair(mockGroupedLogTaskID.Ref(), tc.groups),
+			)
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("unexpected error state: got error = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				if err.Error() != tc.wantErrMsg {
+					t.Fatalf("unexpected error message: got %q, want %q", err.Error(), tc.wantErrMsg)
+				}
+				return
+			}
+
+			if len(result) != len(tc.rawLogs) {
+				t.Fatalf("unexpected result count: got %d, want %d", len(result), len(tc.rawLogs))
+			}
+
+			// Verify ingestion.
+			for _, l := range tc.rawLogs {
+				id, ok := builder.LogAccumulator.ResolveLogID(l.ID)
+				if !ok {
+					t.Errorf("expected log %s to be resolved", l.ID)
+				}
+				if id == 0 {
+					t.Errorf("expected log %s to have valid ID", l.ID)
+				}
+			}
+
+			if verifyFn != nil {
+				verifyFn(t)
+			}
+		})
+	}
+}
+
+func TestNewGroupedLogIngesterTaskV2_ErrorHandling(t *testing.T) {
+	ctx := context.Background()
+	ctx = inspectiontest.WithDefaultTestInspectionTaskContext(ctx)
+	rawLogs := []*log.Log{
+		mustNewLogFromYAML(t, `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`),
+	}
+	groups := LogGroupMap{
+		"group1": {
+			Group: "group1",
+			Logs:  rawLogs,
+		},
+	}
+	expectedErr := errors.New("mock process error")
+
+	ingester := &mockGroupedLogIngester{
+		rawTask:   mockGroupedRawTaskID.Ref(),
+		groupTask: mockGroupedLogTaskID.Ref(),
+		processFn: func(ctx context.Context, l *log.Log, state testState) (*khifilev6.LogChangeSet, testState, error) {
+			return nil, state, expectedErr
+		},
+	}
+
+	tid := taskid.NewDefaultImplementationID[[]*log.Log]("test-grouped-ingester-error")
+	task := NewGroupedLogIngesterTaskV2(tid, ingester)
+
+	builder := khifilev6.NewBuilder()
+	ctx = khictx.WithValue(ctx, inspectioncore_contract.Builder, builder)
+
+	_, _, err := inspectiontest.RunInspectionTask(
+		ctx,
+		task,
+		inspectioncore_contract.TaskModeRun,
+		map[string]any{},
+		tasktest.NewTaskDependencyValuePair(mockGroupedRawTaskID.Ref(), rawLogs),
+		tasktest.NewTaskDependencyValuePair(mockGroupedLogTaskID.Ref(), groups),
+	)
+
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("unexpected error: got %v, want %v", err, expectedErr)
+	}
+}

--- a/pkg/core/inspection/taskbase/logingester_task_v2.go
+++ b/pkg/core/inspection/taskbase/logingester_task_v2.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectiontaskbase
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/progressutil"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// LogIngesterV2 defines the interface for ingesting log metadata into KHI v6 format.
+type LogIngesterV2 interface {
+	// RawLogTask returns the task reference that provides the raw logs to ingest.
+	RawLogTask() taskid.TaskReference[[]*log.Log]
+	// Dependencies returns additional task dependencies of the ingester.
+	Dependencies() []taskid.UntypedTaskReference
+	// ProcessLog is called for each log entry to customize log metadata (summary, severity, timestamp, etc.).
+	ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error)
+}
+
+// NewLogIngesterTaskV2 returns a task that ingests log metadata into the KHI v6 builder.
+func NewLogIngesterTaskV2(taskID taskid.TaskImplementationID[[]*log.Log], ingester LogIngesterV2, labels ...coretask.LabelOpt) coretask.Task[[]*log.Log] {
+	rawLogTaskID := ingester.RawLogTask()
+	dependencies := append([]taskid.UntypedTaskReference{rawLogTaskID}, ingester.Dependencies()...)
+	return NewProgressReportableInspectionTask(taskID, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*log.Log, error) {
+		if taskMode == inspectioncore_contract.TaskModeDryRun {
+			return []*log.Log{}, nil
+		}
+		logs := coretask.GetTaskResult(ctx, rawLogTaskID)
+		builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		concurrency := runtime.GOMAXPROCS(0)
+		pool := worker.NewPool(concurrency)
+		var processedLogCount atomic.Uint32
+		var skippedLogCount atomic.Uint32
+
+		progressUpdator := progressutil.NewProgressUpdator(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
+			current := processedLogCount.Load()
+			if len(logs) > 0 {
+				tp.Percentage = float32(current) / float32(len(logs))
+			}
+			tp.Message = fmt.Sprintf("%d/%d", current, len(logs))
+		})
+		progressUpdator.Start(ctx)
+
+		var sharedErr error
+		var errMu sync.Mutex
+
+		setErr := func(err error) {
+			errMu.Lock()
+			defer errMu.Unlock()
+			if sharedErr == nil {
+				sharedErr = err
+			}
+		}
+
+		hasErr := func() bool {
+			if ctx.Err() != nil {
+				return true
+			}
+			errMu.Lock()
+			defer errMu.Unlock()
+			return sharedErr != nil
+		}
+
+		for c := 0; c < concurrency; c++ {
+			if ctx.Err() != nil {
+				break
+			}
+			pool.Run(func() {
+				for i := c; i < len(logs); i += concurrency {
+					if hasErr() {
+						return
+					}
+					if err := ctx.Err(); err != nil {
+						setErr(err)
+						return
+					}
+					l := logs[i]
+					cs, err := ingester.ProcessLog(ctx, l)
+					processedLogCount.Add(1)
+					if err != nil {
+						logTaskError(ctx, "failed to process log in V2 ingester", err, l)
+						setErr(err)
+						return
+					}
+					if cs != nil {
+						err = cs.Flush(builder.LogAccumulator)
+						if err != nil {
+							logTaskError(ctx, "failed to flush log changeset in V2 ingester", err, l)
+							setErr(err)
+							return
+						}
+					} else {
+						skippedLogCount.Add(1)
+					}
+				}
+			})
+		}
+
+		pool.Wait()
+		progressUpdator.Done()
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if sharedErr != nil {
+			return nil, sharedErr
+		}
+
+		slog.DebugContext(ctx, fmt.Sprintf("LogIngesterTaskV2 %s finished: processed %d logs (skipped %d logs)", taskID.String(), len(logs), skippedLogCount.Load()))
+
+		tracingActive, _ := khictx.GetValue(ctx, inspectioncore_contract.TracingActive)
+		if tracingActive {
+			trace.SpanFromContext(ctx).SetAttributes(
+				attribute.String("log_count", fmt.Sprintf("%d", len(logs))),
+			)
+		}
+		return logs, nil
+	}, append([]coretask.LabelOpt{
+		// Tasks modifying history must be dependent from SerializerTask.
+		coretask.NewSubsequentTaskRefsTaskLabel(inspectioncore_contract.SerializerTaskID.Ref())}, labels...)...)
+}

--- a/pkg/core/inspection/taskbase/logingester_task_v2_test.go
+++ b/pkg/core/inspection/taskbase/logingester_task_v2_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectiontaskbase
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+var mockLogIngesterV2PrevTaskID = taskid.NewDefaultImplementationID[[]*log.Log]("mock-log-ingester-v2-prev")
+
+type mockLogIngesterV2 struct {
+	cancel context.CancelFunc
+}
+
+func (m *mockLogIngesterV2) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return mockLogIngesterV2PrevTaskID.Ref()
+}
+
+func (m *mockLogIngesterV2) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+func (m *mockLogIngesterV2) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	shouldCancel := l.ReadBoolOrDefault("cancel", false)
+	if shouldCancel && m.cancel != nil {
+		m.cancel()
+		time.Sleep(50 * time.Millisecond)
+		return nil, ctx.Err()
+	}
+	shouldErr := l.ReadBoolOrDefault("error", false)
+	if shouldErr {
+		return nil, fmt.Errorf("test error")
+	}
+	shouldSkip := l.ReadBoolOrDefault("skip", false)
+	if shouldSkip {
+		return nil, nil // Return nil changeset (skip)
+	}
+
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+	cs.SetSummary("hello summary")
+	cs.SetTimestamp(time.Now())
+
+	severityID := uint32(1)
+	logTypeID := uint32(2)
+	cs.SetSeverity(&pb.Severity{Id: &severityID})
+	cs.SetLogType(&pb.LogType{Id: &logTypeID})
+	return cs, nil
+}
+
+var _ LogIngesterV2 = (*mockLogIngesterV2)(nil)
+
+func TestLogIngesterTaskV2(t *testing.T) {
+	type testLog struct {
+		yaml         string
+		shouldIngest bool
+	}
+
+	testCases := []struct {
+		desc          string
+		taskMode      inspectioncore_contract.InspectionTaskModeType
+		prevLogs      []testLog
+		wantError     bool
+		cancelContext bool
+		cancelMidWay  bool
+	}{
+		{
+			desc:     "DryRun mode",
+			taskMode: inspectioncore_contract.TaskModeDryRun,
+			prevLogs: []testLog{
+				{
+					yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`,
+					shouldIngest: false,
+				},
+			},
+			wantError: false,
+		},
+		{
+			desc:     "Normal execution with some skipped logs",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			prevLogs: []testLog{
+				{
+					yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1"}`,
+					shouldIngest: true,
+				},
+				{
+					yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-2", "skip": true}`,
+					shouldIngest: false,
+				},
+			},
+			wantError: false,
+		},
+		{
+			desc:     "Execution with error",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			prevLogs: []testLog{
+				{
+					yaml:         `{"apiVersion": "v1", "kind": "Pod", "namespace": "default", "name": "pod-1", "error": true}`,
+					shouldIngest: false,
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tid := taskid.NewDefaultImplementationID[[]*log.Log]("mock-log-ingester-v2")
+
+			ctx := context.Background()
+			ctx = inspectiontest.WithDefaultTestInspectionTaskContext(ctx)
+
+			var cancel context.CancelFunc
+			if tc.cancelContext || tc.cancelMidWay {
+				ctx, cancel = context.WithCancel(ctx)
+			}
+			if tc.cancelContext {
+				cancel()
+			}
+
+			builder := khifilev6.NewBuilder()
+			ctx = khictx.WithValue(ctx, inspectioncore_contract.Builder, builder)
+
+			var logs []*log.Log
+			shouldIngestMap := make(map[string]bool)
+			for _, tl := range tc.prevLogs {
+				l := mustNewLogFromYAML(t, tl.yaml)
+				logs = append(logs, l)
+				shouldIngestMap[l.ID] = tl.shouldIngest
+			}
+
+			task := NewLogIngesterTaskV2(tid, &mockLogIngesterV2{})
+
+			_, _, err := inspectiontest.RunInspectionTask(ctx, task, tc.taskMode, map[string]any{}, tasktest.NewTaskDependencyValuePair(mockLogIngesterV2PrevTaskID.Ref(), logs))
+			if (err != nil) != tc.wantError {
+				t.Fatalf("RunInspectionTask() error = %v, wantError %v", err, tc.wantError)
+			}
+
+			if tc.cancelContext {
+				var expectedErr = context.Canceled
+				if err == nil || err.Error() != expectedErr.Error() {
+					t.Errorf("RunInspectionTask() error = %v, want %v", err, expectedErr)
+				}
+			}
+
+			if !tc.wantError {
+				// Verify whether logs were correctly accumulated in LogAccumulator or not
+				for _, l := range logs {
+					resolvedID, ok := builder.LogAccumulator.ResolveLogID(l.ID)
+					shouldIngest := shouldIngestMap[l.ID]
+					if shouldIngest {
+						if !ok {
+							t.Errorf("expected log %s to be ingested, but ResolveLogID returned false", l.ID)
+						}
+						if resolvedID == 0 {
+							t.Errorf("expected log %s to have a valid resolved ID, got 0", l.ID)
+						}
+					} else if ok {
+						t.Errorf("expected log %s NOT to be ingested, but ResolveLogID returned true with ID %d", l.ID, resolvedID)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/core/inspection/taskbase/utils.go
+++ b/pkg/core/inspection/taskbase/utils.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectiontaskbase
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+)
+
+// logTaskError logs an error message using slog.ErrorContext with raw log content.
+func logTaskError(ctx context.Context, message string, err error, l *log.Log) {
+	var yaml string
+	if l != nil {
+		yamlBytes, err2 := l.Serialize("", &structured.YAMLNodeSerializer{})
+		if err2 != nil {
+			yaml = "ERROR!! failed to dump in yaml"
+		} else {
+			yaml = string(yamlBytes)
+		}
+	} else {
+		yaml = "nil log"
+	}
+
+	// TODO(#705): Use slog's attr after improving KHI's logger.
+	slog.ErrorContext(ctx, fmt.Sprintf("%s\nerror: %v\nlogContent:\n%s", message, err, yaml))
+}


### PR DESCRIPTION
This PR adds new base task utility for ingesting a log into the final serialized log with parsed summaries.

The logic to add summary for a log was done in timeline mapper traditionally because it was one of responsibility that ChangeSet type handled. From the file format change, the ChangeSet responsibility was split to TimelineChangeSet and LogChangeSet. 
These tasks will handle the log part only.