### PR TITLE
Add FeatureTaskLabelV2

### DIFF
--- a/pkg/task/inspection/inspectioncore/contract/tasklabel.go
+++ b/pkg/task/inspection/inspectioncore/contract/tasklabel.go
@@ -74,6 +74,8 @@ var _ coretask.LabelOpt = (*ProgressReportableTaskLabelOptImpl)(nil)
 
 // FeatureTaskLabelImpl is an implementation of task.LabelOpt.
 // This annotate a task to be a feature in inspection.
+//
+// Deprecated: Use FeatureTaskLabelV2Impl instead.
 type FeatureTaskLabelImpl struct {
 	title            string
 	description      string
@@ -83,6 +85,7 @@ type FeatureTaskLabelImpl struct {
 	inspectionTypes  []string
 }
 
+// Write implements task.LabelOpt.
 func (ftl *FeatureTaskLabelImpl) Write(label *typedmap.TypedMap) {
 	typedmap.Set(label, LabelKeyInspectionFeatureFlag, true)
 	typedmap.Set(label, LabelKeyFeatureTaskTargetLogType, ftl.logType)
@@ -95,13 +98,11 @@ func (ftl *FeatureTaskLabelImpl) Write(label *typedmap.TypedMap) {
 	}
 }
 
-func (ftl *FeatureTaskLabelImpl) WithDescription(description string) *FeatureTaskLabelImpl {
-	ftl.description = description
-	return ftl
-}
-
 var _ coretask.LabelOpt = (*FeatureTaskLabelImpl)(nil)
 
+// FeatureTaskLabel returns a LabelOpt that annotates a task to be a feature in inspection.
+//
+// Deprecated: Use FeatureTaskLabelV2 instead.
 func FeatureTaskLabel(title string, description string, logType enum.LogType, featureOrder int, isDefaultFeature bool, inspectionTypes ...string) *FeatureTaskLabelImpl {
 	for i, t := range inspectionTypes {
 		if t == "" {
@@ -116,6 +117,36 @@ Please define task IDs and types used in its type parameter in a different packa
 		featureOrder:     featureOrder,
 		isDefaultFeature: isDefaultFeature,
 		inspectionTypes:  inspectionTypes,
+	}
+}
+
+// FeatureTaskLabelV2Impl is an implementation of task.LabelOpt.
+// This annotates a task to be a feature in inspection for v6 format.
+type FeatureTaskLabelV2Impl struct {
+	title            string
+	description      string
+	featureOrder     int
+	isDefaultFeature bool
+}
+
+// Write implements task.LabelOpt.
+func (ftl *FeatureTaskLabelV2Impl) Write(label *typedmap.TypedMap) {
+	typedmap.Set(label, LabelKeyInspectionFeatureFlag, true)
+	typedmap.Set(label, LabelKeyFeatureTaskTitle, ftl.title)
+	typedmap.Set(label, LabelKeyFeatureTaskDescription, ftl.description)
+	typedmap.Set(label, LabelKeyFeatureTaskOrder, ftl.featureOrder)
+	typedmap.Set(label, LabelKeyInspectionDefaultFeatureFlag, ftl.isDefaultFeature)
+}
+
+var _ coretask.LabelOpt = (*FeatureTaskLabelV2Impl)(nil)
+
+// FeatureTaskLabelV2 returns a LabelOpt to mark the task as a feature in the inspection for v6 format.
+func FeatureTaskLabelV2(title string, description string, featureOrder int, isDefaultFeature bool) *FeatureTaskLabelV2Impl {
+	return &FeatureTaskLabelV2Impl{
+		title:            title,
+		description:      description,
+		featureOrder:     featureOrder,
+		isDefaultFeature: isDefaultFeature,
 	}
 }
 

--- a/pkg/task/inspection/inspectioncore/contract/tasklabel_test.go
+++ b/pkg/task/inspection/inspectioncore/contract/tasklabel_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectioncore_contract
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestFeatureTaskLabels tests FeatureTaskLabelV2.
+func TestFeatureTaskLabels(t *testing.T) {
+	t.Run("FeatureTaskLabelV2", func(t *testing.T) {
+		labelOpt := FeatureTaskLabelV2(
+			"v2 title",
+			"v2 description",
+			100,
+			true,
+		)
+		label := coretask.NewLabelSet(labelOpt)
+
+		type expectations struct {
+			FeatureFlag        bool
+			Title              string
+			Description        string
+			Order              int
+			DefaultFeatureFlag bool
+		}
+
+		got := expectations{
+			FeatureFlag:        typedmap.GetOrDefault(label, LabelKeyInspectionFeatureFlag, false),
+			Title:              typedmap.GetOrDefault(label, LabelKeyFeatureTaskTitle, ""),
+			Description:        typedmap.GetOrDefault(label, LabelKeyFeatureTaskDescription, ""),
+			Order:              typedmap.GetOrDefault(label, LabelKeyFeatureTaskOrder, 0),
+			DefaultFeatureFlag: typedmap.GetOrDefault(label, LabelKeyInspectionDefaultFeatureFlag, false),
+		}
+
+		want := expectations{
+			FeatureFlag:        true,
+			Title:              "v2 title",
+			Description:        "v2 description",
+			Order:              100,
+			DefaultFeatureFlag: true,
+		}
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("FeatureTaskLabelV2 label mismatch (-want +got):\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
This PR adds new TaskLabel `FeatureTaskLabelV2`.
The previous task label used `enum.LogType` in its parameter. But now these `LogType`s are set by dedicated log parsers defined for specific set of logs. 

I defined the type `V2` is for gradual migration. I will remove the old implementation and rename `V2` to the original name before completing this epic branch.