### PR TITLE
Migrate GKE cluster autoscaler log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudloggkeautoscaler/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/contract/fieldset.go
@@ -22,6 +22,7 @@ import (
 )
 
 type AutoscalerLogFieldSet struct {
+	ClusterName   string
 	DecisionLog   *DecisionLog
 	NoDecisionLog *NoDecisionStatusLog
 	ResultInfoLog *ResultInfoLog
@@ -44,6 +45,7 @@ func (a *AutoscalerLogFieldSetReader) FieldSetKind() string {
 // Read implements log.FieldSetReader.
 func (a *AutoscalerLogFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	var result AutoscalerLogFieldSet
+	result.ClusterName = reader.ReadStringOrDefault("resource.labels.cluster_name", "")
 	switch {
 	case reader.Has("jsonPayload.decision"):
 		decisionLog, err := parseDecisionFromReader(reader)

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/contract/fieldset_test.go
@@ -63,6 +63,7 @@ receiveTimestamp: "2025-11-09T02:15:28.437679991Z"
 timestamp: "2025-11-09T02:15:27.768533131Z"
 `,
 			want: &AutoscalerLogFieldSet{
+				ClusterName: "ca-cluster",
 				DecisionLog: &DecisionLog{
 					DecideTime: "1762654527",
 					EventID:    "be492585-c6ca-4286-ac59-dd846560d64a",
@@ -130,6 +131,7 @@ receiveTimestamp: "2025-11-09T02:15:28.437679991Z"
 timestamp: "2025-11-09T02:15:27.768533131Z"
 `,
 			want: &AutoscalerLogFieldSet{
+				ClusterName: "ca-cluster",
 				NoDecisionLog: &NoDecisionStatusLog{
 					MeasureTime: "1762654527",
 					NoScaleDown: &NoScaleDownItem{
@@ -175,6 +177,7 @@ receiveTimestamp: "2025-11-09T02:16:43.703446262Z"
 timestamp: "2025-11-09T02:16:43.237461906Z"
 `,
 			want: &AutoscalerLogFieldSet{
+				ClusterName: "ca-cluster",
 				ResultInfoLog: &ResultInfoLog{
 					MeasureTime: "1762654602",
 					Results: []Result{

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/contract/timeline_path.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/contract/timeline_path.go
@@ -25,8 +25,8 @@ import (
 
 // MustAutoscalerTimeline returns the timeline path for GKE cluster autoscaler under the Kubernetes Cluster timeline.
 func MustAutoscalerTimeline(ctx context.Context, clusterTimeline *khifilev6.TimelinePath) *khifilev6.TimelinePath {
-	if clusterTimeline == nil || clusterTimeline.Type.GetId() != inspectioncore_contract.TimelineTypeK8sCluster.GetId() {
-		panic("parent timeline path must be K8sCluster type")
+	if clusterTimeline == nil || clusterTimeline.Type.GetId() != googlecloudcommon_contract.TimelineTypeGKE.GetId() {
+		panic("parent timeline path must be GKE type")
 	}
 	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
 	return builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser.go
@@ -20,173 +20,196 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudloggkeautoscaler_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudloggkeautoscaler/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"gopkg.in/yaml.v3"
 )
 
+// FieldSetReaderTask reads autoscaler fields from the raw logs.
 var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudloggkeautoscaler_contract.FieldSetReaderTaskID, googlecloudloggkeautoscaler_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
 	&googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSetReader{},
 })
 
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(googlecloudloggkeautoscaler_contract.LogIngesterTaskID, googlecloudloggkeautoscaler_contract.ListLogEntriesTaskID.Ref())
+type autoscalerLogIngester struct{}
 
+// RawLogTask returns the task that provides raw logs for ingestion.
+func (i *autoscalerLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudloggkeautoscaler_contract.FieldSetReaderTaskID.Ref()
+}
+
+// Dependencies returns additional dependencies of the ingester.
+func (i *autoscalerLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog ingests metadata for a single log.
+func (i *autoscalerLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	cs.SetLogType(googlecloudloggkeautoscaler_contract.LogTypeAutoscaler)
+
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
+	}
+
+	autoscalerFieldSet, err := log.GetFieldSet(l, &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case autoscalerFieldSet.DecisionLog != nil:
+		cs.SetSeverity(inspectioncore_contract.SeverityWarning)
+		cs.SetSummary(getDecisionSummary(autoscalerFieldSet.DecisionLog))
+	case autoscalerFieldSet.NoDecisionLog != nil:
+		cs.SetSeverity(inspectioncore_contract.SeverityInfo)
+		cs.SetSummary(getNoDecisionSummary(autoscalerFieldSet.NoDecisionLog))
+	case autoscalerFieldSet.ResultInfoLog != nil:
+		cs.SetSeverity(inspectioncore_contract.SeverityInfo)
+		cs.SetSummary(getResultInfoSummary(autoscalerFieldSet.ResultInfoLog))
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*autoscalerLogIngester)(nil)
+
+// LogIngesterTask serializes the ingested log metadata into the builder.
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(
+	googlecloudloggkeautoscaler_contract.LogIngesterTaskID,
+	&autoscalerLogIngester{},
+)
+
+// LogGrouperTask groups logs (no grouping needed for autoscaler logs).
 var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudloggkeautoscaler_contract.LogGrouperTaskID, googlecloudloggkeautoscaler_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
 		return "" // No grouping
 	},
 )
 
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudloggkeautoscaler_contract.LogToTimelineMapperTaskID, &autoscalerLogToTimelineMapperTaskSetting{},
-	inspectioncore_contract.FeatureTaskLabel(`GKE Autoscaler Logs`,
+type autoscalerTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
+}
+
+// LogIngesterTask returns the prerequisite log serializer task.
+func (m *autoscalerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudloggkeautoscaler_contract.LogIngesterTaskID.Ref()
+}
+
+// Dependencies returns additional dependencies of the mapper.
+func (m *autoscalerTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// GroupedLogTask returns the log grouper task reference.
+func (m *autoscalerTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudloggkeautoscaler_contract.LogGrouperTaskID.Ref()
+}
+
+// ProcessLogByGroup processes a single log and registers its timeline event/revision mutations.
+func (m *autoscalerTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
+	autoscalerFieldSet, err := log.GetFieldSet(l, &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{})
+	if err != nil {
+		return nil, struct{}{}, err
+	}
+	clusterName := autoscalerFieldSet.ClusterName
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+
+	if autoscalerFieldSet.DecisionLog != nil {
+		err := mapDecision(ctx, clusterName, autoscalerFieldSet.DecisionLog, cs)
+		if err != nil {
+			return nil, struct{}{}, err
+		}
+	}
+	if autoscalerFieldSet.NoDecisionLog != nil {
+		err := mapNoDecision(ctx, clusterName, autoscalerFieldSet.NoDecisionLog, cs)
+		if err != nil {
+			return nil, struct{}{}, err
+		}
+	}
+	if autoscalerFieldSet.ResultInfoLog != nil {
+		err := mapResultInfo(ctx, clusterName, autoscalerFieldSet.ResultInfoLog, cs)
+		if err != nil {
+			return nil, struct{}{}, err
+		}
+	}
+	return cs, struct{}{}, nil
+}
+
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*autoscalerTimelineMapper)(nil)
+
+// LogToTimelineMapperTask maps the autoscaler logs to respective resource timelines.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
+	googlecloudloggkeautoscaler_contract.LogToTimelineMapperTaskID,
+	&autoscalerTimelineMapper{},
+	inspectioncore_contract.FeatureTaskLabelV2(
+		`GKE Autoscaler Logs`,
 		`Gather logs related to cluster autoscaler behavior to show them on the timelines of resources related to the autoscaler decision.`,
-		enum.LogTypeAutoscaler,
 		8000,
 		true,
 	),
 )
 
-type autoscalerLogToTimelineMapperTaskSetting struct{}
-
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (a *autoscalerLogToTimelineMapperTaskSetting) Dependencies() []taskid.UntypedTaskReference {
-	return []taskid.UntypedTaskReference{
-		googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(),
-	}
-}
-
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (a *autoscalerLogToTimelineMapperTaskSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
-	return googlecloudloggkeautoscaler_contract.LogGrouperTaskID.Ref()
-}
-
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (a *autoscalerLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
-	return googlecloudloggkeautoscaler_contract.LogIngesterTaskID.Ref()
-}
-
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (a *autoscalerLogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
-	autoscalerFieldSet := log.MustGetFieldSet(l, &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{})
-	clusterName := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref())
-
-	if autoscalerFieldSet.DecisionLog != nil {
-		parseDecision(clusterName, autoscalerFieldSet.DecisionLog, cs)
-	}
-	if autoscalerFieldSet.NoDecisionLog != nil {
-		parseNoDecision(clusterName, autoscalerFieldSet.NoDecisionLog, cs)
-	}
-	if autoscalerFieldSet.ResultInfoLog != nil {
-		err := parseResultInfo(clusterName, autoscalerFieldSet.ResultInfoLog, cs)
-		if err != nil {
-			return struct{}{}, err
-		}
-	}
-	return struct{}{}, nil
-}
-
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*autoscalerLogToTimelineMapperTaskSetting)(nil)
-
-func parseDecision(clusterName string, decision *googlecloudloggkeautoscaler_contract.DecisionLog, cs *history.ChangeSet) {
-	// Parse scale up event
+func getDecisionSummary(decision *googlecloudloggkeautoscaler_contract.DecisionLog) string {
 	if decision.ScaleUp != nil {
 		scaleUp := decision.ScaleUp
 		nodepoolNames := []string{}
 		requestedSum := 0
 		for _, mig := range scaleUp.IncreasedMigs {
-			cs.AddEvent(resourcepath.Mig(clusterName, mig.Mig.Nodepool, mig.Mig.Name))
 			nodepoolNames = append(nodepoolNames, mig.Mig.Nodepool)
 			requestedSum += mig.RequestedNodes
 		}
-		for _, pod := range scaleUp.TriggeringPods {
-			cs.AddEvent(resourcepath.Pod(pod.Namespace, pod.Name))
-		}
-		cs.SetLogSummary(fmt.Sprintf("Scaling up nodepools by autoscaler: %s (requested: %d in total)", strings.Join(common.DedupStringArray(nodepoolNames), ","), requestedSum))
+		return fmt.Sprintf("Scaling up nodepools by autoscaler: %s (requested: %d in total)", strings.Join(common.DedupStringArray(nodepoolNames), ","), requestedSum)
 	}
-	// Parse scale down event
 	if decision.ScaleDown != nil {
 		scaleDown := decision.ScaleDown
 		nodepoolNames := []string{}
 		for _, nodeToBeRemoved := range scaleDown.NodesToBeRemoved {
-			cs.AddEvent(resourcepath.Node(nodeToBeRemoved.Node.Name))
-			cs.AddEvent(resourcepath.Mig(clusterName, nodeToBeRemoved.Node.Mig.Nodepool, nodeToBeRemoved.Node.Mig.Name))
-			for _, pod := range nodeToBeRemoved.EvictedPods {
-				cs.AddEvent(resourcepath.Pod(pod.Namespace, pod.Name))
-			}
 			nodepoolNames = append(nodepoolNames, nodeToBeRemoved.Node.Mig.Nodepool)
 		}
-		cs.SetLogSummary(fmt.Sprintf("Scaling down nodepools by autoscaler: %s (Removing %d nodes in total)", strings.Join(common.DedupStringArray(nodepoolNames), ","), len(scaleDown.NodesToBeRemoved)))
+		return fmt.Sprintf("Scaling down nodepools by autoscaler: %s (Removing %d nodes in total)", strings.Join(common.DedupStringArray(nodepoolNames), ","), len(scaleDown.NodesToBeRemoved))
 	}
-	// Nodepool creation event
 	if decision.NodePoolCreated != nil {
 		nodePoolCreated := decision.NodePoolCreated
 		nodepools := []string{}
 		for _, nodepool := range nodePoolCreated.NodePools {
-			cs.AddEvent(resourcepath.Nodepool(clusterName, nodepool.Name))
-			for _, mig := range nodepool.Migs {
-				cs.AddEvent(resourcepath.Mig(clusterName, mig.Nodepool, mig.Name))
-			}
 			nodepools = append(nodepools, nodepool.Name)
 		}
-		cs.SetLogSummary(fmt.Sprintf("Nodepool created by node auto provisioner: %s", strings.Join(nodepools, ",")))
+		return fmt.Sprintf("Nodepool created by node auto provisioner: %s", strings.Join(nodepools, ","))
 	}
 	if decision.NodePoolDeleted != nil {
 		nodepoolDeleted := decision.NodePoolDeleted
-		for _, nodepool := range nodepoolDeleted.NodePoolNames {
-			cs.AddEvent(resourcepath.Nodepool(clusterName, nodepool))
-		}
-		cs.SetLogSummary(fmt.Sprintf("Nodepool deleted by node auto provisioner: %s", strings.Join(nodepoolDeleted.NodePoolNames, ",")))
+		return fmt.Sprintf("Nodepool deleted by node auto provisioner: %s", strings.Join(nodepoolDeleted.NodePoolNames, ","))
 	}
-	cs.SetLogSeverity(enum.SeverityWarning)
-	cs.AddEvent(resourcepath.Autoscaler(clusterName))
+	return ""
 }
 
-func parseNoDecision(clusterName string, noDecision *googlecloudloggkeautoscaler_contract.NoDecisionStatusLog, cs *history.ChangeSet) {
+func getNoDecisionSummary(noDecision *googlecloudloggkeautoscaler_contract.NoDecisionStatusLog) string {
 	if noDecision.NoScaleUp != nil {
-		noScaleUp := noDecision.NoScaleUp
-		for _, mig := range noScaleUp.SkippedMigs {
-			cs.AddEvent(resourcepath.Mig(clusterName, mig.Mig.Nodepool, mig.Mig.Name))
-		}
-		for _, groupItem := range noScaleUp.UnhandledPodGroups {
-			cs.AddEvent(resourcepath.Pod(groupItem.PodGroup.SamplePod.Namespace, groupItem.PodGroup.SamplePod.Name))
-			for _, rejectedMig := range groupItem.RejectedMigs {
-				cs.AddEvent(resourcepath.Mig(clusterName, rejectedMig.Mig.Nodepool, rejectedMig.Mig.Name))
-			}
-		}
-		cs.SetLogSummary("autoscaler decided not to scale up")
+		return "autoscaler decided not to scale up"
 	}
-
 	if noDecision.NoScaleDown != nil {
-		noScaleDown := noDecision.NoScaleDown
-		migs := map[string]googlecloudloggkeautoscaler_contract.MIGItem{}
-		for _, node := range noScaleDown.Nodes {
-			cs.AddEvent(resourcepath.Node(node.Node.Name))
-			migs[node.Node.Mig.Id()] = node.Node.Mig
-		}
-		for _, mig := range migs {
-			migResourcePath := resourcepath.Mig(clusterName, mig.Nodepool, mig.Name)
-			cs.AddEvent(migResourcePath)
-		}
 		parameterStr := strings.Join(noDecision.NoScaleDown.Reason.Parameters, ",")
 		if parameterStr != "" {
 			parameterStr = fmt.Sprintf("(%s)", parameterStr)
 		}
-		cs.SetLogSummary(fmt.Sprintf("autoscaler decided not to scale down: %s%s", noDecision.NoScaleDown.Reason.MessageId, parameterStr))
+		return fmt.Sprintf("autoscaler decided not to scale down: %s%s", noDecision.NoScaleDown.Reason.MessageId, parameterStr)
 	}
-	cs.SetLogSeverity(enum.SeverityInfo)
-	cs.AddEvent(resourcepath.Autoscaler(clusterName))
+	return ""
 }
 
-func parseResultInfo(clusterName string, resultInfo *googlecloudloggkeautoscaler_contract.ResultInfoLog, cs *history.ChangeSet) error {
-	commonFieldSet := log.MustGetFieldSet(cs.Log, &log.CommonFieldSet{})
+func getResultInfoSummary(resultInfo *googlecloudloggkeautoscaler_contract.ResultInfoLog) string {
 	statuses := []string{}
 	for _, r := range resultInfo.Results {
 		status := r.EventID
@@ -201,9 +224,130 @@ func parseResultInfo(clusterName string, resultInfo *googlecloudloggkeautoscaler
 		}
 		statuses = append(statuses, status)
 	}
-	revisionState := enum.RevisionAutoscalerNoError
+	return fmt.Sprintf("autoscaler finished events: %s", strings.Join(statuses, ","))
+}
+
+func getAutoscalerTimeline(ctx context.Context, clusterName string) *khifilev6.TimelinePath {
+	clusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, clusterName)
+	return googlecloudloggkeautoscaler_contract.MustAutoscalerTimeline(ctx, clusterTimeline)
+}
+
+func getNodepoolTimeline(ctx context.Context, clusterName string, nodepoolName string) *khifilev6.TimelinePath {
+	gkeClusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, clusterName)
+	return googlecloudcommon_contract.MustGKENodePoolTimeline(ctx, gkeClusterTimeline, nodepoolName)
+}
+
+func getMigTimeline(ctx context.Context, clusterName string, nodepoolName string, migName string) *khifilev6.TimelinePath {
+	nodepoolTimeline := getNodepoolTimeline(ctx, clusterName, nodepoolName)
+	return googlecloudloggkeautoscaler_contract.MustMigTimeline(ctx, nodepoolTimeline, migName)
+}
+
+func getPodTimeline(ctx context.Context, clusterName string, namespace string, podName string) *khifilev6.TimelinePath {
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+	namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, namespace)
+	return commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, podName)
+}
+
+func getNodeTimeline(ctx context.Context, clusterName string, nodeName string) *khifilev6.TimelinePath {
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")
+	return commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindTimeline, nodeName)
+}
+
+func mapDecision(ctx context.Context, clusterName string, decision *googlecloudloggkeautoscaler_contract.DecisionLog, cs *khifilev6.TimelineChangeSet) error {
+	if decision.ScaleUp != nil {
+		scaleUp := decision.ScaleUp
+		for _, mig := range scaleUp.IncreasedMigs {
+			migPath := getMigTimeline(ctx, clusterName, mig.Mig.Nodepool, mig.Mig.Name)
+			cs.AddEvent(migPath)
+		}
+		for _, pod := range scaleUp.TriggeringPods {
+			podPath := getPodTimeline(ctx, clusterName, pod.Namespace, pod.Name)
+			cs.AddEvent(podPath)
+		}
+	}
+	if decision.ScaleDown != nil {
+		scaleDown := decision.ScaleDown
+		for _, nodeToBeRemoved := range scaleDown.NodesToBeRemoved {
+			nodePath := getNodeTimeline(ctx, clusterName, nodeToBeRemoved.Node.Name)
+			cs.AddEvent(nodePath)
+			migPath := getMigTimeline(ctx, clusterName, nodeToBeRemoved.Node.Mig.Nodepool, nodeToBeRemoved.Node.Mig.Name)
+			cs.AddEvent(migPath)
+			for _, pod := range nodeToBeRemoved.EvictedPods {
+				podPath := getPodTimeline(ctx, clusterName, pod.Namespace, pod.Name)
+				cs.AddEvent(podPath)
+			}
+		}
+	}
+	if decision.NodePoolCreated != nil {
+		nodePoolCreated := decision.NodePoolCreated
+		for _, nodepool := range nodePoolCreated.NodePools {
+			nodepoolPath := getNodepoolTimeline(ctx, clusterName, nodepool.Name)
+			cs.AddEvent(nodepoolPath)
+			for _, mig := range nodepool.Migs {
+				migPath := getMigTimeline(ctx, clusterName, mig.Nodepool, mig.Name)
+				cs.AddEvent(migPath)
+			}
+		}
+	}
+	if decision.NodePoolDeleted != nil {
+		nodepoolDeleted := decision.NodePoolDeleted
+		for _, nodepool := range nodepoolDeleted.NodePoolNames {
+			nodepoolPath := getNodepoolTimeline(ctx, clusterName, nodepool)
+			cs.AddEvent(nodepoolPath)
+		}
+	}
+	autoscalerPath := getAutoscalerTimeline(ctx, clusterName)
+	cs.AddEvent(autoscalerPath)
+	return nil
+}
+
+func mapNoDecision(ctx context.Context, clusterName string, noDecision *googlecloudloggkeautoscaler_contract.NoDecisionStatusLog, cs *khifilev6.TimelineChangeSet) error {
+	if noDecision.NoScaleUp != nil {
+		noScaleUp := noDecision.NoScaleUp
+		for _, mig := range noScaleUp.SkippedMigs {
+			migPath := getMigTimeline(ctx, clusterName, mig.Mig.Nodepool, mig.Mig.Name)
+			cs.AddEvent(migPath)
+		}
+		for _, groupItem := range noScaleUp.UnhandledPodGroups {
+			podPath := getPodTimeline(ctx, clusterName, groupItem.PodGroup.SamplePod.Namespace, groupItem.PodGroup.SamplePod.Name)
+			cs.AddEvent(podPath)
+			for _, rejectedMig := range groupItem.RejectedMigs {
+				migPath := getMigTimeline(ctx, clusterName, rejectedMig.Mig.Nodepool, rejectedMig.Mig.Name)
+				cs.AddEvent(migPath)
+			}
+		}
+	}
+
+	if noDecision.NoScaleDown != nil {
+		noScaleDown := noDecision.NoScaleDown
+		migs := map[string]googlecloudloggkeautoscaler_contract.MIGItem{}
+		for _, node := range noScaleDown.Nodes {
+			nodePath := getNodeTimeline(ctx, clusterName, node.Node.Name)
+			cs.AddEvent(nodePath)
+			migs[node.Node.Mig.Id()] = node.Node.Mig
+		}
+		for _, mig := range migs {
+			migPath := getMigTimeline(ctx, clusterName, mig.Nodepool, mig.Name)
+			cs.AddEvent(migPath)
+		}
+	}
+	autoscalerPath := getAutoscalerTimeline(ctx, clusterName)
+	cs.AddEvent(autoscalerPath)
+	return nil
+}
+
+func mapResultInfo(ctx context.Context, clusterName string, resultInfo *googlecloudloggkeautoscaler_contract.ResultInfoLog, cs *khifilev6.TimelineChangeSet) error {
+	commonFieldSet, err := log.GetFieldSet(cs.Log, &log.CommonFieldSet{})
+	if err != nil {
+		return err
+	}
+	revisionState := googlecloudloggkeautoscaler_contract.RevisionAutoscalerNoError
 	if resultInfoHasErrors(resultInfo) {
-		revisionState = enum.RevisionAutoscalerHasErrors
+		revisionState = googlecloudloggkeautoscaler_contract.RevisionAutoscalerHasErrors
 	}
 
 	serializedResultsRaw, err := yaml.Marshal(resultInfo)
@@ -211,18 +355,21 @@ func parseResultInfo(clusterName string, resultInfo *googlecloudloggkeautoscaler
 		return err
 	}
 
-	cs.AddRevision(resourcepath.Autoscaler(clusterName), &history.StagingResourceRevision{
-		ChangeTime: commonFieldSet.Timestamp,
-		State:      revisionState,
-		Requestor:  "cluster-autoscaler",
-		Body:       string(serializedResultsRaw),
+	bodyNode, err := structured.FromYAML(string(serializedResultsRaw))
+	if err != nil {
+		return err
+	}
+
+	autoscalerPath := getAutoscalerTimeline(ctx, clusterName)
+	cs.AddRevision(autoscalerPath, &khifilev6.StagingRevision{
+		ChangedTime:  commonFieldSet.Timestamp,
+		StateType:    revisionState,
+		Principal:    "cluster-autoscaler",
+		ResourceBody: bodyNode,
 	})
-	cs.SetLogSeverity(enum.SeverityInfo)
-	cs.SetLogSummary(fmt.Sprintf("autoscaler finished events: %s", strings.Join(statuses, ",")))
 	return nil
 }
 
-// resultInfoHasErrors returns if the given resultInfo contains any error events.
 func resultInfoHasErrors(resultInfo *googlecloudloggkeautoscaler_contract.ResultInfoLog) bool {
 	if resultInfo == nil {
 		return false

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser_test.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser_test.go
@@ -15,27 +15,266 @@
 package googlecloudloggkeautoscaler_impl
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
-	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudloggkeautoscaler_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudloggkeautoscaler/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestLogToTimelineMapperTask(t *testing.T) {
+func TestAutoscalerLogIngester_ProcessLog(t *testing.T) {
 	testTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	testCases := []struct {
-		desc     string
-		input    *googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet
-		asserter []testchangeset.ChangeSetAsserter
+		name         string
+		input        *googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet
+		wantSummary  string
+		wantSeverity *pb.Severity
 	}{
 		{
-			desc: "scale up",
+			name: "scale up",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				DecisionLog: &googlecloudloggkeautoscaler_contract.DecisionLog{
+					ScaleUp: &googlecloudloggkeautoscaler_contract.ScaleUpItem{
+						IncreasedMigs: []googlecloudloggkeautoscaler_contract.IncreasedMIGItem{
+							{
+								Mig: googlecloudloggkeautoscaler_contract.MIGItem{
+									Nodepool: "default-pool",
+									Name:     "test-cluster-default-pool-a0c72690-grp",
+								},
+								RequestedNodes: 1,
+							},
+						},
+					},
+				},
+			},
+			wantSummary:  "Scaling up nodepools by autoscaler: default-pool (requested: 1 in total)",
+			wantSeverity: inspectioncore_contract.SeverityWarning,
+		},
+		{
+			name: "scale down",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				DecisionLog: &googlecloudloggkeautoscaler_contract.DecisionLog{
+					ScaleDown: &googlecloudloggkeautoscaler_contract.ScaleDownItem{
+						NodesToBeRemoved: []googlecloudloggkeautoscaler_contract.NodeToBeRemovedItem{
+							{
+								Node: googlecloudloggkeautoscaler_contract.NodeItem{
+									Name: "test-cluster-default-pool-c47ef39f-p395",
+									Mig: googlecloudloggkeautoscaler_contract.MIGItem{
+										Nodepool: "default-pool",
+										Name:     "test-cluster-default-pool-c47ef39f-grp",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantSummary:  "Scaling down nodepools by autoscaler: default-pool (Removing 1 nodes in total)",
+			wantSeverity: inspectioncore_contract.SeverityWarning,
+		},
+		{
+			name: "nodepool created",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				DecisionLog: &googlecloudloggkeautoscaler_contract.DecisionLog{
+					NodePoolCreated: &googlecloudloggkeautoscaler_contract.NodepoolCreatedItem{
+						NodePools: []googlecloudloggkeautoscaler_contract.NodepoolItem{
+							{
+								Name: "nap-n1-standard-1-1kwag2qv",
+							},
+						},
+					},
+				},
+			},
+			wantSummary:  "Nodepool created by node auto provisioner: nap-n1-standard-1-1kwag2qv",
+			wantSeverity: inspectioncore_contract.SeverityWarning,
+		},
+		{
+			name: "nodepool deleted",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				DecisionLog: &googlecloudloggkeautoscaler_contract.DecisionLog{
+					NodePoolDeleted: &googlecloudloggkeautoscaler_contract.NodepoolDeletedItem{
+						NodePoolNames: []string{
+							"nap-n1-highcpu-8-ydj4ewil",
+						},
+					},
+				},
+			},
+			wantSummary:  "Nodepool deleted by node auto provisioner: nap-n1-highcpu-8-ydj4ewil",
+			wantSeverity: inspectioncore_contract.SeverityWarning,
+		},
+		{
+			name: "no scale up",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				NoDecisionLog: &googlecloudloggkeautoscaler_contract.NoDecisionStatusLog{
+					NoScaleUp: &googlecloudloggkeautoscaler_contract.NoScaleUpItem{},
+				},
+			},
+			wantSummary:  "autoscaler decided not to scale up",
+			wantSeverity: inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name: "no scale down with param",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				NoDecisionLog: &googlecloudloggkeautoscaler_contract.NoDecisionStatusLog{
+					NoScaleDown: &googlecloudloggkeautoscaler_contract.NoScaleDownItem{
+						Reason: googlecloudloggkeautoscaler_contract.ReasonItem{
+							MessageId:  "no.scale.down.in.backoff",
+							Parameters: []string{"param1", "param2"},
+						},
+					},
+				},
+			},
+			wantSummary:  "autoscaler decided not to scale down: no.scale.down.in.backoff(param1,param2)",
+			wantSeverity: inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name: "no scale down without param",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				NoDecisionLog: &googlecloudloggkeautoscaler_contract.NoDecisionStatusLog{
+					NoScaleDown: &googlecloudloggkeautoscaler_contract.NoScaleDownItem{
+						Reason: googlecloudloggkeautoscaler_contract.ReasonItem{
+							MessageId: "no.scale.down.in.backoff",
+						},
+					},
+				},
+			},
+			wantSummary:  "autoscaler decided not to scale down: no.scale.down.in.backoff",
+			wantSeverity: inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name: "result info success",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				ResultInfoLog: &googlecloudloggkeautoscaler_contract.ResultInfoLog{
+					Results: []googlecloudloggkeautoscaler_contract.Result{
+						{
+							EventID: "2fca91cd-7345-47fc-9770-838e05e28b17",
+						},
+					},
+				},
+			},
+			wantSummary:  "autoscaler finished events: 2fca91cd-7345-47fc-9770-838e05e28b17(Success)",
+			wantSeverity: inspectioncore_contract.SeverityInfo,
+		},
+		{
+			name: "result info error",
+			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
+				ResultInfoLog: &googlecloudloggkeautoscaler_contract.ResultInfoLog{
+					Results: []googlecloudloggkeautoscaler_contract.Result{
+						{
+							EventID: "ea2e964c-49b8-4cd7-8fa9-fefb0827f9a6",
+							ErrorMsg: &googlecloudloggkeautoscaler_contract.ErrorMessageItem{
+								MessageId:  "scale.down.error.failed.to.delete.node.min.size.reached",
+								Parameters: []string{"test-cluster-default-pool-5c90f485-nk80"},
+							},
+						},
+					},
+				},
+			},
+			wantSummary:  "autoscaler finished events: ea2e964c-49b8-4cd7-8fa9-fefb0827f9a6(Error:scale.down.error.failed.to.delete.node.min.size.reached(test-cluster-default-pool-5c90f485-nk80))",
+			wantSeverity: inspectioncore_contract.SeverityInfo,
+		},
+	}
+
+	ingester := &autoscalerLogIngester{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: testTime},
+				tc.input,
+			)
+			cs, err := ingester.ProcessLog(t.Context(), l)
+			if err != nil {
+				t.Fatalf("ProcessLog() error = %v", err)
+			}
+
+			testchangeset.AssertLog(t, cs).
+				HasSummary(tc.wantSummary).
+				HasSeverity(tc.wantSeverity).
+				HasLogType(googlecloudloggkeautoscaler_contract.LogTypeAutoscaler).
+				HasTimestamp(testTime)
+		})
+	}
+}
+
+var nodeCmpOpt = cmp.Transformer("StructuredNodeToJSON", func(n structured.Node) string {
+	if n == nil {
+		return "nil"
+	}
+	serializer := &structured.JSONNodeSerializer{}
+	bytes, err := serializer.Serialize(n)
+	if err != nil {
+		return fmt.Sprintf("error serializing structured node: %v", err)
+	}
+	return string(bytes)
+})
+
+func TestAutoscalerTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	testTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// 1. Initialize the Builder first.
+	builder := khifilev6.NewBuilder()
+
+	// 2. Resolve comparative path instances using the Builder's accumulator.
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+	autoscalerPath := googlecloudloggkeautoscaler_contract.MustAutoscalerTimeline(ctx, clusterTimeline)
+
+	gkeClusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, "test-cluster")
+	nodepoolTimeline := googlecloudcommon_contract.MustGKENodePoolTimeline(ctx, gkeClusterTimeline, "default-pool")
+	migPath := googlecloudloggkeautoscaler_contract.MustMigTimeline(ctx, nodepoolTimeline, "test-cluster-default-pool-a0c72690-grp")
+
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+	namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "default")
+	podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "test-85958b848b-ptc7n")
+
+	// Additional paths for other test cases
+	scaleDownMigPath := googlecloudloggkeautoscaler_contract.MustMigTimeline(ctx, nodepoolTimeline, "test-cluster-default-pool-c47ef39f-grp")
+
+	kubeDnsNamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "kube-system")
+	kubeDnsPodPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, kubeDnsNamespaceTimeline, "kube-dns-5c44c7b6b6-xvpbk")
+
+	nodeKindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")
+	nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, nodeKindTimeline, "test-cluster-default-pool-c47ef39f-p395")
+
+	// Node auto provisioning creation
+	napNodepoolTimeline := googlecloudcommon_contract.MustGKENodePoolTimeline(ctx, gkeClusterTimeline, "nap-n1-standard-1-1kwag2qv")
+	napMigPath := googlecloudloggkeautoscaler_contract.MustMigTimeline(ctx, napNodepoolTimeline, "test-cluster-nap-n1-standard--b4fcc348-grp")
+
+	// Node auto provisioning deletion
+	napDeletedNodepoolTimeline := googlecloudcommon_contract.MustGKENodePoolTimeline(ctx, gkeClusterTimeline, "nap-n1-highcpu-8-ydj4ewil")
+
+	// No scale up
+	skippedNodepoolTimeline := googlecloudcommon_contract.MustGKENodePoolTimeline(ctx, gkeClusterTimeline, "nap-n1-highmem-4-1cywzhvf")
+	skippedMigPath := googlecloudloggkeautoscaler_contract.MustMigTimeline(ctx, skippedNodepoolTimeline, "test-cluster-nap-n1-highmem-4-fbdca585-grp")
+
+	unhandledPodNamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "autoscaling-1661")
+	unhandledPodPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, unhandledPodNamespaceTimeline, "memory-reservation2-6zg8m")
+
+	rejectedMigPath := googlecloudloggkeautoscaler_contract.MustMigTimeline(ctx, nodepoolTimeline, "test-cluster-default-pool-b1808ff9-grp")
+
+	// No scale down
+	noScaleDownNodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, nodeKindTimeline, "test-cluster-default-pool-f74c1617-fbhk")
+	noScaleDownMigPath := googlecloudloggkeautoscaler_contract.MustMigTimeline(ctx, nodepoolTimeline, "test-cluster-default-pool-f74c1617-grp")
+
+	testCases := []struct {
+		name   string
+		input  *googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet
+		assert func(t *testing.T, cs *khifilev6.TimelineChangeSet)
+	}{
+		{
+			name: "scale up",
 			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
 				DecisionLog: &googlecloudloggkeautoscaler_contract.DecisionLog{
 					ScaleUp: &googlecloudloggkeautoscaler_contract.ScaleUpItem{
@@ -57,21 +296,15 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 					},
 				},
 			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-						"@Cluster#nodepool#test-cluster#default-pool#test-cluster-default-pool-a0c72690-grp",
-						"core/v1#pod#default#test-85958b848b-ptc7n",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "Scaling up nodepools by autoscaler: default-pool (requested: 1 in total)",
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(autoscalerPath).
+					HasEvent(migPath).
+					HasEvent(podPath)
 			},
 		},
 		{
-			desc: "scale down",
+			name: "scale down",
 			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
 				DecisionLog: &googlecloudloggkeautoscaler_contract.DecisionLog{
 					ScaleDown: &googlecloudloggkeautoscaler_contract.ScaleDownItem{
@@ -95,22 +328,16 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 					},
 				},
 			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-						"core/v1#node#cluster-scope#test-cluster-default-pool-c47ef39f-p395",
-						"@Cluster#nodepool#test-cluster#default-pool#test-cluster-default-pool-c47ef39f-grp",
-						"core/v1#pod#kube-system#kube-dns-5c44c7b6b6-xvpbk",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "Scaling down nodepools by autoscaler: default-pool (Removing 1 nodes in total)",
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(autoscalerPath).
+					HasEvent(nodePath).
+					HasEvent(scaleDownMigPath).
+					HasEvent(kubeDnsPodPath)
 			},
 		},
 		{
-			desc: "nodepool created",
+			name: "nodepool created",
 			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
 				DecisionLog: &googlecloudloggkeautoscaler_contract.DecisionLog{
 					NodePoolCreated: &googlecloudloggkeautoscaler_contract.NodepoolCreatedItem{
@@ -128,21 +355,15 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 					},
 				},
 			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-						"@Cluster#nodepool#test-cluster#nap-n1-standard-1-1kwag2qv",
-						"@Cluster#nodepool#test-cluster#nap-n1-standard-1-1kwag2qv#test-cluster-nap-n1-standard--b4fcc348-grp",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "Nodepool created by node auto provisioner: nap-n1-standard-1-1kwag2qv",
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(autoscalerPath).
+					HasEvent(napNodepoolTimeline).
+					HasEvent(napMigPath)
 			},
 		},
 		{
-			desc: "nodepool deleted",
+			name: "nodepool deleted",
 			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
 				DecisionLog: &googlecloudloggkeautoscaler_contract.DecisionLog{
 					NodePoolDeleted: &googlecloudloggkeautoscaler_contract.NodepoolDeletedItem{
@@ -152,20 +373,14 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 					},
 				},
 			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-						"@Cluster#nodepool#test-cluster#nap-n1-highcpu-8-ydj4ewil",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "Nodepool deleted by node auto provisioner: nap-n1-highcpu-8-ydj4ewil",
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(autoscalerPath).
+					HasEvent(napDeletedNodepoolTimeline)
 			},
 		},
 		{
-			desc: "no scale up",
+			name: "no scale up",
 			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
 				NoDecisionLog: &googlecloudloggkeautoscaler_contract.NoDecisionStatusLog{
 					NoScaleUp: &googlecloudloggkeautoscaler_contract.NoScaleUpItem{
@@ -198,22 +413,16 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 					},
 				},
 			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-						"@Cluster#nodepool#test-cluster#default-pool#test-cluster-default-pool-b1808ff9-grp",
-						"@Cluster#nodepool#test-cluster#nap-n1-highmem-4-1cywzhvf#test-cluster-nap-n1-highmem-4-fbdca585-grp",
-						"core/v1#pod#autoscaling-1661#memory-reservation2-6zg8m",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "autoscaler decided not to scale up",
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(autoscalerPath).
+					HasEvent(skippedMigPath).
+					HasEvent(unhandledPodPath).
+					HasEvent(rejectedMigPath)
 			},
 		},
 		{
-			desc: "no scale down",
+			name: "no scale down",
 			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
 				NoDecisionLog: &googlecloudloggkeautoscaler_contract.NoDecisionStatusLog{
 					NoScaleDown: &googlecloudloggkeautoscaler_contract.NoScaleDownItem{
@@ -235,56 +444,15 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 					},
 				},
 			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-						"core/v1#node#cluster-scope#test-cluster-default-pool-f74c1617-fbhk",
-						"@Cluster#nodepool#test-cluster#default-pool#test-cluster-default-pool-f74c1617-grp",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "autoscaler decided not to scale down: no.scale.down.in.backoff(param1,param2)",
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(autoscalerPath).
+					HasEvent(noScaleDownNodePath).
+					HasEvent(noScaleDownMigPath)
 			},
 		},
 		{
-			desc: "no scale down wihout param",
-			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
-				NoDecisionLog: &googlecloudloggkeautoscaler_contract.NoDecisionStatusLog{
-					NoScaleDown: &googlecloudloggkeautoscaler_contract.NoScaleDownItem{
-						Nodes: []googlecloudloggkeautoscaler_contract.NoScaleDownNodeItem{
-							{
-								Node: googlecloudloggkeautoscaler_contract.NodeItem{
-									Name: "test-cluster-default-pool-f74c1617-fbhk",
-									Mig: googlecloudloggkeautoscaler_contract.MIGItem{
-										Nodepool: "default-pool",
-										Name:     "test-cluster-default-pool-f74c1617-grp",
-									},
-								},
-							},
-						},
-						Reason: googlecloudloggkeautoscaler_contract.ReasonItem{
-							MessageId: "no.scale.down.in.backoff",
-						},
-					},
-				},
-			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-						"core/v1#node#cluster-scope#test-cluster-default-pool-f74c1617-fbhk",
-						"@Cluster#nodepool#test-cluster#default-pool#test-cluster-default-pool-f74c1617-grp",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "autoscaler decided not to scale down: no.scale.down.in.backoff",
-				},
-			},
-		},
-		{
-			desc: "result info success",
+			name: "result info success",
 			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
 				ResultInfoLog: &googlecloudloggkeautoscaler_contract.ResultInfoLog{
 					Results: []googlecloudloggkeautoscaler_contract.Result{
@@ -294,31 +462,26 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 					},
 				},
 			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "autoscaler finished events: 2fca91cd-7345-47fc-9770-838e05e28b17(Success)",
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-					WantRevision: history.StagingResourceRevision{
-						ChangeTime: testTime,
-						Requestor:  "cluster-autoscaler",
-						State:      enum.RevisionAutoscalerNoError,
-						Body: `measureTime: ""
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				bodyYAML := `measureTime: ""
 results:
     - eventId: 2fca91cd-7345-47fc-9770-838e05e28b17
-`,
-					},
-				},
+`
+				bodyNode, err := structured.FromYAML(bodyYAML)
+				if err != nil {
+					t.Fatalf("failed to parse body YAML: %v", err)
+				}
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(autoscalerPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						Principal:    "cluster-autoscaler",
+						StateType:    googlecloudloggkeautoscaler_contract.RevisionAutoscalerNoError,
+						ResourceBody: bodyNode,
+					}, nodeCmpOpt)
 			},
 		},
 		{
-			desc: "result info error",
+			name: "result info error",
 			input: &googlecloudloggkeautoscaler_contract.AutoscalerLogFieldSet{
 				ResultInfoLog: &googlecloudloggkeautoscaler_contract.ResultInfoLog{
 					Results: []googlecloudloggkeautoscaler_contract.Result{
@@ -332,50 +495,47 @@ results:
 					},
 				},
 			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{
-						"@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-					},
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "autoscaler finished events: ea2e964c-49b8-4cd7-8fa9-fefb0827f9a6(Error:scale.down.error.failed.to.delete.node.min.size.reached(test-cluster-default-pool-5c90f485-nk80))",
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#autoscaler",
-					WantRevision: history.StagingResourceRevision{
-						ChangeTime: testTime,
-						Requestor:  "cluster-autoscaler",
-						State:      enum.RevisionAutoscalerHasErrors,
-						Body: `measureTime: ""
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				bodyYAML := `measureTime: ""
 results:
     - eventId: ea2e964c-49b8-4cd7-8fa9-fefb0827f9a6
       errorMsg:
         messageId: scale.down.error.failed.to.delete.node.min.size.reached
         parameters:
             - test-cluster-default-pool-5c90f485-nk80
-`,
-					},
-				},
+`
+				bodyNode, err := structured.FromYAML(bodyYAML)
+				if err != nil {
+					t.Fatalf("failed to parse body YAML: %v", err)
+				}
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(autoscalerPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						Principal:    "cluster-autoscaler",
+						StateType:    googlecloudloggkeautoscaler_contract.RevisionAutoscalerHasErrors,
+						ResourceBody: bodyNode,
+					}, nodeCmpOpt)
 			},
 		},
 	}
+
+	mapper := &autoscalerTimelineMapper{}
 	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.input.ClusterName = "test-cluster"
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
 			l := log.NewLogWithFieldSetsForTest(
 				&log.CommonFieldSet{Timestamp: testTime},
 				tc.input,
 			)
-			cs := history.NewChangeSet(l)
-			ctx := tasktest.WithTaskResult(t.Context(), googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(), "test-cluster")
-			_, err := (&autoscalerLogToTimelineMapperTaskSetting{}).ProcessLogByGroup(ctx, l, cs, nil, struct{}{})
+
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {
 				t.Fatalf("ProcessLogByGroup() error = %v", err)
 			}
-			for _, asserter := range tc.asserter {
-				asserter.Assert(t, cs)
-			}
-		})
 
+			tc.assert(t, cs)
+		})
 	}
 }

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser_test.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser_test.go
@@ -227,10 +227,11 @@ func TestAutoscalerTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	// 2. Resolve comparative path instances using the Builder's accumulator.
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
-	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
-	autoscalerPath := googlecloudloggkeautoscaler_contract.MustAutoscalerTimeline(ctx, clusterTimeline)
-
 	gkeClusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, "test-cluster")
+	autoscalerPath := googlecloudloggkeautoscaler_contract.MustAutoscalerTimeline(ctx, gkeClusterTimeline)
+
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+
 	nodepoolTimeline := googlecloudcommon_contract.MustGKENodePoolTimeline(ctx, gkeClusterTimeline, "default-pool")
 	migPath := googlecloudloggkeautoscaler_contract.MustMigTimeline(ctx, nodepoolTimeline, "test-cluster-default-pool-a0c72690-grp")
 


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.