### PR TITLE
Migrate K8s controlplane log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/fieldset.go
@@ -15,13 +15,15 @@
 package googlecloudlogk8scontrolplane_contract
 
 import (
+	"context"
 	"regexp"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 )
 
 type ControlplaneComponentParserType string
@@ -55,10 +57,6 @@ func (k *K8sControlplaneComponentFieldSet) ComponentParserType() ControlplaneCom
 		return parserType
 	}
 	return ComponentParserTypeOther
-}
-
-func (k *K8sControlplaneComponentFieldSet) ResourcePath() resourcepath.ResourcePath {
-	return resourcepath.ControlplaneComponent(k.ClusterName, k.ComponentName)
 }
 
 var _ log.FieldSet = (*K8sControlplaneComponentFieldSet)(nil)
@@ -123,10 +121,6 @@ func (k *K8sSchedulerComponentFieldSet) HasPodField() bool {
 	return k.PodName != "" && k.PodNamespace != ""
 }
 
-func (k *K8sSchedulerComponentFieldSet) ResourcePath() resourcepath.ResourcePath {
-	return resourcepath.Pod(k.PodNamespace, k.PodName)
-}
-
 var _ log.FieldSet = (*K8sSchedulerComponentFieldSet)(nil)
 
 type K8sSchedulerComponentFieldSetReader struct {
@@ -161,19 +155,21 @@ var _ log.FieldSetReader = (*K8sSchedulerComponentFieldSetReader)(nil)
 
 type K8sControllerManagerComponentFieldSet struct {
 	Controller          string
-	AssociatedResources []resourcepath.ResourcePath
-}
-
-func (k *K8sControllerManagerComponentFieldSet) ControlPlaneResourcePath(clusterName string) resourcepath.ResourcePath {
-	if k.Controller == "" {
-		return resourcepath.ControlplaneComponent(clusterName, "controller-manager")
-	}
-	return resourcepath.ControllerManagerControlplaneComponent(clusterName, k.Controller)
+	AssociatedResources []*commonlogk8saudit_contract.ResourceIdentity
 }
 
 // Kind implements log.FieldSet.
 func (k *K8sControllerManagerComponentFieldSet) Kind() string {
 	return "k8s_controller_manager_component"
+}
+
+// AssociatedResourceTimelines resolves and returns the timeline paths for all associated resources in the fieldset.
+func (k *K8sControllerManagerComponentFieldSet) AssociatedResourceTimelines(ctx context.Context, clusterName string) []*khifilev6.TimelinePath {
+	var result []*khifilev6.TimelinePath
+	for _, resource := range k.AssociatedResources {
+		result = append(result, commonlogk8saudit_contract.MustResourceTimeline(ctx, clusterName, resource))
+	}
+	return result
 }
 
 var _ log.FieldSet = (*K8sControllerManagerComponentFieldSet)(nil)
@@ -227,8 +223,8 @@ func (k *K8sControllerManagerComponentFieldSetReader) readController(structured 
 	return "", nil
 }
 
-func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociations(structured *logutil.ParseStructuredLogResult) []resourcepath.ResourcePath {
-	var result []resourcepath.ResourcePath
+func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociations(structured *logutil.ParseStructuredLogResult) []*commonlogk8saudit_contract.ResourceIdentity {
+	var result []*commonlogk8saudit_contract.ResourceIdentity
 	fromKindField := k.readResourceAssociationFromKindField(structured)
 	result = append(result, fromKindField...)
 
@@ -236,7 +232,7 @@ func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociations(s
 	result = append(result, fromControllerSpecificField...)
 
 	fromItems := k.readResourceAssociationFromItems(structured)
-	if fromItems.Path != "" {
+	if fromItems != nil {
 		result = append(result, fromItems)
 	}
 
@@ -245,8 +241,8 @@ func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociations(s
 
 // readResourceAssociationFromKindField reads the kind klog field to associate resource with this log.
 // Example log: '"Finished syncing" kind="ReplicaSet" key="1-4-basic-ingresses/ready-repeat-app-554f6b9d95" duration="32.336593ms"'
-func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFromKindField(structured *logutil.ParseStructuredLogResult) []resourcepath.ResourcePath {
-	var result []resourcepath.ResourcePath
+func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFromKindField(structured *logutil.ParseStructuredLogResult) []*commonlogk8saudit_contract.ResourceIdentity {
+	var result []*commonlogk8saudit_contract.ResourceIdentity
 	kind, err := structured.StringField("kind")
 	if err == nil && kind != "" {
 		kind = strings.ToLower(kind)
@@ -259,9 +255,19 @@ func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFro
 						if len(splittedKey) != 2 {
 							continue
 						}
-						result = append(result, resourcepath.NameLayerGeneralItem(pair.APIVersion, pair.KindName, splittedKey[0], splittedKey[1]))
+						result = append(result, &commonlogk8saudit_contract.ResourceIdentity{
+							APIVersion: pair.APIVersion,
+							Kind:       pair.KindName,
+							Namespace:  splittedKey[0],
+							Name:       splittedKey[1],
+						})
 					} else {
-						result = append(result, resourcepath.NameLayerGeneralItem(pair.APIVersion, pair.KindName, "cluster-scope", key))
+						result = append(result, &commonlogk8saudit_contract.ResourceIdentity{
+							APIVersion: pair.APIVersion,
+							Kind:       pair.KindName,
+							Namespace:  "cluster-scope",
+							Name:       key,
+						})
 					}
 				}
 			}
@@ -272,8 +278,8 @@ func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFro
 
 // readResourceAssociationFromControllerSpecificField reads the associated resource of this log from controller specific key name.
 // Example log: '"Error syncing deployment" deployment="1-4-basic-ingresses/ig-ready-repeat-app" err="Operation cannot be fulfilled on deployments.apps \"ig-ready-repeat-app\": the object has been modified; please apply your changes to the latest version and try again"'
-func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFromControllerSpecificField(structured *logutil.ParseStructuredLogResult) []resourcepath.ResourcePath {
-	var result []resourcepath.ResourcePath
+func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFromControllerSpecificField(structured *logutil.ParseStructuredLogResult) []*commonlogk8saudit_contract.ResourceIdentity {
+	var result []*commonlogk8saudit_contract.ResourceIdentity
 	for _, pair := range k.WellKnownKindToKLogFieldPairs {
 		field, err := structured.StringField(pair.KLogField)
 		if err != nil || field == "" {
@@ -284,7 +290,12 @@ func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFro
 			if len(splittedField) != 2 {
 				continue
 			}
-			result = append(result, resourcepath.NameLayerGeneralItem(pair.APIVersion, pair.KindName, splittedField[0], splittedField[1]))
+			result = append(result, &commonlogk8saudit_contract.ResourceIdentity{
+				APIVersion: pair.APIVersion,
+				Kind:       pair.KindName,
+				Namespace:  splittedField[0],
+				Name:       splittedField[1],
+			})
 		} else {
 			resourceName := field
 
@@ -294,15 +305,20 @@ func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFro
 				resourceName = field[lastSlashIndex+1:]
 			}
 
-			result = append(result, resourcepath.NameLayerGeneralItem(pair.APIVersion, pair.KindName, "cluster-scope", resourceName))
+			result = append(result, &commonlogk8saudit_contract.ResourceIdentity{
+				APIVersion: pair.APIVersion,
+				Kind:       pair.KindName,
+				Namespace:  "cluster-scope",
+				Name:       resourceName,
+			})
 		}
 	}
 	return result
 }
 
 // Example log: "Deleting item" logger="garbage-collector-controller" item="[coordination.k8s.io/v1/Lease, namespace: kube-node-lease, name: gke-p0-gke-basic-1-default-pool-4ca7ca8d-2k4v, uid: 8aba20bf-0392-40c9-ae35-240b7c099523]" propagationPolicy="Background"'
-func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFromItems(structured *logutil.ParseStructuredLogResult) resourcepath.ResourcePath {
-	var result resourcepath.ResourcePath
+func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFromItems(structured *logutil.ParseStructuredLogResult) *commonlogk8saudit_contract.ResourceIdentity {
+	var result *commonlogk8saudit_contract.ResourceIdentity
 	item, err := structured.StringField("item")
 	if item != "" && err == nil {
 		matches := itemsCaptureRegex.FindStringSubmatch(item)
@@ -321,9 +337,19 @@ func (k *K8sControllerManagerComponentFieldSetReader) readResourceAssociationFro
 			}
 			kind = strings.ToLower(kind)
 			if namespace == "" {
-				result = resourcepath.NameLayerGeneralItem(apiVersion, kind, "cluster-scope", name)
+				result = &commonlogk8saudit_contract.ResourceIdentity{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Namespace:  "cluster-scope",
+					Name:       name,
+				}
 			} else {
-				result = resourcepath.NameLayerGeneralItem(apiVersion, kind, namespace, name)
+				result = &commonlogk8saudit_contract.ResourceIdentity{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Namespace:  namespace,
+					Name:       name,
+				}
 			}
 		}
 	}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/fieldset_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -226,20 +226,30 @@ func TestK8sControllerManagerComponentFieldSetReader_ReadResourceAssociationFrom
 	testCases := []struct {
 		desc  string
 		input string
-		want  []resourcepath.ResourcePath
+		want  []*commonlogk8saudit_contract.ResourceIdentity
 	}{
 		{
 			desc:  "with kind and namespaced key",
 			input: `"Finished syncing" kind="Pod" key="default/my-pod"`,
-			want: []resourcepath.ResourcePath{
-				resourcepath.NameLayerGeneralItem("core/v1", "pod", "default", "my-pod"),
+			want: []*commonlogk8saudit_contract.ResourceIdentity{
+				{
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-pod",
+				},
 			},
 		},
 		{
 			desc:  "with kind and cluster-scoped key",
 			input: `"Finished syncing" kind="Node" key="my-node"`,
-			want: []resourcepath.ResourcePath{
-				resourcepath.NameLayerGeneralItem("core/v1", "node", "cluster-scope", "my-node"),
+			want: []*commonlogk8saudit_contract.ResourceIdentity{
+				{
+					APIVersion: "core/v1",
+					Kind:       "node",
+					Namespace:  "cluster-scope",
+					Name:       "my-node",
+				},
 			},
 		},
 		{
@@ -290,29 +300,54 @@ func TestK8sControllerManagerComponentFieldSetReader_ReadResourceAssociationFrom
 	testCases := []struct {
 		desc  string
 		input string
-		want  []resourcepath.ResourcePath
+		want  []*commonlogk8saudit_contract.ResourceIdentity
 	}{
 		{
 			desc:  "with multiple resources",
 			input: `"Finished syncing" pod="default/my-job" node="node-foo"`,
-			want: []resourcepath.ResourcePath{
-				resourcepath.NameLayerGeneralItem("core/v1", "pod", "default", "my-job"),
-				resourcepath.NameLayerGeneralItem("core/v1", "node", "cluster-scope", "node-foo"),
+			want: []*commonlogk8saudit_contract.ResourceIdentity{
+				{
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-job",
+				},
+				{
+					APIVersion: "core/v1",
+					Kind:       "node",
+					Namespace:  "cluster-scope",
+					Name:       "node-foo",
+				},
 			},
 		},
 		{
 			desc:  "with single resource",
 			input: `"Finished syncing" pod="default/my-job"`,
-			want: []resourcepath.ResourcePath{
-				resourcepath.NameLayerGeneralItem("core/v1", "pod", "default", "my-job"),
+			want: []*commonlogk8saudit_contract.ResourceIdentity{
+				{
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-job",
+				},
 			},
 		},
 		{
 			desc:  "with kind and cluster-scoped key and longer name",
 			input: `"attacherDetacher.DetachVolume started" logger="persistentvolume-attach-detach-controller" node="node-foo" volumeName="kubernetes.io/csi/pd.csi.storage.gke.io^projects/UNSPECIFIED/zones/us-central1-a/disks/pvc-fe42fc7f-7618-4d3b-94d1-a2490cfd009d"`,
-			want: []resourcepath.ResourcePath{
-				resourcepath.NameLayerGeneralItem("core/v1", "node", "cluster-scope", "node-foo"),
-				resourcepath.NameLayerGeneralItem("core/v1", "persistentvolume", "cluster-scope", "pvc-fe42fc7f-7618-4d3b-94d1-a2490cfd009d"),
+			want: []*commonlogk8saudit_contract.ResourceIdentity{
+				{
+					APIVersion: "core/v1",
+					Kind:       "node",
+					Namespace:  "cluster-scope",
+					Name:       "node-foo",
+				},
+				{
+					APIVersion: "core/v1",
+					Kind:       "persistentvolume",
+					Namespace:  "cluster-scope",
+					Name:       "pvc-fe42fc7f-7618-4d3b-94d1-a2490cfd009d",
+				},
 			},
 		},
 		{
@@ -348,7 +383,9 @@ func TestK8sControllerManagerComponentFieldSetReader_ReadResourceAssociationFrom
 
 			klogParser := logutil.NewKLogTextParser(false)
 			paths := reader.readResourceAssociationFromControllerSpecificField(klogParser.TryParse(tc.input))
-			if diff := cmp.Diff(tc.want, paths, cmpopts.SortSlices(func(a, b resourcepath.ResourcePath) int { return strings.Compare(a.Path, b.Path) })); diff != "" {
+			if diff := cmp.Diff(tc.want, paths, cmpopts.SortSlices(func(a, b *commonlogk8saudit_contract.ResourceIdentity) int {
+				return strings.Compare(a.ResourcePathString(), b.ResourcePathString())
+			})); diff != "" {
 				t.Errorf("readResourceAssociationFromControllerSpecificField() mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -359,37 +396,52 @@ func TestK8sControllerManagerComponentFieldSetReader_ReadResourceAssociationFrom
 	testCases := []struct {
 		desc  string
 		input string
-		want  resourcepath.ResourcePath
+		want  *commonlogk8saudit_contract.ResourceIdentity
 	}{
 		{
 			desc:  "valid item field - namespaced",
 			input: `"Deleting item" logger="garbage-collector-controller" item="[coordination.k8s.io/v1/Lease, namespace: kube-node-lease, name: gke-p0-gke-basic-1-default-pool-4ca7ca8d-2k4v, uid: 8aba20bf-0392-40c9-ae35-240b7c099523]" propagationPolicy="Background"`,
-			want:  resourcepath.NameLayerGeneralItem("coordination.k8s.io/v1", "lease", "kube-node-lease", "gke-p0-gke-basic-1-default-pool-4ca7ca8d-2k4v"),
+			want: &commonlogk8saudit_contract.ResourceIdentity{
+				APIVersion: "coordination.k8s.io/v1",
+				Kind:       "lease",
+				Namespace:  "kube-node-lease",
+				Name:       "gke-p0-gke-basic-1-default-pool-4ca7ca8d-2k4v",
+			},
 		},
 		{
 			desc:  "valid item field - cluster-scoped",
 			input: `"Deleting item" logger="garbage-collector-controller" item="[rbac.authorization.k8s.io/v1/ClusterRole, namespace: , name: admin, uid: 8aba20bf-0392-40c9-ae35-240b7c099523]" propagationPolicy="Background"`,
-			want:  resourcepath.NameLayerGeneralItem("rbac.authorization.k8s.io/v1", "clusterrole", "cluster-scope", "admin"),
+			want: &commonlogk8saudit_contract.ResourceIdentity{
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Kind:       "clusterrole",
+				Namespace:  "cluster-scope",
+				Name:       "admin",
+			},
 		},
 		{
 			desc:  "valid item field - in core api version",
 			input: `"Deleting item" logger="garbage-collector-controller" item="[v1/Pod, namespace: kube-system, name: gke-p0-gke-basic-1-default-pool-4ca7ca8d-2k4v, uid: 8aba20bf-0392-40c9-ae35-240b7c099523]" propagationPolicy="Background"`,
-			want:  resourcepath.NameLayerGeneralItem("core/v1", "pod", "kube-system", "gke-p0-gke-basic-1-default-pool-4ca7ca8d-2k4v"),
+			want: &commonlogk8saudit_contract.ResourceIdentity{
+				APIVersion: "core/v1",
+				Kind:       "pod",
+				Namespace:  "kube-system",
+				Name:       "gke-p0-gke-basic-1-default-pool-4ca7ca8d-2k4v",
+			},
 		},
 		{
 			desc:  "item field missing",
 			input: `"Deleting item" logger="garbage-collector-controller" propagationPolicy="Background"`,
-			want:  resourcepath.ResourcePath{},
+			want:  nil,
 		},
 		{
 			desc:  "item field malformed",
 			input: `"Deleting item" logger="garbage-collector-controller" item="malformed-item" propagationPolicy="Background"`,
-			want:  resourcepath.ResourcePath{},
+			want:  nil,
 		},
 		{
 			desc:  "item field malformed - no slash contained in apiVersion",
 			input: `"Deleting item" logger="garbage-collector-controller" item="[Pod, namespace: kube-system, name: gke-p0-gke-basic-1-default-pool-4ca7ca8d-2k4v, uid: 8aba20bf-0392-40c9-ae35-240b7c099523]" propagationPolicy="Background"`,
-			want:  resourcepath.ResourcePath{},
+			want:  nil,
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/timeline.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/timeline.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8scontrolplane_contract
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// MustControlPlaneComponentTimeline returns the timeline path for a Kubernetes control plane component.
+func MustControlPlaneComponentTimeline(ctx context.Context, clusterName string, componentName string) *khifilev6.TimelinePath {
+	clusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, clusterName)
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: componentName,
+		Type: TimelineTypeControlPlaneComponent,
+	})
+}
+
+// MustControllerManagerControlPlaneTimeline returns the timeline path for a Kubernetes controller manager control plane component.
+func MustControllerManagerControlPlaneTimeline(ctx context.Context, clusterName string, controllerName string) *khifilev6.TimelinePath {
+	if controllerName == "" {
+		return MustControlPlaneComponentTimeline(ctx, clusterName, "controller-manager")
+	}
+	return MustControlPlaneComponentTimeline(ctx, clusterName, fmt.Sprintf("%s(controller-manager)", controllerName))
+}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/timeline_type.go
@@ -28,7 +28,7 @@ var (
 		"crown",
 		0.6,
 		style.ColorWhite,
-		style.ColorWhite,
+		style.ColorBlack,
 		style.MustForceConvertSRGBHex("#FF5555"),
 		true,
 		11000,

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task.go
@@ -19,7 +19,8 @@ import (
 
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
@@ -33,15 +34,51 @@ var TailTask = inspectiontaskbase.NewInspectionTask(googlecloudlogk8scontrolplan
 	func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) (struct{}, error) {
 		return struct{}{}, nil
 	},
-	inspectioncore_contract.FeatureTaskLabel(
+	inspectioncore_contract.FeatureTaskLabelV2(
 		"Kubernetes Control plane component logs",
 		"Gather Kubernetes control plane component(e.g kube-scheduler, kube-controller-manager,api-server) logs",
-		enum.LogTypeControlPlaneComponent,
 		9000,
 		false,
 	),
 )
 
+// K8sControlPlaneLogIngester is a log ingester for Kubernetes control plane component logs.
+type K8sControlPlaneLogIngester struct{}
+
+// RawLogTask implements inspectiontaskbase.LogIngesterV2.
+func (i *K8sControlPlaneLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogk8scontrolplane_contract.CommonFieldSetReaderTaskID.Ref()
+}
+
+// Dependencies implements inspectiontaskbase.LogIngesterV2.
+func (i *K8sControlPlaneLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog implements inspectiontaskbase.LogIngesterV2.
+func (i *K8sControlPlaneLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+	cs.SetLogType(googlecloudlogk8scontrolplane_contract.LogTypeControlPlaneComponent)
+
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
+	}
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	if msgFS, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet{}); err == nil {
+		cs.SetSummary(msgFS.Message)
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*K8sControlPlaneLogIngester)(nil)
+
 // LogIngesterTask serializes logs to history for timeline mappers to associate event or revisions in later tasks.
-// No control plane logs are discarded, thus this LogIngesterTask simply receives logs from the ListLogEntriesTask.
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(googlecloudlogk8scontrolplane_contract.LogIngesterTaskID, googlecloudlogk8scontrolplane_contract.ListLogEntriesTaskID.Ref())
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(googlecloudlogk8scontrolplane_contract.LogIngesterTaskID, &K8sControlPlaneLogIngester{})

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8scontrolplane_impl
+
+import (
+	"testing"
+	"time"
+
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+)
+
+func TestK8sControlPlaneLogIngester_ProcessLog(t *testing.T) {
+	testTime := time.Date(2026, time.May, 27, 12, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name   string
+		input  *log.Log
+		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
+	}{
+		{
+			name: "successful control plane log ingestion with all fields",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
+				},
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityInfo,
+				},
+				&googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet{
+					Message: "scheduler starting",
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(testTime).
+					HasSeverity(inspectioncore_contract.SeverityInfo).
+					HasLogType(googlecloudlogk8scontrolplane_contract.LogTypeControlPlaneComponent).
+					HasSummary("scheduler starting")
+			},
+		},
+		{
+			name: "successful control plane log ingestion with missing optional message and severity",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(testTime).
+					HasLogType(googlecloudlogk8scontrolplane_contract.LogTypeControlPlaneComponent).
+					HasSummary("")
+			},
+		},
+	}
+
+	ingester := &K8sControlPlaneLogIngester{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs, err := ingester.ProcessLog(t.Context(), tc.input)
+			if err != nil {
+				t.Fatalf("ProcessLog() returned unexpected error: %v", err)
+			}
+			tc.assert(t, cs)
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task.go
@@ -16,15 +16,15 @@ package googlecloudlogk8scontrolplane_impl
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
@@ -91,63 +91,119 @@ var ControllerManagerGrouperTask = inspectiontaskbase.NewLogGrouperTask(
 	},
 )
 
-var ControllerManagerLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudlogk8scontrolplane_contract.ControllerManagerLogToTimelineMapperTaskID, &controllerManagerLogToTimelineMapperTaskSetting{})
+var ControllerManagerLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[struct{}](googlecloudlogk8scontrolplane_contract.ControllerManagerLogToTimelineMapperTaskID, &ControllerManagerTimelineMapper{})
 
-type controllerManagerLogToTimelineMapperTaskSetting struct {
+// ControllerManagerTimelineMapper maps controller manager logs to timeline paths.
+type ControllerManagerTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
 	uidPrefixTokenCandidates []rune
 }
 
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (o *controllerManagerLogToTimelineMapperTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+// Dependencies implements inspectiontaskbase.LogToTimelineMapperV2.
+func (o *ControllerManagerTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(),
 	}
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *controllerManagerLogToTimelineMapperTaskSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapperV2.
+func (o *ControllerManagerTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
 	return googlecloudlogk8scontrolplane_contract.ControllerManagerLogGrouperTaskID.Ref()
 }
 
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *controllerManagerLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapperV2.
+func (o *ControllerManagerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogk8scontrolplane_contract.LogIngesterTaskID.Ref()
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (o *controllerManagerLogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
+// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapperV2.
+func (o *ControllerManagerTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
 	componentFieldSet, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 	commonMainMessage, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 	controllerManagerFieldSet, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sControllerManagerComponentFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 
+	cs := khifilev6.NewTimelineChangeSet(l)
 	resources := patternfinder.FindAllWithStarterRunes(commonMainMessage.Message, finder, false, o.uidPrefixTokenCandidates...)
-	writtenResourcePaths := map[string]struct{}{}
-	cs.SetLogSummary(commonMainMessage.Message)
-	cs.AddEvent(controllerManagerFieldSet.ControlPlaneResourcePath(componentFieldSet.ClusterName))
+	writtenResourcePaths := map[uint32]struct{}{}
+
+	compTimeline := resolveControllerManagerTimelinePath(ctx, componentFieldSet.ClusterName, controllerManagerFieldSet.Controller)
+	cs.AddEvent(compTimeline)
+
 	for _, resourcePath := range controllerManagerFieldSet.AssociatedResources {
-		cs.AddEvent(resourcePath)
-		writtenResourcePaths[resourcePath.Path] = struct{}{}
+		if tPath, err := resolveTimelinePathFromRawString(ctx, componentFieldSet.ClusterName, resourcePath.Path); err == nil {
+			cs.AddEvent(tPath)
+			writtenResourcePaths[tPath.ID] = struct{}{}
+		}
 	}
+
 	for _, resource := range resources {
 		path := resource.Value.ResourcePathString()
-		if _, ok := writtenResourcePaths[path]; ok {
-			continue
+		if tPath, err := resolveTimelinePathFromRawString(ctx, componentFieldSet.ClusterName, path); err == nil {
+			if _, ok := writtenResourcePaths[tPath.ID]; ok {
+				continue
+			}
+			cs.AddEvent(tPath)
+			writtenResourcePaths[tPath.ID] = struct{}{}
 		}
-		cs.AddEvent(resourcepath.ResourcePath{
-			Path:               path,
-			ParentRelationship: enum.RelationshipChild,
-		})
-		writtenResourcePaths[path] = struct{}{}
 	}
-	return struct{}{}, nil
+
+	return cs, struct{}{}, nil
+}
+
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*ControllerManagerTimelineMapper)(nil)
+
+// resolveTimelinePathFromRawString converts a resource path string formatted as APIVersion#Kind#Namespace#Name into a *TimelinePath.
+func resolveTimelinePathFromRawString(ctx context.Context, clusterName string, pathStr string) (*khifilev6.TimelinePath, error) {
+	parts := strings.Split(pathStr, "#")
+	if len(parts) < 4 {
+		return nil, fmt.Errorf("invalid resource path string: %s", pathStr)
+	}
+	apiVersion := parts[0]
+	if !strings.Contains(apiVersion, "/") {
+		if apiVersion == "v1" {
+			apiVersion = "core/v1"
+		} else {
+			apiVersion = "core/" + apiVersion
+		}
+	}
+	kind := strings.ToLower(parts[1])
+	namespace := parts[2]
+	name := parts[3]
+
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, apiVersion)
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, kind)
+
+	var resourceTimeline *khifilev6.TimelinePath
+	if namespace == "cluster-scope" {
+		resourceTimeline = commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindTimeline, name)
+	} else {
+		namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, namespace)
+		resourceTimeline = commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, name)
+	}
+
+	if len(parts) >= 5 {
+		subresource := parts[4]
+		return commonlogk8saudit_contract.MustK8sSubresourceTimeline(ctx, resourceTimeline, subresource), nil
+	}
+
+	return resourceTimeline, nil
+}
+
+// resolveControllerManagerTimelinePath resolves a controller manager component timeline path.
+func resolveControllerManagerTimelinePath(ctx context.Context, clusterName string, controllerName string) *khifilev6.TimelinePath {
+	if controllerName == "" {
+		return MustControlPlaneComponentTimeline(ctx, clusterName, "controller-manager")
+	}
+	return MustControlPlaneComponentTimeline(ctx, clusterName, fmt.Sprintf("%s(controller-manager)", controllerName))
 }

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task.go
@@ -17,7 +17,6 @@ package googlecloudlogk8scontrolplane_impl
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
@@ -139,22 +138,18 @@ func (o *ControllerManagerTimelineMapper) ProcessLogByGroup(ctx context.Context,
 	compTimeline := resolveControllerManagerTimelinePath(ctx, componentFieldSet.ClusterName, controllerManagerFieldSet.Controller)
 	cs.AddEvent(compTimeline)
 
-	for _, resourcePath := range controllerManagerFieldSet.AssociatedResources {
-		if tPath, err := resolveTimelinePathFromRawString(ctx, componentFieldSet.ClusterName, resourcePath.Path); err == nil {
-			cs.AddEvent(tPath)
-			writtenResourcePaths[tPath.ID] = struct{}{}
-		}
+	for _, tPath := range controllerManagerFieldSet.AssociatedResourceTimelines(ctx, componentFieldSet.ClusterName) {
+		cs.AddEvent(tPath)
+		writtenResourcePaths[tPath.ID] = struct{}{}
 	}
 
 	for _, resource := range resources {
-		path := resource.Value.ResourcePathString()
-		if tPath, err := resolveTimelinePathFromRawString(ctx, componentFieldSet.ClusterName, path); err == nil {
-			if _, ok := writtenResourcePaths[tPath.ID]; ok {
-				continue
-			}
-			cs.AddEvent(tPath)
-			writtenResourcePaths[tPath.ID] = struct{}{}
+		tPath := commonlogk8saudit_contract.MustResourceTimeline(ctx, componentFieldSet.ClusterName, resource.Value)
+		if _, ok := writtenResourcePaths[tPath.ID]; ok {
+			continue
 		}
+		cs.AddEvent(tPath)
+		writtenResourcePaths[tPath.ID] = struct{}{}
 	}
 
 	return cs, struct{}{}, nil
@@ -162,48 +157,10 @@ func (o *ControllerManagerTimelineMapper) ProcessLogByGroup(ctx context.Context,
 
 var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*ControllerManagerTimelineMapper)(nil)
 
-// resolveTimelinePathFromRawString converts a resource path string formatted as APIVersion#Kind#Namespace#Name into a *TimelinePath.
-func resolveTimelinePathFromRawString(ctx context.Context, clusterName string, pathStr string) (*khifilev6.TimelinePath, error) {
-	parts := strings.Split(pathStr, "#")
-	if len(parts) < 4 {
-		return nil, fmt.Errorf("invalid resource path string: %s", pathStr)
-	}
-	apiVersion := parts[0]
-	if !strings.Contains(apiVersion, "/") {
-		if apiVersion == "v1" {
-			apiVersion = "core/v1"
-		} else {
-			apiVersion = "core/" + apiVersion
-		}
-	}
-	kind := strings.ToLower(parts[1])
-	namespace := parts[2]
-	name := parts[3]
-
-	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
-	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, apiVersion)
-	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, kind)
-
-	var resourceTimeline *khifilev6.TimelinePath
-	if namespace == "cluster-scope" {
-		resourceTimeline = commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindTimeline, name)
-	} else {
-		namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, namespace)
-		resourceTimeline = commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, name)
-	}
-
-	if len(parts) >= 5 {
-		subresource := parts[4]
-		return commonlogk8saudit_contract.MustK8sSubresourceTimeline(ctx, resourceTimeline, subresource), nil
-	}
-
-	return resourceTimeline, nil
-}
-
 // resolveControllerManagerTimelinePath resolves a controller manager component timeline path.
 func resolveControllerManagerTimelinePath(ctx context.Context, clusterName string, controllerName string) *khifilev6.TimelinePath {
 	if controllerName == "" {
-		return MustControlPlaneComponentTimeline(ctx, clusterName, "controller-manager")
+		return googlecloudlogk8scontrolplane_contract.MustControlPlaneComponentTimeline(ctx, clusterName, "controller-manager")
 	}
-	return MustControlPlaneComponentTimeline(ctx, clusterName, fmt.Sprintf("%s(controller-manager)", controllerName))
+	return googlecloudlogk8scontrolplane_contract.MustControlPlaneComponentTimeline(ctx, clusterName, fmt.Sprintf("%s(controller-manager)", controllerName))
 }

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task_test.go
@@ -25,6 +25,7 @@ import (
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
@@ -33,19 +34,23 @@ import (
 func TestControllerManagerLogToTimelineMapperTask(t *testing.T) {
 	builder := khifilev6.NewBuilder()
 
-	clusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+	gkeClusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
 		Name: "test-cluster",
-		Type: inspectioncore_contract.TimelineTypeK8sCluster,
+		Type: googlecloudcommon_contract.TimelineTypeGKE,
 	})
-	wantCompTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+	wantCompTimeline := builder.TimelineAccumulator.GetPath(gkeClusterTimeline, khifilev6.PathSegment{
 		Name: "deployment-controller(controller-manager)",
 		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
 	})
-	wantControlManagerTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+	wantControlManagerTimeline := builder.TimelineAccumulator.GetPath(gkeClusterTimeline, khifilev6.PathSegment{
 		Name: "controller-manager",
 		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
 	})
 
+	clusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: inspectioncore_contract.TimelineTypeK8sCluster,
+	})
 	corev1Timeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
 		Name: "core/v1",
 		Type: inspectioncore_contract.TimelineTypeAPIVersion,
@@ -67,7 +72,11 @@ func TestControllerManagerLogToTimelineMapperTask(t *testing.T) {
 		Name: "node",
 		Type: inspectioncore_contract.TimelineTypeKind,
 	})
-	wantNodeTimeline := builder.TimelineAccumulator.GetPath(nodeKindTimeline, khifilev6.PathSegment{
+	nodeNamespaceTimeline := builder.TimelineAccumulator.GetPath(nodeKindTimeline, khifilev6.PathSegment{
+		Name: "cluster-scope",
+		Type: inspectioncore_contract.TimelineTypeNamespace,
+	})
+	wantNodeTimeline := builder.TimelineAccumulator.GetPath(nodeNamespaceTimeline, khifilev6.PathSegment{
 		Name: "node-1",
 		Type: inspectioncore_contract.TimelineTypeResource,
 	})

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task_test.go
@@ -15,26 +15,69 @@
 package googlecloudlogk8scontrolplane_impl
 
 import (
+	"context"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
-	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 )
 
 func TestControllerManagerLogToTimelineMapperTask(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+
+	clusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: inspectioncore_contract.TimelineTypeK8sCluster,
+	})
+	wantCompTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: "deployment-controller(controller-manager)",
+		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
+	})
+	wantControlManagerTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: "controller-manager",
+		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
+	})
+
+	corev1Timeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: "core/v1",
+		Type: inspectioncore_contract.TimelineTypeAPIVersion,
+	})
+	podKindTimeline := builder.TimelineAccumulator.GetPath(corev1Timeline, khifilev6.PathSegment{
+		Name: "pod",
+		Type: inspectioncore_contract.TimelineTypeKind,
+	})
+	nsTimeline := builder.TimelineAccumulator.GetPath(podKindTimeline, khifilev6.PathSegment{
+		Name: "default",
+		Type: inspectioncore_contract.TimelineTypeNamespace,
+	})
+	wantPodTimeline := builder.TimelineAccumulator.GetPath(nsTimeline, khifilev6.PathSegment{
+		Name: "pod-foo",
+		Type: inspectioncore_contract.TimelineTypeResource,
+	})
+
+	nodeKindTimeline := builder.TimelineAccumulator.GetPath(corev1Timeline, khifilev6.PathSegment{
+		Name: "node",
+		Type: inspectioncore_contract.TimelineTypeKind,
+	})
+	wantNodeTimeline := builder.TimelineAccumulator.GetPath(nodeKindTimeline, khifilev6.PathSegment{
+		Name: "node-1",
+		Type: inspectioncore_contract.TimelineTypeResource,
+	})
+
 	testCases := []struct {
 		desc                           string
 		inputComponentField            googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet
 		inputMessageField              googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet
 		inputControllerManagerFieldSet googlecloudlogk8scontrolplane_contract.K8sControllerManagerComponentFieldSet
-		asserters                      []testchangeset.ChangeSetAsserter
+		assert                         func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc: "with standard input",
@@ -52,16 +95,11 @@ func TestControllerManagerLogToTimelineMapperTask(t *testing.T) {
 					resourcepath.Node("node-1"),
 				},
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasEvent{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#deployment-controller(controller-manager)",
-				},
-				&testchangeset.HasEvent{
-					ResourcePath: "core/v1#pod#default#pod-foo",
-				},
-				&testchangeset.HasEvent{
-					ResourcePath: "core/v1#node#cluster-scope#node-1",
-				},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantCompTimeline).
+					HasEvent(wantPodTimeline).
+					HasEvent(wantNodeTimeline)
 			},
 		},
 		{
@@ -80,35 +118,27 @@ func TestControllerManagerLogToTimelineMapperTask(t *testing.T) {
 					resourcepath.Node("node-1"),
 				},
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasEvent{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#controller-manager",
-				},
-				&testchangeset.HasEvent{
-					ResourcePath: "core/v1#pod#default#pod-foo",
-				},
-				&testchangeset.HasEvent{
-					ResourcePath: "core/v1#node#cluster-scope#node-1",
-				},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantControlManagerTimeline).
+					HasEvent(wantPodTimeline).
+					HasEvent(wantNodeTimeline)
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			l := log.NewLogWithFieldSetsForTest(&tc.inputComponentField, &tc.inputControllerManagerFieldSet, &tc.inputMessageField)
-			modifier := controllerManagerLogToTimelineMapperTaskSetting{}
-			cs := history.NewChangeSet(l)
-			ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 			finder := patternfinder.NewTriePatternFinder[*commonlogk8saudit_contract.ResourceIdentity]()
 			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(), finder)
-			_, err := modifier.ProcessLogByGroup(ctx, l, cs, nil, struct{}{})
+
+			l := log.NewLogWithFieldSetsForTest(&tc.inputComponentField, &tc.inputControllerManagerFieldSet, &tc.inputMessageField)
+			mapper := &ControllerManagerTimelineMapper{}
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {
-				t.Errorf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
+				t.Fatalf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
 			}
-			for _, asserter := range tc.asserters {
-				asserter.Assert(t, cs)
-			}
+			tc.assert(t, ctx, cs)
 		})
 	}
-
 }

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
@@ -99,9 +98,19 @@ func TestControllerManagerLogToTimelineMapperTask(t *testing.T) {
 			},
 			inputControllerManagerFieldSet: googlecloudlogk8scontrolplane_contract.K8sControllerManagerComponentFieldSet{
 				Controller: "deployment-controller",
-				AssociatedResources: []resourcepath.ResourcePath{
-					resourcepath.Pod("default", "pod-foo"),
-					resourcepath.Node("node-1"),
+				AssociatedResources: []*commonlogk8saudit_contract.ResourceIdentity{
+					{
+						APIVersion: "core/v1",
+						Kind:       "pod",
+						Namespace:  "default",
+						Name:       "pod-foo",
+					},
+					{
+						APIVersion: "core/v1",
+						Kind:       "node",
+						Namespace:  "cluster-scope",
+						Name:       "node-1",
+					},
 				},
 			},
 			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
@@ -122,9 +131,19 @@ func TestControllerManagerLogToTimelineMapperTask(t *testing.T) {
 			},
 			inputControllerManagerFieldSet: googlecloudlogk8scontrolplane_contract.K8sControllerManagerComponentFieldSet{
 				Controller: "",
-				AssociatedResources: []resourcepath.ResourcePath{
-					resourcepath.Pod("default", "pod-foo"),
-					resourcepath.Node("node-1"),
+				AssociatedResources: []*commonlogk8saudit_contract.ResourceIdentity{
+					{
+						APIVersion: "core/v1",
+						Kind:       "pod",
+						Namespace:  "default",
+						Name:       "pod-foo",
+					},
+					{
+						APIVersion: "core/v1",
+						Kind:       "node",
+						Namespace:  "cluster-scope",
+						Name:       "node-1",
+					},
 				},
 			},
 			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/fieldsetreader_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/fieldsetreader_task.go
@@ -17,6 +17,7 @@ package googlecloudlogk8scontrolplane_impl
 import (
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
 )
 
@@ -25,5 +26,7 @@ var CommonFieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googleclou
 	googlecloudlogk8scontrolplane_contract.ListLogEntriesTaskID.Ref(),
 	[]log.FieldSetReader{
 		&googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSetReader{},
+		&googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSetReader{},
+		&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
 	},
 )

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task.go
@@ -19,7 +19,7 @@ import (
 
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
 )
@@ -55,40 +55,40 @@ var OtherGrouperTask = inspectiontaskbase.NewLogGrouperTask(
 	},
 )
 
-var OtherLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudlogk8scontrolplane_contract.OtherLogToTimelineMapperTaskID, &otherLogToTimelineMapperTaskSetting{})
-
-type otherLogToTimelineMapperTaskSetting struct {
+// OtherTimelineMapper maps other control plane logs to timeline paths.
+type OtherTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
 }
 
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (o *otherLogToTimelineMapperTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+// Dependencies implements inspectiontaskbase.LogToTimelineMapperV2.
+func (o *OtherTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{}
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *otherLogToTimelineMapperTaskSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapperV2.
+func (o *OtherTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
 	return googlecloudlogk8scontrolplane_contract.OtherLogGrouperTaskID.Ref()
 }
 
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *otherLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapperV2.
+func (o *OtherTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogk8scontrolplane_contract.LogIngesterTaskID.Ref()
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (o *otherLogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
+// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapperV2.
+func (o *OtherTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	componentFieldSet, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{})
 	if err != nil {
-		return struct{}{}, err
-	}
-	commonMainMessage, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet{})
-	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 
-	cs.SetLogSummary(commonMainMessage.Message)
-	cs.AddEvent(componentFieldSet.ResourcePath())
-	return struct{}{}, nil
+	cs := khifilev6.NewTimelineChangeSet(l)
+	compTimeline := MustControlPlaneComponentTimeline(ctx, componentFieldSet.ClusterName, componentFieldSet.ComponentName)
+	cs.AddEvent(compTimeline)
+
+	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*otherLogToTimelineMapperTaskSetting)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*OtherTimelineMapper)(nil)
+
+var OtherLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[struct{}](googlecloudlogk8scontrolplane_contract.OtherLogToTimelineMapperTaskID, &OtherTimelineMapper{})

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task.go
@@ -83,7 +83,7 @@ func (o *OtherTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log,
 	}
 
 	cs := khifilev6.NewTimelineChangeSet(l)
-	compTimeline := MustControlPlaneComponentTimeline(ctx, componentFieldSet.ClusterName, componentFieldSet.ComponentName)
+	compTimeline := googlecloudlogk8scontrolplane_contract.MustControlPlaneComponentTimeline(ctx, componentFieldSet.ClusterName, componentFieldSet.ComponentName)
 	cs.AddEvent(compTimeline)
 
 	return cs, struct{}{}, nil

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
@@ -29,11 +30,11 @@ import (
 func TestOtherLogToTimelineMapperTask(t *testing.T) {
 	builder := khifilev6.NewBuilder()
 
-	clusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+	gkeClusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
 		Name: "test-cluster",
-		Type: inspectioncore_contract.TimelineTypeK8sCluster,
+		Type: googlecloudcommon_contract.TimelineTypeGKE,
 	})
-	wantCompTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+	wantCompTimeline := builder.TimelineAccumulator.GetPath(gkeClusterTimeline, khifilev6.PathSegment{
 		Name: "apiserver",
 		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
 	})

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task_test.go
@@ -15,20 +15,34 @@
 package googlecloudlogk8scontrolplane_impl
 
 import (
+	"context"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 )
 
 func TestOtherLogToTimelineMapperTask(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+
+	clusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: inspectioncore_contract.TimelineTypeK8sCluster,
+	})
+	wantCompTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: "apiserver",
+		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
+	})
+
 	testCases := []struct {
 		desc                string
 		inputComponentField googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet
 		inputMessageField   googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet
-		asserters           []testchangeset.ChangeSetAsserter
+		assert              func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc: "with standard message",
@@ -39,25 +53,22 @@ func TestOtherLogToTimelineMapperTask(t *testing.T) {
 			inputMessageField: googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet{
 				Message: "foo",
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasEvent{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#apiserver",
-				},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantCompTimeline)
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 			l := log.NewLogWithFieldSetsForTest(&tc.inputComponentField, &tc.inputMessageField)
-			modifier := otherLogToTimelineMapperTaskSetting{}
-			cs := history.NewChangeSet(l)
-			_, err := modifier.ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
+			mapper := &OtherTimelineMapper{}
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {
-				t.Errorf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
+				t.Fatalf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
 			}
-			for _, asserter := range tc.asserters {
-				asserter.Assert(t, cs)
-			}
+			tc.assert(t, ctx, cs)
 		})
 	}
 }

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task.go
@@ -17,12 +17,16 @@ package googlecloudlogk8scontrolplane_impl
 import (
 	"context"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
 var SchedulerLogFilterTask = inspectiontaskbase.NewLogFilterTask(
@@ -55,47 +59,64 @@ var SchedulerGrouperTask = inspectiontaskbase.NewLogGrouperTask(
 	},
 )
 
-var SchedulerLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudlogk8scontrolplane_contract.SchedulerLogToTimelineMapperTaskID, &schedulerLogToTimelineMapperTaskSetting{})
-
-type schedulerLogToTimelineMapperTaskSetting struct {
+// SchedulerTimelineMapper maps scheduler logs to timeline paths.
+type SchedulerTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
 }
 
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (o *schedulerLogToTimelineMapperTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+// Dependencies implements inspectiontaskbase.LogToTimelineMapperV2.
+func (m *SchedulerTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{}
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *schedulerLogToTimelineMapperTaskSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapperV2.
+func (m *SchedulerTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
 	return googlecloudlogk8scontrolplane_contract.SchedulerLogGrouperTaskID.Ref()
 }
 
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *schedulerLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapperV2.
+func (m *SchedulerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogk8scontrolplane_contract.LogIngesterTaskID.Ref()
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (o *schedulerLogToTimelineMapperTaskSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
+// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapperV2.
+func (m *SchedulerTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	componentFieldSet, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{})
 	if err != nil {
-		return struct{}{}, err
-	}
-	commonMainMessage, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet{})
-	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 	schedulerMessageFieldSet, err := log.GetFieldSet(l, &googlecloudlogk8scontrolplane_contract.K8sSchedulerComponentFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 
-	cs.SetLogSummary(commonMainMessage.Message)
-	cs.AddEvent(componentFieldSet.ResourcePath())
+	cs := khifilev6.NewTimelineChangeSet(l)
+
+	compTimeline := MustControlPlaneComponentTimeline(ctx, componentFieldSet.ClusterName, componentFieldSet.ComponentName)
+	cs.AddEvent(compTimeline)
+
 	if schedulerMessageFieldSet.HasPodField() {
-		cs.AddEvent(schedulerMessageFieldSet.ResourcePath())
+		clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, componentFieldSet.ClusterName)
+		apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+		kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+		namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, schedulerMessageFieldSet.PodNamespace)
+		podTimeline := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, schedulerMessageFieldSet.PodName)
+		cs.AddEvent(podTimeline)
 	}
-	return struct{}{}, nil
+
+	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*schedulerLogToTimelineMapperTaskSetting)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*SchedulerTimelineMapper)(nil)
+
+var SchedulerLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(googlecloudlogk8scontrolplane_contract.SchedulerLogToTimelineMapperTaskID, &SchedulerTimelineMapper{})
+
+// MustControlPlaneComponentTimeline returns the timeline path for a Kubernetes control plane component.
+func MustControlPlaneComponentTimeline(ctx context.Context, clusterName string, componentName string) *khifilev6.TimelinePath {
+	clusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, clusterName)
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: componentName,
+		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
+	})
+}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task.go
@@ -17,16 +17,13 @@ package googlecloudlogk8scontrolplane_impl
 import (
 	"context"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
-	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
 var SchedulerLogFilterTask = inspectiontaskbase.NewLogFilterTask(
@@ -92,7 +89,7 @@ func (m *SchedulerTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.
 
 	cs := khifilev6.NewTimelineChangeSet(l)
 
-	compTimeline := MustControlPlaneComponentTimeline(ctx, componentFieldSet.ClusterName, componentFieldSet.ComponentName)
+	compTimeline := googlecloudlogk8scontrolplane_contract.MustControlPlaneComponentTimeline(ctx, componentFieldSet.ClusterName, componentFieldSet.ComponentName)
 	cs.AddEvent(compTimeline)
 
 	if schedulerMessageFieldSet.HasPodField() {
@@ -110,13 +107,3 @@ func (m *SchedulerTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.
 var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*SchedulerTimelineMapper)(nil)
 
 var SchedulerLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(googlecloudlogk8scontrolplane_contract.SchedulerLogToTimelineMapperTaskID, &SchedulerTimelineMapper{})
-
-// MustControlPlaneComponentTimeline returns the timeline path for a Kubernetes control plane component.
-func MustControlPlaneComponentTimeline(ctx context.Context, clusterName string, componentName string) *khifilev6.TimelinePath {
-	clusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, clusterName)
-	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
-	return builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
-		Name: componentName,
-		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
-	})
-}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
@@ -29,13 +30,18 @@ import (
 func TestSchedulerLogToTimelineMapperTask(t *testing.T) {
 	builder := khifilev6.NewBuilder()
 
+	gkeClusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: googlecloudcommon_contract.TimelineTypeGKE,
+	})
+	wantCompTimeline := builder.TimelineAccumulator.GetPath(gkeClusterTimeline, khifilev6.PathSegment{
+		Name: "scheduler",
+		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
+	})
+
 	clusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
 		Name: "test-cluster",
 		Type: inspectioncore_contract.TimelineTypeK8sCluster,
-	})
-	wantCompTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
-		Name: "scheduler",
-		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
 	})
 
 	apiVersionTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task_test.go
@@ -15,21 +15,52 @@
 package googlecloudlogk8scontrolplane_impl
 
 import (
+	"context"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 )
 
 func TestSchedulerLogToTimelineMapperTask(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+
+	clusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: inspectioncore_contract.TimelineTypeK8sCluster,
+	})
+	wantCompTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: "scheduler",
+		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
+	})
+
+	apiVersionTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: "core/v1",
+		Type: inspectioncore_contract.TimelineTypeAPIVersion,
+	})
+	kindTimeline := builder.TimelineAccumulator.GetPath(apiVersionTimeline, khifilev6.PathSegment{
+		Name: "pod",
+		Type: inspectioncore_contract.TimelineTypeKind,
+	})
+	namespaceTimeline := builder.TimelineAccumulator.GetPath(kindTimeline, khifilev6.PathSegment{
+		Name: "test-namespace",
+		Type: inspectioncore_contract.TimelineTypeNamespace,
+	})
+	wantPodTimeline := builder.TimelineAccumulator.GetPath(namespaceTimeline, khifilev6.PathSegment{
+		Name: "test-pod",
+		Type: inspectioncore_contract.TimelineTypeResource,
+	})
+
 	testCases := []struct {
 		desc                   string
 		inputComponentField    googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet
 		inputMessageField      googlecloudlogk8scontrolplane_contract.K8sControlplaneCommonMessageFieldSet
 		inputSchedulerFieldSet googlecloudlogk8scontrolplane_contract.K8sSchedulerComponentFieldSet
-		asserters              []testchangeset.ChangeSetAsserter
+		assert                 func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc: "with pod name and namespace given",
@@ -44,13 +75,10 @@ func TestSchedulerLogToTimelineMapperTask(t *testing.T) {
 				PodName:      "test-pod",
 				PodNamespace: "test-namespace",
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasEvent{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#scheduler",
-				},
-				&testchangeset.HasEvent{
-					ResourcePath: "core/v1#pod#test-namespace#test-pod",
-				},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantCompTimeline).
+					HasEvent(wantPodTimeline)
 			},
 		},
 		{
@@ -63,25 +91,23 @@ func TestSchedulerLogToTimelineMapperTask(t *testing.T) {
 				Message: "foo",
 			},
 			inputSchedulerFieldSet: googlecloudlogk8scontrolplane_contract.K8sSchedulerComponentFieldSet{},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasEvent{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#scheduler",
-				},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantCompTimeline).
+					HasNoEvent(wantPodTimeline)
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 			l := log.NewLogWithFieldSetsForTest(&tc.inputComponentField, &tc.inputSchedulerFieldSet, &tc.inputMessageField)
-			modifier := schedulerLogToTimelineMapperTaskSetting{}
-			cs := history.NewChangeSet(l)
-			_, err := modifier.ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
+			mapper := &SchedulerTimelineMapper{}
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {
-				t.Errorf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
+				t.Fatalf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
 			}
-			for _, asserter := range tc.asserters {
-				asserter.Assert(t, cs)
-			}
+			tc.assert(t, ctx, cs)
 		})
 	}
 }


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.