### PR TITLE
Handle slog attributes in KHI log formatter

### DIFF
--- a/pkg/core/inspection/logger/format.go
+++ b/pkg/core/inspection/logger/format.go
@@ -42,9 +42,10 @@ var colors = []string{
 }
 
 type KHILogFormatHandler struct {
-	out       io.Writer
-	withColor bool
-	attrs     []slog.Attr
+	out             io.Writer
+	withColor       bool
+	attrs           []slog.Attr
+	ignoredAttrKeys map[string]struct{}
 }
 
 // Enabled implements slog.Handler.
@@ -68,16 +69,11 @@ func (lh *KHILogFormatHandler) Handle(ctx context.Context, r slog.Record) error 
 
 // WithAttrs implements slog.Handler.
 func (lh *KHILogFormatHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	if len(attrs) == 0 {
-		return lh
-	}
-	newAttrs := make([]slog.Attr, 0, len(lh.attrs)+len(attrs))
-	newAttrs = append(newAttrs, lh.attrs...)
-	newAttrs = append(newAttrs, attrs...)
 	return &KHILogFormatHandler{
-		out:       lh.out,
-		attrs:     newAttrs,
-		withColor: lh.withColor,
+		out:             lh.out,
+		attrs:           append(append([]slog.Attr{}, lh.attrs...), attrs...),
+		withColor:       lh.withColor,
+		ignoredAttrKeys: lh.ignoredAttrKeys,
 	}
 }
 
@@ -96,12 +92,12 @@ func (lh *KHILogFormatHandler) formatMessage(r slog.Record) string {
 		attrs = append(attrs, attr)
 		return true
 	})
-	if len(attrs) == 0 {
-		return r.Message
-	}
 	formattedAttrs := make([]string, 0, len(attrs))
 	for _, attr := range attrs {
 		if attr.Key == "" {
+			continue
+		}
+		if lh.isIgnoredAttrKey(attr.Key) {
 			continue
 		}
 		value := attr.Value.Resolve()
@@ -111,6 +107,11 @@ func (lh *KHILogFormatHandler) formatMessage(r slog.Record) string {
 		return r.Message
 	}
 	return fmt.Sprintf("%s %s", r.Message, strings.Join(formattedAttrs, " "))
+}
+
+func (lh *KHILogFormatHandler) isIgnoredAttrKey(key string) bool {
+	_, found := lh.ignoredAttrKeys[key]
+	return found
 }
 
 func (lh *KHILogFormatHandler) taskIdToColor(tid string) string {
@@ -158,5 +159,8 @@ func NewKHIFormatLogger(out io.Writer, withColor bool) *KHILogFormatHandler {
 	return &KHILogFormatHandler{
 		out:       out,
 		withColor: withColor,
+		ignoredAttrKeys: map[string]struct{}{
+			LogKindAttrKey: {},
+		},
 	}
 }

--- a/pkg/core/inspection/logger/format.go
+++ b/pkg/core/inspection/logger/format.go
@@ -68,9 +68,15 @@ func (lh *KHILogFormatHandler) Handle(ctx context.Context, r slog.Record) error 
 
 // WithAttrs implements slog.Handler.
 func (lh *KHILogFormatHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return lh
+	}
+	newAttrs := make([]slog.Attr, 0, len(lh.attrs)+len(attrs))
+	newAttrs = append(newAttrs, lh.attrs...)
+	newAttrs = append(newAttrs, attrs...)
 	return &KHILogFormatHandler{
 		out:       lh.out,
-		attrs:     append(append([]slog.Attr{}, lh.attrs...), attrs...),
+		attrs:     newAttrs,
 		withColor: lh.withColor,
 	}
 }
@@ -81,7 +87,11 @@ func (lh *KHILogFormatHandler) WithGroup(name string) slog.Handler {
 }
 
 func (lh *KHILogFormatHandler) formatMessage(r slog.Record) string {
-	attrs := append([]slog.Attr{}, lh.attrs...)
+	if len(lh.attrs) == 0 && r.NumAttrs() == 0 {
+		return r.Message
+	}
+	attrs := make([]slog.Attr, 0, len(lh.attrs)+r.NumAttrs())
+	attrs = append(attrs, lh.attrs...)
 	r.Attrs(func(attr slog.Attr) bool {
 		attrs = append(attrs, attr)
 		return true

--- a/pkg/core/inspection/logger/format.go
+++ b/pkg/core/inspection/logger/format.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
@@ -54,11 +55,12 @@ func (*KHILogFormatHandler) Enabled(context.Context, slog.Level) bool {
 // Handle implements slog.Handler.
 func (lh *KHILogFormatHandler) Handle(ctx context.Context, r slog.Record) error {
 	tid, found := khictx.GetValue(ctx, core_contract.TaskImplementationIDContextKey)
+	message := lh.formatMessage(r)
 	var logLine string
 	if found == nil {
-		logLine = fmt.Sprintf("%s%s >%s %s %s\n", lh.taskIdToColor(tid.String()), tid, lh.resetColor(), lh.wrapColorByLevel(r.Level, r.Level.String()), lh.wrapColorByLevel(r.Level, r.Message))
+		logLine = fmt.Sprintf("%s%s >%s %s %s\n", lh.taskIdToColor(tid.String()), tid, lh.resetColor(), lh.wrapColorByLevel(r.Level, r.Level.String()), lh.wrapColorByLevel(r.Level, message))
 	} else {
-		logLine = fmt.Sprintf("global > %s %s\n", lh.wrapColorByLevel(r.Level, r.Level.String()), lh.wrapColorByLevel(r.Level, r.Message))
+		logLine = fmt.Sprintf("global > %s %s\n", lh.wrapColorByLevel(r.Level, r.Level.String()), lh.wrapColorByLevel(r.Level, message))
 	}
 	lh.out.Write([]byte(logLine))
 	return nil
@@ -68,7 +70,7 @@ func (lh *KHILogFormatHandler) Handle(ctx context.Context, r slog.Record) error 
 func (lh *KHILogFormatHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &KHILogFormatHandler{
 		out:       lh.out,
-		attrs:     attrs,
+		attrs:     append(append([]slog.Attr{}, lh.attrs...), attrs...),
 		withColor: lh.withColor,
 	}
 }
@@ -76,6 +78,29 @@ func (lh *KHILogFormatHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 // WithGroup implements slog.Handler.
 func (lh *KHILogFormatHandler) WithGroup(name string) slog.Handler {
 	return lh // this is not supporting group
+}
+
+func (lh *KHILogFormatHandler) formatMessage(r slog.Record) string {
+	attrs := append([]slog.Attr{}, lh.attrs...)
+	r.Attrs(func(attr slog.Attr) bool {
+		attrs = append(attrs, attr)
+		return true
+	})
+	if len(attrs) == 0 {
+		return r.Message
+	}
+	formattedAttrs := make([]string, 0, len(attrs))
+	for _, attr := range attrs {
+		if attr.Key == "" {
+			continue
+		}
+		value := attr.Value.Resolve()
+		formattedAttrs = append(formattedAttrs, fmt.Sprintf("%s=%s", attr.Key, value.String()))
+	}
+	if len(formattedAttrs) == 0 {
+		return r.Message
+	}
+	return fmt.Sprintf("%s %s", r.Message, strings.Join(formattedAttrs, " "))
 }
 
 func (lh *KHILogFormatHandler) taskIdToColor(tid string) string {

--- a/pkg/core/inspection/logger/format_test.go
+++ b/pkg/core/inspection/logger/format_test.go
@@ -124,6 +124,26 @@ func TestKHILogFormatHandler_WithAttrsAppends(t *testing.T) {
 	}
 }
 
+func TestKHILogFormatHandler_IgnoresControlAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewKHIFormatLogger(&buf, false)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "message", 0)
+	record.AddAttrs(
+		slog.String(LogKindAttrKey, "progress"),
+		slog.String("component", "parser"),
+	)
+
+	if err := handler.Handle(context.Background(), record); err != nil {
+		t.Fatalf("Handle() failed: %v", err)
+	}
+
+	expectedOutput := "global > INFO message component=parser\n"
+	if got := buf.String(); got != expectedOutput {
+		t.Errorf("mismatched log output:\ngot:  %q\nwant: %q", got, expectedOutput)
+	}
+}
+
 func TestKHILogFormatHandler_WithGroup(t *testing.T) {
 	handler1 := NewKHIFormatLogger(new(bytes.Buffer), false)
 	handler2 := handler1.WithGroup("my-group")

--- a/pkg/core/inspection/logger/format_test.go
+++ b/pkg/core/inspection/logger/format_test.go
@@ -86,24 +86,41 @@ func TestKHILogFormatHandler_Handle(t *testing.T) {
 }
 
 func TestKHILogFormatHandler_WithAttrs(t *testing.T) {
-	var buf1, buf2 bytes.Buffer
-	handler1 := NewKHIFormatLogger(&buf1, false)
-	handler2Source := NewKHIFormatLogger(&buf2, false)
-	handler2 := handler2Source.WithAttrs([]slog.Attr{slog.String("key", "value")})
+	var buf bytes.Buffer
+	handlerSource := NewKHIFormatLogger(&buf, false)
+	handler := handlerSource.WithAttrs([]slog.Attr{slog.String("component", "parser")})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "message", 0)
+	record.AddAttrs(slog.Int("count", 10))
+	ctx := context.Background()
+
+	if err := handler.Handle(ctx, record); err != nil {
+		t.Fatalf("Handle() failed: %v", err)
+	}
+
+	expectedOutput := "global > INFO message component=parser count=10\n"
+	if got := buf.String(); got != expectedOutput {
+		t.Errorf("mismatched log output:\ngot:  %q\nwant: %q", got, expectedOutput)
+	}
+}
+
+func TestKHILogFormatHandler_WithAttrsAppends(t *testing.T) {
+	var buf bytes.Buffer
+	handlerSource := NewKHIFormatLogger(&buf, false)
+	handler := handlerSource.
+		WithAttrs([]slog.Attr{slog.String("component", "parser")}).
+		WithAttrs([]slog.Attr{slog.String("phase", "read")})
 
 	record := slog.NewRecord(time.Now(), slog.LevelInfo, "message", 0)
 	ctx := context.Background()
 
-	if err := handler1.Handle(ctx, record); err != nil {
-		t.Fatalf("handler1.Handle() failed: %v", err)
-	}
-	if err := handler2.Handle(ctx, record); err != nil {
-		t.Fatalf("handler2.Handle() failed: %v", err)
+	if err := handler.Handle(ctx, record); err != nil {
+		t.Fatalf("Handle() failed: %v", err)
 	}
 
-	// The current implementation does not print attrs, so output should be identical.
-	if got1, got2 := buf1.String(), buf2.String(); got1 != got2 {
-		t.Errorf("output should be identical, but got1=%q, got2=%q", got1, got2)
+	expectedOutput := "global > INFO message component=parser phase=read\n"
+	if got := buf.String(); got != expectedOutput {
+		t.Errorf("mismatched log output:\ngot:  %q\nwant: %q", got, expectedOutput)
 	}
 }
 


### PR DESCRIPTION
## Summary
- include handler-level and record-level `slog.Attr` values in KHI formatted log output
- preserve the existing log prefix and color behavior
- make repeated `WithAttrs` calls append attrs instead of replacing prior attrs

## Why
`KHILogFormatHandler` only printed the main log message, so callers had to format structured data manually with `fmt.Sprintf`. This allows calls such as `slog.WarnContext(ctx, "hello", "number", 10)` to show the structured fields in the formatted log line.

Fixes #705.

## Tests
- `go test ./pkg/core/inspection/logger`
- `git diff --check`
