### PR TITLE
Migrate GKE audit log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,84 +22,142 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudloggkeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudloggkeapiaudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
 // FieldSetReaderTask is a task that reads and parses field sets from GKE audit logs.
-// It uses GCPOperationAuditLogFieldSetReader and GKEAuditLogResourceFieldSetReader
-// to extract common GCP audit log fields and GKE-specific resource fields.
+// It uses GCPOperationAuditLogFieldSetReader, GKEAuditLogResourceFieldSetReader,
+// and GCPDefaultSeverityFieldSetReader to extract fields.
 var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudloggkeapiaudit_contract.FieldSetReaderTaskID, googlecloudloggkeapiaudit_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
 	&googlecloudcommon_contract.GCPOperationAuditLogFieldSetReader{},
 	&googlecloudloggkeapiaudit_contract.GKEAuditLogResourceFieldSetReader{},
+	&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
 })
 
 // LogIngesterTask is a task that serializes GKE audit logs for storage in the history builder.
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(googlecloudloggkeapiaudit_contract.LogIngesterTaskID, googlecloudloggkeapiaudit_contract.ListLogEntriesTaskID.Ref())
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(googlecloudloggkeapiaudit_contract.LogIngesterTaskID, &gkeAuditLogLogIngester{})
 
-// LogGrouperTask is a task that groups GKE audit logs by their resource path.
-// This grouping allows for parallel processing of logs related to the same resource.
+// gkeAuditLogLogIngester implements LogIngesterV2.
+type gkeAuditLogLogIngester struct{}
+
+// RawLogTask returns the task reference that provides the raw logs to ingest.
+func (i *gkeAuditLogLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudloggkeapiaudit_contract.FieldSetReaderTaskID.Ref()
+}
+
+// Dependencies returns additional task dependencies of the ingester.
+func (i *gkeAuditLogLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog parses raw log entry and manually populates the LogChangeSet.
+func (i *gkeAuditLogLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	cs.SetLogType(googlecloudloggkeapiaudit_contract.LogTypeGkeAudit)
+
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
+	}
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	if auditFieldSet, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{}); err == nil {
+		switch {
+		case auditFieldSet.Starting():
+			cs.SetSummary(fmt.Sprintf("%s Started", auditFieldSet.MethodName))
+		case auditFieldSet.Ending():
+			cs.SetSummary(fmt.Sprintf("%s Finished", auditFieldSet.MethodName))
+		default:
+			cs.SetSummary(auditFieldSet.MethodName)
+		}
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*gkeAuditLogLogIngester)(nil)
+
+// LogGrouperTask is a task that groups GKE audit logs by GKE cluster or nodepool name.
 var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudloggkeapiaudit_contract.LogGrouperTaskID, googlecloudloggkeapiaudit_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
 		resourceFieldSet, err := log.GetFieldSet(l, &googlecloudloggkeapiaudit_contract.GKEAuditLogResourceFieldSet{})
 		if err != nil {
 			return ""
 		}
-		return resourceFieldSet.ResourcePath().Path
+		if resourceFieldSet.IsCluster() {
+			return fmt.Sprintf("cluster/%s", resourceFieldSet.ClusterName)
+		}
+		return fmt.Sprintf("nodepool/%s/%s", resourceFieldSet.ClusterName, resourceFieldSet.NodepoolName)
 	},
 )
 
-// LogToTimelineMapperTask is a task that adds revisions/events regarding logs.
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudloggkeapiaudit_contract.LogToTimelineMapperTaskID, &gkeAuditLogLogToTimelineMapperSetting{},
-	inspectioncore_contract.FeatureTaskLabel(`GKE Audit logs`,
-		`Gather GKE audit log to show creation/upgrade/deletion of logs cluster/nodepool`,
-		enum.LogTypeGkeAudit,
+// LogToTimelineMapperTask is a task that maps GKE audit logs to timeline elements.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[struct{}](googlecloudloggkeapiaudit_contract.LogToTimelineMapperTaskID, &gkeAuditLogLogToTimelineMapperSetting{},
+	inspectioncore_contract.FeatureTaskLabelV2(`GKE Audit logs`,
+		`Gather GKE audit log to show creation/upgrade/deletion of cluster/nodepool`,
 		5000,
 		true),
 )
 
-// gkeAuditLogLogToTimelineMapperSetting implements the LogToTimelineMapper interface for GKE audit logs.
+// gkeAuditLogLogToTimelineMapperSetting implements the LogToTimelineMapperV2 interface for GKE audit logs.
 type gkeAuditLogLogToTimelineMapperSetting struct {
+	inspectiontaskbase.StatelessMapperBase
 }
 
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-// It returns a list of task references that this timeline mapper depends on.
+// Dependencies returns additional task references used in timeline mapper.
 func (g *gkeAuditLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{}
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
+// GroupedLogTask returns a reference to the task that provides the grouped logs.
 func (g *gkeAuditLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
 	return googlecloudloggkeapiaudit_contract.LogGrouperTaskID.Ref()
 }
 
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
+// LogIngesterTask returns a reference to the log ingester task.
 func (g *gkeAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudloggkeapiaudit_contract.LogIngesterTaskID.Ref()
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (g *gkeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
+// ProcessLogByGroup maps GKE audit log resource updates to timeline events/revisions.
+func (g *gkeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	commonFieldSet, err := log.GetFieldSet(l, &log.CommonFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 	auditFieldSet, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 	resourceFieldSet, err := log.GetFieldSet(l, &googlecloudloggkeapiaudit_contract.GKEAuditLogResourceFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
+
+	clusterTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, resourceFieldSet.ClusterName)
+
+	var targetTimeline *khifilev6.TimelinePath
+	if resourceFieldSet.IsCluster() {
+		targetTimeline = clusterTimeline
+	} else {
+		targetTimeline = googlecloudcommon_contract.MustGKENodePoolTimeline(ctx, clusterTimeline, resourceFieldSet.NodepoolName)
+	}
+
+	cs := khifilev6.NewTimelineChangeSet(l)
 
 	if !auditFieldSet.ImmediateOperation() {
 		resourceBodyField := ""
-
 		if resourceFieldSet.IsCluster() {
 			resourceBodyField = "cluster"
 		} else {
@@ -111,65 +169,61 @@ func (g *gkeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Co
 
 		switch shortMethodName {
 		case "CreateCluster", "CreateNodePool":
-			var bodyRaw []byte
-			state := enum.RevisionStateProvisioning
+			var bodyNode structured.Node
+			state := googlecloudloggkeapiaudit_contract.RevisionStateProvisioning
 			if auditFieldSet.Ending() {
-				state = enum.RevisionStateExisting
+				state = commonlogk8saudit_contract.RevisionStateK8sResourceExisting
 			}
 			if auditFieldSet.Request != nil {
-				bodyRaw, _ = auditFieldSet.Request.Serialize(resourceBodyField, &structured.YAMLNodeSerializer{})
+				if subReader, err := auditFieldSet.Request.GetReader(resourceBodyField); err == nil {
+					bodyNode = subReader.Node
+				}
 			}
-			cs.AddRevision(resourceFieldSet.ResourcePath(), &history.StagingResourceRevision{
-				Verb:       enum.RevisionVerbCreate,
-				State:      state,
-				Requestor:  auditFieldSet.PrincipalEmail,
-				ChangeTime: commonFieldSet.Timestamp,
-				Partial:    false,
-				Body:       string(bodyRaw),
+			cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    state,
+				Principal:    auditFieldSet.PrincipalEmail,
+				ChangedTime:  commonFieldSet.Timestamp,
+				ResourceBody: bodyNode,
 			})
 		case "DeleteCluster", "DeleteNodePool":
-			state := enum.RevisionStateDeleting
+			state := commonlogk8saudit_contract.RevisionStateK8sResourceDeleting
 			if auditFieldSet.Ending() {
-				state = enum.RevisionStateDeleted
+				state = commonlogk8saudit_contract.RevisionStateK8sResourceIsDeleted
 			}
-			cs.AddRevision(resourceFieldSet.ResourcePath(), &history.StagingResourceRevision{
-				Verb:       enum.RevisionVerbDelete,
-				State:      state,
-				Requestor:  auditFieldSet.PrincipalEmail,
-				ChangeTime: commonFieldSet.Timestamp,
-				Partial:    false,
-				Body:       "",
+			cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbDelete,
+				StateType:    state,
+				Principal:    auditFieldSet.PrincipalEmail,
+				ChangedTime:  commonFieldSet.Timestamp,
+				ResourceBody: nil,
 			})
 		}
 
-		state := enum.RevisionStateOperationStarted
-		verb := enum.RevisionVerbOperationStart
+		state := googlecloudcommon_contract.RevisionStateOperationStarted
+		verb := googlecloudcommon_contract.VerbOperationStart
 		if auditFieldSet.Ending() {
-			state = enum.RevisionStateOperationFinished
-			verb = enum.RevisionVerbOperationFinish
+			state = googlecloudcommon_contract.RevisionStateOperationFinished
+			verb = googlecloudcommon_contract.VerbOperationFinish
 		}
-		requestBody, _ := auditFieldSet.RequestString()
-		cs.AddRevision(auditFieldSet.OperationPath(resourceFieldSet.ResourcePath()), &history.StagingResourceRevision{
-			Body:       requestBody,
-			Verb:       verb,
-			State:      state,
-			Requestor:  auditFieldSet.PrincipalEmail,
-			ChangeTime: commonFieldSet.Timestamp,
-			Partial:    false,
+		var bodyNode structured.Node
+		if auditFieldSet.Request != nil {
+			bodyNode = auditFieldSet.Request.Node
+		}
+
+		operationTimeline := googlecloudcommon_contract.MustGCPOperationTimeline(ctx, targetTimeline, shortMethodName, auditFieldSet.OperationID)
+		cs.AddRevision(operationTimeline, &khifilev6.StagingRevision{
+			VerbType:     verb,
+			StateType:    state,
+			Principal:    auditFieldSet.PrincipalEmail,
+			ChangedTime:  commonFieldSet.Timestamp,
+			ResourceBody: bodyNode,
 		})
 	} else {
-		cs.AddEvent(resourceFieldSet.ResourcePath())
+		cs.AddEvent(targetTimeline)
 	}
 
-	switch {
-	case auditFieldSet.Starting():
-		cs.SetLogSummary(fmt.Sprintf("%s Started", auditFieldSet.MethodName))
-	case auditFieldSet.Ending():
-		cs.SetLogSummary(fmt.Sprintf("%s Finished", auditFieldSet.MethodName))
-	default:
-		cs.SetLogSummary(auditFieldSet.MethodName)
-	}
-	return struct{}{}, nil
+	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*gkeAuditLogLogToTimelineMapperSetting)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*gkeAuditLogLogToTimelineMapperSetting)(nil)

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,13 +18,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudloggkeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudloggkeapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+	"github.com/google/go-cmp/cmp"
 )
 
 func testReaderFromYAML(t *testing.T, yaml string) *structured.NodeReader {
@@ -36,16 +39,54 @@ func testReaderFromYAML(t *testing.T, yaml string) *structured.NodeReader {
 	return structured.NewNodeReader(node)
 }
 
+var compareNodeOption = cmp.Transformer("StructuredNodeToYAML", func(n structured.Node) string {
+	if n == nil {
+		return ""
+	}
+	serializer := &structured.YAMLNodeSerializer{}
+	bytes, err := serializer.Serialize(n)
+	if err != nil {
+		return "serialization error"
+	}
+	return string(bytes)
+})
+
 func TestLogToTimelineMapperTask(t *testing.T) {
+	// 1. Initialize the Builder.
+	builder := khifilev6.NewBuilder()
+
+	// 2. Set up expected path references.
+	wantClusterPath := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: googlecloudcommon_contract.TimelineTypeGKE,
+	})
+	wantNodepoolPath := builder.TimelineAccumulator.GetPath(wantClusterPath, khifilev6.PathSegment{
+		Name: "test-nodepool",
+		Type: googlecloudcommon_contract.TimelineTypeGKENodePool,
+	})
+	wantClusterOpPath := builder.TimelineAccumulator.GetPath(wantClusterPath, khifilev6.PathSegment{
+		Name: "CreateCluster-op-1",
+		Type: googlecloudcommon_contract.TimelineTypeOperation,
+	})
+	wantNodepoolOp1Path := builder.TimelineAccumulator.GetPath(wantNodepoolPath, khifilev6.PathSegment{
+		Name: "CreateNodePool-op-2",
+		Type: googlecloudcommon_contract.TimelineTypeOperation,
+	})
+	wantNodepoolOp2Path := builder.TimelineAccumulator.GetPath(wantNodepoolPath, khifilev6.PathSegment{
+		Name: "DeleteNodePool-op-2",
+		Type: googlecloudcommon_contract.TimelineTypeOperation,
+	})
+
 	testTime := time.Date(2025, time.January, 1, 1, 1, 1, 1, time.UTC)
 	testCommonFieldSet := &log.CommonFieldSet{
 		Timestamp: testTime,
 	}
+
 	testCases := []struct {
 		desc          string
 		inputResource googlecloudloggkeapiaudit_contract.GKEAuditLogResourceFieldSet
 		inputAudit    googlecloudcommon_contract.GCPAuditLogFieldSet
-		asserters     []testchangeset.ChangeSetAsserter
+		assert        func(t *testing.T, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc: "cluster create started",
@@ -63,30 +104,31 @@ func TestLogToTimelineMapperTask(t *testing.T) {
   initialNodeCount: 1
   name: test-cluster`),
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbCreate,
-						State:      enum.RevisionStateProvisioning,
-						Requestor:  "foobar@qux.test",
-						Body:       "initialNodeCount: 1\nname: test-cluster\n",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#CreateCluster-op-1",
-					WantRevision: history.StagingResourceRevision{
-						Verb:      enum.RevisionVerbOperationStart,
-						State:     enum.RevisionStateOperationStarted,
-						Requestor: "foobar@qux.test",
-						Body: `cluster:
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				var bodyNode structured.Node
+				if subReader, err := testReaderFromYAML(t, `cluster:
   initialNodeCount: 1
-  name: test-cluster
-`,
-						ChangeTime: testTime,
-					},
-				},
+  name: test-cluster`).GetReader("cluster"); err == nil {
+					bodyNode = subReader.Node
+				}
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantClusterPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    googlecloudloggkeapiaudit_contract.RevisionStateProvisioning,
+						Principal:    "foobar@qux.test",
+						ChangedTime:  testTime,
+						ResourceBody: bodyNode,
+					}, compareNodeOption).
+					HasRevision(wantClusterOpPath, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationStart,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationStarted,
+						Principal:   "foobar@qux.test",
+						ChangedTime: testTime,
+						ResourceBody: testReaderFromYAML(t, `cluster:
+  initialNodeCount: 1
+  name: test-cluster`).Node,
+					}, compareNodeOption)
 			},
 		},
 		{
@@ -103,27 +145,20 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbCreate,
-						State:      enum.RevisionStateExisting,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#controlplane#cluster-scope#test-cluster#CreateCluster-op-1",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbOperationFinish,
-						State:      enum.RevisionStateOperationFinished,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantClusterPath, &khifilev6.StagingRevision{
+						VerbType:    commonlogk8saudit_contract.VerbCreate,
+						StateType:   commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
+						Principal:   "foobar@qux.test",
+						ChangedTime: testTime,
+					}, compareNodeOption).
+					HasRevision(wantClusterOpPath, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationFinished,
+						Principal:   "foobar@qux.test",
+						ChangedTime: testTime,
+					}, compareNodeOption)
 			},
 		},
 		{
@@ -142,30 +177,31 @@ func TestLogToTimelineMapperTask(t *testing.T) {
   initialNodeCount: 1
   name: test-nodepool`),
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbCreate,
-						State:      enum.RevisionStateProvisioning,
-						Requestor:  "foobar@qux.test",
-						Body:       "initialNodeCount: 1\nname: test-nodepool\n",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool#CreateNodePool-op-2",
-					WantRevision: history.StagingResourceRevision{
-						Verb:      enum.RevisionVerbOperationStart,
-						State:     enum.RevisionStateOperationStarted,
-						Requestor: "foobar@qux.test",
-						Body: `nodePool:
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				var bodyNode structured.Node
+				if subReader, err := testReaderFromYAML(t, `nodePool:
   initialNodeCount: 1
-  name: test-nodepool
-`,
-						ChangeTime: testTime,
-					},
-				},
+  name: test-nodepool`).GetReader("nodePool"); err == nil {
+					bodyNode = subReader.Node
+				}
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    googlecloudloggkeapiaudit_contract.RevisionStateProvisioning,
+						Principal:    "foobar@qux.test",
+						ChangedTime:  testTime,
+						ResourceBody: bodyNode,
+					}, compareNodeOption).
+					HasRevision(wantNodepoolOp1Path, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationStart,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationStarted,
+						Principal:   "foobar@qux.test",
+						ChangedTime: testTime,
+						ResourceBody: testReaderFromYAML(t, `nodePool:
+  initialNodeCount: 1
+  name: test-nodepool`).Node,
+					}, compareNodeOption)
 			},
 		},
 		{
@@ -182,27 +218,20 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbCreate,
-						State:      enum.RevisionStateExisting,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool#CreateNodePool-op-2",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbOperationFinish,
-						State:      enum.RevisionStateOperationFinished,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						VerbType:    commonlogk8saudit_contract.VerbCreate,
+						StateType:   commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
+						Principal:   "foobar@qux.test",
+						ChangedTime: testTime,
+					}, compareNodeOption).
+					HasRevision(wantNodepoolOp1Path, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationFinished,
+						Principal:   "foobar@qux.test",
+						ChangedTime: testTime,
+					}, compareNodeOption)
 			},
 		},
 		{
@@ -219,27 +248,20 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbDelete,
-						State:      enum.RevisionStateDeleted,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
-				&testchangeset.HasRevision{
-					ResourcePath: "@Cluster#nodepool#test-cluster#test-nodepool#DeleteNodePool-op-2",
-					WantRevision: history.StagingResourceRevision{
-						Verb:       enum.RevisionVerbOperationFinish,
-						State:      enum.RevisionStateOperationFinished,
-						Requestor:  "foobar@qux.test",
-						Body:       "",
-						ChangeTime: testTime,
-					},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						VerbType:    commonlogk8saudit_contract.VerbDelete,
+						StateType:   commonlogk8saudit_contract.RevisionStateK8sResourceIsDeleted,
+						Principal:   "foobar@qux.test",
+						ChangedTime: testTime,
+					}, compareNodeOption).
+					HasRevision(wantNodepoolOp2Path, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationFinished,
+						Principal:   "foobar@qux.test",
+						ChangedTime: testTime,
+					}, compareNodeOption)
 			},
 		},
 		{
@@ -256,27 +278,26 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				PrincipalEmail: "foobar@qux.test",
 				Request:        nil,
 			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{"@Cluster#nodepool#test-cluster#test-nodepool"},
-				},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantNodepoolPath)
 			},
 		},
 	}
+
+	mapperSetting := &gkeAuditLogLogToTimelineMapperSetting{}
+
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			l := log.NewLogWithFieldSetsForTest(testCommonFieldSet, &tc.inputAudit, &tc.inputResource)
-			mapperSetting := &gkeAuditLogLogToTimelineMapperSetting{}
-			cs := history.NewChangeSet(l)
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
-			_, err := mapperSetting.ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
+			cs, _, err := mapperSetting.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {
-				t.Errorf("got error %v, want nil", err)
+				t.Errorf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
 			}
 
-			for _, asserter := range tc.asserters {
-				asserter.Assert(t, cs)
-			}
+			tc.assert(t, cs)
 		})
 	}
 }


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.