### PR TITLE
Migrate OSS event parser to KHI file format v6

### DIFF
--- a/pkg/task/inspection/ossclusterk8s/contract/fieldset.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/fieldset.go
@@ -16,6 +16,7 @@ package ossclusterk8s_contract
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
@@ -110,3 +111,65 @@ func verbStringToVerb(verbStr string) *pb.Verb {
 		return commonlogk8saudit_contract.VerbUnknown
 	}
 }
+
+// OSSK8sEventFieldSet holds the structured data from a Kubernetes Event log.
+type OSSK8sEventFieldSet struct {
+	// APIVersion is the API version of the involved object.
+	APIVersion string
+	// ResourceKind is the kind of the involved object.
+	ResourceKind string
+	// Namespace is the namespace of the involved object.
+	Namespace string
+	// Resource is the name of the involved object.
+	Resource string
+	// Subresource is the subresource of the involved object.
+	Subresource string
+	// Reason is the short, machine-understandable string explaining why the event was triggered.
+	Reason string
+	// Message is the human-readable description of the status of this operation.
+	Message string
+}
+
+// Kind returns the kind of this FieldSet.
+func (o *OSSK8sEventFieldSet) Kind() string {
+	return "ossclusterk8s.khi.google.com/EventFieldSet"
+}
+
+// ResourceIdentity returns the ResourceIdentity representation of the involved object.
+func (o *OSSK8sEventFieldSet) ResourceIdentity() *commonlogk8saudit_contract.ResourceIdentity {
+	return &commonlogk8saudit_contract.ResourceIdentity{
+		APIVersion:      o.APIVersion,
+		Kind:            o.ResourceKind,
+		Name:            o.Resource,
+		Namespace:       o.Namespace,
+		SubresourceName: o.Subresource,
+	}
+}
+
+var _ log.FieldSet = (*OSSK8sEventFieldSet)(nil)
+
+// OSSK8sEventFieldSetReader extracts OSSK8sEventFieldSet from a raw log.
+type OSSK8sEventFieldSetReader struct{}
+
+// FieldSetKind returns the Kind of the field set this reader constructs.
+func (o *OSSK8sEventFieldSetReader) FieldSetKind() string {
+	return (&OSSK8sEventFieldSet{}).Kind()
+}
+
+// Read extracts event fields from `responseObject` of the Event log.
+func (o *OSSK8sEventFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
+	var result OSSK8sEventFieldSet
+	result.APIVersion = reader.ReadStringOrDefault("responseObject.involvedObject.apiVersion", "core/v1")
+	if !strings.Contains(result.APIVersion, "/") {
+		result.APIVersion = "core/" + result.APIVersion
+	}
+	result.ResourceKind = strings.ToLower(reader.ReadStringOrDefault("responseObject.involvedObject.kind", "unknown"))
+	result.Namespace = reader.ReadStringOrDefault("responseObject.involvedObject.namespace", "cluster-scope")
+	result.Resource = reader.ReadStringOrDefault("responseObject.involvedObject.name", "unknown")
+	result.Subresource = reader.ReadStringOrDefault("responseObject.involvedObject.subresource", "")
+	result.Reason = reader.ReadStringOrDefault("responseObject.reason", "???")
+	result.Message = reader.ReadStringOrDefault("responseObject.message", "")
+	return &result, nil
+}
+
+var _ log.FieldSetReader = (*OSSK8sEventFieldSetReader)(nil)

--- a/pkg/task/inspection/ossclusterk8s/contract/fieldset_test.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/fieldset_test.go
@@ -196,3 +196,74 @@ stageTimestamp: "2023-10-26T10:00:00Z"
 		})
 	}
 }
+
+func TestOSSK8sEventFieldSetReader(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input string
+		want  *OSSK8sEventFieldSet
+	}{
+		{
+			desc: "standard event log",
+			input: `
+responseObject:
+  involvedObject:
+    apiVersion: "apps/v1"
+    kind: "Deployment"
+    namespace: "default"
+    name: "test-deployment"
+    subresource: "status"
+  reason: "ScalingReplicaSet"
+  message: "Scaled up replica set test-deployment-123 to 3"
+`,
+			want: &OSSK8sEventFieldSet{
+				APIVersion:   "apps/v1",
+				ResourceKind: "deployment",
+				Namespace:    "default",
+				Resource:     "test-deployment",
+				Subresource:  "status",
+				Reason:       "ScalingReplicaSet",
+				Message:      "Scaled up replica set test-deployment-123 to 3",
+			},
+		},
+		{
+			desc: "default core apiVersion",
+			input: `
+responseObject:
+  involvedObject:
+    apiVersion: "v1"
+    kind: "Pod"
+    namespace: "default"
+    name: "test-pod"
+  reason: "Scheduled"
+  message: "Successfully assigned default/test-pod to node-1"
+`,
+			want: &OSSK8sEventFieldSet{
+				APIVersion:   "core/v1",
+				ResourceKind: "pod",
+				Namespace:    "default",
+				Resource:     "test-pod",
+				Subresource:  "",
+				Reason:       "Scheduled",
+				Message:      "Successfully assigned default/test-pod to node-1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l, err := log.NewLogFromYAMLString(tc.input)
+			if err != nil {
+				t.Fatalf("failed to parse YAML test input to log: %v", err)
+			}
+			err = l.SetFieldSetReader(&OSSK8sEventFieldSetReader{})
+			if err != nil {
+				t.Errorf("failed to run OSSK8sEventFieldSetReader.Read(): %v", err)
+			}
+			got := log.MustGetFieldSet(l, &OSSK8sEventFieldSet{})
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("OSSK8sEventFieldSet mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/ossclusterk8s/contract/taskid.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/taskid.go
@@ -15,6 +15,7 @@
 package ossclusterk8s_contract
 
 import (
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	"github.com/GoogleCloudPlatform/khi/pkg/server/upload"
@@ -28,7 +29,10 @@ var InputAuditLogFilesFormTaskID = taskid.NewDefaultImplementationID[upload.Uplo
 var AuditLogFileReaderTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "audit-log-reader")
 var NonEventAuditLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "audit-log-filter-non-event-audit")
 var EventAuditLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "audit-log-filter-event-audit")
-var OSSK8sEventLogParserTaskID = taskid.NewDefaultImplementationID[struct{}](OSSTaskPrefix + "event-parser")
+var OSSK8sEventFieldSetReadTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "event-fieldset-read")
+var OSSK8sEventLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "event-log-ingester")
+var OSSK8sEventLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](OSSTaskPrefix + "event-log-grouper")
+var OSSK8sEventLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](OSSTaskPrefix + "event-timeline-mapper")
 
 var OSSK8sAuditLogProviderTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogProviderRef, "oss")
 var OSSK8sAuditLogParserTailTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogParserTailRef, "oss")

--- a/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task.go
@@ -1,6 +1,4 @@
-package ossclusterk8s_impl
-
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,76 +12,132 @@ package ossclusterk8s_impl
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package ossclusterk8s_impl
+
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/legacyparser"
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/enum"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/grouper"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourcepath"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	ossclusterk8s_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/ossclusterk8s/contract"
 )
 
-type OSSK8sEventFromK8sAudit struct {
+// OSSK8sEventFieldSetReadTask reads event field sets in parallel.
+var OSSK8sEventFieldSetReadTask = inspectiontaskbase.NewFieldSetReadTask(
+	ossclusterk8s_contract.OSSK8sEventFieldSetReadTaskID,
+	ossclusterk8s_contract.EventAuditLogFilterTaskID.Ref(),
+	[]log.FieldSetReader{
+		&ossclusterk8s_contract.OSSK8sEventFieldSetReader{},
+		&ossclusterk8s_contract.OSSK8sAuditLogCommonFieldSetReader{},
+	},
+)
+
+// OSSK8sEventLogIngester handles event log metadata ingestion.
+type OSSK8sEventLogIngester struct{}
+
+// RawLogTask returns the task reference providing raw event logs.
+func (i *OSSK8sEventLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+	return ossclusterk8s_contract.OSSK8sEventFieldSetReadTaskID.Ref()
 }
 
-// Dependencies implements parsertask.Parser.
-func (o *OSSK8sEventFromK8sAudit) Dependencies() []taskid.UntypedTaskReference {
+// Dependencies returns additional dependencies of the ingester.
+func (i *OSSK8sEventLogIngester) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{}
 }
 
-// Description implements parsertask.Parser.
-func (o *OSSK8sEventFromK8sAudit) Description() string {
-	return `The event log parser for OSS kubernetes from the audit log`
-}
+// ProcessLog populates metadata into the LogChangeSet.
+func (i *OSSK8sEventLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+	cs, err := khifilev6.NewLogChangeSet(l)
+	if err != nil {
+		return nil, err
+	}
+	cs.SetLogType(commonlogk8saudit_contract.LogTypeEvent)
 
-// GetParserName implements parsertask.Parser.
-func (o *OSSK8sEventFromK8sAudit) GetParserName() string {
-	return "OSS Kubernetes Event logs from JSONL audit log"
-}
-
-// Grouper implements parsertask.Parser.
-func (o *OSSK8sEventFromK8sAudit) Grouper() grouper.LogGrouper {
-	return grouper.AllDependentLogGrouper
-}
-
-// LogTask implements parsertask.Parser.
-func (o *OSSK8sEventFromK8sAudit) LogTask() taskid.TaskReference[[]*log.Log] {
-	return ossclusterk8s_contract.EventAuditLogFilterTaskID.Ref()
-}
-
-// Parse implements parsertask.Parser.
-func (o *OSSK8sEventFromK8sAudit) Parse(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder) error {
-	apiVersion := l.ReadStringOrDefault("responseObject.involvedObject.apiVersion", "core/v1")
-	kind := strings.ToLower(l.ReadStringOrDefault("responseObject.involvedObject.kind", "unknown"))
-	namespace := l.ReadStringOrDefault("responseObject.involvedObject.namespace", "cluster-scope")
-	name := l.ReadStringOrDefault("responseObject.involvedObject.name", "unknown")
-	subresource := l.ReadStringOrDefault("responseObject.involvedObject.subresource", "")
-
-	if subresource == "" {
-		cs.AddEvent(resourcepath.NameLayerGeneralItem(apiVersion, kind, namespace, name))
-	} else {
-		cs.AddEvent(resourcepath.SubresourceLayerGeneralItem(apiVersion, kind, namespace, name, subresource))
+	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
+		cs.SetTimestamp(commonFS.Timestamp)
 	}
 
-	reason := l.ReadStringOrDefault("responseObject.reason", "???")
-	message := l.ReadStringOrDefault("responseObject.message", "")
-	cs.SetLogSummary(fmt.Sprintf("【%s】%s", reason, message))
-	return nil
+	eventFS, err := log.GetFieldSet(l, &ossclusterk8s_contract.OSSK8sEventFieldSet{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OSS k8s event fieldset: %w", err)
+	}
+	cs.SetSummary(fmt.Sprintf("【%s】%s", eventFS.Reason, eventFS.Message))
+	cs.SetSeverity(inspectioncore_contract.SeverityUnknown)
+
+	return cs, nil
 }
 
-// TargetLogType implements parsertask.Parser.
-func (o *OSSK8sEventFromK8sAudit) TargetLogType() enum.LogType {
-	return enum.LogTypeAudit
+var _ inspectiontaskbase.LogIngesterV2 = (*OSSK8sEventLogIngester)(nil)
+
+// OSSK8sEventLogIngesterTask is the V2 log ingester task.
+var OSSK8sEventLogIngesterTask = inspectiontaskbase.NewLogIngesterTaskV2(
+	ossclusterk8s_contract.OSSK8sEventLogIngesterTaskID,
+	&OSSK8sEventLogIngester{},
+)
+
+// OSSK8sEventLogGrouperTask groups event logs by their resource path.
+var OSSK8sEventLogGrouperTask = inspectiontaskbase.NewLogGrouperTask(
+	ossclusterk8s_contract.OSSK8sEventLogGrouperTaskID,
+	ossclusterk8s_contract.OSSK8sEventFieldSetReadTaskID.Ref(),
+	func(ctx context.Context, l *log.Log) string {
+		event, err := log.GetFieldSet(l, &ossclusterk8s_contract.OSSK8sEventFieldSet{})
+		if err != nil {
+			return "unknown"
+		}
+		return event.ResourceIdentity().ResourcePathString()
+	},
+)
+
+// OSSK8sEventTimelineMapper maps grouped events to timeline paths.
+type OSSK8sEventTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
 }
 
-var _ legacyparser.Parser = (*OSSK8sEventFromK8sAudit)(nil)
+// LogIngesterTask returns the prerequisite log ingester task.
+func (m *OSSK8sEventTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return ossclusterk8s_contract.OSSK8sEventLogIngesterTaskID.Ref()
+}
 
-var OSSK8sEventLogParserTask = legacyparser.NewParserTaskFromParser(
-	ossclusterk8s_contract.OSSK8sEventLogParserTaskID,
-	&OSSK8sEventFromK8sAudit{}, 2000, true, []string{})
+// Dependencies returns additional mapper dependencies.
+func (m *OSSK8sEventTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// GroupedLogTask returns the task providing grouped logs.
+func (m *OSSK8sEventTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return ossclusterk8s_contract.OSSK8sEventLogGrouperTaskID.Ref()
+}
+
+// ProcessLogByGroup maps a single event log to its resource timeline.
+func (m *OSSK8sEventTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
+	event, err := log.GetFieldSet(l, &ossclusterk8s_contract.OSSK8sEventFieldSet{})
+	if err != nil {
+		return nil, struct{}{}, fmt.Errorf("failed to get OSS k8s event fieldset: %w", err)
+	}
+
+	targetPath := commonlogk8saudit_contract.MustResourceTimeline(ctx, "cluster", event.ResourceIdentity())
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+	cs.AddEvent(targetPath)
+
+	return cs, struct{}{}, nil
+}
+
+var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*OSSK8sEventTimelineMapper)(nil)
+
+// OSSK8sEventLogToTimelineMapperTask is the V2 log to timeline mapper task.
+var OSSK8sEventLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
+	ossclusterk8s_contract.OSSK8sEventLogToTimelineMapperTaskID,
+	&OSSK8sEventTimelineMapper{},
+	inspectioncore_contract.FeatureTaskLabelV2(
+		"OSS Kubernetes Event logs from JSONL audit log",
+		"The event log parser for OSS kubernetes from the audit log",
+		2000,
+		true,
+	),
+)

--- a/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task_test.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ossclusterk8s_impl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	ossclusterk8s_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/ossclusterk8s/contract"
+	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+)
+
+func TestOSSK8sEventLogIngester_ProcessLog(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  *log.Log
+		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
+	}{
+		{
+			name: "successful event log ingestion",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+				},
+				&ossclusterk8s_contract.OSSK8sEventFieldSet{
+					Reason:  "Scheduled",
+					Message: "Successfully assigned default/test-pod to node-1",
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)).
+					HasLogType(commonlogk8saudit_contract.LogTypeEvent).
+					HasSummary("【Scheduled】Successfully assigned default/test-pod to node-1")
+			},
+		},
+	}
+
+	ingester := &OSSK8sEventLogIngester{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			cs, err := ingester.ProcessLog(ctx, tc.input)
+			if err != nil {
+				t.Fatalf("ProcessLog() returned unexpected error: %v", err)
+			}
+
+			tc.assert(t, cs)
+		})
+	}
+}
+
+func TestOSSK8sEventTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	// Initialize the shared Builder reference.
+	builder := khifilev6.NewBuilder()
+
+	testCases := []struct {
+		desc   string
+		input  ossclusterk8s_contract.OSSK8sEventFieldSet
+		assert func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+	}{
+		{
+			desc: "namespaced resource event",
+			input: ossclusterk8s_contract.OSSK8sEventFieldSet{
+				APIVersion:   "apps/v1",
+				ResourceKind: "deployment",
+				Namespace:    "default",
+				Resource:     "test-deployment",
+				Subresource:  "",
+				Reason:       "ScalingReplicaSet",
+				Message:      "Scaled up replica set test-deployment-xyz to 3",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "apps/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "deployment")
+				namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "default")
+				expectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "test-deployment")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath)
+			},
+		},
+		{
+			desc: "namespaced subresource event",
+			input: ossclusterk8s_contract.OSSK8sEventFieldSet{
+				APIVersion:   "apps/v1",
+				ResourceKind: "deployment",
+				Namespace:    "default",
+				Resource:     "test-deployment",
+				Subresource:  "status",
+				Reason:       "ScalingReplicaSet",
+				Message:      "Scaled up replica set test-deployment-xyz to 3",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "apps/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "deployment")
+				namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "default")
+				resourceTimeline := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "test-deployment")
+				expectedPath := commonlogk8saudit_contract.MustK8sSubresourceTimeline(ctx, resourceTimeline, "status")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath)
+			},
+		},
+		{
+			desc: "cluster-scoped resource event",
+			input: ossclusterk8s_contract.OSSK8sEventFieldSet{
+				APIVersion:   "core/v1",
+				ResourceKind: "node",
+				Namespace:    "cluster-scope",
+				Resource:     "my-node",
+				Subresource:  "",
+				Reason:       "Starting",
+				Message:      "Starting kubelet.",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "node")
+				expectedPath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindTimeline, "my-node")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l := log.NewLogWithFieldSetsForTest(&tc.input)
+
+			// Set up context with the same Builder reference.
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			mapper := OSSK8sEventTimelineMapper{}
+
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
+			if err != nil {
+				t.Fatalf("ProcessLogByGroup returned an unexpected error: %v", err)
+			}
+
+			tc.assert(t, ctx, cs)
+		})
+	}
+}

--- a/pkg/task/inspection/ossclusterk8s/impl/registration.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/registration.go
@@ -41,7 +41,10 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 		AuditLogFileReaderTask,
 		EventAuditLogFilterTask,
 		NonEventAuditLogFilterTask,
-		OSSK8sEventLogParserTask,
+		OSSK8sEventFieldSetReadTask,
+		OSSK8sEventLogIngesterTask,
+		OSSK8sEventLogGrouperTask,
+		OSSK8sEventLogToTimelineMapperTask,
 		OSSK8sAuditLogFieldExtractorTask,
 		OSSK8sAuditLogParserTailTask,
 	)


### PR DESCRIPTION
This PR migrates the current implementations of the parsers into the new parser task base types.
See https://github.com/GoogleCloudPlatform/khi/pull/720 for the rules used during the migration.