### PR TITLE
Optimized structured data storing in domain store

### DIFF
--- a/web/src/app/parser/v6/blueprint.ts
+++ b/web/src/app/parser/v6/blueprint.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { fromBinary } from '@bufbuild/protobuf';
+import { fromBinary, toBinary } from '@bufbuild/protobuf';
+import { InternedStructSchema } from 'src/app/generated/khifile/shared_pb';
 import {
   ChunkDefinition,
   IDataAssembler,
@@ -282,7 +283,7 @@ export class V6LogAssembler implements IDataAssembler<LogChunk> {
         logTypeId: log.logTypeId,
         severityTypeId: log.severityTypeId,
         summaryStringId: log.summaryStringId,
-        body: log.body,
+        body: log.body ? toBinary(InternedStructSchema, log.body) : undefined,
       });
     }
   }
@@ -333,7 +334,9 @@ export class V6TimelineAssembler implements IDataAssembler<TimelineChunk> {
           principalStringId: r.principalStringId,
           verbTypeId: r.verbType,
           stateTypeId: r.stateType,
-          body: r.resourceBody,
+          body: r.resourceBody
+            ? toBinary(InternedStructSchema, r.resourceBody)
+            : undefined,
         });
         revisionIds.push(id);
       }

--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -231,6 +231,62 @@ describe('LogStore', () => {
     expect(() => store.getLog(99)).toThrowError('Log ID 99 not found');
   });
 
+  it('should cache body in WeakRef and re-decode when GC collected', () => {
+    internPool.addStrings([
+      { id: 10, value: 'user' },
+      { id: 11, value: 'alice' },
+    ]);
+
+    internPool.addFieldPathSets([{ id: 1, fieldPathStringIds: [10] }]);
+
+    const struct = create(InternedStructSchema, {
+      fieldPathSetId: 1,
+      values: [
+        create(InternedValueSchema, {
+          kind: { case: 'stringValue', value: 11 },
+        }),
+      ],
+    });
+
+    const logs: LogDTO[] = [
+      {
+        id: 1,
+        ts: 10n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+        body: toBinary(InternedStructSchema, struct),
+      },
+    ];
+
+    store.initialize(logs, 1);
+
+    const log = store.getLog(1);
+
+    const spyDecode = spyOn(store, '_decodeBody').and.callThrough();
+    const body1 = log.body;
+    expect(body1).toEqual({ user: 'alice' });
+    expect(spyDecode).toHaveBeenCalledTimes(1);
+
+    spyDecode.calls.reset();
+    const body2 = log.body;
+    expect(body2).toBe(body1);
+    expect(spyDecode).not.toHaveBeenCalled();
+
+    const logRecord = log as Record<string, unknown>;
+    const internalBodyRef = logRecord['_body'] as WeakRef<
+      Record<string, unknown>
+    >;
+    expect(internalBodyRef).toBeInstanceOf(WeakRef);
+    spyOn(internalBodyRef, 'deref').and.returnValue(undefined);
+
+    spyDecode.calls.reset();
+    const body3 = log.body;
+    expect(body3).toEqual({ user: 'alice' });
+    expect(body3).not.toBe(body1);
+    expect(spyDecode).toHaveBeenCalledTimes(1);
+  });
+
   it('should return count and iterator correctly', () => {
     const logs: LogDTO[] = [
       { id: 1, ts: 1000n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },

--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -263,28 +263,42 @@ describe('LogStore', () => {
 
     const log = store.getLog(1);
 
-    const spyDecode = spyOn(store, '_decodeBody').and.callThrough();
+    const storeRecord = store as unknown as Record<string, unknown>;
+    const decoder = storeRecord['decoder'] as {
+      decode: (struct: unknown) => Record<string, unknown>;
+    };
+    const spyDecoderDecode = spyOn(decoder, 'decode').and.callThrough();
+
+    // First access decodes the raw binary body and populates the cache.
     const body1 = log.body;
     expect(body1).toEqual({ user: 'alice' });
-    expect(spyDecode).toHaveBeenCalledTimes(1);
+    expect(spyDecoderDecode).toHaveBeenCalledTimes(1);
 
-    spyDecode.calls.reset();
+    // Reset the spy to track subsequent decode calls accurately.
+    spyDecoderDecode.calls.reset();
+
+    // Second access should hit the cache in LogStore, avoiding another decode invocation.
     const body2 = log.body;
     expect(body2).toBe(body1);
-    expect(spyDecode).not.toHaveBeenCalled();
+    expect(spyDecoderDecode).not.toHaveBeenCalled();
 
-    const logRecord = log as Record<string, unknown>;
-    const internalBodyRef = logRecord['_body'] as WeakRef<
+    // Access the private decodedBodyCache array to simulate garbage collection.
+    const decodedBodyCache = storeRecord['decodedBodyCache'] as WeakRef<
       Record<string, unknown>
-    >;
+    >[];
+    const internalBodyRef = decodedBodyCache[0];
     expect(internalBodyRef).toBeInstanceOf(WeakRef);
+
+    // Mock deref() returning undefined to simulate that the WeakRef target has been garbage collected.
     spyOn(internalBodyRef, 'deref').and.returnValue(undefined);
 
-    spyDecode.calls.reset();
+    spyDecoderDecode.calls.reset();
+
+    // Third access fails the deref() check, triggering a re-decode of the binary body.
     const body3 = log.body;
     expect(body3).toEqual({ user: 'alice' });
     expect(body3).not.toBe(body1);
-    expect(spyDecode).toHaveBeenCalledTimes(1);
+    expect(spyDecoderDecode).toHaveBeenCalledTimes(1);
   });
 
   it('should return count and iterator correctly', () => {

--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -17,7 +17,7 @@
 import { LogStore, LogDTO } from 'src/app/store/domain/log-store';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
-import { create } from '@bufbuild/protobuf';
+import { create, toBinary } from '@bufbuild/protobuf';
 import {
   InternedStructSchema,
   InternedValueSchema,
@@ -214,7 +214,7 @@ describe('LogStore', () => {
         logTypeId: 1,
         severityTypeId: 1,
         summaryStringId: 1,
-        body: struct,
+        body: toBinary(InternedStructSchema, struct),
       },
       { id: 2, ts: 20n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
     ];

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -18,9 +18,10 @@ import { Log } from 'src/app/store/domain/log';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { InternedStructDecoder } from 'src/app/store/domain/struct-decoder';
-import { InternedStruct } from 'src/app/generated/khifile/shared_pb';
+import { InternedStructSchema } from 'src/app/generated/khifile/shared_pb';
 import { LogType, Severity } from 'src/app/store/domain/style';
 import { ReadonlyDomainElement, Undefinable } from 'src/app/store/domain/types';
+import { fromBinary } from '@bufbuild/protobuf';
 
 /**
  * Raw Log object interface from the assembler.
@@ -34,7 +35,7 @@ export interface LogDTO {
   readonly logTypeId: number;
   readonly severityTypeId: number;
   readonly summaryStringId: number;
-  readonly body?: InternedStruct;
+  readonly body?: Uint8Array;
 }
 
 /**
@@ -47,7 +48,7 @@ export class LogStore {
   private severityIds = new Uint32Array(0);
   private summaryStringIds = new Uint32Array(0);
 
-  private bodies: Undefinable<InternedStruct>[] = [];
+  private bodies: Undefinable<Uint8Array>[] = [];
   private idToIndex: Undefinable<number>[] = [];
   private readonly decoder: InternedStructDecoder;
 
@@ -71,7 +72,7 @@ export class LogStore {
     this.severityIds = new Uint32Array(count);
     this.summaryStringIds = new Uint32Array(count);
 
-    this.bodies = new Array<Undefinable<InternedStruct>>(count);
+    this.bodies = new Array<Undefinable<Uint8Array>>(count);
     this.idToIndex = [];
 
     let index = 0;
@@ -167,8 +168,9 @@ export class LogStore {
     id: number,
   ): ReadonlyDomainElement<Record<string, unknown>> | null {
     const index = this.getIndex(id);
-    const struct = this.bodies[index];
-    if (!struct) return null;
+    const body = this.bodies[index];
+    if (!body) return null;
+    const struct = fromBinary(InternedStructSchema, body);
     return this.decoder.decode(struct);
   }
 

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -49,6 +49,9 @@ export class LogStore {
   private summaryStringIds = new Uint32Array(0);
 
   private bodies: Undefinable<Uint8Array>[] = [];
+  private decodedBodyCache: WeakRef<
+    ReadonlyDomainElement<Record<string, unknown>>
+  >[] = [];
   private idToIndex: Undefinable<number>[] = [];
   private readonly decoder: InternedStructDecoder;
 
@@ -73,6 +76,9 @@ export class LogStore {
     this.summaryStringIds = new Uint32Array(count);
 
     this.bodies = new Array<Undefinable<Uint8Array>>(count);
+    this.decodedBodyCache = new Array<
+      WeakRef<ReadonlyDomainElement<Record<string, unknown>>>
+    >(count);
     this.idToIndex = [];
 
     let index = 0;
@@ -168,10 +174,17 @@ export class LogStore {
     id: number,
   ): ReadonlyDomainElement<Record<string, unknown>> | null {
     const index = this.getIndex(id);
+    const cached = this.decodedBodyCache[index]?.deref();
+    if (cached) {
+      return cached;
+    }
+
     const body = this.bodies[index];
     if (!body) return null;
     const struct = fromBinary(InternedStructSchema, body);
-    return this.decoder.decode(struct);
+    const decoded = this.decoder.decode(struct);
+    this.decodedBodyCache[index] = new WeakRef(decoded);
+    return decoded;
   }
 
   /**

--- a/web/src/app/store/domain/log.ts
+++ b/web/src/app/store/domain/log.ts
@@ -25,7 +25,9 @@ import { BigIntTimeUtil } from 'src/app/utils/bigint-time-util';
  * Evaluates fields on demand and ensures deep immutability.
  */
 export class Log {
-  private _body?: ReadonlyDomainElement<Record<string, unknown>> | null;
+  private _body?: WeakRef<
+    ReadonlyDomainElement<Record<string, unknown>>
+  > | null;
 
   constructor(
     public readonly id: number,
@@ -79,12 +81,24 @@ export class Log {
    * Gets the structured log attributes decoded from Intern pool data stores.
    */
   get body(): ReadonlyDomainElement<Record<string, unknown>> | null {
-    if (this._body === undefined) {
-      this._body = this.store._decodeBody(this.id) as ReadonlyDomainElement<
-        Record<string, unknown>
-      > | null;
+    if (this._body === null) {
+      return null;
     }
-    return this._body;
+    if (this._body !== undefined) {
+      const deref = this._body.deref();
+      if (deref !== undefined) {
+        return deref;
+      }
+    }
+    const decoded = this.store._decodeBody(this.id) as ReadonlyDomainElement<
+      Record<string, unknown>
+    > | null;
+    if (decoded === null) {
+      this._body = null;
+    } else {
+      this._body = new WeakRef(decoded);
+    }
+    return decoded;
   }
 
   /**

--- a/web/src/app/store/domain/log.ts
+++ b/web/src/app/store/domain/log.ts
@@ -25,10 +25,6 @@ import { BigIntTimeUtil } from 'src/app/utils/bigint-time-util';
  * Evaluates fields on demand and ensures deep immutability.
  */
 export class Log {
-  private _body?: WeakRef<
-    ReadonlyDomainElement<Record<string, unknown>>
-  > | null;
-
   constructor(
     public readonly id: number,
     private readonly store: LogStore,
@@ -81,24 +77,7 @@ export class Log {
    * Gets the structured log attributes decoded from Intern pool data stores.
    */
   get body(): ReadonlyDomainElement<Record<string, unknown>> | null {
-    if (this._body === null) {
-      return null;
-    }
-    if (this._body !== undefined) {
-      const deref = this._body.deref();
-      if (deref !== undefined) {
-        return deref;
-      }
-    }
-    const decoded = this.store._decodeBody(this.id) as ReadonlyDomainElement<
-      Record<string, unknown>
-    > | null;
-    if (decoded === null) {
-      this._body = null;
-    } else {
-      this._body = new WeakRef(decoded);
-    }
-    return decoded;
+    return this.store._decodeBody(this.id);
   }
 
   /**

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -23,6 +23,11 @@ import {
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { LogStore } from 'src/app/store/domain/log-store';
+import { create, toBinary } from '@bufbuild/protobuf';
+import {
+  InternedStructSchema,
+  InternedValueSchema,
+} from 'src/app/generated/khifile/shared_pb';
 
 describe('TimelineStore', () => {
   let internPool: InternPoolStore;
@@ -220,5 +225,75 @@ describe('TimelineStore', () => {
     expect(() => store._getChildIdsForTimeline(999)).toThrowError(
       'Timeline ID 999 not found',
     );
+  });
+
+  it('should return decoded revision body correctly', () => {
+    internPool.addStrings([
+      { id: 10, value: 'user' },
+      { id: 11, value: 'status' },
+      { id: 12, value: 'alice' },
+    ]);
+
+    internPool.addFieldPathSets([{ id: 1, fieldPathStringIds: [10, 11] }]);
+
+    const struct = create(InternedStructSchema, {
+      fieldPathSetId: 1,
+      values: [
+        create(InternedValueSchema, {
+          kind: { case: 'stringValue', value: 12 },
+        }),
+        create(InternedValueSchema, {
+          kind: { case: 'int64Value', value: 42n },
+        }),
+      ],
+    });
+
+    const rawTimelines: TimelineDTO[] = [
+      {
+        id: 10,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [100, 101],
+        eventIds: [],
+      },
+    ];
+
+    const rawRevisions: RevisionDTO[] = [
+      {
+        id: 100,
+        logId: 1,
+        changedTime: 10n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+        body: toBinary(InternedStructSchema, struct),
+      },
+      {
+        id: 101,
+        logId: 2,
+        changedTime: 20n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+      },
+    ];
+
+    const logs = [
+      { id: 1, ts: 10n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+      { id: 2, ts: 20n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+    ];
+    logStore.initialize(logs, 2);
+
+    store.initialize(rawTimelines, 1, rawRevisions, 2, [], 0);
+
+    const t = store.getTimeline(10);
+    expect(t.revisions[0].body).toEqual({
+      user: 'alice',
+      status: 42,
+    });
+    expect(t.revisions[0].bodyYAML).toBe('user: alice\nstatus: 42\n');
+    expect(t.revisions[1].body).toBeNull();
+    expect(t.revisions[1].bodyYAML).toBe('');
   });
 });

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -296,4 +296,77 @@ describe('TimelineStore', () => {
     expect(t.revisions[1].body).toBeNull();
     expect(t.revisions[1].bodyYAML).toBe('');
   });
+
+  it('should cache revision body in WeakRef and re-decode when GC collected', () => {
+    internPool.addStrings([
+      { id: 10, value: 'user' },
+      { id: 11, value: 'alice' },
+    ]);
+
+    internPool.addFieldPathSets([{ id: 1, fieldPathStringIds: [10] }]);
+
+    const struct = create(InternedStructSchema, {
+      fieldPathSetId: 1,
+      values: [
+        create(InternedValueSchema, {
+          kind: { case: 'stringValue', value: 11 },
+        }),
+      ],
+    });
+
+    const rawTimelines: TimelineDTO[] = [
+      {
+        id: 10,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [100],
+        eventIds: [],
+      },
+    ];
+
+    const rawRevisions: RevisionDTO[] = [
+      {
+        id: 100,
+        logId: 1,
+        changedTime: 10n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+        body: toBinary(InternedStructSchema, struct),
+      },
+    ];
+
+    const logs = [
+      { id: 1, ts: 10n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+    ];
+    logStore.initialize(logs, 1);
+
+    store.initialize(rawTimelines, 1, rawRevisions, 1, [], 0);
+
+    const revision = store.getTimeline(10).revisions[0];
+
+    const spyDecode = spyOn(store, '_decodeRevisionBody').and.callThrough();
+    const body1 = revision.body;
+    expect(body1).toEqual({ user: 'alice' });
+    expect(spyDecode).toHaveBeenCalledTimes(1);
+
+    spyDecode.calls.reset();
+    const body2 = revision.body;
+    expect(body2).toBe(body1);
+    expect(spyDecode).not.toHaveBeenCalled();
+
+    const revRecord = revision as Record<string, unknown>;
+    const internalBodyRef = revRecord['_body'] as WeakRef<
+      Record<string, unknown>
+    >;
+    expect(internalBodyRef).toBeInstanceOf(WeakRef);
+    spyOn(internalBodyRef, 'deref').and.returnValue(undefined);
+
+    spyDecode.calls.reset();
+    const body3 = revision.body;
+    expect(body3).toEqual({ user: 'alice' });
+    expect(body3).not.toBe(body1);
+    expect(spyDecode).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -346,27 +346,43 @@ describe('TimelineStore', () => {
 
     const revision = store.getTimeline(10).revisions[0];
 
-    const spyDecode = spyOn(store, '_decodeRevisionBody').and.callThrough();
+    // Access the private decoder inside TimelineStore to spy on the actual decoding call.
+    // This lets us verify whether a cache hit bypasses the heavy decoding process.
+    const storeRecord = store as unknown as Record<string, unknown>;
+    const decoder = storeRecord['decoder'] as {
+      decode: (struct: unknown) => Record<string, unknown>;
+    };
+    const spyDecoderDecode = spyOn(decoder, 'decode').and.callThrough();
+
+    // First access decodes the raw binary body and populates the cache.
     const body1 = revision.body;
     expect(body1).toEqual({ user: 'alice' });
-    expect(spyDecode).toHaveBeenCalledTimes(1);
+    expect(spyDecoderDecode).toHaveBeenCalledTimes(1);
 
-    spyDecode.calls.reset();
+    // Reset the spy to track subsequent decode calls accurately.
+    spyDecoderDecode.calls.reset();
+
+    // Second access should hit the cache in TimelineStore, avoiding another decode invocation.
     const body2 = revision.body;
     expect(body2).toBe(body1);
-    expect(spyDecode).not.toHaveBeenCalled();
+    expect(spyDecoderDecode).not.toHaveBeenCalled();
 
-    const revRecord = revision as Record<string, unknown>;
-    const internalBodyRef = revRecord['_body'] as WeakRef<
-      Record<string, unknown>
-    >;
+    // Access the private revisionDecodedBodyCache array to simulate garbage collection.
+    const revisionDecodedBodyCache = storeRecord[
+      'revisionDecodedBodyCache'
+    ] as WeakRef<Record<string, unknown>>[];
+    const internalBodyRef = revisionDecodedBodyCache[0];
     expect(internalBodyRef).toBeInstanceOf(WeakRef);
+
+    // Mock deref() returning undefined to simulate that the WeakRef target has been garbage collected.
     spyOn(internalBodyRef, 'deref').and.returnValue(undefined);
 
-    spyDecode.calls.reset();
+    spyDecoderDecode.calls.reset();
+
+    // Third access fails the deref() check, triggering a re-decode of the binary body.
     const body3 = revision.body;
     expect(body3).toEqual({ user: 'alice' });
     expect(body3).not.toBe(body1);
-    expect(spyDecode).toHaveBeenCalledTimes(1);
+    expect(spyDecoderDecode).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -85,6 +85,9 @@ export class TimelineStore {
   private revisionVerbTypeIds = new Uint32Array(0);
   private revisionStateTypeIds = new Uint32Array(0);
   private readonly revisionBodies: Uint8Array[] = [];
+  private readonly revisionDecodedBodyCache: WeakRef<
+    ReadonlyDomainElement<Record<string, unknown>>
+  >[] = [];
   private revisionIdToIndex: { [rid: number]: number } = {};
 
   // Event metadata
@@ -164,6 +167,7 @@ export class TimelineStore {
     this.revisionPrincipalStringIds = new Uint32Array(revisionCount);
     this.revisionVerbTypeIds = new Uint32Array(revisionCount);
     this.revisionStateTypeIds = new Uint32Array(revisionCount);
+    this.revisionDecodedBodyCache.length = revisionCount;
 
     // Load revisions
     let rIndex = 0;
@@ -372,10 +376,18 @@ export class TimelineStore {
   public _decodeRevisionBody(
     id: number,
   ): ReadonlyDomainElement<Record<string, unknown>> | null {
-    const body = this.revisionBodies[this.getRevisionIndex(id)];
+    const index = this.getRevisionIndex(id);
+    const cached = this.revisionDecodedBodyCache[index]?.deref();
+    if (cached) {
+      return cached;
+    }
+
+    const body = this.revisionBodies[index];
     if (!body) return null;
     const struct = fromBinary(InternedStructSchema, body);
-    return this.decoder.decode(struct);
+    const decoded = this.decoder.decode(struct);
+    this.revisionDecodedBodyCache[index] = new WeakRef(decoded);
+    return decoded;
   }
 
   private getRevisionIndex(id: number): number {

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -23,10 +23,11 @@ import {
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { InternedStructDecoder } from 'src/app/store/domain/struct-decoder';
-import { InternedStruct } from 'src/app/generated/khifile/shared_pb';
+import { InternedStructSchema } from 'src/app/generated/khifile/shared_pb';
 import { RevisionState, TimelineType, Verb } from 'src/app/store/domain/style';
 import { LogStore } from 'src/app/store/domain/log-store';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import { fromBinary } from '@bufbuild/protobuf';
 
 /**
  * Raw timeline object interface from the assembler.
@@ -50,7 +51,7 @@ export interface RevisionDTO {
   readonly principalStringId: number;
   readonly verbTypeId: number;
   readonly stateTypeId: number;
-  readonly body?: InternedStruct;
+  readonly body?: Uint8Array;
 }
 
 /**
@@ -83,7 +84,7 @@ export class TimelineStore {
   private revisionPrincipalStringIds = new Uint32Array(0);
   private revisionVerbTypeIds = new Uint32Array(0);
   private revisionStateTypeIds = new Uint32Array(0);
-  private readonly revisionBodies: InternedStruct[] = [];
+  private readonly revisionBodies: Uint8Array[] = [];
   private revisionIdToIndex: { [rid: number]: number } = {};
 
   // Event metadata
@@ -371,8 +372,9 @@ export class TimelineStore {
   public _decodeRevisionBody(
     id: number,
   ): ReadonlyDomainElement<Record<string, unknown>> | null {
-    const struct = this.revisionBodies[this.getRevisionIndex(id)];
-    if (!struct) return null;
+    const body = this.revisionBodies[this.getRevisionIndex(id)];
+    if (!body) return null;
+    const struct = fromBinary(InternedStructSchema, body);
     return this.decoder.decode(struct);
   }
 

--- a/web/src/app/store/domain/timeline.spec.ts
+++ b/web/src/app/store/domain/timeline.spec.ts
@@ -23,7 +23,7 @@ import {
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { LogStore, LogDTO } from 'src/app/store/domain/log-store';
-import { create } from '@bufbuild/protobuf';
+import { create, toBinary } from '@bufbuild/protobuf';
 import {
   InternedStructSchema,
   InternedValueSchema,
@@ -594,7 +594,7 @@ describe('Timeline', () => {
             principalStringId: 2,
             verbTypeId: 1,
             stateTypeId: 1,
-            body: struct,
+            body: toBinary(InternedStructSchema, struct),
           },
           {
             id: 101,

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -36,7 +36,9 @@ export interface TimelinePathNode {
  * Lazy adapter for a resource revision.
  */
 export class Revision {
-  private _body?: ReadonlyDomainElement<Record<string, unknown>> | null;
+  private _body?: WeakRef<
+    ReadonlyDomainElement<Record<string, unknown>>
+  > | null;
   private _log?: ReadonlyDomainElement<Log>;
 
   constructor(
@@ -140,10 +142,24 @@ export class Revision {
    * Gets the optional structured resource manifest parameters at the snapshot moment.
    */
   get body(): ReadonlyDomainElement<Record<string, unknown>> | null {
-    if (this._body === undefined) {
-      this._body = this.timelineStore._decodeRevisionBody(this.id);
+    if (this._body === null) {
+      return null;
     }
-    return this._body;
+    if (this._body !== undefined) {
+      const deref = this._body.deref();
+      if (deref !== undefined) {
+        return deref;
+      }
+    }
+    const decoded = this.timelineStore._decodeRevisionBody(
+      this.id,
+    ) as ReadonlyDomainElement<Record<string, unknown>> | null;
+    if (decoded === null) {
+      this._body = null;
+    } else {
+      this._body = new WeakRef(decoded);
+    }
+    return decoded;
   }
 
   /**

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -36,9 +36,6 @@ export interface TimelinePathNode {
  * Lazy adapter for a resource revision.
  */
 export class Revision {
-  private _body?: WeakRef<
-    ReadonlyDomainElement<Record<string, unknown>>
-  > | null;
   private _log?: ReadonlyDomainElement<Log>;
 
   constructor(
@@ -142,24 +139,7 @@ export class Revision {
    * Gets the optional structured resource manifest parameters at the snapshot moment.
    */
   get body(): ReadonlyDomainElement<Record<string, unknown>> | null {
-    if (this._body === null) {
-      return null;
-    }
-    if (this._body !== undefined) {
-      const deref = this._body.deref();
-      if (deref !== undefined) {
-        return deref;
-      }
-    }
-    const decoded = this.timelineStore._decodeRevisionBody(
-      this.id,
-    ) as ReadonlyDomainElement<Record<string, unknown>> | null;
-    if (decoded === null) {
-      this._body = null;
-    } else {
-      this._body = new WeakRef(decoded);
-    }
-    return decoded;
+    return this.timelineStore._decodeRevisionBody(this.id);
   }
 
   /**


### PR DESCRIPTION
Previously KHI decoded all the InternedStruct proto data into the decoded object. This fills JSHeap with very rapid speeds.
In this change, the implemenation encode then into InternedStruct again to keep them on ArrayBuffer not to consume JSHeap.