### PR TITLE
Migrate GCE serial port log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudlogserialport/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/fieldset.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 )
 
@@ -45,11 +44,6 @@ type GCESerialPortLogFieldSet struct {
 // Kind implements log.FieldSet.
 func (g *GCESerialPortLogFieldSet) Kind() string {
 	return "gce-serialport"
-}
-
-// GetResorucePath returns the ResourcePath representing the serialport timeline.
-func (g *GCESerialPortLogFieldSet) GetResourcePath() resourcepath.ResourcePath {
-	return resourcepath.NodeSerialport(g.NodeName, g.Port)
 }
 
 var _ log.FieldSet = (*GCESerialPortLogFieldSet)(nil)

--- a/pkg/task/inspection/googlecloudlogserialport/contract/timeline_path.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/timeline_path.go
@@ -25,16 +25,6 @@ import (
 
 // MustSerialPortTimeline returns the hierarchical timeline path for a serial port of a GCE node.
 func MustSerialPortTimeline(ctx context.Context, clusterName, nodeName, port string) *khifilev6.TimelinePath {
-	if clusterName == "" {
-		panic("cluster name must not be empty")
-	}
-	if nodeName == "" {
-		panic("node name must not be empty")
-	}
-	if port == "" {
-		panic("port must not be empty")
-	}
-
 	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
 	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
 	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")

--- a/pkg/task/inspection/googlecloudlogserialport/contract/timeline_path.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/timeline_path.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogserialport_contract
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// MustSerialPortTimeline returns the hierarchical timeline path for a serial port of a GCE node.
+func MustSerialPortTimeline(ctx context.Context, clusterName, nodeName, port string) *khifilev6.TimelinePath {
+	if clusterName == "" {
+		panic("cluster name must not be empty")
+	}
+	if nodeName == "" {
+		panic("node name must not be empty")
+	}
+	if port == "" {
+		panic("port must not be empty")
+	}
+
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")
+	nodeTimeline := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindTimeline, nodeName)
+
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(nodeTimeline, khifilev6.PathSegment{
+		Name: port,
+		Type: TimelineTypeSerialPort,
+	})
+}

--- a/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks.go
@@ -16,81 +16,149 @@ package googlecloudlogserialport_impl
 
 import (
 	"context"
+	"fmt"
 
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogserialport_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogserialport/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
 // FieldSetReadTask is the task to run GCESerialPortLogFieldSetReader on logs to parse serial port logs.
-var FieldSetReadTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlogserialport_contract.FieldSetReadTaskID, googlecloudlogserialport_contract.LogQueryTaskID.Ref(), []log.FieldSetReader{
-	&googlecloudlogserialport_contract.GCESerialPortLogFieldSetReader{},
-})
+var FieldSetReadTask = inspectiontaskbase.NewFieldSetReadTask(
+	googlecloudlogserialport_contract.FieldSetReadTaskID,
+	googlecloudlogserialport_contract.LogQueryTaskID.Ref(),
+	[]log.FieldSetReader{
+		&googlecloudlogserialport_contract.GCESerialPortLogFieldSetReader{},
+		&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
+	},
+)
 
 // LogFilterTask removes logs with empty message.
 // This message is mostly just contained escape sequences and stripped by ANSIEscapeSequenceStripper.
-var LogFilterTask = inspectiontaskbase.NewLogFilterTask(googlecloudlogserialport_contract.LogFilterTaskID, googlecloudlogserialport_contract.FieldSetReadTaskID.Ref(),
+var LogFilterTask = inspectiontaskbase.NewLogFilterTask(
+	googlecloudlogserialport_contract.LogFilterTaskID,
+	googlecloudlogserialport_contract.FieldSetReadTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
 		return log.MustGetFieldSet(l, &googlecloudlogserialport_contract.GCESerialPortLogFieldSet{}).Message != ""
 	},
 )
 
-// LogIngesterTask is the log serializer task for GCE serial port logs.
-// It includes all logs gathered from log list.
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(
+// serialPortLogIngester implements the LogIngesterV2 interface.
+type serialPortLogIngester struct{}
+
+// RawLogTask returns the task reference that provides the raw logs to ingest.
+func (i *serialPortLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogserialport_contract.LogFilterTaskID.Ref()
+}
+
+// Dependencies returns additional task dependencies of the ingester.
+func (i *serialPortLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog parses raw log entry and manually populates the LogChangeSet.
+func (i *serialPortLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	cs.SetLogType(googlecloudlogserialport_contract.LogTypeSerialPort)
+
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
+	}
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	if serialFS, err := log.GetFieldSet(l, &googlecloudlogserialport_contract.GCESerialPortLogFieldSet{}); err == nil {
+		cs.SetSummary(serialFS.Message)
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*serialPortLogIngester)(nil)
+
+// LogIngesterTask is the V2 log ingester task.
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(
 	googlecloudlogserialport_contract.LogIngesterTaskID,
-	googlecloudlogserialport_contract.LogFilterTaskID.Ref(),
+	&serialPortLogIngester{},
 )
 
 // LogGrouperTask is the grouper task for GCE serial port logs.
-// It groups logs by the node name and port name
+// It groups logs by the node name and port name.
 var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(
 	googlecloudlogserialport_contract.LogGrouperTaskID,
 	googlecloudlogserialport_contract.LogFilterTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
-		return log.MustGetFieldSet(l, &googlecloudlogserialport_contract.GCESerialPortLogFieldSet{}).GetResourcePath().Path
+		serialFS := log.MustGetFieldSet(l, &googlecloudlogserialport_contract.GCESerialPortLogFieldSet{})
+		return fmt.Sprintf("%s#%s", serialFS.NodeName, serialFS.Port)
 	},
 )
 
-// LogToTimelineMapperTask is the task to map logs into events on serial port logs.
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](
-	googlecloudlogserialport_contract.LogToTimelineMapperTaskID,
-	&serialportLogToTimelineMapper{},
-	inspectioncore_contract.FeatureTaskLabel(
-		"GCE Node Serialport log",
-		`Serialport logs from GCE instances. This helps detailed investigation on VM bootstrapping issue on GCE instance.`,
-		enum.LogTypeSerialPort,
-		10000, false,
-	),
-)
-
+// serialportLogToTimelineMapper maps logs to hierarchical node serial port timelines.
 type serialportLogToTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (s *serialportLogToTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
-	return googlecloudlogserialport_contract.LogGrouperTaskID.Ref()
-}
-
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
+// LogIngesterTask implements the LogToTimelineMapperV2 interface.
 func (s *serialportLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogserialport_contract.LogIngesterTaskID.Ref()
 }
 
+// GroupedLogTask implements the LogToTimelineMapperV2 interface.
+func (s *serialportLogToTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogserialport_contract.LogGrouperTaskID.Ref()
+}
+
+// Dependencies implements the LogToTimelineMapperV2 interface.
 func (s *serialportLogToTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
-	return []taskid.UntypedTaskReference{}
+	return []taskid.UntypedTaskReference{
+		googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(),
+	}
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (s *serialportLogToTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
-	serialportFieldSet := log.MustGetFieldSet(l, &googlecloudlogserialport_contract.GCESerialPortLogFieldSet{})
-	cs.AddEvent(serialportFieldSet.GetResourcePath())
-	cs.SetLogSummary(serialportFieldSet.Message)
-	return struct{}{}, nil
+// ProcessLogByGroup processes each log inside the group and stages the event on the timeline.
+func (s *serialportLogToTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
+	serialportFieldSet, err := log.GetFieldSet(l, &googlecloudlogserialport_contract.GCESerialPortLogFieldSet{})
+	if err != nil {
+		return nil, struct{}{}, err
+	}
+
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref())
+
+	targetPath := googlecloudlogserialport_contract.MustSerialPortTimeline(
+		ctx,
+		clusterIdentity.ClusterName,
+		serialportFieldSet.NodeName,
+		serialportFieldSet.Port,
+	)
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+	cs.AddEvent(targetPath)
+
+	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*serialportLogToTimelineMapper)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*serialportLogToTimelineMapper)(nil)
+
+// LogToTimelineMapperTask is the V2 timeline mapper task.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
+	googlecloudlogserialport_contract.LogToTimelineMapperTaskID,
+	&serialportLogToTimelineMapper{},
+	inspectioncore_contract.FeatureTaskLabelV2(
+		"GCE Node Serialport log",
+		`Serialport logs from GCE instances. This helps detailed investigation on VM bootstrapping issue on GCE instance.`,
+		10000,
+		false,
+	),
+)

--- a/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,49 +15,124 @@
 package googlecloudlogserialport_impl
 
 import (
+	"context"
 	"testing"
+	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogserialport_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogserialport/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 )
 
-func TestLogToTimelineMapperTask(t *testing.T) {
+func TestSerialPortLogIngester_ProcessLog(t *testing.T) {
+	testTime := time.Date(2025, 9, 29, 6, 39, 24, 0, time.UTC)
 	testCases := []struct {
-		desc     string
-		fieldSet googlecloudlogserialport_contract.GCESerialPortLogFieldSet
-		asserter []testchangeset.ChangeSetAsserter
+		name   string
+		input  *log.Log
+		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
 	}{
 		{
-			desc: "with standard input",
-			fieldSet: googlecloudlogserialport_contract.GCESerialPortLogFieldSet{
-				Message:  "foo",
-				NodeName: "node-name-bar",
-				Port:     "serial_port_output_qux",
-			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{"core/v1#node#cluster-scope#node-name-bar#serial_port_output_qux"},
+			name: "successful log ingestion",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
 				},
-				&testchangeset.HasEvent{
-					ResourcePath: "core/v1#node#cluster-scope#node-name-bar#serial_port_output_qux",
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityError,
 				},
+				&googlecloudlogserialport_contract.GCESerialPortLogFieldSet{
+					Message:  "foo payload",
+					NodeName: "node-name-bar",
+					Port:     "serial_port_output_qux",
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("foo payload").
+					HasTimestamp(testTime).
+					HasSeverity(inspectioncore_contract.SeverityError).
+					HasLogType(googlecloudlogserialport_contract.LogTypeSerialPort)
 			},
 		},
 	}
+
+	ingester := &serialPortLogIngester{}
 	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			l := log.NewLogWithFieldSetsForTest(&tc.fieldSet)
-			modifier := serialportLogToTimelineMapper{}
-			cs := history.NewChangeSet(l)
-			_, err := modifier.ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			cs, err := ingester.ProcessLog(ctx, tc.input)
 			if err != nil {
-				t.Errorf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
+				t.Fatalf("ProcessLog() returned unexpected error: %v", err)
 			}
-			for _, asserter := range tc.asserter {
-				asserter.Assert(t, cs)
+			tc.assert(t, cs)
+		})
+	}
+}
+
+func TestSerialPortLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+
+	clusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: inspectioncore_contract.TimelineTypeK8sCluster,
+	})
+	apiVersionTimeline := builder.TimelineAccumulator.GetPath(clusterTimeline, khifilev6.PathSegment{
+		Name: "core/v1",
+		Type: inspectioncore_contract.TimelineTypeAPIVersion,
+	})
+	kindTimeline := builder.TimelineAccumulator.GetPath(apiVersionTimeline, khifilev6.PathSegment{
+		Name: "node",
+		Type: inspectioncore_contract.TimelineTypeKind,
+	})
+	nodeTimeline := builder.TimelineAccumulator.GetPath(kindTimeline, khifilev6.PathSegment{
+		Name: "node-name-bar",
+		Type: inspectioncore_contract.TimelineTypeResource,
+	})
+	wantSerialPortPath := builder.TimelineAccumulator.GetPath(nodeTimeline, khifilev6.PathSegment{
+		Name: "serial_port_output_qux",
+		Type: googlecloudlogserialport_contract.TimelineTypeSerialPort,
+	})
+
+	testCases := []struct {
+		name     string
+		inputLog *log.Log
+		assert   func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+	}{
+		{
+			name: "create timeline event",
+			inputLog: log.NewLogWithFieldSetsForTest(
+				&googlecloudlogserialport_contract.GCESerialPortLogFieldSet{
+					Message:  "foo payload",
+					NodeName: "node-name-bar",
+					Port:     "serial_port_output_qux",
+				},
+			),
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantSerialPortPath)
+			},
+		},
+	}
+
+	mapper := &serialportLogToTimelineMapper{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(), googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			})
+
+			cs, _, err := mapper.ProcessLogByGroup(ctx, tc.inputLog, struct{}{})
+			if err != nil {
+				t.Fatalf("ProcessLogByGroup() returned unexpected error: %v", err)
 			}
+
+			tc.assert(t, ctx, cs)
 		})
 	}
 }

--- a/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks_test.go
@@ -89,7 +89,11 @@ func TestSerialPortLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 		Name: "node",
 		Type: inspectioncore_contract.TimelineTypeKind,
 	})
-	nodeTimeline := builder.TimelineAccumulator.GetPath(kindTimeline, khifilev6.PathSegment{
+	namespaceTimeline := builder.TimelineAccumulator.GetPath(kindTimeline, khifilev6.PathSegment{
+		Name: "cluster-scope",
+		Type: inspectioncore_contract.TimelineTypeNamespace,
+	})
+	nodeTimeline := builder.TimelineAccumulator.GetPath(namespaceTimeline, khifilev6.PathSegment{
 		Name: "node-name-bar",
 		Type: inspectioncore_contract.TimelineTypeResource,
 	})


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.