### PR TITLE
Migrate GCE network audit log  parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
@@ -35,30 +35,69 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// FieldSetReaderTask is a task that reads fieldsets needed for GCE network API logs.
 var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlognetworkapiaudit_contract.FieldSetReaderTaskID, googlecloudlognetworkapiaudit_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
 	&googlecloudcommon_contract.GCPOperationAuditLogFieldSetReader{},
+	&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
 })
 
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(googlecloudlognetworkapiaudit_contract.LogIngesterTaskID, googlecloudlognetworkapiaudit_contract.ListLogEntriesTaskID.Ref())
+type networkAPILogIngester struct{}
 
+// RawLogTask returns the task reference that provides the raw logs to ingest.
+func (i *networkAPILogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlognetworkapiaudit_contract.FieldSetReaderTaskID.Ref()
+}
+
+// Dependencies returns additional task dependencies of the ingester.
+func (i *networkAPILogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog parses raw log entry and manually populates the LogChangeSet.
+func (i *networkAPILogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	cs.SetLogType(googlecloudlognetworkapiaudit_contract.LogTypeNetworkAPI)
+
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
+	}
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	if auditFieldSet, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{}); err == nil {
+		switch {
+		case auditFieldSet.Starting():
+			cs.SetSummary(fmt.Sprintf("%s Started", auditFieldSet.MethodName))
+		case auditFieldSet.Ending():
+			cs.SetSummary(fmt.Sprintf("%s Finished", auditFieldSet.MethodName))
+		default:
+			cs.SetSummary(auditFieldSet.MethodName)
+		}
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*networkAPILogIngester)(nil)
+
+// LogIngesterTask is the task id to finalize the logs to be included in the final output.
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(googlecloudlognetworkapiaudit_contract.LogIngesterTaskID, &networkAPILogIngester{})
+
+// LogGrouperTask groups logs by the NEG resource name.
 var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlognetworkapiaudit_contract.LogGrouperTaskID, googlecloudlognetworkapiaudit_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
-		// Group logs by the NEG resource name.
 		audit, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
 		if err != nil {
 			return "unknown"
 		}
 		return audit.ResourceName
 	},
-)
-
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[*perNEGHistoryModificationStatus](googlecloudlognetworkapiaudit_contract.LogToTimelineMapperTaskID, &networkAPILogToTimelineMapperTaskSetting{},
-	inspectioncore_contract.FeatureTaskLabel(`GCE Network Logs`,
-		`Gather GCE Network API logs to visualize statuses of Network Endpoint Groups(NEG)`,
-		enum.LogTypeNetworkAPI,
-		7000,
-		true,
-	),
 )
 
 type negAttachOrDetachRequestEndpoint struct {
@@ -75,72 +114,93 @@ type perNEGHistoryModificationStatus struct {
 	LastNegAttachRequest *negAttachOrDetachRequest
 }
 
-type networkAPILogToTimelineMapperTaskSetting struct{}
+type networkAPITimelineMapper struct {
+	inspectiontaskbase.SinglePassMapperBase[*perNEGHistoryModificationStatus]
+}
 
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (n *networkAPILogToTimelineMapperTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+// LogIngesterTask is the task reference that provides the ingested logs.
+func (m *networkAPITimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlognetworkapiaudit_contract.LogIngesterTaskID.Ref()
+}
+
+// Dependencies are the additional references used in timeline mapper.
+func (m *networkAPITimelineMapper) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
+		googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(),
 		googlecloudk8scommon_contract.NEGNamesDiscoveryTaskID.Ref(),
 		commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref(),
 		googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(),
 	}
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (n *networkAPILogToTimelineMapperTaskSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+// GroupedLogTask returns a reference to the task that provides the grouped logs.
+func (m *networkAPITimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
 	return googlecloudlognetworkapiaudit_contract.LogGrouperTaskID.Ref()
 }
 
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (n *networkAPILogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
-	return googlecloudlognetworkapiaudit_contract.LogIngesterTaskID.Ref()
-}
-
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (n *networkAPILogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData *perNEGHistoryModificationStatus) (*perNEGHistoryModificationStatus, error) {
+// ProcessLogByGroup maps the NEG audit log to resource timelines as state revisions.
+func (m *networkAPITimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData *perNEGHistoryModificationStatus) (*khifilev6.TimelineChangeSet, *perNEGHistoryModificationStatus, error) {
 	commonFieldSet := log.MustGetFieldSet(l, &log.CommonFieldSet{})
 	auditFieldSet := log.MustGetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
 	if prevGroupData == nil {
 		prevGroupData = &perNEGHistoryModificationStatus{}
 	}
 
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref())
 	negs := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref())
-	var negResourcePath resourcepath.ResourcePath
+	var negResourcePath *khifilev6.TimelinePath
 	negName := getNegNameFromResourceName(auditFieldSet.ResourceName)
 
 	if negResource, found := negs[negName]; found {
-		negResourcePath = resourcepath.NetworkEndpointGroup(negResource.Namespace, negName)
+		negResourcePath = googlecloudlognetworkapiaudit_contract.MustNEGTimeline(ctx, clusterIdentity.ClusterName, negResource.Namespace, negName)
 	} else {
-		negResourcePath = resourcepath.NetworkEndpointGroup("unknown", negName)
+		negResourcePath = googlecloudlognetworkapiaudit_contract.MustNEGTimeline(ctx, clusterIdentity.ClusterName, "unknown", negName)
 	}
 
-	// Add operation subresource under sneg resource
-	negOperationPath := auditFieldSet.OperationPath(negResourcePath)
+	cs := khifilev6.NewTimelineChangeSet(l)
+
+	// Add operation subresource under neg resource.
+	var negOperationPath *khifilev6.TimelinePath
+	if auditFieldSet.ImmediateOperation() {
+		negOperationPath = negResourcePath
+	} else {
+		negOperationPath = googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, negResourcePath, auditFieldSet.MethodName, auditFieldSet.OperationID)
+	}
+
 	if auditFieldSet.ImmediateOperation() {
 		cs.AddEvent(negOperationPath)
 	} else {
-		state := enum.RevisionStateOperationStarted
-		verb := enum.RevisionVerbOperationStart
+		var state *pb.RevisionState
+		var verb *pb.Verb
 		if auditFieldSet.Ending() {
-			state = enum.RevisionStateOperationFinished
-			verb = enum.RevisionVerbOperationFinish
+			state = googlecloudcommon_contract.RevisionStateOperationFinished
+			verb = googlecloudcommon_contract.VerbOperationFinish
+		} else {
+			state = googlecloudcommon_contract.RevisionStateOperationStarted
+			verb = googlecloudcommon_contract.VerbOperationStart
 		}
 		requestBody, _ := auditFieldSet.RequestString()
-		cs.AddRevision(negOperationPath, &history.StagingResourceRevision{
-			Body:       requestBody,
-			Verb:       verb,
-			State:      state,
-			Requestor:  auditFieldSet.PrincipalEmail,
-			ChangeTime: commonFieldSet.Timestamp,
+		var bodyNode structured.Node
+		if requestBody != "" {
+			if node, err := structured.FromYAML(requestBody); err == nil {
+				bodyNode = node
+			}
+		}
+		cs.AddRevision(negOperationPath, &khifilev6.StagingRevision{
+			ChangedTime:  commonFieldSet.Timestamp,
+			ResourceBody: bodyNode,
+			VerbType:     verb,
+			StateType:    state,
+			Principal:    auditFieldSet.PrincipalEmail,
 		})
 	}
 
 	ipLeases := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref())
-	// Add neg subresource under resources with the same IP of the endpoint
+	// Add neg subresource under resources with the same IP of the endpoint.
 	shortMethodName := getShortMethodNameFromMethodName(auditFieldSet.MethodName)
 	var negRequest *negAttachOrDetachRequest
-	var verb enum.RevisionVerb
-	var state enum.RevisionState
+	var verb *pb.Verb
+	var state *pb.RevisionState
 	switch shortMethodName {
 	case "attachNetworkEndpoints":
 		if auditFieldSet.Starting() {
@@ -148,15 +208,15 @@ func (n *networkAPILogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context
 			var err error
 			request, err := parseNEGAttachOrDetachRequest(l)
 			if err != nil {
-				return prevGroupData, err
+				return nil, prevGroupData, err
 			}
 			prevGroupData.LastNegAttachRequest = request // Save the neg attach request in the per group status, and it will be consumed in the next ending operation log.
 			break
 		}
 		negRequest = prevGroupData.LastNegAttachRequest
 		prevGroupData.LastNegAttachRequest = nil
-		verb = enum.RevisionVerbReady
-		state = enum.RevisionStateConditionTrue
+		verb = commonlogk8saudit_contract.VerbReady
+		state = commonlogk8saudit_contract.RevisionStateConditionTrue
 	case "detachNetworkEndpoints":
 		if auditFieldSet.Ending() {
 			break
@@ -164,11 +224,12 @@ func (n *networkAPILogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context
 		var err error
 		negRequest, err = parseNEGAttachOrDetachRequest(l)
 		if err != nil {
-			return prevGroupData, err
+			return nil, prevGroupData, err
 		}
-		verb = enum.RevisionVerbNonReady
-		state = enum.RevisionStateConditionFalse
+		verb = commonlogk8saudit_contract.VerbNonReady
+		state = commonlogk8saudit_contract.RevisionStateConditionFalse
 	}
+
 	if negRequest != nil {
 		negToBS := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref())
 		for _, endpoint := range negRequest.NetworkEndpoints {
@@ -179,42 +240,48 @@ func (n *networkAPILogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context
 			}
 			holder := lease.Holder
 			if holder.Kind == "pod" {
-				podPath := resourcepath.Pod(holder.Namespace, holder.Name)
-				negSubresourcePath := resourcepath.NetworkEndpointGroupUnderResource(podPath, holder.Namespace, negName)
-				cs.AddRevision(negSubresourcePath, &history.StagingResourceRevision{
-					Verb:       verb,
-					State:      state,
-					Requestor:  auditFieldSet.PrincipalEmail,
-					ChangeTime: commonFieldSet.Timestamp,
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "pod")
+				nsPath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, holder.Namespace)
+				podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, holder.Name)
+
+				negSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, podPath, negName)
+				cs.AddRevision(negSubresourcePath, &khifilev6.StagingRevision{
+					ChangedTime: commonFieldSet.Timestamp,
+					VerbType:    verb,
+					StateType:   state,
+					Principal:   auditFieldSet.PrincipalEmail,
 				})
+
 				if bsName, found := negToBS[negName]; found {
 					// BackendService is usually global in the context of gsmrsvd backends.
-					bsPath := resourcepath.GCPResource(fmt.Sprintf("projects/unknown/global/backendServices/%s", bsName))
-					negSubresourcePath := resourcepath.NetworkEndpointGroupUnderResource(bsPath, holder.Namespace, holder.Name)
-					cs.AddRevision(negSubresourcePath, &history.StagingResourceRevision{
-						Verb:       verb,
-						State:      state,
-						Requestor:  auditFieldSet.PrincipalEmail,
-						ChangeTime: commonFieldSet.Timestamp,
+					bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, clusterIdentity.ProjectID, "backendServices", bsName)
+					negSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, holder.Name)
+					cs.AddRevision(negSubresourcePath, &khifilev6.StagingRevision{
+						ChangedTime: commonFieldSet.Timestamp,
+						VerbType:    verb,
+						StateType:   state,
+						Principal:   auditFieldSet.PrincipalEmail,
 					})
 				}
 			}
 		}
-
 	}
 
-	switch {
-	case auditFieldSet.Starting():
-		cs.SetLogSummary(fmt.Sprintf("%s Started", auditFieldSet.MethodName))
-	case auditFieldSet.Ending():
-		cs.SetLogSummary(fmt.Sprintf("%s Finished", auditFieldSet.MethodName))
-	default:
-		cs.SetLogSummary(auditFieldSet.MethodName)
-	}
-	return prevGroupData, nil
+	return cs, prevGroupData, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[*perNEGHistoryModificationStatus] = (*networkAPILogToTimelineMapperTaskSetting)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[*perNEGHistoryModificationStatus] = (*networkAPITimelineMapper)(nil)
+
+// LogToTimelineMapperTask registers the mapper to resolve network status in timeline.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(googlecloudlognetworkapiaudit_contract.LogToTimelineMapperTaskID, &networkAPITimelineMapper{},
+	inspectioncore_contract.FeatureTaskLabelV2(`GCE Network Logs`,
+		`Gather GCE Network API logs to visualize statuses of Network Endpoint Groups(NEG)`,
+		7000,
+		true,
+	),
+)
 
 func getNegNameFromResourceName(resourceName string) string {
 	lastSlashIndex := strings.LastIndex(resourceName, "/")

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlognetworkapiaudit_impl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourceinfo/resourcelease"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlognetworkapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlognetworkapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+	"github.com/google/go-cmp/cmp"
+)
+
+func testReaderFromYAML(t *testing.T, yaml string) *structured.NodeReader {
+	t.Helper()
+	node, err := structured.FromYAML(yaml)
+	if err != nil {
+		t.Fatalf("failed to parse yaml: %v", err)
+	}
+	return structured.NewNodeReader(node)
+}
+
+var nodeTransformer = cmp.Transformer("NodeToString", func(n structured.Node) string {
+	if n == nil {
+		return ""
+	}
+	serializer := &structured.JSONNodeSerializer{}
+	bytes, err := serializer.Serialize(n)
+	if err != nil {
+		return ""
+	}
+	return string(bytes)
+})
+
+func TestNetworkAPILogIngester_ProcessLog(t *testing.T) {
+	testTime := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		name   string
+		input  *log.Log
+		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
+	}{
+		{
+			name: "successful audit log ingestion starting",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
+				},
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityInfo,
+				},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints",
+					OperationID:    "op-1",
+					OperationFirst: true,
+					OperationLast:  false,
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints Started").
+					HasTimestamp(testTime).
+					HasLogType(googlecloudlognetworkapiaudit_contract.LogTypeNetworkAPI)
+			},
+		},
+		{
+			name: "successful audit log ingestion ending",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
+				},
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityInfo,
+				},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints",
+					OperationID:    "op-1",
+					OperationFirst: false,
+					OperationLast:  true,
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints Finished").
+					HasTimestamp(testTime).
+					HasLogType(googlecloudlognetworkapiaudit_contract.LogTypeNetworkAPI)
+			},
+		},
+	}
+
+	ingester := &networkAPILogIngester{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs, err := ingester.ProcessLog(t.Context(), tc.input)
+			if err != nil {
+				t.Fatalf("ProcessLog() returned unexpected error: %v", err)
+			}
+			tc.assert(t, cs)
+		})
+	}
+}
+
+func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
+	testTime := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	builder := khifilev6.NewBuilder()
+
+	// Define expected timeline paths.
+	wantNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGTimeline(khictx.WithValue(context.Background(), inspectioncore_contract.Builder, builder), "cluster", "test-ns", "test-neg")
+
+	testCases := []struct {
+		name          string
+		inputLog      *log.Log
+		prevGroupData *perNEGHistoryModificationStatus
+		wantGroupData *perNEGHistoryModificationStatus
+		setupContext  func(ctx context.Context) context.Context
+		assert        func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+	}{
+		{
+			name: "operation started revision is correctly created",
+			inputLog: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
+				},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-1",
+					OperationFirst: true,
+					OperationLast:  false,
+					PrincipalEmail: "test-user@google.com",
+					Request:        testReaderFromYAML(t, "networkEndpoints:\n- instance: test-node\n  ipAddress: 10.0.0.1\n  port: \"80\""),
+				},
+			),
+			prevGroupData: &perNEGHistoryModificationStatus{},
+			wantGroupData: &perNEGHistoryModificationStatus{
+				LastNegAttachRequest: &negAttachOrDetachRequest{
+					NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+						{
+							Instance:  "test-node",
+							IpAddress: "10.0.0.1",
+							Port:      "80",
+						},
+					},
+				},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				return tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints", "op-1")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						Principal:    "test-user@google.com",
+						VerbType:     googlecloudcommon_contract.VerbOperationStart,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationStarted,
+						ResourceBody: testReaderFromYAML(t, "networkEndpoints:\n- instance: test-node\n  ipAddress: 10.0.0.1\n  port: \"80\"").Node,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "operation finished revision is correctly created",
+			inputLog: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
+				},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-1",
+					OperationFirst: false,
+					OperationLast:  true,
+					PrincipalEmail: "test-user@google.com",
+				},
+			),
+			prevGroupData: &perNEGHistoryModificationStatus{
+				LastNegAttachRequest: &negAttachOrDetachRequest{
+					NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+						{
+							Instance:  "test-node",
+							IpAddress: "10.0.0.1",
+							Port:      "80",
+						},
+					},
+				},
+			},
+			wantGroupData: &perNEGHistoryModificationStatus{
+				LastNegAttachRequest: nil,
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				ipLeases := resourcelease.NewResourceLeaseHistory[*commonlogk8saudit_contract.ResourceIdentity]()
+				ipLeases.TouchResourceLease("10.0.0.1", testTime, &commonlogk8saudit_contract.ResourceIdentity{
+					Kind:      "pod",
+					Namespace: "test-ns",
+					Name:      "test-pod",
+				})
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref(), ipLeases)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints", "op-1")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationFinished,
+					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "pod")
+				nsPath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, "test-ns")
+				podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, "test-pod")
+				wantPodNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, podPath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantPodNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbReady,
+						StateType:   commonlogk8saudit_contract.RevisionStateConditionTrue,
+					}, nodeTransformer)
+
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
+				wantBSNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, "test-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbReady,
+						StateType:   commonlogk8saudit_contract.RevisionStateConditionTrue,
+					}, nodeTransformer)
+			},
+		},
+	}
+
+	mapper := &networkAPITimelineMapper{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := khictx.WithValue(t.Context(), core_contract.TaskImplementationIDContextKey, googlecloudlognetworkapiaudit_contract.LogToTimelineMapperTaskID.(taskid.UntypedTaskImplementationID))
+			ctx = khictx.WithValue(ctx, inspectioncore_contract.Builder, builder)
+
+			// Provide default empty inventories.
+			clusterIdentity := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "cluster",
+				ProjectID:   "test-project",
+			}
+			negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{}
+			ipLeases := resourcelease.NewResourceLeaseHistory[*commonlogk8saudit_contract.ResourceIdentity]()
+			negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{}
+
+			ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(), clusterIdentity)
+			ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref(), ipLeases)
+			ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+			if tc.setupContext != nil {
+				ctx = tc.setupContext(ctx)
+			}
+
+			cs, gotGroupData, err := mapper.ProcessLogByGroup(ctx, tc.inputLog, tc.prevGroupData)
+			if err != nil {
+				t.Fatalf("ProcessLogByGroup() returned unexpected error: %v", err)
+			}
+
+			if tc.assert != nil {
+				tc.assert(t, ctx, cs)
+			}
+
+			// Wait, assert the returned group data.
+			if tc.wantGroupData != nil {
+				if tc.wantGroupData.LastNegAttachRequest == nil {
+					if gotGroupData.LastNegAttachRequest != nil {
+						t.Errorf("want LastNegAttachRequest to be nil, but got %v", gotGroupData.LastNegAttachRequest)
+					}
+				} else {
+					if gotGroupData.LastNegAttachRequest == nil {
+						t.Errorf("want LastNegAttachRequest to be %v, but got nil", tc.wantGroupData.LastNegAttachRequest)
+					} else {
+						// check network endpoints
+						for i, wantEndpoint := range tc.wantGroupData.LastNegAttachRequest.NetworkEndpoints {
+							gotEndpoint := gotGroupData.LastNegAttachRequest.NetworkEndpoints[i]
+							if gotEndpoint.Instance != wantEndpoint.Instance || gotEndpoint.IpAddress != wantEndpoint.IpAddress || gotEndpoint.Port != wantEndpoint.Port {
+								t.Errorf("endpoint mismatch: want %+v, got %+v", wantEndpoint, gotEndpoint)
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
@@ -320,6 +320,9 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 						t.Errorf("want LastNegAttachRequest to be %v, but got nil", tc.wantGroupData.LastNegAttachRequest)
 					} else {
 						// check network endpoints
+						if len(gotGroupData.LastNegAttachRequest.NetworkEndpoints) != len(tc.wantGroupData.LastNegAttachRequest.NetworkEndpoints) {
+							t.Fatalf("network endpoints length mismatch: want %d, got %d", len(tc.wantGroupData.LastNegAttachRequest.NetworkEndpoints), len(gotGroupData.LastNegAttachRequest.NetworkEndpoints))
+						}
 						for i, wantEndpoint := range tc.wantGroupData.LastNegAttachRequest.NetworkEndpoints {
 							gotEndpoint := gotGroupData.LastNegAttachRequest.NetworkEndpoints[i]
 							if gotEndpoint.Instance != wantEndpoint.Instance || gotEndpoint.IpAddress != wantEndpoint.IpAddress || gotEndpoint.Port != wantEndpoint.Port {


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.