### PR TITLE
Migrate Compute API audit log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract/timeline.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract/timeline.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomputeapiaudit_contract
+
+import (
+	"context"
+
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+)
+
+// MustNodeTimelinePath returns the hierarchical TimelinePath for a Kubernetes Node resource under V6 format.
+func MustNodeTimelinePath(ctx context.Context, clusterName string, nodeName string) *khifilev6.TimelinePath {
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")
+	namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "cluster-scope")
+	return commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, nodeName)
+}

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks.go
@@ -20,26 +20,30 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogcomputeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
+// FieldSetReaderTask parses GCPOperationAuditLogFieldSet from raw Compute API logs.
 var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlogcomputeapiaudit_contract.FieldSetReaderTaskID, googlecloudlogcomputeapiaudit_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
 	&googlecloudcommon_contract.GCPOperationAuditLogFieldSetReader{},
 })
 
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(googlecloudlogcomputeapiaudit_contract.LogIngesterTaskID, googlecloudlogcomputeapiaudit_contract.ListLogEntriesTaskID.Ref())
+// LogIngesterTask is a V2 task that ingests log metadata (timestamp, severity, summary, log type) into KHI v6 format.
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(googlecloudlogcomputeapiaudit_contract.LogIngesterTaskID, &gcpComputeAuditLogLogIngester{})
 
+// LogGrouperTask groups GCE API audit logs by node resource name for parallel mapper processing.
 var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogcomputeapiaudit_contract.LogGrouperTaskID, googlecloudlogcomputeapiaudit_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
-		// Compute Engine Audit log parser is stateless and it doesn't require grouping to work, but grouping them by its associated instance resource name for better performance to process them in parallel.
 		audit, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
 		if err != nil {
 			return "unknown"
@@ -47,80 +51,164 @@ var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogcomputea
 		return getInstanceNameFromResourceName(audit.ResourceName)
 	})
 
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudlogcomputeapiaudit_contract.LogToTimelineMapperTaskID, &gcpComputeAuditLogLogToTimelineMapperSetting{},
-	inspectioncore_contract.FeatureTaskLabel(`Compute API Logs`,
+// LogToTimelineMapperTask maps GCE API audit logs to timeline events and revisions in parallel.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[struct{}](googlecloudlogcomputeapiaudit_contract.LogToTimelineMapperTaskID, &gcpComputeAuditLogLogToTimelineMapperSetting{},
+	inspectioncore_contract.FeatureTaskLabelV2(`Compute API Logs`,
 		`Gather Compute API audit logs to show the timings of the provisioning of resources(e.g creating/deleting GCE VM,mounting Persistent Disk...etc) on associated timelines.`,
-		enum.LogTypeComputeApi,
 		6000,
 		true,
 	),
 )
 
-type gcpComputeAuditLogLogToTimelineMapperSetting struct {
+type gcpComputeAuditLogLogIngester struct{}
+
+// RawLogTask returns the task reference that provides the raw logs to ingest.
+func (i *gcpComputeAuditLogLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogcomputeapiaudit_contract.FieldSetReaderTaskID.Ref()
 }
 
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (g *gcpComputeAuditLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
+// Dependencies returns additional task dependencies of the ingester.
+func (i *gcpComputeAuditLogLogIngester) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{}
 }
 
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (g *gcpComputeAuditLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
-	return googlecloudlogcomputeapiaudit_contract.LogGrouperTaskID.Ref()
+// ProcessLog parses raw log entry and manually populates the LogChangeSet.
+func (i *gcpComputeAuditLogLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	commonSet, err := log.GetFieldSet(l, &log.CommonFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+	cs.SetTimestamp(commonSet.Timestamp)
+
+	if severitySet, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severitySet.Severity)
+	} else {
+		cs.SetSeverity(inspectioncore_contract.SeverityUnknown)
+	}
+
+	cs.SetLogType(googlecloudlogcomputeapiaudit_contract.LogTypeComputeApi)
+
+	audit, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
+	if err != nil {
+		return nil, err
+	}
+
+	var summary string
+	switch {
+	case audit.Starting():
+		summary = fmt.Sprintf("%s Started", audit.MethodName)
+	case audit.Ending():
+		summary = fmt.Sprintf("%s Finished", audit.MethodName)
+	default:
+		summary = audit.MethodName
+	}
+	cs.SetSummary(summary)
+
+	return cs, nil
 }
 
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
+// Explicit interface compliance assertion.
+var _ inspectiontaskbase.LogIngesterV2 = (*gcpComputeAuditLogLogIngester)(nil)
+
+type gcpComputeAuditLogLogToTimelineMapperSetting struct {
+	inspectiontaskbase.StatelessMapperBase
+}
+
+// LogIngesterTask returns a reference to the log ingester task.
 func (g *gcpComputeAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogcomputeapiaudit_contract.LogIngesterTaskID.Ref()
 }
 
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (g *gcpComputeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
+// Dependencies returns additional task dependencies.
+func (g *gcpComputeAuditLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{
+		googlecloudlogcomputeapiaudit_contract.ClusterIdentityTaskID.Ref(),
+	}
+}
+
+// GroupedLogTask returns a reference to the log grouper task.
+func (g *gcpComputeAuditLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogcomputeapiaudit_contract.LogGrouperTaskID.Ref()
+}
+
+// ProcessLogByGroup translates a single GCE API audit log into timeline event/revision changesets.
+func (g *gcpComputeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	commonLogFieldSet, err := log.GetFieldSet(l, &log.CommonFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 	audit, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
 	if err != nil {
-		return struct{}{}, err
+		return nil, struct{}{}, err
 	}
 
-	nodeResourcePath := resourcepath.Node(getInstanceNameFromResourceName(audit.ResourceName))
-	resourcePath := audit.OperationPath(nodeResourcePath)
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogcomputeapiaudit_contract.ClusterIdentityTaskID.Ref())
+	nodeTimelinePath := ResolveNodeTimelinePath(ctx, clusterIdentity.ClusterName, getInstanceNameFromResourceName(audit.ResourceName))
+
+	var targetPath *khifilev6.TimelinePath
+	if audit.ImmediateOperation() {
+		targetPath = nodeTimelinePath
+	} else {
+		methodNameSplitted := strings.Split(audit.MethodName, ".")
+		shortMethodName := "unknown"
+		if len(methodNameSplitted) > 0 {
+			shortMethodName = methodNameSplitted[len(methodNameSplitted)-1]
+		}
+		targetPath = ResolveOperationTimelinePath(ctx, nodeTimelinePath, shortMethodName, audit.OperationID)
+	}
+
+	cs := khifilev6.NewTimelineChangeSet(l)
 
 	if audit.ImmediateOperation() {
-		cs.AddEvent(resourcePath)
+		cs.AddEvent(targetPath)
 	} else {
-		state := enum.RevisionStateOperationStarted
-		verb := enum.RevisionVerbOperationStart
+		state := googlecloudcommon_contract.RevisionStateOperationStarted
+		verb := googlecloudcommon_contract.VerbOperationStart
 		if audit.Ending() {
-			state = enum.RevisionStateOperationFinished
-			verb = enum.RevisionVerbOperationFinish
+			state = googlecloudcommon_contract.RevisionStateOperationFinished
+			verb = googlecloudcommon_contract.VerbOperationFinish
 		}
-		requestBody, _ := audit.RequestString()
-		cs.AddRevision(resourcePath, &history.StagingResourceRevision{
-			Body:       requestBody,
-			Verb:       verb,
-			State:      state,
-			Requestor:  audit.PrincipalEmail,
-			ChangeTime: commonLogFieldSet.Timestamp,
-			Partial:    false,
+		var body structured.Node
+		if audit.Request != nil {
+			body = audit.Request.Node
+		}
+		cs.AddRevision(targetPath, &khifilev6.StagingRevision{
+			ResourceBody: body,
+			VerbType:     verb,
+			StateType:    state,
+			Principal:    audit.PrincipalEmail,
+			ChangedTime:  commonLogFieldSet.Timestamp,
 		})
 	}
 
-	switch {
-	case audit.Starting():
-		cs.SetLogSummary(fmt.Sprintf("%s Started", audit.MethodName))
-	case audit.Ending():
-		cs.SetLogSummary(fmt.Sprintf("%s Finished", audit.MethodName))
-	default:
-		cs.SetLogSummary(audit.MethodName)
-	}
-
-	return struct{}{}, nil
+	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*gcpComputeAuditLogLogToTimelineMapperSetting)(nil)
+// Explicit interface compliance assertion.
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*gcpComputeAuditLogLogToTimelineMapperSetting)(nil)
+
+// ResolveNodeTimelinePath returns the hierarchical TimelinePath for a Kubernetes Node resource under V6 format.
+func ResolveNodeTimelinePath(ctx context.Context, clusterName string, nodeName string) *khifilev6.TimelinePath {
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")
+	namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "cluster-scope")
+	return commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, nodeName)
+}
+
+// ResolveOperationTimelinePath returns the Operation timeline nested under the parent Resource timeline path.
+func ResolveOperationTimelinePath(ctx context.Context, parentPath *khifilev6.TimelinePath, shortMethodName string, operationID string) *khifilev6.TimelinePath {
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(parentPath, khifilev6.PathSegment{
+		Name: fmt.Sprintf("%s-%s", shortMethodName, operationID),
+		Type: googlecloudcommon_contract.TimelineTypeOperation,
+	})
+}
 
 func getInstanceNameFromResourceName(resourceName string) string {
 	resourceNameSplitted := strings.Split(resourceName, "/")

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks.go
@@ -20,14 +20,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogcomputeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
@@ -148,7 +146,7 @@ func (g *gcpComputeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx con
 	}
 
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogcomputeapiaudit_contract.ClusterIdentityTaskID.Ref())
-	nodeTimelinePath := ResolveNodeTimelinePath(ctx, clusterIdentity.ClusterName, getInstanceNameFromResourceName(audit.ResourceName))
+	nodeTimelinePath := googlecloudlogcomputeapiaudit_contract.MustNodeTimelinePath(ctx, clusterIdentity.ClusterName, getInstanceNameFromResourceName(audit.ResourceName))
 
 	var targetPath *khifilev6.TimelinePath
 	if audit.ImmediateOperation() {
@@ -159,7 +157,7 @@ func (g *gcpComputeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx con
 		if len(methodNameSplitted) > 0 {
 			shortMethodName = methodNameSplitted[len(methodNameSplitted)-1]
 		}
-		targetPath = ResolveOperationTimelinePath(ctx, nodeTimelinePath, shortMethodName, audit.OperationID)
+		targetPath = googlecloudcommon_contract.MustGCPOperationTimeline(ctx, nodeTimelinePath, shortMethodName, audit.OperationID)
 	}
 
 	cs := khifilev6.NewTimelineChangeSet(l)
@@ -191,24 +189,6 @@ func (g *gcpComputeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx con
 
 // Explicit interface compliance assertion.
 var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*gcpComputeAuditLogLogToTimelineMapperSetting)(nil)
-
-// ResolveNodeTimelinePath returns the hierarchical TimelinePath for a Kubernetes Node resource under V6 format.
-func ResolveNodeTimelinePath(ctx context.Context, clusterName string, nodeName string) *khifilev6.TimelinePath {
-	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
-	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
-	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")
-	namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "cluster-scope")
-	return commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, nodeName)
-}
-
-// ResolveOperationTimelinePath returns the Operation timeline nested under the parent Resource timeline path.
-func ResolveOperationTimelinePath(ctx context.Context, parentPath *khifilev6.TimelinePath, shortMethodName string, operationID string) *khifilev6.TimelinePath {
-	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
-	return builder.TimelineAccumulator.GetPath(parentPath, khifilev6.PathSegment{
-		Name: fmt.Sprintf("%s-%s", shortMethodName, operationID),
-		Type: googlecloudcommon_contract.TimelineTypeOperation,
-	})
-}
 
 func getInstanceNameFromResourceName(resourceName string) string {
 	resourceNameSplitted := strings.Split(resourceName, "/")

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks_test.go
@@ -15,145 +15,238 @@
 package googlecloudlogcomputeapiaudit_impl
 
 import (
+	"context"
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogcomputeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 )
 
-func TestLogToTimelineMapperTask(t *testing.T) {
-	testCommonFieldSet := &log.CommonFieldSet{
-		Timestamp: time.Date(2025, time.January, 1, 1, 1, 1, 1, time.UTC),
-	}
+func TestLogIngester_ProcessLog(t *testing.T) {
+	testTime := time.Date(2025, time.January, 1, 1, 1, 1, 1, time.UTC)
 	testCases := []struct {
-		desc      string
-		input     googlecloudcommon_contract.GCPAuditLogFieldSet
-		asserters []testchangeset.ChangeSetAsserter
+		name   string
+		input  *log.Log
+		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
 	}{
 		{
-			desc: "operation started",
-			input: googlecloudcommon_contract.GCPAuditLogFieldSet{
+			name: "ingest compute API audit log - start",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
+				},
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityInfo,
+				},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "compute.instances.insert",
+					OperationFirst: true,
+					OperationLast:  false,
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("compute.instances.insert Started").
+					HasLogType(googlecloudlogcomputeapiaudit_contract.LogTypeComputeApi).
+					HasTimestamp(testTime)
+			},
+		},
+		{
+			name: "ingest compute API audit log - finish",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: testTime,
+				},
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityError,
+				},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "compute.instances.insert",
+					OperationFirst: false,
+					OperationLast:  true,
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("compute.instances.insert Finished").
+					HasLogType(googlecloudlogcomputeapiaudit_contract.LogTypeComputeApi).
+					HasTimestamp(testTime)
+			},
+		},
+	}
+
+	ingester := &gcpComputeAuditLogLogIngester{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs, err := ingester.ProcessLog(t.Context(), tc.input)
+			if err != nil {
+				t.Fatalf("ProcessLog() returned unexpected error: %v", err)
+			}
+			tc.assert(t, cs)
+		})
+	}
+}
+
+func TestLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+
+	// Setup context with task result mapping containing ClusterIdentity
+	taskResults := typedmap.NewTypedMap()
+	typedmap.Set(taskResults, typedmap.NewTypedKey[googlecloudk8scommon_contract.GoogleCloudClusterIdentity](googlecloudlogcomputeapiaudit_contract.ClusterIdentityTaskID.Ref().ReferenceIDString()), googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+	})
+
+	baseCtx := khictx.WithValue(t.Context(), core_contract.TaskResultMapContextKey, taskResults)
+	ctx := khictx.WithValue(baseCtx, inspectioncore_contract.Builder, builder)
+
+	// Independently build the expected paths segment-by-segment
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+	apiTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiTimeline, "node")
+	nsTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "cluster-scope")
+
+	wantNodeAbcPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsTimeline, "abc")
+	wantOp1Path := builder.TimelineAccumulator.GetPath(wantNodeAbcPath, khifilev6.PathSegment{
+		Name: "insert-op-1",
+		Type: googlecloudcommon_contract.TimelineTypeOperation,
+	})
+
+	wantNodeDefPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsTimeline, "def")
+
+	wantNodeGhiPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsTimeline, "ghi")
+	wantOp3Path := builder.TimelineAccumulator.GetPath(wantNodeGhiPath, khifilev6.PathSegment{
+		Name: "delete-op-3",
+		Type: googlecloudcommon_contract.TimelineTypeOperation,
+	})
+
+	testTime := time.Date(2025, time.January, 1, 1, 1, 1, 1, time.UTC)
+	testCommonFieldSet := &log.CommonFieldSet{
+		Timestamp: testTime,
+	}
+
+	testCases := []struct {
+		name     string
+		inputLog *log.Log
+		assert   func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+	}{
+		{
+			name: "operation started",
+			inputLog: log.NewLogWithFieldSetsForTest(testCommonFieldSet, &googlecloudcommon_contract.GCPAuditLogFieldSet{
 				OperationID:    "op-1",
 				OperationFirst: true,
 				OperationLast:  false,
 				MethodName:     "compute.instances.insert",
 				ResourceName:   "projects/123/resources/abc",
 				PrincipalEmail: "foobar@qux.test",
-			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "core/v1#node#cluster-scope#abc#insert-op-1",
-					WantRevision: history.StagingResourceRevision{
-						ChangeTime: testCommonFieldSet.Timestamp,
-						State:      enum.RevisionStateOperationStarted,
-						Verb:       enum.RevisionVerbOperationStart,
-						Requestor:  "foobar@qux.test",
-					},
-				},
+			}),
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOp1Path, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationStarted,
+						VerbType:    googlecloudcommon_contract.VerbOperationStart,
+						Principal:   "foobar@qux.test",
+					})
 			},
 		},
 		{
-			desc: "operation finished",
-			input: googlecloudcommon_contract.GCPAuditLogFieldSet{
+			name: "operation finished",
+			inputLog: log.NewLogWithFieldSetsForTest(testCommonFieldSet, &googlecloudcommon_contract.GCPAuditLogFieldSet{
 				OperationID:    "op-1",
 				OperationFirst: false,
 				OperationLast:  true,
 				MethodName:     "compute.instances.insert",
 				ResourceName:   "projects/123/resources/abc",
 				PrincipalEmail: "foobar@qux.test",
-			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "core/v1#node#cluster-scope#abc#insert-op-1",
-					WantRevision: history.StagingResourceRevision{
-						ChangeTime: testCommonFieldSet.Timestamp,
-						State:      enum.RevisionStateOperationFinished,
-						Verb:       enum.RevisionVerbOperationFinish,
-						Requestor:  "foobar@qux.test",
-					},
-				},
+			}),
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOp1Path, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationFinished,
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						Principal:   "foobar@qux.test",
+					})
 			},
 		},
 		{
-			desc: "immediate operation",
-			input: googlecloudcommon_contract.GCPAuditLogFieldSet{
+			name: "immediate operation",
+			inputLog: log.NewLogWithFieldSetsForTest(testCommonFieldSet, &googlecloudcommon_contract.GCPAuditLogFieldSet{
 				OperationID:    "op-2",
 				OperationFirst: true,
 				OperationLast:  true,
 				MethodName:     "compute.instances.delete",
 				ResourceName:   "projects/123/resources/def",
 				PrincipalEmail: "foobar@qux.test",
-			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{"core/v1#node#cluster-scope#def"},
-				},
+			}),
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantNodeDefPath)
 			},
 		},
 		{
-			desc: "deletion operation started",
-			input: googlecloudcommon_contract.GCPAuditLogFieldSet{
+			name: "deletion operation started",
+			inputLog: log.NewLogWithFieldSetsForTest(testCommonFieldSet, &googlecloudcommon_contract.GCPAuditLogFieldSet{
 				OperationID:    "op-3",
 				OperationFirst: true,
 				OperationLast:  false,
 				MethodName:     "compute.instances.delete",
 				ResourceName:   "projects/123/resources/ghi",
 				PrincipalEmail: "foobar@qux.test",
-			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "core/v1#node#cluster-scope#ghi#delete-op-3",
-					WantRevision: history.StagingResourceRevision{
-						ChangeTime: testCommonFieldSet.Timestamp,
-						State:      enum.RevisionStateOperationStarted,
-						Verb:       enum.RevisionVerbOperationStart,
-						Requestor:  "foobar@qux.test",
-					},
-				},
+			}),
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOp3Path, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationStarted,
+						VerbType:    googlecloudcommon_contract.VerbOperationStart,
+						Principal:   "foobar@qux.test",
+					})
 			},
 		},
 		{
-			desc: "deletion operation finished",
-			input: googlecloudcommon_contract.GCPAuditLogFieldSet{
+			name: "deletion operation finished",
+			inputLog: log.NewLogWithFieldSetsForTest(testCommonFieldSet, &googlecloudcommon_contract.GCPAuditLogFieldSet{
 				OperationID:    "op-3",
 				OperationFirst: false,
 				OperationLast:  true,
 				MethodName:     "compute.instances.delete",
 				ResourceName:   "projects/123/resources/ghi",
 				PrincipalEmail: "foobar@qux.test",
-			},
-			asserters: []testchangeset.ChangeSetAsserter{
-				&testchangeset.HasRevision{
-					ResourcePath: "core/v1#node#cluster-scope#ghi#delete-op-3",
-					WantRevision: history.StagingResourceRevision{
-						ChangeTime: testCommonFieldSet.Timestamp,
-						State:      enum.RevisionStateOperationFinished,
-						Verb:       enum.RevisionVerbOperationFinish,
-						Requestor:  "foobar@qux.test",
-					},
-				},
+			}),
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOp3Path, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationFinished,
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						Principal:   "foobar@qux.test",
+					})
 			},
 		},
 	}
 
+	mapper := &gcpComputeAuditLogLogToTimelineMapperSetting{}
 	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			l := log.NewLogWithFieldSetsForTest(testCommonFieldSet, &tc.input)
-			mapperSetting := &gcpComputeAuditLogLogToTimelineMapperSetting{}
-			cs := history.NewChangeSet(l)
-
-			_, err := mapperSetting.ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
+		t.Run(tc.name, func(t *testing.T) {
+			testCtx := khictx.WithValue(ctx, inspectioncore_contract.Builder, builder)
+			cs, _, err := mapper.ProcessLogByGroup(testCtx, tc.inputLog, struct{}{})
 			if err != nil {
-				t.Errorf("got error %v, want nil", err)
+				t.Fatalf("ProcessLogByGroup() returned unexpected error: %v", err)
 			}
 
-			for _, asserter := range tc.asserters {
-				asserter.Assert(t, cs)
-			}
+			tc.assert(t, testCtx, cs)
 		})
 	}
 }


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.