### PR TITLE
Migrate K8s event log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task.go
@@ -20,21 +20,75 @@ import (
 
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogk8sevent_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8sevent/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlogk8sevent_contract.FieldSetReaderTaskID, googlecloudlogk8sevent_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
-	&googlecloudlogk8sevent_contract.GCPKubernetesEventFieldSetReader{},
-})
+// FieldSetReaderTask is the task to read the fieldsets required for GKE Event Log parsing.
+var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(
+	googlecloudlogk8sevent_contract.FieldSetReaderTaskID,
+	googlecloudlogk8sevent_contract.ListLogEntriesTaskID.Ref(),
+	[]log.FieldSetReader{
+		&googlecloudlogk8sevent_contract.GCPKubernetesEventFieldSetReader{},
+		&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
+	},
+)
 
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(googlecloudlogk8sevent_contract.LogIngesterTaskID, googlecloudlogk8sevent_contract.ListLogEntriesTaskID.Ref())
+// KubernetesEventLogIngester handles log ingestion into the KHI v6 builder format.
+type KubernetesEventLogIngester struct{}
 
-var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogk8sevent_contract.LogGrouperTaskID, googlecloudlogk8sevent_contract.FieldSetReaderTaskID.Ref(),
+// RawLogTask returns the task providing the raw logs to ingest.
+func (i *KubernetesEventLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogk8sevent_contract.FieldSetReaderTaskID.Ref()
+}
+
+// Dependencies returns additional task dependencies of the ingester.
+func (i *KubernetesEventLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog processes a raw log entry and populates its metadata into LogChangeSet.
+func (i *KubernetesEventLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+	cs.SetLogType(commonlogk8saudit_contract.LogTypeEvent)
+
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
+	}
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	eventFS, err := log.GetFieldSet(l, &googlecloudlogk8sevent_contract.KubernetesEventFieldSet{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubernetes event fieldset: %w", err)
+	}
+	cs.SetSummary(fmt.Sprintf("【%s】%s", eventFS.Reason, eventFS.Message))
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*KubernetesEventLogIngester)(nil)
+
+// LogIngesterTask is the log ingester task for GKE Event Logs.
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(
+	googlecloudlogk8sevent_contract.LogIngesterTaskID,
+	&KubernetesEventLogIngester{},
+)
+
+// LogGrouperTask groups logs by the event's resource path so they can be mapped to timelines.
+var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(
+	googlecloudlogk8sevent_contract.LogGrouperTaskID,
+	googlecloudlogk8sevent_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
 		event, err := log.GetFieldSet(l, &googlecloudlogk8sevent_contract.KubernetesEventFieldSet{})
 		if err != nil {
@@ -44,44 +98,70 @@ var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogk8sevent
 	},
 )
 
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudlogk8sevent_contract.LogToTimelineMapperTaskID, &KubernetesEventLogToTimelineMapperSetting{}, inspectioncore_contract.FeatureTaskLabel(
-	"Kubernetes Event Logs",
-	"Gather kubernetes event logs and visualize these on the associated resource timeline.",
-	enum.LogTypeEvent,
-	2000,
-	true,
-))
-
-type KubernetesEventLogToTimelineMapperSetting struct {
+// KubernetesEventTimelineMapper maps grouped GKE Event Logs to resource timelines.
+type KubernetesEventTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
 }
 
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (k *KubernetesEventLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
+// LogIngesterTask returns the prerequisite log ingester task.
+func (m *KubernetesEventTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogk8sevent_contract.LogIngesterTaskID.Ref()
+}
+
+// Dependencies returns additional task dependencies.
+func (m *KubernetesEventTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(),
 	}
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (k *KubernetesEventLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+// GroupedLogTask returns the task providing grouped logs.
+func (m *KubernetesEventTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
 	return googlecloudlogk8sevent_contract.LogGrouperTaskID.Ref()
 }
 
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (k *KubernetesEventLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
-	return googlecloudlogk8sevent_contract.LogIngesterTaskID.Ref()
-}
-
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (k *KubernetesEventLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
+// ProcessLogByGroup maps a single GKE Event Log to its resource timeline path.
+func (m *KubernetesEventTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	event, err := log.GetFieldSet(l, &googlecloudlogk8sevent_contract.KubernetesEventFieldSet{})
 	if err != nil {
-		return struct{}{}, fmt.Errorf("failed to get kubernetes event fieldset: %w", err)
+		return nil, struct{}{}, fmt.Errorf("failed to get kubernetes event fieldset: %w", err)
 	}
 
-	cs.AddEvent(event.ResourcePath())
-	cs.SetLogSummary(fmt.Sprintf("【%s】%s", event.Reason, event.Message))
-	return struct{}{}, nil
+	targetPath := MustResolveK8sResourceTimelinePath(ctx, event)
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+	cs.AddEvent(targetPath)
+
+	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*KubernetesEventLogToTimelineMapperSetting)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*KubernetesEventTimelineMapper)(nil)
+
+// LogToTimelineMapperTask is the task to map GKE Event Logs into timeline events.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
+	googlecloudlogk8sevent_contract.LogToTimelineMapperTaskID,
+	&KubernetesEventTimelineMapper{},
+	inspectioncore_contract.FeatureTaskLabelV2(
+		"Kubernetes Event Logs",
+		"Gather kubernetes event logs and visualize these on the associated resource timeline.",
+		2000,
+		true,
+	),
+)
+
+// MustResolveK8sResourceTimelinePath resolves a KubernetesEventFieldSet to a V2 *khifilev6.TimelinePath.
+func MustResolveK8sResourceTimelinePath(ctx context.Context, event *googlecloudlogk8sevent_contract.KubernetesEventFieldSet) *khifilev6.TimelinePath {
+	if event.Resource == "" {
+		gkeTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, event.ClusterName)
+		return googlecloudlogk8sevent_contract.MustEventExporterTimeline(ctx, gkeTimeline)
+	}
+
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, event.ClusterName)
+	apiVersionPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, event.APIVersion)
+	kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionPath, event.ResourceKind)
+	if event.Namespace == "cluster-scope" || event.Namespace == "" {
+		return commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, event.Resource)
+	}
+	namespacePath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, event.Namespace)
+	return commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespacePath, event.Resource)
+}

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task_test.go
@@ -15,22 +15,31 @@
 package googlecloudlogk8sevent_impl
 
 import (
+	"context"
 	"testing"
+	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8sevent_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8sevent/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 )
 
 func TestLogToTimelineMapperTask(t *testing.T) {
+	// Initialize the shared Builder reference.
+	builder := khifilev6.NewBuilder()
+
 	testCases := []struct {
-		desc      string
-		input     googlecloudlogk8sevent_contract.KubernetesEventFieldSet
-		asserters []testchangeset.ChangeSetAsserter
+		desc   string
+		input  googlecloudlogk8sevent_contract.KubernetesEventFieldSet
+		assert func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
-			desc: "simple event",
+			desc: "namespaced resource event",
 			input: googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
 				ClusterName:  "test-cluster",
 				APIVersion:   "apps/v1",
@@ -40,27 +49,120 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				Reason:       "ScalingReplicaSet",
 				Message:      "Scaled up replica set test-deployment-xyz to 3",
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{"apps/v1#deployment#default#test-deployment"},
-				},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "apps/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "deployment")
+				namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "default")
+				expectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "test-deployment")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath)
+			},
+		},
+		{
+			desc: "cluster-scoped resource event",
+			input: googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+				ClusterName:  "test-cluster",
+				APIVersion:   "core/v1",
+				ResourceKind: "node",
+				Namespace:    "cluster-scope",
+				Resource:     "my-node",
+				Reason:       "Starting",
+				Message:      "Starting kubelet.",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")
+				expectedPath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindTimeline, "my-node")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath)
+			},
+		},
+		{
+			desc: "empty resource name event (EventExporter fallback)",
+			input: googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+				ClusterName:  "test-cluster",
+				APIVersion:   "",
+				ResourceKind: "",
+				Namespace:    "",
+				Resource:     "",
+				Reason:       "ExporterStarted",
+				Message:      "Event exporter started watching.",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, "test-cluster")
+				expectedPath := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+					Name: "event-exporter",
+					Type: googlecloudlogk8sevent_contract.TimelineTypeEventExporter,
+				})
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath)
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			l := log.NewLogWithFieldSetsForTest(&tc.input)
-			cs := history.NewChangeSet(l)
-			modifier := KubernetesEventLogToTimelineMapperSetting{}
 
-			_, err := modifier.ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
+			// Set up context with the same Builder reference.
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			mapper := KubernetesEventTimelineMapper{}
+
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {
-				t.Errorf("ProcessLogByGroup returned an unexpected error: %v", err)
+				t.Fatalf("ProcessLogByGroup returned an unexpected error: %v", err)
 			}
 
-			for _, asserter := range tc.asserters {
-				asserter.Assert(t, cs)
+			tc.assert(t, ctx, cs)
+		})
+	}
+}
+
+func TestKubernetesEventLogIngester_ProcessLog(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  *log.Log
+		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
+	}{
+		{
+			name: "successful event log ingestion",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+				},
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityInfo,
+				},
+				&googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+					Reason:  "Scheduled",
+					Message: "Successfully assigned default/test-pod to node-1",
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)).
+					HasSeverity(inspectioncore_contract.SeverityInfo).
+					HasLogType(commonlogk8saudit_contract.LogTypeEvent).
+					HasSummary("【Scheduled】Successfully assigned default/test-pod to node-1")
+			},
+		},
+	}
+
+	ingester := &KubernetesEventLogIngester{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			cs, err := ingester.ProcessLog(ctx, tc.input)
+			if err != nil {
+				t.Fatalf("ProcessLog() returned unexpected error: %v", err)
 			}
+
+			tc.assert(t, cs)
 		})
 	}
 }


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.