### PR TITLE
Added handling for non UTF-8 valid string

### DIFF
--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -17,6 +17,7 @@ package khifilev6
 import (
 	"iter"
 	"sort"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -95,6 +96,7 @@ func NewInternPool(idGen *IDGenerator) *InternPool {
 // InternString returns a InternStringRef for the given string.
 // If the string is not already interned, it assigns a new ID from IDGenerator and stores it.
 func (p *InternPool) InternString(value string) *InternStringRef {
+	value = strings.ToValidUTF8(value, "\uFFFD")
 	if id, ok := p.strToID.Load(value); ok {
 		return &InternStringRef{pool: p, id: id.(uint32)}
 	}

--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -96,6 +96,11 @@ func NewInternPool(idGen *IDGenerator) *InternPool {
 // InternString returns a InternStringRef for the given string.
 // If the string is not already interned, it assigns a new ID from IDGenerator and stores it.
 func (p *InternPool) InternString(value string) *InternStringRef {
+	if id, ok := p.strToID.Load(value); ok {
+		return &InternStringRef{pool: p, id: id.(uint32)}
+	}
+
+	// Call ToValidUTF8 for every calls are costly and majority of value are expected not to contain invalid utf8, so check it after the first lookup.
 	value = strings.ToValidUTF8(value, "\uFFFD")
 	if id, ok := p.strToID.Load(value); ok {
 		return &InternStringRef{pool: p, id: id.(uint32)}

--- a/pkg/model/khifile/v6/intern_test.go
+++ b/pkg/model/khifile/v6/intern_test.go
@@ -61,6 +61,50 @@ func TestInternPool_Intern(t *testing.T) {
 	}
 }
 
+func TestInternPool_Intern_InvalidUTF8(t *testing.T) {
+	idGen := &IDGenerator{}
+	pool := NewInternPool(idGen)
+
+	testCases := []struct {
+		name        string
+		input       string
+		wantID      uint32
+		wantResolve string
+	}{
+		{
+			name:        "invalid utf8",
+			input:       "foo\xffbar",
+			wantID:      1,
+			wantResolve: "foo\uFFFDbar",
+		},
+		{
+			name:        "duplicate invalid utf8",
+			input:       "foo\xffbar",
+			wantID:      1,
+			wantResolve: "foo\uFFFDbar",
+		},
+		{
+			name:        "valid replacement string",
+			input:       "foo\uFFFDbar",
+			wantID:      1,
+			wantResolve: "foo\uFFFDbar",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ref := pool.InternString(tc.input)
+			if ref.id != tc.wantID {
+				t.Errorf("Intern(%q) ID = %d, want %d", tc.input, ref.id, tc.wantID)
+			}
+			got := ref.Resolve()
+			if diff := cmp.Diff(tc.wantResolve, got); diff != "" {
+				t.Errorf("Resolve() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestInternPool_ResolveStringFromID(t *testing.T) {
 	idGen := &IDGenerator{}
 	pool := NewInternPool(idGen)
@@ -200,6 +244,12 @@ func TestInternPool_InternFieldSet(t *testing.T) {
 			input:  []string{"a", "b"},
 			want:   []string{"a", "b"},
 			wantID: 1,
+		},
+		{
+			name:   "invalid utf8 set",
+			input:  []string{"foo\xffbar"},
+			want:   []string{"foo\uFFFDbar"},
+			wantID: 3,
 		},
 	}
 


### PR DESCRIPTION
ProtocolBuffer can't store non UTF-8 string and it can result in a panic.
Adding a logic to replace these strings into \uFFFD(�).