### PR TITLE
Adding timeline sorting logic

### DIFF
--- a/pkg/model/khifile/v6/log_accumulator.go
+++ b/pkg/model/khifile/v6/log_accumulator.go
@@ -16,6 +16,7 @@ package khifilev6
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -117,7 +118,7 @@ func (a *LogAccumulator) GetLog(id uint32) *pb.Log {
 }
 
 // Accumulate returns the accumulated list of Log proto messages.
-// The returned list is naturally sorted by log ID.
+// The returned list is sorted chronologically by their timestamp.
 func (a *LogAccumulator) Accumulate() []*pb.Log {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
@@ -127,5 +128,8 @@ func (a *LogAccumulator) Accumulate() []*pb.Log {
 			result = append(result, l)
 		}
 	}
+	slices.SortStableFunc(result, func(a, b *pb.Log) int {
+		return a.GetTs().AsTime().Compare(b.GetTs().AsTime())
+	})
 	return result
 }

--- a/pkg/model/khifile/v6/log_accumulator_test.go
+++ b/pkg/model/khifile/v6/log_accumulator_test.go
@@ -158,6 +158,55 @@ func TestLogAccumulator(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple logs sorted chronologically",
+			logsToAdd: []*StagingLog{
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node1)),
+					Summary:   "test summary 1",
+					Timestamp: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC),
+					LogType:   testLogType,
+					Severity:  testSeverity,
+				},
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node2)),
+					Summary:   "test summary 2",
+					Timestamp: time.Date(2026, 4, 29, 8, 0, 0, 0, time.UTC),
+					LogType:   testLogType,
+					Severity:  testSeverity,
+				},
+				{
+					Log:       log.NewLog(structured.NewNodeReader(node3)),
+					Summary:   "test summary 3",
+					Timestamp: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC),
+					LogType:   testLogType,
+					Severity:  testSeverity,
+				},
+			},
+			wantErr:      false,
+			wantLogCount: 3,
+			validate: func(t *testing.T, acc *LogAccumulator) {
+				logs := acc.Accumulate()
+				// Expected order should be: summary 2 (8:00), summary 3 (9:00), summary 1 (10:00)
+				if logs[0].GetId() != 2 {
+					t.Errorf("expected first log to have ID 2, got %d", logs[0].GetId())
+				}
+				if logs[1].GetId() != 3 {
+					t.Errorf("expected second log to have ID 3, got %d", logs[1].GetId())
+				}
+				if logs[2].GetId() != 1 {
+					t.Errorf("expected third log to have ID 1, got %d", logs[2].GetId())
+				}
+
+				// Verify timestamps are in order
+				t0 := logs[0].GetTs().AsTime()
+				t1 := logs[1].GetTs().AsTime()
+				t2 := logs[2].GetTs().AsTime()
+				if t0.After(t1) || t1.After(t2) {
+					t.Errorf("logs are not sorted chronologically: %v, %v, %v", t0, t1, t2)
+				}
+			},
+		},
+		{
 			name: "missing severity error",
 			logsToAdd: []*StagingLog{
 				{

--- a/pkg/model/khifile/v6/timeline_serializer.go
+++ b/pkg/model/khifile/v6/timeline_serializer.go
@@ -17,6 +17,7 @@ package khifilev6
 import (
 	"cmp"
 	"slices"
+	"strings"
 
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 )
@@ -50,10 +51,56 @@ func extractTimelineItems(registry *TimelineRegistry) []*pb.TimelineItems {
 
 // extractTimelines iterates over the TimelinePathPool to generate Timeline protobufs.
 // It assigns TimelineItemsId appropriately by checking if the builder exists.
+// extractTimelines iterates over the TimelinePathPool to generate Timeline protobufs
+// sorted in parent-to-child (pre-order tree traversal) order.
 func extractTimelines(pool *TimelinePathPool, registry *TimelineRegistry) []*pb.Timeline {
-	var timelines []*pb.Timeline
+	// 1. Build parent-to-children adjacency list
+	parentToChildren := make(map[*TimelinePath][]*TimelinePath)
+	var roots []*TimelinePath
 
 	for path := range pool.Paths() {
+		if path.Parent == nil {
+			roots = append(roots, path)
+		} else {
+			parentToChildren[path.Parent] = append(parentToChildren[path.Parent], path)
+		}
+	}
+
+	// 2. Traverse tree in pre-order (depth-first, parent-first)
+	var sortedPaths []*TimelinePath
+	var traverse func(p *TimelinePath)
+
+	traverse = func(p *TimelinePath) {
+		sortedPaths = append(sortedPaths, p)
+		children := parentToChildren[p]
+		// Sort sibling timelines deterministically by ID
+		slices.SortFunc(children, func(a, b *TimelinePath) int {
+			priorityDiff := int(*a.Type.SortPriority - *b.Type.SortPriority)
+			if priorityDiff != 0 {
+				return priorityDiff
+			}
+			return strings.Compare(a.Name.Resolve(), b.Name.Resolve())
+		})
+		for _, child := range children {
+			traverse(child)
+		}
+	}
+
+	// Sort root timelines deterministically by ID
+	slices.SortFunc(roots, func(a, b *TimelinePath) int {
+		priorityDiff := int(*a.Type.SortPriority - *b.Type.SortPriority)
+		if priorityDiff != 0 {
+			return priorityDiff
+		}
+		return strings.Compare(a.Name.Resolve(), b.Name.Resolve())
+	})
+	for _, r := range roots {
+		traverse(r)
+	}
+
+	// 3. Generate pb.Timeline messages in the sorted order
+	var timelines []*pb.Timeline
+	for _, path := range sortedPaths {
 		var itemsID *uint32
 		if b, ok := registry.GetBuilderIfExists(path); ok && b.HasItems() {
 			id := b.TimelineItemsID
@@ -82,11 +129,6 @@ func extractTimelines(pool *TimelinePathPool, registry *TimelineRegistry) []*pb.
 			ParentTimelineId: parentID,
 		})
 	}
-
-	// Sort timelines by ID to ensure deterministic output
-	slices.SortFunc(timelines, func(a, b *pb.Timeline) int {
-		return cmp.Compare(a.GetId(), b.GetId())
-	})
 
 	return timelines
 }

--- a/pkg/model/khifile/v6/timeline_serializer.go
+++ b/pkg/model/khifile/v6/timeline_serializer.go
@@ -73,9 +73,9 @@ func extractTimelines(pool *TimelinePathPool, registry *TimelineRegistry) []*pb.
 	traverse = func(p *TimelinePath) {
 		sortedPaths = append(sortedPaths, p)
 		children := parentToChildren[p]
-		// Sort sibling timelines deterministically by ID
+		// Sort sibling timelines deterministically by its priority and name
 		slices.SortFunc(children, func(a, b *TimelinePath) int {
-			priorityDiff := int(*a.Type.SortPriority - *b.Type.SortPriority)
+			priorityDiff := int(a.Type.GetSortPriority() - b.Type.GetSortPriority())
 			if priorityDiff != 0 {
 				return priorityDiff
 			}
@@ -86,9 +86,9 @@ func extractTimelines(pool *TimelinePathPool, registry *TimelineRegistry) []*pb.
 		}
 	}
 
-	// Sort root timelines deterministically by ID
+	// Sort root timelines deterministically by its priority and name
 	slices.SortFunc(roots, func(a, b *TimelinePath) int {
-		priorityDiff := int(*a.Type.SortPriority - *b.Type.SortPriority)
+		priorityDiff := int(a.Type.GetSortPriority() - b.Type.GetSortPriority())
 		if priorityDiff != 0 {
 			return priorityDiff
 		}

--- a/pkg/model/khifile/v6/timeline_serializer_test.go
+++ b/pkg/model/khifile/v6/timeline_serializer_test.go
@@ -27,8 +27,10 @@ import (
 func TestExtractTimelinesAndItemsChunkSource(t *testing.T) {
 	id1 := uint32(1)
 	id2 := uint32(2)
-	typeA := &pb.TimelineType{Id: &id1}
-	typeB := &pb.TimelineType{Id: &id2}
+	priorityA := int32(100)
+	priorityB := int32(200)
+	typeA := &pb.TimelineType{Id: &id1, SortPriority: &priorityA}
+	typeB := &pb.TimelineType{Id: &id2, SortPriority: &priorityB}
 
 	type timelineDef struct {
 		id        string
@@ -196,6 +198,13 @@ func TestExtractTimelinesAndItemsChunkSource(t *testing.T) {
 			})
 
 			gotTimelines, gotItems := ExtractTimelinesAndItemsChunkSource(pathPool, registry)
+
+			slices.SortFunc(gotTimelines, func(a, b *pb.Timeline) int {
+				return cmp.Compare(a.GetId(), b.GetId())
+			})
+			slices.SortFunc(gotItems, func(a, b *pb.TimelineItems) int {
+				return cmp.Compare(a.GetId(), b.GetId())
+			})
 
 			if diff := googlecmp.Diff(wantTimelines, gotTimelines, protocmp.Transform()); diff != "" {
 				t.Errorf("Timelines mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
This PR adds capability to sort timelines and logs.

Logs in the file must be sorted by its time. Timelines must be sorted by its hierarchical structure.