### PR TITLE
Migrate K8s container log parsers to file format v6

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
@@ -29,6 +29,7 @@ var jsonPayloadMessageFieldNames = []string{
 }
 
 type K8sContainerLogFieldSet struct {
+	ClusterName   string
 	Namespace     string
 	PodName       string
 	ContainerName string
@@ -42,7 +43,7 @@ func (k *K8sContainerLogFieldSet) Kind() string {
 
 // GroupKey returns the group key string for this container's Pod.
 func (k *K8sContainerLogFieldSet) GroupKey() string {
-	return fmt.Sprintf("core/v1#pod#%s#%s", k.Namespace, k.PodName)
+	return fmt.Sprintf("%s/%s", k.Namespace, k.PodName)
 }
 
 var _ log.FieldSet = (*K8sContainerLogFieldSet)(nil)
@@ -58,6 +59,7 @@ func (k *K8sContainerLogFieldSetReader) FieldSetKind() string {
 // Read implements log.FieldSetReader.
 func (k *K8sContainerLogFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	var result K8sContainerLogFieldSet
+	result.ClusterName = reader.ReadStringOrDefault("resource.labels.cluster_name", "unknown")
 	result.Namespace = reader.ReadStringOrDefault("resource.labels.namespace_name", "unknown")
 	result.PodName = reader.ReadStringOrDefault("resource.labels.pod_name", "unknown")
 	result.ContainerName = reader.ReadStringOrDefault("resource.labels.container_name", "unknown")

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 )
 
@@ -41,8 +40,9 @@ func (k *K8sContainerLogFieldSet) Kind() string {
 	return "k8s_container"
 }
 
-func (k *K8sContainerLogFieldSet) ResourcePath() resourcepath.ResourcePath {
-	return resourcepath.Container(k.Namespace, k.PodName, k.ContainerName)
+// GroupKey returns the group key string for this container's Pod.
+func (k *K8sContainerLogFieldSet) GroupKey() string {
+	return fmt.Sprintf("core/v1#pod#%s#%s", k.Namespace, k.PodName)
 }
 
 var _ log.FieldSet = (*K8sContainerLogFieldSet)(nil)

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
@@ -167,3 +167,15 @@ labels:
 	}
 
 }
+
+func TestK8sContainerLogFieldSet_GroupKey(t *testing.T) {
+	fs := &K8sContainerLogFieldSet{
+		Namespace: "test-namespace",
+		PodName:   "test-pod",
+	}
+	want := "core/v1#pod#test-namespace#test-pod"
+	got := fs.GroupKey()
+	if got != want {
+		t.Errorf("GroupKey() = %q, want %q", got, want)
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
@@ -31,12 +31,14 @@ func TestK8sContainerLogFieldSetReader_ResourceLabels(t *testing.T) {
 		{
 			desc: "from resource labels",
 			want: &K8sContainerLogFieldSet{
+				ClusterName:   "test-cluster",
 				Namespace:     "test-namespace",
 				PodName:       "test-pod",
 				ContainerName: "test-container",
 			},
 			input: `resource:
   labels:
+    cluster_name: test-cluster
     namespace_name: test-namespace
     pod_name: test-pod
     container_name: test-container`,
@@ -44,6 +46,7 @@ func TestK8sContainerLogFieldSetReader_ResourceLabels(t *testing.T) {
 		{
 			desc: "missing resource labels",
 			want: &K8sContainerLogFieldSet{
+				ClusterName:   "unknown",
 				Namespace:     "unknown",
 				PodName:       "unknown",
 				ContainerName: "unknown",
@@ -173,7 +176,7 @@ func TestK8sContainerLogFieldSet_GroupKey(t *testing.T) {
 		Namespace: "test-namespace",
 		PodName:   "test-pod",
 	}
-	want := "core/v1#pod#test-namespace#test-pod"
+	want := "test-namespace/test-pod"
 	got := fs.GroupKey()
 	if got != want {
 		t.Errorf("GroupKey() = %q, want %q", got, want)

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/timeline.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/timeline.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8scontainer_contract
+
+import (
+	"context"
+
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+)
+
+// MustK8sContainerTimeline returns the hierarchical timeline path for a Kubernetes Container log under the specified cluster, namespace, pod, and container name.
+func MustK8sContainerTimeline(ctx context.Context, clusterName string, namespace string, podName string, containerName string) *khifilev6.TimelinePath {
+	clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	apiVersionPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+	kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionPath, "pod")
+	namespacePath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, namespace)
+	podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespacePath, podName)
+
+	return commonlogk8saudit_contract.MustK8sContainerTimeline(ctx, podPath, containerName)
+}

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,67 +18,132 @@ import (
 	"context"
 
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8scontainer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontainer/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
+// FieldSetReaderTask reads fields in parallel.
 var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlogk8scontainer_contract.FieldSetReaderTaskID, googlecloudlogk8scontainer_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
 	&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSetReader{},
+	&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
 })
 
-var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(googlecloudlogk8scontainer_contract.LogIngesterTaskID, googlecloudlogk8scontainer_contract.ListLogEntriesTaskID.Ref())
+// containerLogIngester implements inspectiontaskbase.LogIngesterV2.
+type containerLogIngester struct{}
 
+// RawLogTask returns the task reference that provides the raw logs to ingest.
+func (i *containerLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogk8scontainer_contract.FieldSetReaderTaskID.Ref()
+}
+
+// Dependencies returns additional task dependencies of the ingester.
+func (i *containerLogIngester) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog is called for each log entry to customize log metadata.
+func (i *containerLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+
+	cs.SetLogType(googlecloudlogk8scontainer_contract.LogTypeContainer)
+
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
+	}
+
+	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
+		cs.SetSeverity(severityFS.Severity)
+	}
+
+	if containerFields, err := log.GetFieldSet(l, &googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{}); err == nil {
+		cs.SetSummary(containerFields.Message)
+	}
+
+	return cs, nil
+}
+
+var _ inspectiontaskbase.LogIngesterV2 = (*containerLogIngester)(nil)
+
+// LogIngesterTask is the task that ingests log metadata into KHI v6 builder.
+var LogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(
+	googlecloudlogk8scontainer_contract.LogIngesterTaskID,
+	&containerLogIngester{},
+)
+
+// LogGrouperTask groups logs by associated Pod path.
 var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogk8scontainer_contract.LogGrouperTaskID, googlecloudlogk8scontainer_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
-		// container log parser is stateless and it doesn't require grouping to work, but grouping them by its associated instance resource name for better performance to process them in parallel.
 		containerFields, err := log.GetFieldSet(l, &googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{})
 		if err != nil {
 			return "unknown"
 		}
-		return containerFields.ResourcePath().Path
+		return containerFields.GroupKey()
 	})
 
-var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[struct{}](googlecloudlogk8scontainer_contract.LogToTimelineMapperTaskID, &containerLogLogToTimelineMapperSetting{},
-	inspectioncore_contract.FeatureTaskLabel(`Kubernetes container logs`,
-		`Gather stdout/stderr logs of containers on the cluster to visualize them on the timeline under an associated Pod. Log volume can be huge when the cluster has many Pods.`,
-		enum.LogTypeContainer,
+// containerLogLogToTimelineMapper maps container logs to resource timelines.
+type containerLogLogToTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
+}
+
+// LogIngesterTask returns the task reference of LogIngester.
+func (m *containerLogLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogk8scontainer_contract.LogIngesterTaskID.Ref()
+}
+
+// Dependencies returns task dependencies of this mapper.
+func (m *containerLogLogToTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{
+		googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref(),
+	}
+}
+
+// GroupedLogTask returns a reference to the task that provides grouped logs.
+func (m *containerLogLogToTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogk8scontainer_contract.LogGrouperTaskID.Ref()
+}
+
+// ProcessLogByGroup is called for each log entry to stage mutations via TimelineChangeSet.
+func (m *containerLogLogToTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
+	containerFields, err := log.GetFieldSet(l, &googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{})
+	if err != nil {
+		return nil, struct{}{}, nil
+	}
+
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref())
+
+	clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
+	apiVersionPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+	kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionPath, "pod")
+	namespacePath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, containerFields.Namespace)
+	podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespacePath, containerFields.PodName)
+
+	containerPath := commonlogk8saudit_contract.MustK8sContainerTimeline(ctx, podPath, containerFields.ContainerName)
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+	cs.AddEvent(containerPath)
+
+	return cs, struct{}{}, nil
+}
+
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*containerLogLogToTimelineMapper)(nil)
+
+// LogToTimelineMapperTask creates a task that modifies the KHI v6 TimelineRegistry.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[struct{}](
+	googlecloudlogk8scontainer_contract.LogToTimelineMapperTaskID,
+	&containerLogLogToTimelineMapper{},
+	inspectioncore_contract.FeatureTaskLabelV2(
+		"Kubernetes container logs",
+		"Gather stdout/stderr logs of containers on the cluster to visualize them on the timeline under an associated Pod. Log volume can be huge when the cluster has many Pods.",
 		4000,
 		false,
 	),
 )
-
-type containerLogLogToTimelineMapperSetting struct {
-}
-
-// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
-func (c *containerLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
-	return []taskid.UntypedTaskReference{}
-}
-
-// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
-func (c *containerLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
-	return googlecloudlogk8scontainer_contract.LogGrouperTaskID.Ref()
-}
-
-// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (c *containerLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
-	return googlecloudlogk8scontainer_contract.LogIngesterTaskID.Ref()
-}
-
-// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
-func (c *containerLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevGroupData struct{}) (struct{}, error) {
-	containerFields, err := log.GetFieldSet(l, &googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{})
-	if err != nil {
-		return struct{}{}, nil
-	}
-
-	cs.AddEvent(containerFields.ResourcePath())
-	cs.SetLogSummary(containerFields.Message)
-	return struct{}{}, nil
-}
-
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*containerLogLogToTimelineMapperSetting)(nil)

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
@@ -22,7 +22,6 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogk8scontainer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontainer/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
@@ -118,15 +117,19 @@ func (m *containerLogLogToTimelineMapper) ProcessLogByGroup(ctx context.Context,
 		return nil, struct{}{}, nil
 	}
 
-	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref())
+	clusterName := containerFields.ClusterName
+	if clusterName == "" || clusterName == "unknown" {
+		clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref())
+		clusterName = clusterIdentity.ClusterName
+	}
 
-	clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
-	apiVersionPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
-	kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionPath, "pod")
-	namespacePath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, containerFields.Namespace)
-	podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespacePath, containerFields.PodName)
-
-	containerPath := commonlogk8saudit_contract.MustK8sContainerTimeline(ctx, podPath, containerFields.ContainerName)
+	containerPath := googlecloudlogk8scontainer_contract.MustK8sContainerTimeline(
+		ctx,
+		clusterName,
+		containerFields.Namespace,
+		containerFields.PodName,
+		containerFields.ContainerName,
+	)
 
 	cs := khifilev6.NewTimelineChangeSet(l)
 	cs.AddEvent(containerPath)

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,76 +15,133 @@
 package googlecloudlogk8scontainer_impl
 
 import (
+	"context"
 	"testing"
+	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogk8scontainer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontainer/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 )
 
-func TestLogToTimelineMapperTask(t *testing.T) {
+// TestLogIngester_ProcessLog tests the containerLogIngester.ProcessLog function.
+func TestLogIngester_ProcessLog(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		input    googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet
-		asserter []testchangeset.ChangeSetAsserter
+		name   string
+		input  *log.Log
+		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
 	}{
 		{
-			desc: "simple container log",
-			input: googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
-				Namespace:     "test-namespace",
-				PodName:       "test-pod",
-				ContainerName: "test-container",
-				Message:       "test message",
-			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{"core/v1#pod#test-namespace#test-pod#test-container"},
+			name: "successful container log ingestion",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
 				},
-				&testchangeset.HasEvent{
-					ResourcePath: "core/v1#pod#test-namespace#test-pod#test-container",
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityInfo,
 				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "test message",
+				&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+					Namespace:     "test-namespace",
+					PodName:       "test-pod",
+					ContainerName: "test-container",
+					Message:       "test message",
 				},
-			},
-		},
-		{
-			desc: "container log with empty message",
-			input: googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
-				Namespace:     "test-namespace",
-				PodName:       "test-pod",
-				ContainerName: "test-container",
-				Message:       "",
-			},
-			asserter: []testchangeset.ChangeSetAsserter{
-				&testchangeset.MatchResourcePathSet{
-					WantResourcePaths: []string{"core/v1#pod#test-namespace#test-pod#test-container"},
-				},
-				&testchangeset.HasEvent{
-					ResourcePath: "core/v1#pod#test-namespace#test-pod#test-container",
-				},
-				&testchangeset.HasLogSummary{
-					WantLogSummary: "",
-				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("test message").
+					HasSeverity(inspectioncore_contract.SeverityInfo).
+					HasLogType(googlecloudlogk8scontainer_contract.LogTypeContainer).
+					HasTimestamp(time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC))
 			},
 		},
 	}
+
+	ingester := &containerLogIngester{}
 	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			l := log.NewLogWithFieldSetsForTest(&tc.input)
-			cs := history.NewChangeSet(l)
-			modifier := containerLogLogToTimelineMapperSetting{}
-
-			_, err := modifier.ProcessLogByGroup(t.Context(), l, cs, nil, struct{}{})
-
+		t.Run(tc.name, func(t *testing.T) {
+			cs, err := ingester.ProcessLog(t.Context(), tc.input)
 			if err != nil {
-				t.Errorf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
+				t.Fatalf("ProcessLog() returned unexpected error: %v", err)
 			}
+			tc.assert(t, cs)
+		})
+	}
+}
 
-			for _, asserter := range tc.asserter {
-				asserter.Assert(t, cs)
+// TestLogToTimelineMapper_ProcessLogByGroup tests the containerLogLogToTimelineMapper.ProcessLogByGroup function.
+func TestLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+	namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "test-namespace")
+	podTimeline := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "test-pod")
+	expectedPath := commonlogk8saudit_contract.MustK8sContainerTimeline(ctx, podTimeline, "test-container")
+
+	testCases := []struct {
+		name     string
+		inputLog *log.Log
+		cluster  googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		assert   func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+	}{
+		{
+			name: "simple container log mapping",
+			inputLog: log.NewLogWithFieldSetsForTest(
+				&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+					Namespace:     "test-namespace",
+					PodName:       "test-pod",
+					ContainerName: "test-container",
+					Message:       "test message",
+				},
+			),
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath)
+			},
+		},
+		{
+			name: "container log with empty message",
+			inputLog: log.NewLogWithFieldSetsForTest(
+				&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+					Namespace:     "test-namespace",
+					PodName:       "test-pod",
+					ContainerName: "test-container",
+					Message:       "",
+				},
+			),
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath)
+			},
+		},
+	}
+
+	mapper := &containerLogLogToTimelineMapper{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref(), tc.cluster)
+
+			cs, _, err := mapper.ProcessLogByGroup(ctx, tc.inputLog, struct{}{})
+			if err != nil {
+				t.Fatalf("ProcessLogByGroup() returned unexpected error: %v", err)
 			}
+			tc.assert(t, ctx, cs)
 		})
 	}
 }


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.