### PR TITLE
Fixed Makefile to generate proto artifacts automatically before building other codes

### DIFF
--- a/.cloudbuild/github-deploy-ondemand.yaml
+++ b/.cloudbuild/github-deploy-ondemand.yaml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 steps:
-  - name: 'node:22-trixie'
+  - name: "node:22-trixie"
     args:
-      - '-c'
+      - "-c"
       - |
         cd ./web
         npm ci
+        cd ..
+        npx @bufbuild/buf generate
+        touch scripts/make/build-proto.done
     id: dependency_web
     waitFor:
-      - '-'
+      - "-"
     entrypoint: /bin/bash
-  - name: 'golang:1.25-trixie'
+  - name: "golang:1.25-trixie"
     args:
-      - '-c'
+      - "-c"
       - |
         echo "dev-${SHORT_SHA}" > VERSION
         apt-get update && apt-get install jq -y
@@ -35,9 +38,9 @@ steps:
     waitFor:
       - dependency_web
     entrypoint: /bin/bash
-  - name: 'node:22-trixie'
+  - name: "node:22-trixie"
     args:
-      - '-c'
+      - "-c"
       - |
         make build-web
     id: build_web
@@ -46,7 +49,7 @@ steps:
     entrypoint: /bin/bash
   - name: gcr.io/cloud-builders/docker
     args:
-      - '-c'
+      - "-c"
       - |
         docker buildx create --driver docker-container --name container --use
         docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA --push .

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GIT_TAG_NAME := "release-"$(VERSION)
 DUMMY_DIR := scripts/make
 GENERATE_FRONTEND_DUMMY := $(DUMMY_DIR)/generate-frontend.done
 GENERATE_BACKEND_DUMMY := $(DUMMY_DIR)/generate-backend.done
+GENERATE_PROTO_DUMMY := $(DUMMY_DIR)/build-proto.done
 FRONTEND_GENERATED_ASSETS_DUMMY := $(DUMMY_DIR)/generate-font-atlas.done
 MSDF_SETUP_DUMMY := $(DUMMY_DIR)/msdf-setup.done
 
@@ -37,9 +38,9 @@ clean: ## Clean build artifacts and generated files
 	@echo "Cleaning test and coverage reports..."
 	rm -rf go-cover.html go-cover.output result.json
 	@echo "Cleaning intermediate generated files..."
-	find . -path "./web" -prune -o -path "./.git" -prune -o -type f -name "zzz_*.go" -exec rm -f {} + -o -type f -name "zzz_*.json" -exec rm -f {} +
+	find . -path "./scripts" -path "./web" -prune -o -path "./.git" -prune -o -type f -name "zzz_*.go" -exec rm -f {} + -o -type f -name "zzz_*.json" -exec rm -f {} +
 	rm -rf pkg/generated
-	rm -rf web/src/app/zzz-generated.scss web/src/app/zzz-generated.ts web/angular.json web/src/environments/version.*.ts
+	rm -rf web/angular.json web/src/environments/version.*.ts
 	@echo "Cleaning make dummy files..."
 	rm -rf scripts/make/*.done
 

--- a/pkg/model/khifile/v6/style/timeline.go
+++ b/pkg/model/khifile/v6/style/timeline.go
@@ -15,7 +15,7 @@
 package style
 
 import (
-	_ "embed"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -26,14 +26,8 @@ import (
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 )
 
-//go:embed assets/zzz-icon-codepoints.json
-var iconCodepointsBytes []byte
-
-//go:embed assets/zzz-material-icons-msdf.json
-var materialIconsMSDFJSONBytes []byte
-
-//go:embed assets/zzz-material-icons-msdf.png
-var materialIconsMSDFPNGBytes []byte
+//go:embed assets
+var assetsFS embed.FS
 
 var (
 	iconAtlasOnce   sync.Once
@@ -43,6 +37,21 @@ var (
 // GetIconAtlas returns the embedded IconAtlas instance cached globally.
 func GetIconAtlas() *pb.IconAtlas {
 	iconAtlasOnce.Do(func() {
+		iconCodepointsBytes, err := assetsFS.ReadFile("assets/zzz-icon-codepoints.json")
+		if err != nil {
+			panic("failed to read embedded zzz-icon-codepoints.json: " + err.Error())
+		}
+
+		materialIconsMSDFJSONBytes, err := assetsFS.ReadFile("assets/zzz-material-icons-msdf.json")
+		if err != nil {
+			panic("failed to read embedded zzz-material-icons-msdf.json: " + err.Error())
+		}
+
+		materialIconsMSDFPNGBytes, err := assetsFS.ReadFile("assets/zzz-material-icons-msdf.png")
+		if err != nil {
+			panic("failed to read embedded zzz-material-icons-msdf.png: " + err.Error())
+		}
+
 		var codepoints map[string]string
 		if err := json.Unmarshal(iconCodepointsBytes, &codepoints); err != nil {
 			panic("failed to unmarshal embedded zzz-icon-codepoints.json: " + err.Error())
@@ -281,5 +290,21 @@ func GenerateChunk() *pb.TimelineStyleChunk {
 		RevisionStates: slices.Clone(revisionStates),
 		TimelineTypes:  slices.Clone(timelineTypes),
 		IconAtlas:      GetIconAtlas(),
+	}
+}
+
+// GenerateChunkWithoutIconAtlas generates a TimelineStyleChunk without the icon atlas.
+// This is only used in the icon generation step to gather available timeline types but not to depend on the icon atlas to cause the circular dependency.
+func GenerateChunkWithoutIconAtlas() *pb.TimelineStyleChunk {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	return &pb.TimelineStyleChunk{
+		Severities:     slices.Clone(severities),
+		Verbs:          slices.Clone(verbs),
+		LogTypes:       slices.Clone(logTypes),
+		RevisionStates: slices.Clone(revisionStates),
+		TimelineTypes:  slices.Clone(timelineTypes),
+		IconAtlas:      nil,
 	}
 }

--- a/scripts/fontlist-gen/main.go
+++ b/scripts/fontlist-gen/main.go
@@ -43,8 +43,12 @@ func main() {
 	}
 
 	// Generate icons.json storing all the icons used in revision states to generate the icon font atlas.
-	var icons = map[string]struct{}{}
-	chunk := style.GenerateChunk()
+	var icons = map[string]struct{}{
+		// TODO: Remove fofllowing icons. These are registered temporary for the mock data.
+		"step_over": {},
+		"skull":     {},
+	}
+	chunk := style.GenerateChunkWithoutIconAtlas()
 	for _, revisionState := range chunk.RevisionStates {
 		icon := revisionState.GetIcon()
 		if icon != "" {

--- a/scripts/make/codegen.mk
+++ b/scripts/make/codegen.mk
@@ -1,7 +1,19 @@
 # codegen.mk
 # This file contains make tasks for generating config or source code.
 
-$(GENERATE_FRONTEND_DUMMY): web/angular.json web/src/environments/version.*.ts $(FRONTEND_GENERATED_ASSETS_DUMMY)
+PROTO_SRCS := $(shell find proto -name "*.proto")
+PROTO_DEPS := $(PROTO_SRCS) buf.gen.yaml
+
+$(GENERATE_PROTO_DUMMY): $(PROTO_DEPS)
+	npx @bufbuild/buf generate
+	gofmt -s -w pkg/generated
+	cd web && npx prettier --write "src/app/generated/**/*.d.ts"
+	touch $(GENERATE_PROTO_DUMMY)
+
+.PHONY: build-proto
+build-proto: $(GENERATE_PROTO_DUMMY) ## Generate code from protobuf definitions
+
+$(GENERATE_FRONTEND_DUMMY): $(GENERATE_PROTO_DUMMY) web/angular.json web/src/environments/version.*.ts $(FRONTEND_GENERATED_ASSETS_DUMMY)
 	touch $(GENERATE_FRONTEND_DUMMY)
 .PHONY: generate-frontend
 generate-frontend: $(GENERATE_FRONTEND_DUMMY) ## Generate frontend source code
@@ -21,7 +33,7 @@ fontlist-gen: scripts/msdf-generator/zzz_generated_used_icons.json
 web/src/environments/version.*.ts: VERSION
 	./scripts/generate-version.sh
 
-$(GENERATE_BACKEND_DUMMY): ## Generate backend source code
+$(GENERATE_BACKEND_DUMMY): $(GENERATE_PROTO_DUMMY) ## Generate backend source code
 	go run ./scripts/backend-codegen/
 	touch $(GENERATE_BACKEND_DUMMY)
 .PHONY: generate-backend
@@ -46,7 +58,4 @@ $(MSDF_SETUP_DUMMY):
 add-licenses: ## Add license headers to all files
 	go tool addlicense  -c "Google LLC" -l apache .
 
-.PHONY: build-proto
-build-proto: ## Generate code from protobuf definitions
-	npx @bufbuild/buf generate
 


### PR DESCRIPTION
This PR updates the Makefile for the current code base to make `make clean && make build` works again.
`make build-proto` wasn't called with `make build-go` or `make build-web` automatically.

This PR also includes the change for `timeline.go`. That changed the code not to depend on specific embed files and to depend on embed folder instead. This is because the icon atlas generation needs to call style registry and its produces the embedded file's dependency and fails build because the file is missing at initial. 