### PR TITLE
Migrate GKE multicloud audit log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/fieldset.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 )
 
@@ -49,14 +48,6 @@ func (g *MulticloudAPIAuditResourceFieldSet) IsCluster() bool {
 // IsNodepool returns true if the log entry is related to a nodepool operation (i.e., a nodepool name is present).
 func (g *MulticloudAPIAuditResourceFieldSet) IsNodepool() bool {
 	return g.NodepoolName != ""
-}
-
-func (g *MulticloudAPIAuditResourceFieldSet) ResourcePath() resourcepath.ResourcePath {
-	if g.IsCluster() {
-		return resourcepath.Cluster(g.ClusterName)
-	} else {
-		return resourcepath.Nodepool(g.ClusterName, g.NodepoolName)
-	}
 }
 
 var _ log.FieldSet = (*MulticloudAPIAuditResourceFieldSet)(nil)

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/timeline_path.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/timeline_path.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogmulticloudapiaudit_contract
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// MustProjectTimeline returns the hierarchical timeline path for a Google Cloud Project.
+func MustProjectTimeline(ctx context.Context, projectID string) *khifilev6.TimelinePath {
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "projects/" + projectID,
+		Type: TimelineTypeProject,
+	})
+}
+
+// MustMultiCloudClusterTimeline returns the hierarchical timeline path for a MultiCloud Cluster.
+func MustMultiCloudClusterTimeline(ctx context.Context, parent *khifilev6.TimelinePath, clusterName string) *khifilev6.TimelinePath {
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(parent, khifilev6.PathSegment{
+		Name: clusterName,
+		Type: TimelineTypeMultiCloudCluster,
+	})
+}
+
+// MustMultiCloudNodepoolTimeline returns the hierarchical timeline path for a MultiCloud NodePool.
+func MustMultiCloudNodepoolTimeline(ctx context.Context, parent *khifilev6.TimelinePath, nodepoolName string) *khifilev6.TimelinePath {
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(parent, khifilev6.PathSegment{
+		Name: nodepoolName,
+		Type: TimelineTypeMultiCloudNodepool,
+	})
+}
+
+// MustOperationTimeline returns the hierarchical timeline path for an operation on a resource.
+func MustOperationTimeline(ctx context.Context, parent *khifilev6.TimelinePath, shortMethodName string, operationID string) *khifilev6.TimelinePath {
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(parent, khifilev6.PathSegment{
+		Name: shortMethodName + "-" + operationID,
+		Type: inspectioncore_contract.TimelineTypeSubresource,
+	})
+}

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/timeline_type.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogmulticloudapiaudit_contract
+
+import (
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+var (
+	// TimelineTypeProject is the timeline type for a Google Cloud project.
+	TimelineTypeProject = style.MustRegisterTimelineType(
+		"project",
+		"Google Cloud Project",
+		"cloud",
+		0.6,
+		style.MustForceConvertSRGBHex("#111111"),
+		style.ColorWhite,
+		style.MustForceConvertSRGBHex("#F5F5F5"),
+		true,
+		50,
+	)
+
+	// TimelineTypeMultiCloudCluster is the timeline type style for MultiCloud Cluster resources.
+	TimelineTypeMultiCloudCluster = style.MustRegisterTimelineType(
+		"multicloudCluster",
+		"MultiCloud Cluster",
+		"dns",
+		1.0,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#4285F4"),
+		true,
+		1000,
+	)
+
+	// TimelineTypeMultiCloudNodepool is the timeline type style for MultiCloud Nodepool resources.
+	TimelineTypeMultiCloudNodepool = style.MustRegisterTimelineType(
+		"multicloudNodepool",
+		"MultiCloud NodePool",
+		"list",
+		1.0,
+		style.ColorWhite,
+		style.ColorBlack,
+		style.MustForceConvertSRGBHex("#34A853"),
+		true,
+		1100,
+	)
+
+	// RevisionStateProvisioning is the style for a resource that is being provisioned.
+	RevisionStateProvisioning = style.MustRegisterRevisionState(
+		"Resource is being provisioned",
+		"deployed_code_history",
+		"Resource is being provisioned",
+		style.MustForceConvertSRGBHex("#6666ff"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+)

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,79 +22,155 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogmulticloudapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
 // FieldSetReaderTask is a task that reads and parses field sets from MulticloudAPI audit logs.
-// It uses GCPOperationAuditLogFieldSetReader and MulticloudAPIAuditResourceFieldSetReader
-// to extract common GCP audit log fields and multicloud api-specific resource fields.
-var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlogmulticloudapiaudit_contract.FieldSetReaderTaskID, googlecloudlogmulticloudapiaudit_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
-	&googlecloudcommon_contract.GCPOperationAuditLogFieldSetReader{},
-	&googlecloudlogmulticloudapiaudit_contract.MulticloudAPIAuditResourceFieldSetReader{},
-})
+// It uses GCPOperationAuditLogFieldSetReader, MulticloudAPIAuditResourceFieldSetReader, and
+// GCPDefaultSeverityFieldSetReader to extract common GCP audit log fields, severity, and resource fields.
+var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(
+	googlecloudlogmulticloudapiaudit_contract.FieldSetReaderTaskID,
+	googlecloudlogmulticloudapiaudit_contract.ListLogEntriesTaskID.Ref(),
+	[]log.FieldSetReader{
+		&googlecloudcommon_contract.GCPOperationAuditLogFieldSetReader{},
+		&googlecloudlogmulticloudapiaudit_contract.MulticloudAPIAuditResourceFieldSetReader{},
+		&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
+	},
+)
+
+// multicloudAuditLogIngester is a V2 log ingester that parses log metadata.
+type multicloudAuditLogIngester struct{}
+
+// RawLogTask returns the task reference that provides raw logs.
+func (i *multicloudAuditLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogmulticloudapiaudit_contract.FieldSetReaderTaskID.Ref()
+}
+
+// Dependencies returns additional task dependencies.
+func (i *multicloudAuditLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog customizes the log metadata and returns a LogChangeSet.
+func (i *multicloudAuditLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	cs.SetLogType(googlecloudlogmulticloudapiaudit_contract.LogTypeMulticloudAPI)
+
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
+	}
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	auditFieldSet, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case auditFieldSet.Starting():
+		cs.SetSummary(fmt.Sprintf("%s Started", auditFieldSet.MethodName))
+	case auditFieldSet.Ending():
+		cs.SetSummary(fmt.Sprintf("%s Finished", auditFieldSet.MethodName))
+	default:
+		cs.SetSummary(auditFieldSet.MethodName)
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*multicloudAuditLogIngester)(nil)
 
 // LogIngesterTask is a task that serializes MulticloudAPI audit logs for storage in the history builder.
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(googlecloudlogmulticloudapiaudit_contract.LogIngesterTaskID, googlecloudlogmulticloudapiaudit_contract.ListLogEntriesTaskID.Ref())
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(
+	googlecloudlogmulticloudapiaudit_contract.LogIngesterTaskID,
+	&multicloudAuditLogIngester{},
+)
 
-// LogGrouperTask is a task that groups MulticloudAPI audit logs by their resource path.
+// LogGrouperTask is a task that groups MulticloudAPI audit logs by resource identifier.
 // This grouping allows for parallel processing of logs related to the same resource.
-var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogmulticloudapiaudit_contract.LogGrouperTaskID, googlecloudlogmulticloudapiaudit_contract.FieldSetReaderTaskID.Ref(),
+var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(
+	googlecloudlogmulticloudapiaudit_contract.LogGrouperTaskID,
+	googlecloudlogmulticloudapiaudit_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
 		resourceFieldSet, err := log.GetFieldSet(l, &googlecloudlogmulticloudapiaudit_contract.MulticloudAPIAuditResourceFieldSet{})
 		if err != nil {
 			return ""
 		}
-		return resourceFieldSet.ResourcePath().Path
+		if resourceFieldSet.IsCluster() {
+			return fmt.Sprintf("cluster/%s/%s", resourceFieldSet.ClusterType, resourceFieldSet.ClusterName)
+		}
+		return fmt.Sprintf("nodepool/%s/%s/%s", resourceFieldSet.ClusterType, resourceFieldSet.ClusterName, resourceFieldSet.NodepoolName)
 	},
 )
 
-// LogToTimelineMapperTask is a task that adds revisions/events regarding logs.
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudlogmulticloudapiaudit_contract.LogToTimelineMapperTaskID, &multicloudAuditLogLogToTimelineMapperSetting{},
-	inspectioncore_contract.FeatureTaskLabel(`MultiCloud API logs`,
-		`Gather Anthos Multicloud audit log including cluster creation,deletion and upgrades.`,
-		enum.LogTypeGkeAudit,
-		5000,
-		true,
-	),
-)
-
 type multicloudAuditLogLogToTimelineMapperSetting struct {
+	inspectiontaskbase.StatelessMapperBase
 }
 
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
+// Dependencies implements LogToTimelineMapperV2.
 func (m *multicloudAuditLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{}
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
+// GroupedLogTask implements LogToTimelineMapperV2.
 func (m *multicloudAuditLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
 	return googlecloudlogmulticloudapiaudit_contract.LogGrouperTaskID.Ref()
 }
 
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
+// LogIngesterTask implements LogToTimelineMapperV2.
 func (m *multicloudAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogmulticloudapiaudit_contract.LogIngesterTaskID.Ref()
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (m *multicloudAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
+// ProcessLogByGroup maps grouped logs to resource timelines and operations in KHI V6 format.
+func (m *multicloudAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	commonFieldSet, err := log.GetFieldSet(l, &log.CommonFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 	auditFieldSet, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 	resourceFieldSet, err := log.GetFieldSet(l, &googlecloudlogmulticloudapiaudit_contract.MulticloudAPIAuditResourceFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
+
+	// Extract the project ID/number from the resourceName.
+	// Format: projects/<PROJECT_NUMBER>/locations/<LOCATION>/...
+	var projectID string
+	resourceName, _ := l.ReadString("protoPayload.resourceName")
+	splited := strings.Split(resourceName, "/")
+	if len(splited) > 1 && splited[0] == "projects" {
+		projectID = splited[1]
+	} else {
+		projectID = "unknown"
+	}
+
+	projectPath := googlecloudlogmulticloudapiaudit_contract.MustProjectTimeline(ctx, projectID)
+	clusterPath := googlecloudlogmulticloudapiaudit_contract.MustMultiCloudClusterTimeline(ctx, projectPath, resourceFieldSet.ClusterName)
+
+	var targetPath *khifilev6.TimelinePath
+	if resourceFieldSet.IsCluster() {
+		targetPath = clusterPath
+	} else {
+		targetPath = googlecloudlogmulticloudapiaudit_contract.MustMultiCloudNodepoolTimeline(ctx, clusterPath, resourceFieldSet.NodepoolName)
+	}
+
+	cs := khifilev6.NewTimelineChangeSet(l)
 
 	if !auditFieldSet.ImmediateOperation() {
 		resourceBodyField := ""
@@ -112,69 +188,77 @@ func (m *multicloudAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx con
 
 		methodNameParts := strings.Split(auditFieldSet.MethodName, ".")
 		shortMethodName := methodNameParts[len(methodNameParts)-1]
-		shortMethodName = strings.ReplaceAll(shortMethodName, clusterTypeToFragmentInMethodNameMapping[resourceFieldSet.ClusterType], "") // Remove type specific part. Example: converting CreateAwsCluster to CreateCluster.
+		shortMethodName = strings.ReplaceAll(shortMethodName, clusterTypeToFragmentInMethodNameMapping[resourceFieldSet.ClusterType], "") // Remove type specific part.
 
 		switch shortMethodName {
 		case "CreateCluster", "CreateNodePool":
-			var bodyRaw []byte
-			state := enum.RevisionStateProvisioning
+			var bodyNode structured.Node
+			state := googlecloudlogmulticloudapiaudit_contract.RevisionStateProvisioning
 			if auditFieldSet.Ending() {
-				state = enum.RevisionStateExisting
+				state = commonlogk8saudit_contract.RevisionStateK8sResourceExisting
 			}
 			if auditFieldSet.Request != nil {
-				bodyRaw, _ = auditFieldSet.Request.Serialize(resourceBodyField, &structured.YAMLNodeSerializer{})
+				if r, err := auditFieldSet.Request.GetReader(resourceBodyField); err == nil {
+					bodyNode = r.Node
+				}
 			}
-			cs.AddRevision(resourceFieldSet.ResourcePath(), &history.StagingResourceRevision{
-				Verb:       enum.RevisionVerbCreate,
-				State:      state,
-				Requestor:  auditFieldSet.PrincipalEmail,
-				ChangeTime: commonFieldSet.Timestamp,
-				Partial:    false,
-				Body:       string(bodyRaw),
+			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
+				ChangedTime:  commonFieldSet.Timestamp,
+				ResourceBody: bodyNode,
+				Principal:    auditFieldSet.PrincipalEmail,
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    state,
 			})
 		case "DeleteCluster", "DeleteNodePool":
-			state := enum.RevisionStateDeleting
+			state := commonlogk8saudit_contract.RevisionStateK8sResourceDeleting
 			if auditFieldSet.Ending() {
-				state = enum.RevisionStateDeleted
+				state = commonlogk8saudit_contract.RevisionStateK8sResourceIsDeleted
 			}
-			cs.AddRevision(resourceFieldSet.ResourcePath(), &history.StagingResourceRevision{
-				Verb:       enum.RevisionVerbDelete,
-				State:      state,
-				Requestor:  auditFieldSet.PrincipalEmail,
-				ChangeTime: commonFieldSet.Timestamp,
-				Partial:    false,
-				Body:       "",
+			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
+				ChangedTime:  commonFieldSet.Timestamp,
+				ResourceBody: nil,
+				Principal:    auditFieldSet.PrincipalEmail,
+				VerbType:     commonlogk8saudit_contract.VerbDelete,
+				StateType:    state,
 			})
 		}
 
-		state := enum.RevisionStateOperationStarted
-		verb := enum.RevisionVerbOperationStart
+		state := googlecloudcommon_contract.RevisionStateOperationStarted
+		verb := googlecloudcommon_contract.VerbOperationStart
 		if auditFieldSet.Ending() {
-			state = enum.RevisionStateOperationFinished
-			verb = enum.RevisionVerbOperationFinish
+			state = googlecloudcommon_contract.RevisionStateOperationFinished
+			verb = googlecloudcommon_contract.VerbOperationFinish
 		}
-		requestBody, _ := auditFieldSet.RequestString()
-		cs.AddRevision(auditFieldSet.OperationPath(resourceFieldSet.ResourcePath()), &history.StagingResourceRevision{
-			Body:       requestBody,
-			Verb:       verb,
-			State:      state,
-			Requestor:  auditFieldSet.PrincipalEmail,
-			ChangeTime: commonFieldSet.Timestamp,
-			Partial:    false,
+
+		var opBody structured.Node
+		if auditFieldSet.Request != nil {
+			opBody = auditFieldSet.Request.Node
+		}
+
+		opPath := googlecloudlogmulticloudapiaudit_contract.MustOperationTimeline(ctx, targetPath, shortMethodName, auditFieldSet.OperationID)
+		cs.AddRevision(opPath, &khifilev6.StagingRevision{
+			ChangedTime:  commonFieldSet.Timestamp,
+			ResourceBody: opBody,
+			Principal:    auditFieldSet.PrincipalEmail,
+			VerbType:     verb,
+			StateType:    state,
 		})
 	} else {
-		cs.AddEvent(resourceFieldSet.ResourcePath())
+		cs.AddEvent(targetPath)
 	}
 
-	switch {
-	case auditFieldSet.Starting():
-		cs.SetLogSummary(fmt.Sprintf("%s Started", auditFieldSet.MethodName))
-	case auditFieldSet.Ending():
-		cs.SetLogSummary(fmt.Sprintf("%s Finished", auditFieldSet.MethodName))
-	default:
-		cs.SetLogSummary(auditFieldSet.MethodName)
-	}
-	return struct{}{}, nil
+	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*multicloudAuditLogLogToTimelineMapperSetting)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*multicloudAuditLogLogToTimelineMapperSetting)(nil)
+
+// LogToTimelineMapperTask is a task that adds revisions/events regarding logs.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
+	googlecloudlogmulticloudapiaudit_contract.LogToTimelineMapperTaskID,
+	&multicloudAuditLogLogToTimelineMapperSetting{},
+	inspectioncore_contract.FeatureTaskLabelV2(`MultiCloud API logs`,
+		`Gather Anthos MultiCloud audit log including cluster creation, deletion and upgrades.`,
+		5000,
+		true,
+	),
+)

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,13 +18,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogmulticloudapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+	"github.com/google/go-cmp/cmp"
 )
 
 func testReaderFromYAML(t *testing.T, yaml string) *structured.NodeReader {
@@ -37,15 +40,75 @@ func testReaderFromYAML(t *testing.T, yaml string) *structured.NodeReader {
 }
 
 func TestLogToTimelineMapperTask(t *testing.T) {
+	// 1. Initialize the Builder first.
+	builder := khifilev6.NewBuilder()
+
 	testTime := time.Date(2025, time.January, 1, 1, 1, 1, 1, time.UTC)
 	testCommonFieldSet := &log.CommonFieldSet{
 		Timestamp: testTime,
 	}
+
+	// Custom comparer for structured.Node interface.
+	nodeComparer := cmp.Comparer(func(x, y structured.Node) bool {
+		if x == nil && y == nil {
+			return true
+		}
+		if x == nil || y == nil {
+			return false
+		}
+		serializer := &structured.YAMLNodeSerializer{}
+		xBytes, err1 := serializer.Serialize(x)
+		yBytes, err2 := serializer.Serialize(y)
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		return string(xBytes) == string(yBytes)
+	})
+
+	// Resolve comparative path instances independently using low-level accumulator.
+	wantProjPath := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "projects/123456",
+		Type: googlecloudlogmulticloudapiaudit_contract.TimelineTypeProject,
+	})
+	wantClusterPath := builder.TimelineAccumulator.GetPath(wantProjPath, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: googlecloudlogmulticloudapiaudit_contract.TimelineTypeMultiCloudCluster,
+	})
+	wantNodepoolPath := builder.TimelineAccumulator.GetPath(wantClusterPath, khifilev6.PathSegment{
+		Name: "test-nodepool",
+		Type: googlecloudlogmulticloudapiaudit_contract.TimelineTypeMultiCloudNodepool,
+	})
+
+	wantOp1ClusterPath := builder.TimelineAccumulator.GetPath(wantClusterPath, khifilev6.PathSegment{
+		Name: "CreateCluster-op-1",
+		Type: inspectioncore_contract.TimelineTypeSubresource,
+	})
+	wantOp1AzureClusterPath := builder.TimelineAccumulator.GetPath(wantClusterPath, khifilev6.PathSegment{
+		Name: "CreateCluster-op-1",
+		Type: inspectioncore_contract.TimelineTypeSubresource,
+	})
+	wantOp2NodepoolPath := builder.TimelineAccumulator.GetPath(wantNodepoolPath, khifilev6.PathSegment{
+		Name: "CreateNodePool-op-2",
+		Type: inspectioncore_contract.TimelineTypeSubresource,
+	})
+	wantOp2AzureNodepoolPath := builder.TimelineAccumulator.GetPath(wantNodepoolPath, khifilev6.PathSegment{
+		Name: "CreateNodePool-op-2",
+		Type: inspectioncore_contract.TimelineTypeSubresource,
+	})
+	wantOp2DeleteNodepoolPath := builder.TimelineAccumulator.GetPath(wantNodepoolPath, khifilev6.PathSegment{
+		Name: "DeleteNodePool-op-2",
+		Type: inspectioncore_contract.TimelineTypeSubresource,
+	})
+	wantOp2UnknownNodepoolPath := builder.TimelineAccumulator.GetPath(wantNodepoolPath, khifilev6.PathSegment{
+		Name: "UnknownLongRunningOperation-op-2",
+		Type: inspectioncore_contract.TimelineTypeSubresource,
+	})
+
 	testCases := []struct {
 		desc          string
 		inputResource googlecloudlogmulticloudapiaudit_contract.MulticloudAPIAuditResourceFieldSet
 		inputAudit    googlecloudcommon_contract.GCPAuditLogFieldSet
-		asserters     []testchangeset.ChangeSetAsserter
+		assert        func(t *testing.T, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc: "cluster create started",
@@ -64,30 +127,25 @@ func TestLogToTimelineMapperTask(t *testing.T) {
   initialNodeCount: 1
   name: test-cluster`),
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbCreate,
-						State:      enum.RevisionStateProvisioning,
-						Requestor:  "foobar@qux.test",
-						Body:       "initialNodeCount: 1\nname: test-cluster\n",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#CreateAwsCluster-op-1",
-					WantRevision: history.StagingResourceRevision{
-						Verb:      enum.RevisionVerbOperationStart,
-						State:     enum.RevisionStateOperationStarted,
-						Requestor: "foobar@qux.test",
-						Body: `cluster:
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantClusterPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						ResourceBody: testReaderFromYAML(t, `initialNodeCount: 1
+name: test-cluster`).Node,
+						Principal: "foobar@qux.test",
+						VerbType:  commonlogk8saudit_contract.VerbCreate,
+						StateType: googlecloudlogmulticloudapiaudit_contract.RevisionStateProvisioning,
+					}, nodeComparer).
+					HasRevision(wantOp1ClusterPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						ResourceBody: testReaderFromYAML(t, `cluster:
   initialNodeCount: 1
-  name: test-cluster
-`,
-						ChangeTime: testTime,
-					},
-				},
+  name: test-cluster`).Node,
+						Principal: "foobar@qux.test",
+						VerbType:  googlecloudcommon_contract.VerbOperationStart,
+						StateType: googlecloudcommon_contract.RevisionStateOperationStarted,
+					}, nodeComparer)
 			},
 		},
 		{
@@ -105,27 +163,22 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbCreate,
-						State:      enum.RevisionStateExisting,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#CreateAzureCluster-op-1",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbOperationFinish,
-						State:      enum.RevisionStateOperationFinished,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantClusterPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
+					}, nodeComparer).
+					HasRevision(wantOp1AzureClusterPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     googlecloudcommon_contract.VerbOperationFinish,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationFinished,
+					}, nodeComparer)
 			},
 		},
 		{
@@ -145,30 +198,25 @@ func TestLogToTimelineMapperTask(t *testing.T) {
   initialNodeCount: 1
   name: test-nodepool`),
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbCreate,
-						State:      enum.RevisionStateProvisioning,
-						Requestor:  "foobar@qux.test",
-						Body:       "initialNodeCount: 1\nname: test-nodepool\n",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool#CreateAwsNodePool-op-2",
-					WantRevision: history.StagingResourceRevision{
-						Verb:      enum.RevisionVerbOperationStart,
-						State:     enum.RevisionStateOperationStarted,
-						Requestor: "foobar@qux.test",
-						Body: `nodePool:
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						ResourceBody: testReaderFromYAML(t, `initialNodeCount: 1
+name: test-nodepool`).Node,
+						Principal: "foobar@qux.test",
+						VerbType:  commonlogk8saudit_contract.VerbCreate,
+						StateType: googlecloudlogmulticloudapiaudit_contract.RevisionStateProvisioning,
+					}, nodeComparer).
+					HasRevision(wantOp2NodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						ResourceBody: testReaderFromYAML(t, `nodePool:
   initialNodeCount: 1
-  name: test-nodepool
-`,
-						ChangeTime: testTime,
-					},
-				},
+  name: test-nodepool`).Node,
+						Principal: "foobar@qux.test",
+						VerbType:  googlecloudcommon_contract.VerbOperationStart,
+						StateType: googlecloudcommon_contract.RevisionStateOperationStarted,
+					}, nodeComparer)
 			},
 		},
 		{
@@ -186,27 +234,22 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbCreate,
-						State:      enum.RevisionStateExisting,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool#CreateAzureNodePool-op-2",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbOperationFinish,
-						State:      enum.RevisionStateOperationFinished,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
+					}, nodeComparer).
+					HasRevision(wantOp2AzureNodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     googlecloudcommon_contract.VerbOperationFinish,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationFinished,
+					}, nodeComparer)
 			},
 		},
 		{
@@ -224,27 +267,22 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbDelete,
-						State:      enum.RevisionStateDeleted,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool#DeleteAwsNodePool-op-2",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbOperationFinish,
-						State:      enum.RevisionStateOperationFinished,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     commonlogk8saudit_contract.VerbDelete,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceIsDeleted,
+					}, nodeComparer).
+					HasRevision(wantOp2DeleteNodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     googlecloudcommon_contract.VerbOperationFinish,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationFinished,
+					}, nodeComparer)
 			},
 		},
 		{
@@ -262,10 +300,9 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{"@Cluster#nodepool#test-cluster#test-nodepool"},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantNodepoolPath)
 			},
 		},
 		{
@@ -283,34 +320,32 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool#UnknownLongRunningOperation-op-2",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbOperationStart,
-						State:      enum.RevisionStateOperationStarted,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOp2UnknownNodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     googlecloudcommon_contract.VerbOperationStart,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationStarted,
+					}, nodeComparer)
 			},
 		},
 	}
+
+	mapper := &multicloudAuditLogLogToTimelineMapperSetting{}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			l := log.NewLogWithFieldSetsForTest(testCommonFieldSet, &tc.inputAudit, &tc.inputResource)
-			mapperSetting := &multicloudAuditLogLogToTimelineMapperSetting{}
-			cs := history.NewChangeSet(l)
+			l.NodeReader = testReaderFromYAML(t, "protoPayload:\n  resourceName: projects/123456/locations/asia-southeast1/awsClusters/test-cluster/awsNodePools/test-nodepool")
 
-			_, err := mapperSetting.ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {
-				t.Errorf("got error %v, want nil", err)
+				t.Fatalf("ProcessLogByGroup() returned unexpected error: %v", err)
 			}
 
-			for _, asserter := range tc.asserters {
-				asserter.Assert(t, cs)
-			}
+			tc.assert(t, cs)
 		})
 	}
 }


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.