### PR TITLE
Migrate CSM access log and TD resource audit log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
@@ -28,6 +28,7 @@ import (
 )
 
 type GCPAuditLogFieldSet struct {
+	ProjectID      string
 	OperationID    string
 	OperationFirst bool
 	OperationLast  bool
@@ -130,6 +131,7 @@ func (g *GCPOperationAuditLogFieldSetReader) FieldSetKind() string {
 // Read implements log.FieldSetReader.
 func (g *GCPOperationAuditLogFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	var result GCPAuditLogFieldSet
+	result.ProjectID = reader.ReadStringOrDefault("resource.labels.project_id", "unknown")
 	result.OperationID = reader.ReadStringOrDefault("operation.id", "")
 	result.OperationFirst = reader.ReadBoolOrDefault("operation.first", false)
 	result.OperationLast = reader.ReadBoolOrDefault("operation.last", false)

--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
@@ -32,6 +32,11 @@ func TestGCPAuditLogFieldSetReader(t *testing.T) {
 		{
 			name: "full audit log",
 			input: map[string]any{
+				"resource": map[string]any{
+					"labels": map[string]any{
+						"project_id": "p1",
+					},
+				},
 				"operation": map[string]any{
 					"id":    "op-1",
 					"first": true,
@@ -55,6 +60,7 @@ func TestGCPAuditLogFieldSetReader(t *testing.T) {
 				},
 			},
 			want: &GCPAuditLogFieldSet{
+				ProjectID:      "p1",
 				OperationID:    "op-1",
 				OperationFirst: true,
 				OperationLast:  false,
@@ -80,7 +86,8 @@ func TestGCPAuditLogFieldSetReader(t *testing.T) {
 			gotAudit := got.(*GCPAuditLogFieldSet)
 
 			// Compare fields except NodeReaders
-			if gotAudit.OperationID != tc.want.OperationID ||
+			if gotAudit.ProjectID != tc.want.ProjectID ||
+				gotAudit.OperationID != tc.want.OperationID ||
 				gotAudit.OperationFirst != tc.want.OperationFirst ||
 				gotAudit.OperationLast != tc.want.OperationLast ||
 				gotAudit.MethodName != tc.want.MethodName ||

--- a/pkg/task/inspection/googlecloudcommon/contract/timeline.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/timeline.go
@@ -17,6 +17,7 @@ package googlecloudcommon_contract
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
@@ -26,7 +27,8 @@ import (
 // MustGKEClusterTimeline returns the timeline path for a GKE Cluster.
 func MustGKEClusterTimeline(ctx context.Context, clusterName string) *khifilev6.TimelinePath {
 	if clusterName == "" {
-		panic("cluster name must not be empty")
+		clusterName = "unknown"
+		slog.WarnContext(ctx, "clusterName is empty, using unknown instead")
 	}
 
 	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
@@ -42,7 +44,8 @@ func MustGKENodePoolTimeline(ctx context.Context, gkeClusterTimeline *khifilev6.
 		panic("parent timeline path must be GKE type")
 	}
 	if nodePoolName == "" {
-		panic("node pool name must not be empty")
+		nodePoolName = "unknown"
+		slog.WarnContext(ctx, "nodePoolName is empty, using unknown instead")
 	}
 
 	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
@@ -58,8 +61,13 @@ func MustGCPOperationTimeline(ctx context.Context, parentTimeline *khifilev6.Tim
 	if parentTimeline == nil {
 		panic("parent timeline path must not be nil")
 	}
-	if shortMethodName == "" || operationID == "" {
-		panic("shortMethodName and operationID must not be empty")
+	if shortMethodName == "" {
+		shortMethodName = "unknown"
+		slog.WarnContext(ctx, "shortMethodName is empty, using unknown instead")
+	}
+	if operationID == "" {
+		operationID = "unknown"
+		slog.WarnContext(ctx, "operationID is empty, using unknown instead")
 	}
 
 	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
@@ -72,7 +80,8 @@ func MustGCPOperationTimeline(ctx context.Context, parentTimeline *khifilev6.Tim
 // MustGCPProjectTimeline returns the timeline path for a Google Cloud Project root timeline.
 func MustGCPProjectTimeline(ctx context.Context, projectID string) *khifilev6.TimelinePath {
 	if projectID == "" {
-		panic("projectID must not be empty")
+		projectID = "unknown"
+		slog.WarnContext(ctx, "projectID is empty, using unknown instead")
 	}
 	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
 	return builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
@@ -87,7 +96,8 @@ func MustGCPResourceTypeTimeline(ctx context.Context, projectPath *khifilev6.Tim
 		panic("parent timeline path must be GCPProject type")
 	}
 	if resourceType == "" {
-		panic("resourceType must not be empty")
+		resourceType = "unknown"
+		slog.WarnContext(ctx, "resourceType is empty, using unknown instead")
 	}
 	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
 	return builder.TimelineAccumulator.GetPath(projectPath, khifilev6.PathSegment{
@@ -102,7 +112,8 @@ func MustGCPResourceTimeline(ctx context.Context, resourceTypePath *khifilev6.Ti
 		panic("parent timeline path must be GCPResourceType type")
 	}
 	if resourceName == "" {
-		panic("resourceName must not be empty")
+		resourceName = "unknown"
+		slog.WarnContext(ctx, "resourceName is empty, using unknown instead")
 	}
 	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
 	return builder.TimelineAccumulator.GetPath(resourceTypePath, khifilev6.PathSegment{

--- a/pkg/task/inspection/googlecloudcommon/contract/timeline_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/timeline_test.go
@@ -32,46 +32,28 @@ func TestMustGKEClusterTimeline(t *testing.T) {
 	testCases := []struct {
 		name        string
 		clusterName string
-		wantPanic   bool
-		panicMsg    string
+		wantName    string
 	}{
 		{
 			name:        "valid cluster name",
 			clusterName: "my-gke-cluster",
-			wantPanic:   false,
+			wantName:    "my-gke-cluster",
 		},
 		{
 			name:        "empty cluster name",
 			clusterName: "",
-			wantPanic:   true,
-			panicMsg:    "cluster name must not be empty",
+			wantName:    "unknown",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.wantPanic {
-				defer func() {
-					r := recover()
-					if r == nil {
-						t.Error("expected panic but did not panic")
-					} else {
-						errStr := fmt.Sprintf("%v", r)
-						if !strings.Contains(errStr, tc.panicMsg) {
-							t.Errorf("expected panic message to contain %q, got %q", tc.panicMsg, errStr)
-						}
-					}
-				}()
-			}
-
 			got := MustGKEClusterTimeline(ctx, tc.clusterName)
-			if !tc.wantPanic {
-				if got == nil {
-					t.Fatal("expected timeline path to be not nil")
-				}
-				if diff := cmp.Diff(tc.clusterName, got.Name.Resolve()); diff != "" {
-					t.Errorf("MustGKEClusterTimeline() mismatch (-want +got):\n%s", diff)
-				}
+			if got == nil {
+				t.Fatal("expected timeline path to be not nil")
+			}
+			if diff := cmp.Diff(tc.wantName, got.Name.Resolve()); diff != "" {
+				t.Errorf("MustGKEClusterTimeline() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -93,12 +75,14 @@ func TestMustGKENodePoolTimeline(t *testing.T) {
 		nodePoolName string
 		wantPanic    bool
 		panicMsg     string
+		wantName     string
 	}{
 		{
 			name:         "valid nodepool name",
 			parent:       gkeClusterTimeline,
 			nodePoolName: "default-pool",
 			wantPanic:    false,
+			wantName:     "default-pool",
 		},
 		{
 			name:         "invalid parent type",
@@ -111,8 +95,8 @@ func TestMustGKENodePoolTimeline(t *testing.T) {
 			name:         "empty nodepool name",
 			parent:       gkeClusterTimeline,
 			nodePoolName: "",
-			wantPanic:    true,
-			panicMsg:     "node pool name must not be empty",
+			wantPanic:    false,
+			wantName:     "unknown",
 		},
 	}
 
@@ -137,8 +121,261 @@ func TestMustGKENodePoolTimeline(t *testing.T) {
 				if got == nil {
 					t.Fatal("expected timeline path to be not nil")
 				}
-				if diff := cmp.Diff(tc.nodePoolName, got.Name.Resolve()); diff != "" {
+				if diff := cmp.Diff(tc.wantName, got.Name.Resolve()); diff != "" {
 					t.Errorf("MustGKENodePoolTimeline() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestMustGCPOperationTimeline(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	gkeClusterTimeline := MustGKEClusterTimeline(ctx, "test-gke-cluster")
+
+	testCases := []struct {
+		name            string
+		parent          *khifilev6.TimelinePath
+		shortMethodName string
+		operationID     string
+		wantPanic       bool
+		panicMsg        string
+		wantName        string
+	}{
+		{
+			name:            "valid inputs",
+			parent:          gkeClusterTimeline,
+			shortMethodName: "CreateMesh",
+			operationID:     "op1",
+			wantPanic:       false,
+			wantName:        "CreateMesh-op1",
+		},
+		{
+			name:            "nil parent",
+			parent:          nil,
+			shortMethodName: "CreateMesh",
+			operationID:     "op1",
+			wantPanic:       true,
+			panicMsg:        "parent timeline path must not be nil",
+		},
+		{
+			name:            "empty shortMethodName",
+			parent:          gkeClusterTimeline,
+			shortMethodName: "",
+			operationID:     "op1",
+			wantPanic:       false,
+			wantName:        "unknown-op1",
+		},
+		{
+			name:            "empty operationID",
+			parent:          gkeClusterTimeline,
+			shortMethodName: "CreateMesh",
+			operationID:     "",
+			wantPanic:       false,
+			wantName:        "CreateMesh-unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantPanic {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Error("expected panic but did not panic")
+					} else {
+						errStr := fmt.Sprintf("%v", r)
+						if !strings.Contains(errStr, tc.panicMsg) {
+							t.Errorf("expected panic message to contain %q, got %q", tc.panicMsg, errStr)
+						}
+					}
+				}()
+			}
+
+			got := MustGCPOperationTimeline(ctx, tc.parent, tc.shortMethodName, tc.operationID)
+			if !tc.wantPanic {
+				if got == nil {
+					t.Fatal("expected timeline path to be not nil")
+				}
+				if diff := cmp.Diff(tc.wantName, got.Name.Resolve()); diff != "" {
+					t.Errorf("MustGCPOperationTimeline() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestMustGCPProjectTimeline(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	testCases := []struct {
+		name      string
+		projectID string
+		wantName  string
+	}{
+		{
+			name:      "valid project",
+			projectID: "my-project",
+			wantName:  "my-project",
+		},
+		{
+			name:      "empty project",
+			projectID: "",
+			wantName:  "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MustGCPProjectTimeline(ctx, tc.projectID)
+			if got == nil {
+				t.Fatal("expected timeline path to be not nil")
+			}
+			if diff := cmp.Diff(tc.wantName, got.Name.Resolve()); diff != "" {
+				t.Errorf("MustGCPProjectTimeline() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMustGCPResourceTypeTimeline(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")
+	invalidParentTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "invalid",
+		Type: TimelineTypeOperation,
+	})
+
+	testCases := []struct {
+		name         string
+		parent       *khifilev6.TimelinePath
+		resourceType string
+		wantPanic    bool
+		panicMsg     string
+		wantName     string
+	}{
+		{
+			name:         "valid type",
+			parent:       projectTimeline,
+			resourceType: "meshes",
+			wantPanic:    false,
+			wantName:     "meshes",
+		},
+		{
+			name:         "invalid parent type",
+			parent:       invalidParentTimeline,
+			resourceType: "meshes",
+			wantPanic:    true,
+			panicMsg:     "parent timeline path must be GCPProject type",
+		},
+		{
+			name:         "empty resource type",
+			parent:       projectTimeline,
+			resourceType: "",
+			wantPanic:    false,
+			wantName:     "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantPanic {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Error("expected panic but did not panic")
+					} else {
+						errStr := fmt.Sprintf("%v", r)
+						if !strings.Contains(errStr, tc.panicMsg) {
+							t.Errorf("expected panic message to contain %q, got %q", tc.panicMsg, errStr)
+						}
+					}
+				}()
+			}
+
+			got := MustGCPResourceTypeTimeline(ctx, tc.parent, tc.resourceType)
+			if !tc.wantPanic {
+				if got == nil {
+					t.Fatal("expected timeline path to be not nil")
+				}
+				if diff := cmp.Diff(tc.wantName, got.Name.Resolve()); diff != "" {
+					t.Errorf("MustGCPResourceTypeTimeline() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestMustGCPResourceTimeline(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")
+	resourceTypeTimeline := MustGCPResourceTypeTimeline(ctx, projectTimeline, "meshes")
+	invalidParentTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "invalid",
+		Type: TimelineTypeOperation,
+	})
+
+	testCases := []struct {
+		name         string
+		parent       *khifilev6.TimelinePath
+		resourceName string
+		wantPanic    bool
+		panicMsg     string
+		wantName     string
+	}{
+		{
+			name:         "valid resource name",
+			parent:       resourceTypeTimeline,
+			resourceName: "my-mesh",
+			wantPanic:    false,
+			wantName:     "my-mesh",
+		},
+		{
+			name:         "invalid parent type",
+			parent:       invalidParentTimeline,
+			resourceName: "my-mesh",
+			wantPanic:    true,
+			panicMsg:     "parent timeline path must be GCPResourceType type",
+		},
+		{
+			name:         "empty resource name",
+			parent:       resourceTypeTimeline,
+			resourceName: "",
+			wantPanic:    false,
+			wantName:     "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantPanic {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Error("expected panic but did not panic")
+					} else {
+						errStr := fmt.Sprintf("%v", r)
+						if !strings.Contains(errStr, tc.panicMsg) {
+							t.Errorf("expected panic message to contain %q, got %q", tc.panicMsg, errStr)
+						}
+					}
+				}()
+			}
+
+			got := MustGCPResourceTimeline(ctx, tc.parent, tc.resourceName)
+			if !tc.wantPanic {
+				if got == nil {
+					t.Fatal("expected timeline path to be not nil")
+				}
+				if diff := cmp.Diff(tc.wantName, got.Name.Resolve()); diff != "" {
+					t.Errorf("MustGCPResourceTimeline() mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/pkg/task/inspection/googlecloudlogcsm/contract/timeline_path.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/timeline_path.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcsm_contract
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// getK8sNamespacedResourceTimeline constructs a standard namespaced resource timeline path using common K8s contract helpers.
+func getK8sNamespacedResourceTimeline(ctx context.Context, clusterName string, apiVersion string, kind string, namespace string, name string) *khifilev6.TimelinePath {
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, apiVersion)
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, kind)
+	namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, namespace)
+	return commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, name)
+}
+
+// MustCSMServerAccessTimeline returns the timeline path for CSM Server Access under a Pod.
+func MustCSMServerAccessTimeline(ctx context.Context, clusterName string, podNamespace string, podName string, containerName string) *khifilev6.TimelinePath {
+	podPath := getK8sNamespacedResourceTimeline(ctx, clusterName, "core/v1", "pod", podNamespace, podName)
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+
+	suffix := "server"
+	if containerName != "" {
+		suffix = "server:" + containerName
+	}
+	return builder.TimelineAccumulator.GetPath(podPath, khifilev6.PathSegment{
+		Name: suffix,
+		Type: TimelineTypeCSMAccessLog,
+	})
+}
+
+// MustCSMClientAccessTimeline returns the timeline path for CSM Client Access under a Pod.
+func MustCSMClientAccessTimeline(ctx context.Context, clusterName string, podNamespace string, podName string) *khifilev6.TimelinePath {
+	podPath := getK8sNamespacedResourceTimeline(ctx, clusterName, "core/v1", "pod", podNamespace, podName)
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+
+	return builder.TimelineAccumulator.GetPath(podPath, khifilev6.PathSegment{
+		Name: "client",
+		Type: TimelineTypeCSMAccessLog,
+	})
+}
+
+// MustCSMServiceServerAccessTimeline returns the timeline path for CSM Service Server Access.
+func MustCSMServiceServerAccessTimeline(ctx context.Context, clusterName string, serviceNamespace string, serviceName string) *khifilev6.TimelinePath {
+	servicePath := getK8sNamespacedResourceTimeline(ctx, clusterName, "core/v1", "service", serviceNamespace, serviceName)
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+
+	return builder.TimelineAccumulator.GetPath(servicePath, khifilev6.PathSegment{
+		Name: "server",
+		Type: TimelineTypeCSMAccessLog,
+	})
+}
+
+// MustCSMServiceClientAccessTimeline returns the timeline path for CSM Service Client Access.
+func MustCSMServiceClientAccessTimeline(ctx context.Context, clusterName string, serviceNamespace string, serviceName string) *khifilev6.TimelinePath {
+	servicePath := getK8sNamespacedResourceTimeline(ctx, clusterName, "core/v1", "service", serviceNamespace, serviceName)
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+
+	return builder.TimelineAccumulator.GetPath(servicePath, khifilev6.PathSegment{
+		Name: "client",
+		Type: TimelineTypeCSMAccessLog,
+	})
+}

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task.go
@@ -1,17 +1,16 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package googlecloudlogcsm_impl
 
 import (
@@ -19,26 +18,80 @@ import (
 	"fmt"
 
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
+// FieldSetReaderTask is a task that reads CSM access logs field sets.
 var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlogcsm_contract.FieldSetReaderTaskID, googlecloudlogcsm_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
 	&googlecloudcommon_contract.GCPAccessLogFieldSetReader{},
 	&googlecloudlogcsm_contract.IstioAccessLogFieldSetReader{},
+	&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
 })
 
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(
+// CSMAccessLogLogIngester ingests CSM access logs.
+type CSMAccessLogLogIngester struct{}
+
+// RawLogTask returns the task reference that provides raw logs.
+func (i *CSMAccessLogLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogcsm_contract.FieldSetReaderTaskID.Ref()
+}
+
+// Dependencies returns the task dependencies.
+func (i *CSMAccessLogLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog parses raw log entry and populates the LogChangeSet.
+func (i *CSMAccessLogLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+	cs.SetTimestamp(commonFS.Timestamp)
+
+	gcpCommonAccessLog, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAccessLogFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+	istioAccessLog, err := log.GetFieldSet(l, &googlecloudlogcsm_contract.IstioAccessLogFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+
+	summary := fmt.Sprintf("%d %s %s", gcpCommonAccessLog.Status, gcpCommonAccessLog.Method, gcpCommonAccessLog.RequestURL)
+	if istioAccessLog.ResponseFlag != googlecloudlogcsm_contract.ResponseFlagNoError {
+		summary = fmt.Sprintf("【%s(%s)】", istioAccessLog.ResponseFlagMessage(), istioAccessLog.ResponseFlag) + summary
+	}
+	cs.SetSummary(summary)
+	cs.SetLogType(googlecloudlogcsm_contract.LogTypeCSMAccessLog)
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*CSMAccessLogLogIngester)(nil)
+
+// LogIngesterTask is the task that executes CSMAccessLogLogIngester.
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(
 	googlecloudlogcsm_contract.LogIngesterTaskID,
-	googlecloudlogcsm_contract.ListLogEntriesTaskID.Ref(),
+	&CSMAccessLogLogIngester{},
 )
 
+// LogGrouperTask groups CSM access logs by their reporter pod.
 var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogcsm_contract.LogGrouperTaskID, googlecloudlogcsm_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
 		istioAccessLogFieldSet := log.MustGetFieldSet(l, &googlecloudlogcsm_contract.IstioAccessLogFieldSet{})
@@ -46,60 +99,72 @@ var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogcsm_cont
 	},
 )
 
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudlogcsm_contract.LogToTimelineMapperTaskID, &csmAccessLogLogToTimelineMapperSetting{}, inspectioncore_contract.FeatureTaskLabel(
-	"CSM Access Log",
-	"Gather CSM access logs from Cloud Logging and associate them in client or server Pods on timelines",
-	enum.LogTypeCSMAccessLog,
-	10000,
-	false,
-))
-
-type csmAccessLogLogToTimelineMapperSetting struct{}
-
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (c *csmAccessLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
-	return []taskid.UntypedTaskReference{}
+// CSMAccessLogLogToTimelineMapper maps CSM access logs to resource timelines.
+type CSMAccessLogLogToTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (c *csmAccessLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
-	return googlecloudlogcsm_contract.LogGrouperTaskID.Ref()
-}
-
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (c *csmAccessLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+// LogIngesterTask returns a reference to the task that provides ingested logs.
+func (m *CSMAccessLogLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogcsm_contract.LogIngesterTaskID.Ref()
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (c *csmAccessLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
-	gcpCommonAccessLog := log.MustGetFieldSet(l, &googlecloudcommon_contract.GCPAccessLogFieldSet{})
-	istioAccessLog := log.MustGetFieldSet(l, &googlecloudlogcsm_contract.IstioAccessLogFieldSet{})
+// Dependencies returns additional task dependencies.
+func (m *CSMAccessLogLogToTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{
+		googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(),
+	}
+}
+
+// GroupedLogTask returns a reference to the task that provides the grouped logs.
+func (m *CSMAccessLogLogToTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogcsm_contract.LogGrouperTaskID.Ref()
+}
+
+// ProcessLogByGroup maps each log inside a group to one or more timeline events.
+func (m *CSMAccessLogLogToTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
+	istioAccessLog, err := log.GetFieldSet(l, &googlecloudlogcsm_contract.IstioAccessLogFieldSet{})
+	if err != nil {
+		return nil, struct{}{}, err
+	}
+
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref())
+	clusterName := clusterIdentity.ClusterName
+
+	cs := khifilev6.NewTimelineChangeSet(l)
 
 	switch istioAccessLog.Type {
 	case googlecloudlogcsm_contract.AccessLogTypeServer:
-		cs.AddEvent(resourcepath.CSMServerAccess(istioAccessLog.ReporterPodNamespace, istioAccessLog.ReporterPodName, istioAccessLog.ReporterContainerName))
+		cs.AddEvent(googlecloudlogcsm_contract.MustCSMServerAccessTimeline(ctx, clusterName, istioAccessLog.ReporterPodNamespace, istioAccessLog.ReporterPodName, istioAccessLog.ReporterContainerName))
 		if istioAccessLog.SourceName != "" && istioAccessLog.SourceNamespace != "" {
-			cs.AddEvent(resourcepath.CSMClientAccess(istioAccessLog.SourceNamespace, istioAccessLog.SourceName))
+			cs.AddEvent(googlecloudlogcsm_contract.MustCSMClientAccessTimeline(ctx, clusterName, istioAccessLog.SourceNamespace, istioAccessLog.SourceName))
 		}
 		if istioAccessLog.DestinationServiceName != "" && istioAccessLog.DestinationServiceNamespace != "" {
-			cs.AddEvent(resourcepath.CSMServiceServerAccess(istioAccessLog.DestinationServiceNamespace, istioAccessLog.DestinationServiceName))
+			cs.AddEvent(googlecloudlogcsm_contract.MustCSMServiceServerAccessTimeline(ctx, clusterName, istioAccessLog.DestinationServiceNamespace, istioAccessLog.DestinationServiceName))
 		}
 	case googlecloudlogcsm_contract.AccessLogTypeClient:
-		cs.AddEvent(resourcepath.CSMClientAccess(istioAccessLog.ReporterPodNamespace, istioAccessLog.ReporterPodName))
+		cs.AddEvent(googlecloudlogcsm_contract.MustCSMClientAccessTimeline(ctx, clusterName, istioAccessLog.ReporterPodNamespace, istioAccessLog.ReporterPodName))
 		if istioAccessLog.DestinationName != "" && istioAccessLog.DestinationNamespace != "" {
-			cs.AddEvent(resourcepath.CSMServerAccess(istioAccessLog.DestinationNamespace, istioAccessLog.DestinationName, ""))
+			cs.AddEvent(googlecloudlogcsm_contract.MustCSMServerAccessTimeline(ctx, clusterName, istioAccessLog.DestinationNamespace, istioAccessLog.DestinationName, ""))
 		}
 		if istioAccessLog.DestinationServiceName != "" && istioAccessLog.DestinationServiceNamespace != "" {
-			cs.AddEvent(resourcepath.CSMServiceClientAccess(istioAccessLog.DestinationServiceNamespace, istioAccessLog.DestinationServiceName))
+			cs.AddEvent(googlecloudlogcsm_contract.MustCSMServiceClientAccessTimeline(ctx, clusterName, istioAccessLog.DestinationServiceNamespace, istioAccessLog.DestinationServiceName))
 		}
 	}
-	summary := fmt.Sprintf("%d %s %s", gcpCommonAccessLog.Status, gcpCommonAccessLog.Method, gcpCommonAccessLog.RequestURL)
-	if istioAccessLog.ResponseFlag != googlecloudlogcsm_contract.ResponseFlagNoError {
-		summary = fmt.Sprintf("【%s(%s)】", istioAccessLog.ResponseFlagMessage(), istioAccessLog.ResponseFlag) + summary
-	}
-	cs.SetLogSummary(summary)
-	return struct{}{}, nil
+
+	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*csmAccessLogLogToTimelineMapperSetting)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*CSMAccessLogLogToTimelineMapper)(nil)
+
+// LogToTimelineMapperTask maps CSM access logs to timelines.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
+	googlecloudlogcsm_contract.LogToTimelineMapperTaskID,
+	&CSMAccessLogLogToTimelineMapper{},
+	inspectioncore_contract.FeatureTaskLabelV2(
+		"CSM Access Log",
+		"Gather CSM access logs from Cloud Logging and associate them in client or server Pods on timelines",
+		10000,
+		false,
+	),
+)

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,20 +16,79 @@ package googlecloudlogcsm_impl
 
 import (
 	"testing"
+	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 )
 
-func TestLogToTimelineMapper(t *testing.T) {
+func TestCSMAccessLogLogIngester_ProcessLog(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		inputGCPAccessLog   *googlecloudcommon_contract.GCPAccessLogFieldSet
 		inputIstioAccessLog *googlecloudlogcsm_contract.IstioAccessLogFieldSet
-		asserters           []testchangeset.ChangeSetAsserter
+		wantSummary         string
+	}{
+		{
+			desc: "server access log with normal response",
+			inputGCPAccessLog: &googlecloudcommon_contract.GCPAccessLogFieldSet{
+				Status:     200,
+				Method:     "GET",
+				RequestURL: "/productpage",
+			},
+			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
+				Type:         googlecloudlogcsm_contract.AccessLogTypeServer,
+				ResponseFlag: googlecloudlogcsm_contract.ResponseFlagNoError,
+			},
+			wantSummary: "200 GET /productpage",
+		},
+		{
+			desc: "server access log with error response",
+			inputGCPAccessLog: &googlecloudcommon_contract.GCPAccessLogFieldSet{
+				Status:     503,
+				Method:     "GET",
+				RequestURL: "/productpage",
+			},
+			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
+				Type:         googlecloudlogcsm_contract.AccessLogTypeServer,
+				ResponseFlag: googlecloudlogcsm_contract.ResponseFlagNoHealthyUpstream,
+			},
+			wantSummary: "【No healthy upstream(UH)】503 GET /productpage",
+		},
+	}
+
+	ingester := &CSMAccessLogLogIngester{}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l := log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)},
+				tc.inputGCPAccessLog,
+				tc.inputIstioAccessLog,
+			)
+			cs, err := ingester.ProcessLog(t.Context(), l)
+			if err != nil {
+				t.Fatalf("ProcessLog() failed: %v", err)
+			}
+			testchangeset.AssertLog(t, cs).
+				HasSummary(tc.wantSummary).
+				HasLogType(googlecloudlogcsm_contract.LogTypeCSMAccessLog)
+		})
+	}
+}
+
+func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	testCases := []struct {
+		desc                string
+		inputGCPAccessLog   *googlecloudcommon_contract.GCPAccessLogFieldSet
+		inputIstioAccessLog *googlecloudlogcsm_contract.IstioAccessLogFieldSet
+		assert              func(t *testing.T, builder *khifilev6.Builder, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc: "server access log with client and service",
@@ -50,15 +109,36 @@ func TestLogToTimelineMapper(t *testing.T) {
 				DestinationServiceName:      "productpage",
 				DestinationServiceNamespace: "default",
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasLogSummary{WantLogSummary: "200 GET /productpage"},
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"core/v1#pod#default#istio-ingressgateway#client",
-						"core/v1#pod#default#productpage-v1#server:istio-proxy",
-						"core/v1#service#default#productpage#server",
-					},
-				},
+			assert: func(t *testing.T, builder *khifilev6.Builder, cs *khifilev6.TimelineChangeSet) {
+				wantGatewayPath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
+					khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion},
+					khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind},
+					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
+					khifilev6.PathSegment{Name: "istio-ingressgateway", Type: inspectioncore_contract.TimelineTypeResource},
+					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+				)
+				wantProductpagePath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
+					khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion},
+					khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind},
+					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
+					khifilev6.PathSegment{Name: "productpage-v1", Type: inspectioncore_contract.TimelineTypeResource},
+					khifilev6.PathSegment{Name: "server:istio-proxy", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+				)
+				wantServicePath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
+					khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion},
+					khifilev6.PathSegment{Name: "service", Type: inspectioncore_contract.TimelineTypeKind},
+					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
+					khifilev6.PathSegment{Name: "productpage", Type: inspectioncore_contract.TimelineTypeResource},
+					khifilev6.PathSegment{Name: "server", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+				)
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantGatewayPath).
+					HasEvent(wantProductpagePath).
+					HasEvent(wantServicePath)
 			},
 		},
 		{
@@ -80,63 +160,59 @@ func TestLogToTimelineMapper(t *testing.T) {
 				DestinationServiceName:      "details",
 				DestinationServiceNamespace: "default",
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasLogSummary{WantLogSummary: "200 GET /details"},
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"core/v1#pod#default#details-v1#server",
-						"core/v1#pod#default#productpage-v1#client",
-						"core/v1#service#default#details#client",
-					},
-				},
-			},
-		},
-		{
-			desc: "server access log with error",
-			inputGCPAccessLog: &googlecloudcommon_contract.GCPAccessLogFieldSet{
-				Status:     503,
-				Method:     "GET",
-				RequestURL: "/productpage",
-			},
-			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
-				Type:                        googlecloudlogcsm_contract.AccessLogTypeServer,
-				ResponseFlag:                googlecloudlogcsm_contract.ResponseFlagNoHealthyUpstream,
-				ReporterPodNamespace:        "default",
-				ReporterPodName:             "productpage-v1",
-				ReporterContainerName:       "istio-proxy",
-				SourceNamespace:             "default",
-				SourceName:                  "istio-ingressgateway",
-				DestinationNamespace:        "default",
-				DestinationServiceName:      "productpage",
-				DestinationServiceNamespace: "product",
-			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasLogSummary{WantLogSummary: "【No healthy upstream(UH)】503 GET /productpage"},
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"core/v1#pod#default#istio-ingressgateway#client",
-						"core/v1#pod#default#productpage-v1#server:istio-proxy",
-						"core/v1#service#product#productpage#server",
-					},
-				},
+			assert: func(t *testing.T, builder *khifilev6.Builder, cs *khifilev6.TimelineChangeSet) {
+				wantDetailsPath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
+					khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion},
+					khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind},
+					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
+					khifilev6.PathSegment{Name: "details-v1", Type: inspectioncore_contract.TimelineTypeResource},
+					khifilev6.PathSegment{Name: "server", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+				)
+				wantProductpagePath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
+					khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion},
+					khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind},
+					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
+					khifilev6.PathSegment{Name: "productpage-v1", Type: inspectioncore_contract.TimelineTypeResource},
+					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+				)
+				wantDetailsServicePath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
+					khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion},
+					khifilev6.PathSegment{Name: "service", Type: inspectioncore_contract.TimelineTypeKind},
+					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
+					khifilev6.PathSegment{Name: "details", Type: inspectioncore_contract.TimelineTypeResource},
+					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+				)
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantDetailsPath).
+					HasEvent(wantProductpagePath).
+					HasEvent(wantDetailsServicePath)
 			},
 		},
 	}
 
+	mapper := &CSMAccessLogLogToTimelineMapper{}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			l := log.NewLogWithFieldSetsForTest(tc.inputGCPAccessLog, tc.inputIstioAccessLog)
-			cs := history.NewChangeSet(l)
+			builder := khifilev6.NewBuilder()
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(), googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			})
 
-			_, err := (&csmAccessLogLogToTimelineMapperSetting{}).ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
+			l := log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)},
+				tc.inputGCPAccessLog,
+				tc.inputIstioAccessLog,
+			)
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {
 				t.Fatalf("ProcessLogByGroup() failed: %v", err)
 			}
-			for _, asserter := range tc.asserters {
-				asserter.Assert(t, cs)
-			}
+			tc.assert(t, builder, cs)
 		})
-
 	}
 }

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
@@ -36,16 +37,72 @@ var CSMTrafficDirectorFieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTas
 	googlecloudlogcsm_contract.ListCSMTrafficDirectorLogEntriesTaskID.Ref(),
 	[]log.FieldSetReader{
 		&googlecloudcommon_contract.GCPOperationAuditLogFieldSetReader{},
+		&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
 	},
 )
 
-// CSMTrafficDirectorLogIngesterTask is a task that ingests CSM Traffic Director logs into the history builder.
-var CSMTrafficDirectorLogIngesterTask = inspectiontaskbase.NewLogIngesterTask(
+// CSMTrafficDirectorLogIngester V2 LogIngester.
+type CSMTrafficDirectorLogIngester struct{}
+
+// RawLogTask returns the task reference that provides the raw logs to ingest.
+func (i *CSMTrafficDirectorLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogcsm_contract.CSMTrafficDirectorFieldSetReaderTaskID.Ref()
+}
+
+// Dependencies returns the task dependencies.
+func (i *CSMTrafficDirectorLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog parses raw log entry and populates the LogChangeSet.
+func (i *CSMTrafficDirectorLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+	cs.SetTimestamp(commonFS.Timestamp)
+
+	audit, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+
+	methodNameParts := strings.Split(audit.MethodName, ".")
+	shortMethodName := methodNameParts[len(methodNameParts)-1]
+
+	var summary string
+	switch {
+	case audit.Starting():
+		summary = fmt.Sprintf("%s Started", shortMethodName)
+	case audit.Ending():
+		summary = fmt.Sprintf("%s Finished", shortMethodName)
+	default:
+		summary = shortMethodName
+	}
+	cs.SetSummary(summary)
+	cs.SetLogType(googlecloudlogcsm_contract.LogTypeCSMAccessLog)
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*CSMTrafficDirectorLogIngester)(nil)
+
+// CSMTrafficDirectorLogIngesterTask is a task that ingests CSM Traffic Director logs.
+var CSMTrafficDirectorLogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(
 	googlecloudlogcsm_contract.CSMTrafficDirectorLogIngesterTaskID,
-	googlecloudlogcsm_contract.ListCSMTrafficDirectorLogEntriesTaskID.Ref(),
+	&CSMTrafficDirectorLogIngester{},
 )
 
-// CSMTrafficDirectorLogGrouperTask is a task that groups CSM Traffic Director logs by their resource path.
+// CSMTrafficDirectorLogGrouperTask is a task that groups CSM Traffic Director logs by their resource name.
 var CSMTrafficDirectorLogGrouperTask = inspectiontaskbase.NewLogGrouperTask(
 	googlecloudlogcsm_contract.CSMTrafficDirectorLogGrouperTaskID,
 	googlecloudlogcsm_contract.CSMTrafficDirectorFieldSetReaderTaskID.Ref(),
@@ -54,119 +111,161 @@ var CSMTrafficDirectorLogGrouperTask = inspectiontaskbase.NewLogGrouperTask(
 		if err != nil {
 			return "unknown"
 		}
-		return resourcepath.GCPResource(audit.ResourceName).Path
+		return audit.ResourceName
 	},
 )
 
-// LogToTimelineMapperTask is a task that maps CSM Traffic Director logs to resource timelines.
-var CSMTrafficDirectorLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[*googlecloudcommon_contract.GCPOperationStateTracker](
-	googlecloudlogcsm_contract.CSMTrafficDirectorLogToTimelineMapperTaskID,
-	&csmTrafficDirectorLogToTimelineMapperSetting{},
-	inspectioncore_contract.FeatureTaskLabel(
-		"CSM Resource Audit Logs",
-		"Gather audit logs related to TrafficDirector resources created by the TD based CSM. Map them into pseudo timelines with other Kubernetes logs.",
-		enum.LogTypeCSMAccessLog, // TODO: Using the access log type here without defining a new log type. No new log type will be added before merging the file schema v6 change not to cause unnecessary file incompatibility issue.
-		10100,
-		false,
-	),
-)
-
-type csmTrafficDirectorLogToTimelineMapperSetting struct{}
-
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (s *csmTrafficDirectorLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
-	return []taskid.UntypedTaskReference{}
+// CSMTrafficDirectorLogToTimelineMapper maps CSM Traffic Director logs to resource timelines.
+type CSMTrafficDirectorLogToTimelineMapper struct {
+	inspectiontaskbase.SinglePassMapperBase[*googlecloudcommon_contract.GCPOperationStateTracker]
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (s *csmTrafficDirectorLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
-	return googlecloudlogcsm_contract.CSMTrafficDirectorLogGrouperTaskID.Ref()
-}
-
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (s *csmTrafficDirectorLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+// LogIngesterTask returns a reference to the task that provides ingested logs.
+func (m *CSMTrafficDirectorLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogcsm_contract.CSMTrafficDirectorLogIngesterTaskID.Ref()
 }
 
-// InitializeGroupData implements inspectiontaskbase.LogToTimelineMapper.
-func (s *csmTrafficDirectorLogToTimelineMapperSetting) InitializeGroupData(ctx context.Context, groupName string) (*googlecloudcommon_contract.GCPOperationStateTracker, error) {
-	return googlecloudcommon_contract.NewGCPOperationStateTracker(), nil
+// Dependencies returns additional task dependencies.
+func (m *CSMTrafficDirectorLogToTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{
+		googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(),
+	}
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (s *csmTrafficDirectorLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, tracker *googlecloudcommon_contract.GCPOperationStateTracker) (*googlecloudcommon_contract.GCPOperationStateTracker, error) {
+// GroupedLogTask returns a reference to the task that provides the grouped logs.
+func (m *CSMTrafficDirectorLogToTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogcsm_contract.CSMTrafficDirectorLogGrouperTaskID.Ref()
+}
+
+// ProcessLogByGroup maps each log inside a group to one or more timeline events or revisions.
+func (m *CSMTrafficDirectorLogToTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, tracker *googlecloudcommon_contract.GCPOperationStateTracker) (*khifilev6.TimelineChangeSet, *googlecloudcommon_contract.GCPOperationStateTracker, error) {
 	if tracker == nil {
 		tracker = googlecloudcommon_contract.NewGCPOperationStateTracker()
 	}
 	commonLogFieldSet, err := log.GetFieldSet(l, &log.CommonFieldSet{})
 	if err != nil {
-		return tracker, err
+		return nil, tracker, err
 	}
 	audit, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
 	if err != nil {
-		return tracker, err
+		return nil, tracker, err
 	}
 
-	methodNameParts := strings.Split(audit.MethodName, ".")
-	shortMethodName := methodNameParts[len(methodNameParts)-1]
-	verb := audit.GuessRevisionVerb()
+	cs := khifilev6.NewTimelineChangeSet(l)
 
-	resourcePath := resourcepath.GCPResource(audit.ResourceName)
-	operationPath := audit.OperationPath(resourcePath)
+	verb := guessRevisionVerb(audit.MethodName)
+
+	projectID, resourceType, resourceName := parseGCPResource(audit.ResourceName)
+	projectTimeline := googlecloudcommon_contract.MustGCPProjectTimeline(ctx, projectID)
+	typeTimeline := googlecloudcommon_contract.MustGCPResourceTypeTimeline(ctx, projectTimeline, resourceType)
+	resourceTimelinePath := googlecloudcommon_contract.MustGCPResourceTimeline(ctx, typeTimeline, resourceName)
 
 	if !audit.ImmediateOperation() {
-		state := enum.RevisionStateOperationStarted
-		opVerb := enum.RevisionVerbOperationStart
+		state := googlecloudcommon_contract.RevisionStateOperationStarted
+		opVerb := googlecloudcommon_contract.VerbOperationStart
 		if audit.Ending() {
-			state = enum.RevisionStateOperationFinished
-			opVerb = enum.RevisionVerbOperationFinish
+			state = googlecloudcommon_contract.RevisionStateOperationFinished
+			opVerb = googlecloudcommon_contract.VerbOperationFinish
 		}
 		requestBody, _ := audit.RequestString()
-		cs.AddRevision(operationPath, &history.StagingResourceRevision{
-			Body:       requestBody,
-			Verb:       opVerb,
-			State:      state,
-			Requestor:  audit.PrincipalEmail,
-			ChangeTime: commonLogFieldSet.Timestamp,
-			Partial:    false,
+		methodNameParts := strings.Split(audit.MethodName, ".")
+		shortMethodName := methodNameParts[len(methodNameParts)-1]
+		operationTimelinePath := googlecloudcommon_contract.MustGCPOperationTimeline(ctx, resourceTimelinePath, shortMethodName, audit.OperationID)
+		cs.AddRevision(operationTimelinePath, &khifilev6.StagingRevision{
+			ResourceBody: structured.NewStandardScalarNode(requestBody),
+			VerbType:     opVerb,
+			StateType:    state,
+			Principal:    audit.PrincipalEmail,
+			ChangedTime:  commonLogFieldSet.Timestamp,
 		})
 	}
 
 	manifest, shouldUpdate := tracker.TrackAndGetManifest(audit)
 	if shouldUpdate {
 		switch {
-		case verb == enum.RevisionVerbDelete:
-			cs.AddRevision(resourcePath, &history.StagingResourceRevision{
-				Verb:       enum.RevisionVerbDelete,
-				State:      enum.RevisionStateDeleted,
-				Requestor:  audit.PrincipalEmail,
-				ChangeTime: commonLogFieldSet.Timestamp,
-				Partial:    false,
+		case verb == commonlogk8saudit_contract.VerbDelete:
+			cs.AddRevision(resourceTimelinePath, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbDelete,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sResourceIsDeleted,
+				Principal:   audit.PrincipalEmail,
+				ChangedTime: commonLogFieldSet.Timestamp,
 			})
 		case audit.ImmediateOperation():
-			cs.AddEvent(resourcePath)
+			cs.AddEvent(resourceTimelinePath)
 		default:
-			cs.AddRevision(resourcePath, &history.StagingResourceRevision{
-				Body:       manifest,
-				Verb:       verb,
-				State:      enum.RevisionStateExisting,
-				Requestor:  audit.PrincipalEmail,
-				ChangeTime: commonLogFieldSet.Timestamp,
-				Partial:    false,
+			cs.AddRevision(resourceTimelinePath, &khifilev6.StagingRevision{
+				ResourceBody: structured.NewStandardScalarNode(manifest),
+				VerbType:     verb,
+				StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
+				Principal:    audit.PrincipalEmail,
+				ChangedTime:  commonLogFieldSet.Timestamp,
 			})
 		}
 	}
 
-	switch {
-	case audit.Starting():
-		cs.SetLogSummary(fmt.Sprintf("%s Started", shortMethodName))
-	case audit.Ending():
-		cs.SetLogSummary(fmt.Sprintf("%s Finished", shortMethodName))
-	default:
-		cs.SetLogSummary(shortMethodName)
-	}
-
-	return tracker, nil
+	return cs, tracker, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[*googlecloudcommon_contract.GCPOperationStateTracker] = (*csmTrafficDirectorLogToTimelineMapperSetting)(nil)
+// parseGCPResource parses a GCP resource name string into project, type, and name.
+func parseGCPResource(resourceName string) (string, string, string) {
+	if resourceName == "" || resourceName == "unknown" {
+		return "unknown", "unknown", "unknown"
+	}
+	parts := strings.Split(resourceName, "/")
+	project := "unknown"
+	projectIdx := -1
+	for i, p := range parts {
+		if p == "projects" {
+			projectIdx = i
+			break
+		}
+	}
+	if projectIdx != -1 && projectIdx+1 < len(parts) {
+		project = parts[projectIdx+1]
+	}
+
+	var resourceType, name string
+	if len(parts) >= 2 {
+		resourceType = parts[len(parts)-2]
+		name = parts[len(parts)-1]
+	} else {
+		resourceType = "unknown"
+		name = resourceName
+	}
+	return project, resourceType, name
+}
+
+var _ inspectiontaskbase.LogToTimelineMapperV2[*googlecloudcommon_contract.GCPOperationStateTracker] = (*CSMTrafficDirectorLogToTimelineMapper)(nil)
+
+// CSMTrafficDirectorLogToTimelineMapperTask maps CSM Traffic Director logs to timelines.
+var CSMTrafficDirectorLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
+	googlecloudlogcsm_contract.CSMTrafficDirectorLogToTimelineMapperTaskID,
+	&CSMTrafficDirectorLogToTimelineMapper{},
+	inspectioncore_contract.FeatureTaskLabelV2(
+		"CSM Resource Audit Logs",
+		"Gather audit logs related to TrafficDirector resources created by the TD based CSM. Map them into pseudo timelines with other Kubernetes logs.",
+		10100,
+		false,
+	),
+)
+
+// guessRevisionVerb guesses the styled verb type based on the method name.
+func guessRevisionVerb(methodName string) *pb.Verb {
+	methodNameSplitted := strings.Split(methodName, ".")
+	shortMethodName := "unknown"
+	if len(methodNameSplitted) > 0 {
+		shortMethodName = methodNameSplitted[len(methodNameSplitted)-1]
+	}
+	shortMethodName = strings.ToLower(shortMethodName)
+
+	switch {
+	case strings.HasPrefix(shortMethodName, "create"), strings.HasPrefix(shortMethodName, "insert"):
+		return commonlogk8saudit_contract.VerbCreate
+	case strings.HasPrefix(shortMethodName, "delete"):
+		return commonlogk8saudit_contract.VerbDelete
+	case strings.HasPrefix(shortMethodName, "update"), strings.HasPrefix(shortMethodName, "patch"):
+		return commonlogk8saudit_contract.VerbUpdate
+	default:
+		return commonlogk8saudit_contract.VerbUpdate
+	}
+}

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
@@ -155,8 +155,8 @@ func (m *CSMTrafficDirectorLogToTimelineMapper) ProcessLogByGroup(ctx context.Co
 
 	verb := guessRevisionVerb(audit.MethodName)
 
-	projectID, resourceType, resourceName := parseGCPResource(audit.ResourceName)
-	projectTimeline := googlecloudcommon_contract.MustGCPProjectTimeline(ctx, projectID)
+	resourceType, resourceName := parseGCPResource(audit.ResourceName)
+	projectTimeline := googlecloudcommon_contract.MustGCPProjectTimeline(ctx, audit.ProjectID)
 	typeTimeline := googlecloudcommon_contract.MustGCPResourceTypeTimeline(ctx, projectTimeline, resourceType)
 	resourceTimelinePath := googlecloudcommon_contract.MustGCPResourceTimeline(ctx, typeTimeline, resourceName)
 
@@ -206,23 +206,12 @@ func (m *CSMTrafficDirectorLogToTimelineMapper) ProcessLogByGroup(ctx context.Co
 	return cs, tracker, nil
 }
 
-// parseGCPResource parses a GCP resource name string into project, type, and name.
-func parseGCPResource(resourceName string) (string, string, string) {
+// parseGCPResource parses a GCP resource name string into type and name.
+func parseGCPResource(resourceName string) (string, string) {
 	if resourceName == "" || resourceName == "unknown" {
-		return "unknown", "unknown", "unknown"
+		return "unknown", "unknown"
 	}
 	parts := strings.Split(resourceName, "/")
-	project := "unknown"
-	projectIdx := -1
-	for i, p := range parts {
-		if p == "projects" {
-			projectIdx = i
-			break
-		}
-	}
-	if projectIdx != -1 && projectIdx+1 < len(parts) {
-		project = parts[projectIdx+1]
-	}
 
 	var resourceType, name string
 	if len(parts) >= 2 {
@@ -232,7 +221,7 @@ func parseGCPResource(resourceName string) (string, string, string) {
 		resourceType = "unknown"
 		name = resourceName
 	}
-	return project, resourceType, name
+	return resourceType, name
 }
 
 var _ inspectiontaskbase.LogToTimelineMapperV2[*googlecloudcommon_contract.GCPOperationStateTracker] = (*CSMTrafficDirectorLogToTimelineMapper)(nil)

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,20 +15,78 @@
 package googlecloudlogcsm_impl
 
 import (
-	"context"
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestCSMTrafficDirectorLogToTimelineMapperSetting_ProcessLogByGroup(t *testing.T) {
-	now := time.Now().Truncate(time.Second) // Truncate to avoid sub-second diffs if needed, though cmp.Diff handles it.
+func TestCSMTrafficDirectorLogIngester_ProcessLog(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		inputAudit  *googlecloudcommon_contract.GCPAuditLogFieldSet
+		wantSummary string
+	}{
+		{
+			desc: "immediate operation CreateMesh",
+			inputAudit: &googlecloudcommon_contract.GCPAuditLogFieldSet{
+				MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
+				OperationFirst: true,
+				OperationLast:  true,
+			},
+			wantSummary: "CreateMesh",
+		},
+		{
+			desc: "long running operation CreateMesh started",
+			inputAudit: &googlecloudcommon_contract.GCPAuditLogFieldSet{
+				MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
+				OperationFirst: true,
+				OperationLast:  false,
+			},
+			wantSummary: "CreateMesh Started",
+		},
+		{
+			desc: "long running operation CreateMesh finished",
+			inputAudit: &googlecloudcommon_contract.GCPAuditLogFieldSet{
+				MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
+				OperationFirst: false,
+				OperationLast:  true,
+			},
+			wantSummary: "CreateMesh Finished",
+		},
+	}
+
+	ingester := &CSMTrafficDirectorLogIngester{}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l := log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)},
+				tc.inputAudit,
+			)
+			cs, err := ingester.ProcessLog(t.Context(), l)
+			if err != nil {
+				t.Fatalf("ProcessLog() failed: %v", err)
+			}
+			testchangeset.AssertLog(t, cs).
+				HasSummary(tc.wantSummary).
+				HasLogType(googlecloudlogcsm_contract.LogTypeCSMAccessLog)
+		})
+	}
+}
+
+func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
 
 	createReader := func(t *testing.T, data map[string]any) *structured.NodeReader {
 		if data == nil {
@@ -44,7 +102,7 @@ func TestCSMTrafficDirectorLogToTimelineMapperSetting_ProcessLogByGroup(t *testi
 	tests := []struct {
 		name           string
 		auditFieldSets []*googlecloudcommon_contract.GCPAuditLogFieldSet
-		want           [][]testchangeset.ChangeSetAsserter
+		assert         func(t *testing.T, builder *khifilev6.Builder, results []*khifilev6.TimelineChangeSet)
 	}{
 		{
 			name: "Mesh creation log",
@@ -58,11 +116,15 @@ func TestCSMTrafficDirectorLogToTimelineMapperSetting_ProcessLogByGroup(t *testi
 					Response:       createReader(t, map[string]any{"name": "test-mesh", "description": "test"}),
 				},
 			},
-			want: [][]testchangeset.ChangeSetAsserter{
-				{
-					&testchangeset.HasEvent{ResourcePath: "@GCP#CSM#meshes#test-mesh"},
-					&testchangeset.HasLogSummary{WantLogSummary: "CreateMesh"},
-				},
+			assert: func(t *testing.T, builder *khifilev6.Builder, results []*khifilev6.TimelineChangeSet) {
+				wantMeshPath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "test-project", Type: googlecloudcommon_contract.TimelineTypeGCPProject},
+					khifilev6.PathSegment{Name: "meshes", Type: googlecloudcommon_contract.TimelineTypeGCPResourceType},
+					khifilev6.PathSegment{Name: "test-mesh", Type: googlecloudcommon_contract.TimelineTypeGCPResource},
+				)
+
+				testchangeset.AssertTimeline(t, results[0]).
+					HasEvent(wantMeshPath)
 			},
 		},
 		{
@@ -84,54 +146,63 @@ func TestCSMTrafficDirectorLogToTimelineMapperSetting_ProcessLogByGroup(t *testi
 					PrincipalEmail: "u@e.c",
 					OperationFirst: false,
 					OperationLast:  true,
-					// No response
 				},
 			},
-			want: [][]testchangeset.ChangeSetAsserter{
-				{
-					// Creation log shouldn't generate its resource timeline before the operation completes.
-					&testchangeset.HasNoRevision{ResourcePath: "@GCP#meshes#m1"},
-					&testchangeset.HasRevision{
-						ResourcePath: "@GCP#CSM#meshes#m1#CreateMesh-op1",
-						WantRevision: history.StagingResourceRevision{
-							Verb:       enum.RevisionVerbOperationStart,
-							State:      enum.RevisionStateOperationStarted,
-							Requestor:  "u@e.c",
-							Body:       "description: init\n",
-							ChangeTime: now,
-						},
-					},
-				},
-				{
-					&testchangeset.HasRevision{
-						ResourcePath: "@GCP#CSM#meshes#m1",
-						WantRevision: history.StagingResourceRevision{
-							Verb:       enum.RevisionVerbCreate,
-							State:      enum.RevisionStateExisting,
-							Requestor:  "u@e.c",
-							Body:       "description: init\n",
-							ChangeTime: now.Add(time.Second),
-						},
-					},
-					&testchangeset.HasRevision{
-						ResourcePath: "@GCP#CSM#meshes#m1#CreateMesh-op1",
-						WantRevision: history.StagingResourceRevision{
-							Verb:       enum.RevisionVerbOperationFinish,
-							State:      enum.RevisionStateOperationFinished,
-							Requestor:  "u@e.c",
-							Body:       "",
-							ChangeTime: now.Add(time.Second),
-						},
-					},
-				},
+			assert: func(t *testing.T, builder *khifilev6.Builder, results []*khifilev6.TimelineChangeSet) {
+				wantMeshPath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "p", Type: googlecloudcommon_contract.TimelineTypeGCPProject},
+					khifilev6.PathSegment{Name: "meshes", Type: googlecloudcommon_contract.TimelineTypeGCPResourceType},
+					khifilev6.PathSegment{Name: "m1", Type: googlecloudcommon_contract.TimelineTypeGCPResource},
+				)
+				wantOpPath := builder.TimelineAccumulator.GetPath(nil,
+					khifilev6.PathSegment{Name: "p", Type: googlecloudcommon_contract.TimelineTypeGCPProject},
+					khifilev6.PathSegment{Name: "meshes", Type: googlecloudcommon_contract.TimelineTypeGCPResourceType},
+					khifilev6.PathSegment{Name: "m1", Type: googlecloudcommon_contract.TimelineTypeGCPResource},
+					khifilev6.PathSegment{Name: "CreateMesh-op1", Type: googlecloudcommon_contract.TimelineTypeOperation},
+				)
+
+				// First log (starting)
+				testchangeset.AssertTimeline(t, results[0]).
+					HasNoRevision(wantMeshPath).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						VerbType:     googlecloudcommon_contract.VerbOperationStart,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationStarted,
+						Principal:    "u@e.c",
+						ResourceBody: structured.NewStandardScalarNode("description: init\n"),
+						ChangedTime:  now,
+					}, cmp.AllowUnexported(structured.StandardScalarNode[string]{}))
+
+				// Second log (finished)
+				testchangeset.AssertTimeline(t, results[1]).
+					HasRevision(wantMeshPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
+						Principal:    "u@e.c",
+						ResourceBody: structured.NewStandardScalarNode("description: init\n"),
+						ChangedTime:  now.Add(time.Second),
+					}, cmp.AllowUnexported(structured.StandardScalarNode[string]{})).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						VerbType:     googlecloudcommon_contract.VerbOperationFinish,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationFinished,
+						Principal:    "u@e.c",
+						ResourceBody: structured.NewStandardScalarNode(""),
+						ChangedTime:  now.Add(time.Second),
+					}, cmp.AllowUnexported(structured.StandardScalarNode[string]{}))
 			},
 		},
 	}
 
+	mapper := &CSMTrafficDirectorLogToTimelineMapper{}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mapper := &csmTrafficDirectorLogToTimelineMapperSetting{}
+			builder := khifilev6.NewBuilder()
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(), googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			})
+
 			tracker := googlecloudcommon_contract.NewGCPOperationStateTracker()
+			var results []*khifilev6.TimelineChangeSet
 
 			for i, auditFieldSet := range tc.auditFieldSets {
 				logTime := now.Add(time.Duration(i) * time.Second)
@@ -139,19 +210,15 @@ func TestCSMTrafficDirectorLogToTimelineMapperSetting_ProcessLogByGroup(t *testi
 					&log.CommonFieldSet{Timestamp: logTime},
 					auditFieldSet,
 				)
-				cs := history.NewChangeSet(l)
 
-				_, err := mapper.ProcessLogByGroup(context.Background(), l, cs, nil, tracker)
+				cs, _, err := mapper.ProcessLogByGroup(ctx, l, tracker)
 				if err != nil {
 					t.Fatalf("log %d: unexpected error: %v", i, err)
 				}
-
-				if i < len(tc.want) {
-					for _, asserter := range tc.want[i] {
-						asserter.Assert(t, cs)
-					}
-				}
+				results = append(results, cs)
 			}
+
+			tc.assert(t, builder, results)
 		})
 	}
 }

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
@@ -108,6 +108,7 @@ func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			name: "Mesh creation log",
 			auditFieldSets: []*googlecloudcommon_contract.GCPAuditLogFieldSet{
 				{
+					ProjectID:      "test-project",
 					MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
 					ResourceName:   "projects/test-project/locations/global/meshes/test-mesh",
 					PrincipalEmail: "user@example.com",
@@ -131,6 +132,7 @@ func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			name: "Long running operation sequence",
 			auditFieldSets: []*googlecloudcommon_contract.GCPAuditLogFieldSet{
 				{
+					ProjectID:      "p",
 					OperationID:    "op1",
 					MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
 					ResourceName:   "projects/p/locations/global/meshes/m1",
@@ -140,6 +142,7 @@ func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					Request:        createReader(t, map[string]any{"description": "init"}),
 				},
 				{
+					ProjectID:      "p",
 					OperationID:    "op1",
 					MethodName:     "google.cloud.networkservices.v1.NetworkServices.CreateMesh",
 					ResourceName:   "projects/p/locations/global/meshes/m1",
@@ -219,6 +222,44 @@ func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			}
 
 			tc.assert(t, builder, results)
+		})
+	}
+}
+
+func TestParseGCPResource(t *testing.T) {
+	tests := []struct {
+		name             string
+		resourceName     string
+		wantResourceType string
+		wantResourceName string
+	}{
+		{
+			name:             "standard resource path",
+			resourceName:     "projects/12345678/locations/global/meshes/my-mesh",
+			wantResourceType: "meshes",
+			wantResourceName: "my-mesh",
+		},
+		{
+			name:             "empty input",
+			resourceName:     "",
+			wantResourceType: "unknown",
+			wantResourceName: "unknown",
+		},
+		{
+			name:             "unknown input",
+			resourceName:     "unknown",
+			wantResourceType: "unknown",
+			wantResourceName: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, gotName := parseGCPResource(tc.resourceName)
+			if gotType != tc.wantResourceType || gotName != tc.wantResourceName {
+				t.Errorf("parseGCPResource(%q) = (%q, %q), want (%q, %q)",
+					tc.resourceName, gotType, gotName, tc.wantResourceType, tc.wantResourceName)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See #720 for the rules used during the migration.