### PR TITLE
Added severity utils to parse GCP severity

### DIFF
--- a/pkg/model/log/common_field_set.go
+++ b/pkg/model/log/common_field_set.go
@@ -26,12 +26,12 @@ type CommonFieldSet struct {
 	Timestamp time.Time
 	// Severity represents the log severity.
 	//
-	// Deprecated: Severity has been deprecated.
+	// Deprecated: Use DefaultSeverityFieldSet with defining log speicifc FieldSetReader for it.
 	Severity enum.Severity
 	// DisplayID is an unique identifier given from a log.
 	// This is only used for showing and it may be same as the ID.
 	//
-	// Deprecated: DisplayID has been deprecated.
+	// Deprecated: Define custom FieldSet and FieldSetReader instead.
 	DisplayID string
 }
 
@@ -45,7 +45,7 @@ var _ FieldSet = (*CommonFieldSet)(nil)
 // MainMessageFieldSet is an abstract FieldSet struct type to get the main message of its log.
 // This would be read from `textPayload`, `protoPayload` or `jsonPayload` when it is read from Cloud Logging.
 //
-// Deprecated: MainMessageFieldSet has been deprecated.
+// Deprecated: Define custom FieldSet and FieldSetReader instead.
 type MainMessageFieldSet struct {
 	MainMessage string
 }

--- a/pkg/model/log/common_field_set.go
+++ b/pkg/model/log/common_field_set.go
@@ -25,9 +25,13 @@ type CommonFieldSet struct {
 	// Timestamp is the timestamp of the log happens.
 	Timestamp time.Time
 	// Severity represents the log severity.
+	//
+	// Deprecated: Severity has been deprecated.
 	Severity enum.Severity
 	// DisplayID is an unique identifier given from a log.
 	// This is only used for showing and it may be same as the ID.
+	//
+	// Deprecated: DisplayID has been deprecated.
 	DisplayID string
 }
 
@@ -40,6 +44,8 @@ var _ FieldSet = (*CommonFieldSet)(nil)
 
 // MainMessageFieldSet is an abstract FieldSet struct type to get the main message of its log.
 // This would be read from `textPayload`, `protoPayload` or `jsonPayload` when it is read from Cloud Logging.
+//
+// Deprecated: MainMessageFieldSet has been deprecated.
 type MainMessageFieldSet struct {
 	MainMessage string
 }

--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
 type GCPAuditLogFieldSet struct {
@@ -202,3 +203,23 @@ func (g *GCPAccessLogFieldSetReader) Read(reader *structured.NodeReader) (log.Fi
 }
 
 var _ log.FieldSetReader = (*GCPAccessLogFieldSetReader)(nil)
+
+// GCPDefaultSeverityFieldSetReader reads and parses the severity field from a GCP Cloud Logging entry.
+type GCPDefaultSeverityFieldSetReader struct {
+}
+
+// FieldSetKind implements log.FieldSetReader.
+func (g *GCPDefaultSeverityFieldSetReader) FieldSetKind() string {
+	return (&inspectioncore_contract.DefaultSeverityFieldSet{}).Kind()
+}
+
+// Read implements log.FieldSetReader.
+func (g *GCPDefaultSeverityFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
+	severityStr := reader.ReadStringOrDefault("severity", "")
+	parsedSeverity := ParseGCPSeverity(severityStr)
+	return &inspectioncore_contract.DefaultSeverityFieldSet{
+		Severity: parsedSeverity,
+	}, nil
+}
+
+var _ log.FieldSetReader = (*GCPDefaultSeverityFieldSetReader)(nil)

--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
 func TestGCPAuditLogFieldSetReader(t *testing.T) {
@@ -110,6 +111,50 @@ func TestGCPAuditLogFieldSet_GuessRevisionVerb(t *testing.T) {
 			g := &GCPAuditLogFieldSet{MethodName: tc.methodName}
 			if got := g.GuessRevisionVerb(); got != tc.want {
 				t.Errorf("GuessRevisionVerb() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGCPDefaultSeverityFieldSetReader(t *testing.T) {
+	reader := &GCPDefaultSeverityFieldSetReader{}
+	tests := []struct {
+		name  string
+		input map[string]any
+		want  *inspectioncore_contract.DefaultSeverityFieldSet
+	}{
+		{
+			name: "severity info",
+			input: map[string]any{
+				"severity": "INFO",
+			},
+			want: &inspectioncore_contract.DefaultSeverityFieldSet{
+				Severity: inspectioncore_contract.SeverityInfo,
+			},
+		},
+		{
+			name:  "severity absent defaults to empty string which is Unknown",
+			input: map[string]any{},
+			want: &inspectioncore_contract.DefaultSeverityFieldSet{
+				Severity: inspectioncore_contract.SeverityUnknown,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := structured.FromGoValue(tc.input, &structured.AlphabeticalGoMapKeyOrderProvider{})
+			if err != nil {
+				t.Fatalf("failed to create node: %v", err)
+			}
+			nodeReader := structured.NewNodeReader(node)
+			gotFS, err := reader.Read(nodeReader)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			got := gotFS.(*inspectioncore_contract.DefaultSeverityFieldSet)
+			if got.Severity != tc.want.Severity {
+				t.Errorf("Read() severity = %v, want %v", got.Severity, tc.want.Severity)
 			}
 		})
 	}

--- a/pkg/task/inspection/googlecloudcommon/contract/severity.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/severity.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import (
+	"strings"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// ParseGCPSeverity converts a GCP Cloud Logging severity string into a timeline style Severity.
+// It maps the GCP log severities defined in https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
+// to KHI's registered timeline style Severities in the core contract.
+func ParseGCPSeverity(gcpSeverity string) *pb.Severity {
+	gcpSeverity = strings.ToUpper(gcpSeverity)
+	switch gcpSeverity {
+	case "DEFAULT", "DEBUG", "INFO", "NOTICE":
+		return inspectioncore_contract.SeverityInfo
+	case "WARNING":
+		return inspectioncore_contract.SeverityWarning
+	case "ERROR":
+		return inspectioncore_contract.SeverityError
+	case "CRITICAL", "ALERT", "EMERGENCY":
+		return inspectioncore_contract.SeverityFatal
+	default:
+		return inspectioncore_contract.SeverityUnknown
+	}
+}

--- a/pkg/task/inspection/googlecloudcommon/contract/severity.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/severity.go
@@ -25,7 +25,7 @@ import (
 // It maps the GCP log severities defined in https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
 // to KHI's registered timeline style Severities in the core contract.
 func ParseGCPSeverity(gcpSeverity string) *pb.Severity {
-	gcpSeverity = strings.ToUpper(gcpSeverity)
+	gcpSeverity = strings.ToUpper(strings.TrimSpace(gcpSeverity))
 	switch gcpSeverity {
 	case "DEFAULT", "DEBUG", "INFO", "NOTICE":
 		return inspectioncore_contract.SeverityInfo

--- a/pkg/task/inspection/googlecloudcommon/contract/severity_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/severity_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import (
+	"testing"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+func TestParseGCPSeverity(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		want  *pb.Severity
+	}{
+		{
+			name:  "DEFAULT returns Info",
+			input: "DEFAULT",
+			want:  inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name:  "DEBUG returns Info",
+			input: "DEBUG",
+			want:  inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name:  "INFO returns Info",
+			input: "INFO",
+			want:  inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name:  "NOTICE returns Info",
+			input: "NOTICE",
+			want:  inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name:  "WARNING returns Warning",
+			input: "WARNING",
+			want:  inspectioncore_contract.SeverityWarning,
+		},
+		{
+			name:  "ERROR returns Error",
+			input: "ERROR",
+			want:  inspectioncore_contract.SeverityError,
+		},
+		{
+			name:  "CRITICAL returns Fatal",
+			input: "CRITICAL",
+			want:  inspectioncore_contract.SeverityFatal,
+		},
+		{
+			name:  "ALERT returns Fatal",
+			input: "ALERT",
+			want:  inspectioncore_contract.SeverityFatal,
+		},
+		{
+			name:  "EMERGENCY returns Fatal",
+			input: "EMERGENCY",
+			want:  inspectioncore_contract.SeverityFatal,
+		},
+		{
+			name:  "UNKNOWN returns Unknown",
+			input: "UNKNOWN",
+			want:  inspectioncore_contract.SeverityUnknown,
+		},
+		{
+			name:  "invalid string returns Unknown",
+			input: "INVALID_SEVERITY",
+			want:  inspectioncore_contract.SeverityUnknown,
+		},
+		{
+			name:  "empty string returns Unknown",
+			input: "",
+			want:  inspectioncore_contract.SeverityUnknown,
+		},
+		{
+			name:  "case insensitive - lowercase info",
+			input: "info",
+			want:  inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name:  "case insensitive - mixed case warning",
+			input: "WaRnInG",
+			want:  inspectioncore_contract.SeverityWarning,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseGCPSeverity(tc.input)
+			if got != tc.want {
+				t.Errorf("ParseGCPSeverity(%q) = %v; want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudcommon/contract/severity_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/severity_test.go
@@ -97,6 +97,11 @@ func TestParseGCPSeverity(t *testing.T) {
 			input: "WaRnInG",
 			want:  inspectioncore_contract.SeverityWarning,
 		},
+		{
+			name:  "surrounding spaces",
+			input: "  INFO  ",
+			want:  inspectioncore_contract.SeverityInfo,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/task/inspection/inspectioncore/contract/severity.go
+++ b/pkg/task/inspection/inspectioncore/contract/severity.go
@@ -15,7 +15,9 @@
 package inspectioncore_contract
 
 import (
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 )
 
 // The following block defines the registered timeline style Severities.
@@ -28,3 +30,16 @@ var (
 	SeverityError   = style.MustRegisterSeverity("ERROR", "E", style.MustForceConvertSRGBHex("#FF3935"), style.ColorWhite, 3)
 	SeverityFatal   = style.MustRegisterSeverity("FATAL", "F", style.MustForceConvertSRGBHex("#AA66AA"), style.ColorWhite, 4)
 )
+
+// DefaultSeverityFieldSet is a FieldSet struct type to hold the parsed log severity.
+type DefaultSeverityFieldSet struct {
+	// Severity is the parsed severity of the log.
+	Severity *pb.Severity
+}
+
+// Kind implements log.FieldSet.
+func (d *DefaultSeverityFieldSet) Kind() string {
+	return "default_severity"
+}
+
+var _ log.FieldSet = (*DefaultSeverityFieldSet)(nil)


### PR DESCRIPTION
This PR adds new Severity parser that supports the new `*pb.Severity` instead of the old `enum.Severity`.

In addition to migrate the severity, deprecate several common fieldset fields because now logs are ingested by LogIngester separately and read these log fields by each log parsers. The MainMessage or DisplayIDs are too specific to its log producer and should be handled by dedicated parsers.