### PR TITLE
Adding services needed to migrate timeline components to the new domain type

### DIFF
--- a/web/src/app/services/inspection-data-store-v2.service.ts
+++ b/web/src/app/services/inspection-data-store-v2.service.ts
@@ -25,7 +25,7 @@ import {
   IncludeAncestorsFilter,
   ExcludeNoLogsFilter,
   IncludeDescendantsFilter,
-} from '../store/domain/filter/other-filter';
+} from 'src/app/store/domain/filter/other-filter';
 
 /**
  * Service to store and manage the active InspectionDataV2 domain model.

--- a/web/src/app/services/inspection-data-store-v2.service.ts
+++ b/web/src/app/services/inspection-data-store-v2.service.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable, signal, inject } from '@angular/core';
+import { InspectionDataV2 } from 'src/app/store/domain/inspection-data';
+import { TimelineView } from 'src/app/store/domain/timeline-view';
+import {
+  CelTimelineFilter,
+  CelLogFilter,
+} from 'src/app/store/domain/filter/cel-filter';
+import {
+  IncludeAncestorsFilter,
+  ExcludeNoLogsFilter,
+  IncludeDescendantsFilter,
+} from '../store/domain/filter/other-filter';
+
+/**
+ * Service to store and manage the active InspectionDataV2 domain model.
+ * Provides access to the parsed data and derived timeline views.
+ */
+@Injectable({ providedIn: 'root' })
+export class InspectionDataStoreV2 {
+  private readonly _inspectionData = signal<InspectionDataV2 | null>(null);
+  private readonly _timelineView = signal<TimelineView | null>(null);
+  private readonly celTimelineFilter = inject(CelTimelineFilter);
+  private readonly celLogFilter = inject(CelLogFilter);
+  private readonly excludeNoLogsFilter = inject(ExcludeNoLogsFilter);
+
+  /**
+   * Holds the active inspection data. Emits null if no data has been loaded.
+   */
+  public readonly inspectionData = this._inspectionData.asReadonly();
+
+  /**
+   * Exposes the primary TimelineView parsed and processed from the current timeline store.
+   * Automatically updates when the underlying inspection data is changed.
+   */
+  public readonly timelineView = this._timelineView.asReadonly();
+
+  /**
+   * Updates the store with the newly provided inspection data.
+   *
+   * @param data The new inspection data instance to set.
+   */
+  public setNewInspectionData(data: InspectionDataV2): void {
+    this.updateStoreData(data);
+  }
+
+  private updateStoreData(data: InspectionDataV2 | null): void {
+    this._inspectionData.set(data);
+    if (!data) {
+      this._timelineView.set(null);
+      return;
+    }
+    const view = new TimelineView(data.timelineStore);
+    view.addFilter(this.celTimelineFilter);
+    view.addFilter(new IncludeDescendantsFilter());
+    view.addFilter(this.celLogFilter);
+    view.addFilter(new IncludeAncestorsFilter());
+    view.addFilter(this.excludeNoLogsFilter);
+
+    this._timelineView.set(view);
+  }
+}

--- a/web/src/app/services/selection-manager-v2.service.spec.ts
+++ b/web/src/app/services/selection-manager-v2.service.spec.ts
@@ -1,0 +1,295 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { SelectionManagerV2 } from './selection-manager-v2.service';
+import { InspectionDataStoreV2 } from 'src/app/services/inspection-data-store-v2.service';
+import { InspectionDataV2 } from 'src/app/store/domain/inspection-data';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+
+describe('SelectionManagerV2', () => {
+  let service: SelectionManagerV2;
+  let dataStore: InspectionDataStoreV2;
+  let logStore: LogStore;
+  let timelineStore: TimelineStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [InspectionDataStoreV2, SelectionManagerV2],
+    });
+
+    dataStore = TestBed.inject(InspectionDataStoreV2);
+    service = TestBed.inject(SelectionManagerV2);
+
+    const internPool = new InternPoolStore();
+    const styleStore = new StyleStore();
+    logStore = new LogStore(internPool, styleStore);
+    timelineStore = new TimelineStore(internPool, styleStore, logStore);
+
+    styleStore.addSeverities([
+      {
+        id: 1,
+        label: 'Info',
+        shortLabel: 'I',
+        backgroundColor: { r: 0, g: 0, b: 1, a: 1 },
+        foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
+        order: 1,
+      },
+    ]);
+
+    styleStore.addLogTypes([
+      {
+        id: 2,
+        label: 'K8sEvent',
+        description: 'Kubernetes Event',
+        backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+        foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
+      },
+    ]);
+
+    styleStore.addTimelineTypes([
+      {
+        id: 1,
+        label: 'APIVersion',
+        description: 'Kubernetes API Version',
+        backgroundColor: { r: 0, g: 0, b: 1, a: 1 },
+        foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
+        typeChipBackgroundColor: { r: 0, g: 0, b: 1, a: 1 },
+        visible: true,
+        sortPriority: 1,
+      },
+      {
+        id: 2,
+        label: 'Kind',
+        description: 'Kubernetes Resource Kind',
+        backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+        foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
+        typeChipBackgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+        visible: true,
+        sortPriority: 2,
+      },
+      {
+        id: 3,
+        label: 'Namespace',
+        description: 'Kubernetes Namespace',
+        backgroundColor: { r: 0.5, g: 0, b: 0.5, a: 1 },
+        foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
+        typeChipBackgroundColor: { r: 0.5, g: 0, b: 0.5, a: 1 },
+        visible: true,
+        sortPriority: 3,
+      },
+      {
+        id: 4,
+        label: 'Resource',
+        description: 'Kubernetes Resource Instance',
+        backgroundColor: { r: 1, g: 0.5, b: 0, a: 1 },
+        foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
+        typeChipBackgroundColor: { r: 1, g: 0.5, b: 0, a: 1 },
+        visible: true,
+        sortPriority: 4,
+      },
+    ]);
+
+    styleStore.addVerbs([
+      {
+        id: 1,
+        label: 'CREATE',
+        backgroundColor: { r: 0, g: 0.5, b: 1, a: 1 },
+        foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
+        visible: true,
+      },
+    ]);
+
+    styleStore.addRevisionStates([
+      {
+        id: 1,
+        label: 'Existing',
+        icon: '',
+        description: 'Resource exists',
+        backgroundColor: { r: 0, g: 0, b: 1, a: 1 },
+        style: 0,
+      },
+    ]);
+
+    internPool.addStrings([
+      { id: 1, value: 'v1' },
+      { id: 2, value: 'Pod' },
+      { id: 3, value: 'default' },
+      { id: 4, value: 'mock-pod-1' },
+      { id: 5, value: 'Pod created successfully' },
+      { id: 6, value: 'system:serviceaccount:kube-system:generic' },
+    ]);
+
+    logStore.initialize(
+      [
+        {
+          id: 1,
+          ts: 1700000000000000000n,
+          logTypeId: 2,
+          severityTypeId: 1,
+          summaryStringId: 5,
+        },
+      ],
+      1,
+    );
+
+    timelineStore.initialize(
+      [
+        {
+          id: 1,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
+        {
+          id: 2,
+          timelineTypeId: 2,
+          nameStringId: 2,
+          parentTimelineId: 1,
+          revisionIds: [],
+          eventIds: [],
+        },
+        {
+          id: 3,
+          timelineTypeId: 3,
+          nameStringId: 3,
+          parentTimelineId: 2,
+          revisionIds: [],
+          eventIds: [],
+        },
+        {
+          id: 4,
+          timelineTypeId: 4,
+          nameStringId: 4,
+          parentTimelineId: 3,
+          revisionIds: [1],
+          eventIds: [1],
+        },
+      ],
+      4,
+      [
+        {
+          id: 1,
+          logId: 1,
+          changedTime: 1700000000000000000n,
+          principalStringId: 6,
+          verbTypeId: 1,
+          stateTypeId: 1,
+        },
+      ],
+      1,
+      [
+        {
+          id: 1,
+          logId: 1,
+        },
+      ],
+      1,
+    );
+
+    const mockData: InspectionDataV2 = {
+      internPool,
+      styleStore,
+      logStore,
+      timelineStore,
+    };
+    dataStore.setNewInspectionData(mockData);
+  });
+
+  it('should initialize with default null selections', () => {
+    expect(service.selectedTimeline()).toBeNull();
+    expect(service.highlightedTimeline()).toBeNull();
+    expect(service.selectedRevision()).toBeNull();
+    expect(service.selectedLog()).toBeNull();
+    expect(service.selectedLogIndex()).toBe(-1);
+  });
+
+  it('should handle timeline selection', () => {
+    const timelines = timelineStore.getAllTimelines();
+    const targetTimeline = timelines.find((t) => t.id === 4)!;
+
+    service.onSelectTimeline(targetTimeline);
+    expect(service.selectedTimeline()).toBe(targetTimeline);
+  });
+
+  it('should include descendants in selectedTimelinesWithChildren when timelineSelectionShouldIncludeChildren is true', () => {
+    const timelines = timelineStore.getAllTimelines();
+    // Timeline 3 is 'Namespace: default', which parent of Timeline 4 ('Resource: mock-pod-1')
+    const timeline3 = timelines.find((t) => t.id === 3)!;
+    const timeline4 = timelines.find((t) => t.id === 4)!;
+
+    service.timelineSelectionShouldIncludeChildren.set(true);
+    service.onSelectTimeline(timeline3);
+
+    const selection = service.selectedTimelinesWithChildren();
+    expect(selection).toContain(timeline3);
+    expect(selection).toContain(timeline4);
+  });
+
+  it('should NOT include descendants in selectedTimelinesWithChildren when timelineSelectionShouldIncludeChildren is false', () => {
+    const timelines = timelineStore.getAllTimelines();
+    const timeline3 = timelines.find((t) => t.id === 3)!;
+    const timeline4 = timelines.find((t) => t.id === 4)!;
+
+    service.timelineSelectionShouldIncludeChildren.set(false);
+    service.onSelectTimeline(timeline3);
+
+    const selection = service.selectedTimelinesWithChildren();
+    expect(selection).toContain(timeline3);
+    expect(selection).not.toContain(timeline4);
+  });
+
+  it('should sync timeline and revision selections when a log is selected', () => {
+    const logs = Array.from(logStore.logs());
+    const targetLog = logs[0];
+
+    // When log is selected, it should automatically resolve target resource/revision in the hierarchy
+    service.onSelectLog(targetLog);
+
+    expect(service.selectedLog()?.id).toBe(targetLog.id);
+    // Log 1 resides on Resource Timeline (ID 4) inside Revision 1
+    expect(service.selectedTimeline()?.id).toBe(4);
+    expect(service.selectedRevision()?.logIndex).toBe(targetLog.logIndex);
+  });
+
+  it('should automatically clear log/revision selection if newly selected timeline does not contain them (sync effect)', () => {
+    const logs = Array.from(logStore.logs());
+    const targetLog = logs[0];
+    const timelines = timelineStore.getAllTimelines();
+    const unrelatedTimeline = timelines.find((t) => t.id === 1)!;
+
+    // Select log (will select Log 1, Timeline 4, Revision 1)
+    service.onSelectLog(targetLog);
+    expect(service.selectedLog()?.id).toBe(targetLog.id);
+    expect(service.selectedTimeline()?.id).toBe(4);
+
+    // Select unrelated timeline
+    service.onSelectTimeline(unrelatedTimeline);
+
+    // Expectations after effect propagates
+    TestBed.tick();
+
+    expect(service.selectedTimeline()).toBe(unrelatedTimeline);
+    // Since Log 1 is not in Timeline 1, selections must be cleared
+    expect(service.selectedLog()).toBeNull();
+    expect(service.selectedRevision()).toBeNull();
+  });
+});

--- a/web/src/app/services/selection-manager-v2.service.spec.ts
+++ b/web/src/app/services/selection-manager-v2.service.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { SelectionManagerV2 } from './selection-manager-v2.service';
+import { SelectionManagerV2 } from 'src/app/services/selection-manager-v2.service';
 import { InspectionDataStoreV2 } from 'src/app/services/inspection-data-store-v2.service';
 import { InspectionDataV2 } from 'src/app/store/domain/inspection-data';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
@@ -68,41 +68,49 @@ describe('SelectionManagerV2', () => {
         id: 1,
         label: 'APIVersion',
         description: 'Kubernetes API Version',
+        icon: 'settings',
         backgroundColor: { r: 0, g: 0, b: 1, a: 1 },
         foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
         typeChipBackgroundColor: { r: 0, g: 0, b: 1, a: 1 },
         visible: true,
         sortPriority: 1,
+        height: 1,
       },
       {
         id: 2,
         label: 'Kind',
         description: 'Kubernetes Resource Kind',
+        icon: 'workspaces',
         backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
         foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
         typeChipBackgroundColor: { r: 0, g: 1, b: 0, a: 1 },
         visible: true,
         sortPriority: 2,
+        height: 1,
       },
       {
         id: 3,
         label: 'Namespace',
         description: 'Kubernetes Namespace',
+        icon: 'folder',
         backgroundColor: { r: 0.5, g: 0, b: 0.5, a: 1 },
         foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
         typeChipBackgroundColor: { r: 0.5, g: 0, b: 0.5, a: 1 },
         visible: true,
         sortPriority: 3,
+        height: 1,
       },
       {
         id: 4,
         label: 'Resource',
         description: 'Kubernetes Resource Instance',
+        icon: 'description',
         backgroundColor: { r: 1, g: 0.5, b: 0, a: 1 },
         foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
         typeChipBackgroundColor: { r: 1, g: 0.5, b: 0, a: 1 },
         visible: true,
         sortPriority: 4,
+        height: 1,
       },
     ]);
 
@@ -223,7 +231,7 @@ describe('SelectionManagerV2', () => {
   });
 
   it('should handle timeline selection', () => {
-    const timelines = timelineStore.getAllTimelines();
+    const timelines = timelineStore.timelines;
     const targetTimeline = timelines.find((t) => t.id === 4)!;
 
     service.onSelectTimeline(targetTimeline);
@@ -231,7 +239,7 @@ describe('SelectionManagerV2', () => {
   });
 
   it('should include descendants in selectedTimelinesWithChildren when timelineSelectionShouldIncludeChildren is true', () => {
-    const timelines = timelineStore.getAllTimelines();
+    const timelines = timelineStore.timelines;
     // Timeline 3 is 'Namespace: default', which parent of Timeline 4 ('Resource: mock-pod-1')
     const timeline3 = timelines.find((t) => t.id === 3)!;
     const timeline4 = timelines.find((t) => t.id === 4)!;
@@ -245,7 +253,7 @@ describe('SelectionManagerV2', () => {
   });
 
   it('should NOT include descendants in selectedTimelinesWithChildren when timelineSelectionShouldIncludeChildren is false', () => {
-    const timelines = timelineStore.getAllTimelines();
+    const timelines = timelineStore.timelines;
     const timeline3 = timelines.find((t) => t.id === 3)!;
     const timeline4 = timelines.find((t) => t.id === 4)!;
 
@@ -273,7 +281,7 @@ describe('SelectionManagerV2', () => {
   it('should automatically clear log/revision selection if newly selected timeline does not contain them (sync effect)', () => {
     const logs = Array.from(logStore.logs());
     const targetLog = logs[0];
-    const timelines = timelineStore.getAllTimelines();
+    const timelines = timelineStore.timelines;
     const unrelatedTimeline = timelines.find((t) => t.id === 1)!;
 
     // Select log (will select Log 1, Timeline 4, Revision 1)

--- a/web/src/app/services/selection-manager-v2.service.ts
+++ b/web/src/app/services/selection-manager-v2.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable, inject, signal, computed, effect } from '@angular/core';
+import { Injectable, inject, signal, computed } from '@angular/core';
 import { InspectionDataStoreV2 } from 'src/app/services/inspection-data-store-v2.service';
 import { Log } from 'src/app/store/domain/log';
 import { Timeline, Revision, Event } from 'src/app/store/domain/timeline';
@@ -188,36 +188,13 @@ export class SelectionManagerV2 {
     return new Set();
   });
 
-  constructor() {
-    // Synchronize selection status when selected timeline changes.
-    effect(() => {
-      const timeline = this.selectedTimeline();
-      if (!timeline) return;
-
-      const log = this.selectedLog();
-      const revision = this.selectedRevision();
-
-      if (
-        log &&
-        timeline.lookupEventFromLog(log) === null &&
-        timeline.lookupRevisionFromLog(log) === null
-      ) {
-        // Clear log selection if it's not part of the newly selected timeline.
-        this.onSelectLog(null);
-      }
-
-      if (revision && timeline.lookupRevisionFromLog(revision.log) === null) {
-        this.selectedRevision.set(null);
-      }
-    });
-  }
-
   /**
    * Handles selection of a timeline.
    * If the timeline is missing or null, the selection is cleared.
    */
   public onSelectTimeline(timeline?: ReadonlyDomainElement<Timeline> | null) {
     this.selectedTimeline.set(timeline ?? null);
+    this.synchronizeSelection();
   }
 
   /**
@@ -242,6 +219,7 @@ export class SelectionManagerV2 {
    */
   public onSelectLog(log: ReadonlyDomainElement<Log> | null) {
     this.changeSelectionByLogInternal(log, false);
+    this.synchronizeSelection();
   }
 
   /**
@@ -250,6 +228,7 @@ export class SelectionManagerV2 {
   public onSelectEvent(event: ReadonlyDomainElement<Event>) {
     this.selectedTimeline.set(event.timeline);
     this.changeSelectionByLogInternal(event.log, true);
+    this.synchronizeSelection();
   }
 
   /**
@@ -258,11 +237,39 @@ export class SelectionManagerV2 {
   public onSelectRevision(revision: ReadonlyDomainElement<Revision> | null) {
     if (revision === null) {
       this.selectedRevision.set(null);
+      this.synchronizeSelection();
       return;
     }
     this.selectedRevision.set(revision);
     this.selectedTimeline.set(revision.timeline);
     this.changeSelectionByLogInternal(revision.log, true);
+    this.synchronizeSelection();
+  }
+
+  /**
+   * Synchronizes and validates selection status when any dependent signals change.
+   *
+   * Clears the log or revision selection if they are not part of the currently selected timeline.
+   */
+  private synchronizeSelection() {
+    const timeline = this.selectedTimeline();
+    if (!timeline) return;
+
+    const log = this.selectedLog();
+    const revision = this.selectedRevision();
+
+    if (
+      log &&
+      timeline.lookupEventFromLog(log) === null &&
+      timeline.lookupRevisionFromLog(log) === null
+    ) {
+      // Clear log selection if it is not part of the newly selected timeline.
+      this.onSelectLog(null);
+    }
+
+    if (revision && timeline.lookupRevisionFromLog(revision.log) === null) {
+      this.selectedRevision.set(null);
+    }
   }
 
   private changeSelectionByLogInternal(
@@ -270,10 +277,7 @@ export class SelectionManagerV2 {
     ignoreResourceSelect: boolean,
   ) {
     this.selectedLogId.set(log ? log.id : null);
-    if (ignoreResourceSelect) return;
-
-    const selectedLog = this.selectedLog();
-    if (!selectedLog) return;
+    if (ignoreResourceSelect || !log) return;
 
     const timelines = this.filteredTimelines();
 
@@ -282,12 +286,12 @@ export class SelectionManagerV2 {
     let relatedEvent: ReadonlyDomainElement<Event> | null = null;
     let targetTimeline: ReadonlyDomainElement<Timeline> | null = null;
     for (const timeline of timelines) {
-      relatedRevision = timeline.lookupRevisionFromLog(selectedLog);
+      relatedRevision = timeline.lookupRevisionFromLog(log);
       if (relatedRevision !== null) {
         targetTimeline = timeline;
         break;
       }
-      relatedEvent = timeline.lookupEventFromLog(selectedLog);
+      relatedEvent = timeline.lookupEventFromLog(log);
       if (relatedEvent !== null) {
         targetTimeline = timeline;
         break;

--- a/web/src/app/services/selection-manager-v2.service.ts
+++ b/web/src/app/services/selection-manager-v2.service.ts
@@ -1,0 +1,311 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable, inject, signal, computed, effect } from '@angular/core';
+import { InspectionDataStoreV2 } from 'src/app/services/inspection-data-store-v2.service';
+import { Log } from 'src/app/store/domain/log';
+import { Timeline, Revision, Event } from 'src/app/store/domain/timeline';
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+
+/**
+ * SelectionManagerV2 provides selected/highlighted list of logs, timelines, revisions or events from the received user interaction.
+ * Signal-based modern version of SelectionManagerService.
+ */
+@Injectable({ providedIn: 'root' })
+export class SelectionManagerV2 {
+  private readonly inspectionDataStore = inject(InspectionDataStoreV2);
+
+  // Writable signals representing internal state.
+  private readonly selectedLogId = signal<number | null>(null);
+  private readonly highlightedLogIds = signal<Set<number>>(new Set<number>());
+  /**
+   * Computes all timelines available in the current inspection data.
+   */
+  private readonly filteredTimelines = computed<
+    ReadonlyDomainElement<Timeline[]>
+  >(() => this.inspectionDataStore.timelineView()?.filteredTimelines() ?? []);
+
+  /**
+   * Holds the currently selected timeline.
+   */
+  public readonly selectedTimeline =
+    signal<ReadonlyDomainElement<Timeline> | null>(null);
+
+  /**
+   * Holds the currently highlighted timeline.
+   */
+  public readonly highlightedTimeline =
+    signal<ReadonlyDomainElement<Timeline> | null>(null);
+
+  /**
+   * Holds the currently selected revision.
+   */
+  public readonly selectedRevision =
+    signal<ReadonlyDomainElement<Revision> | null>(null);
+
+  /**
+   * Indicates whether child timelines should be included in the timeline selection.
+   */
+  public readonly timelineSelectionShouldIncludeChildren =
+    signal<boolean>(true);
+
+  // Derived computed signals.
+
+  /**
+   * Computes the currently selected log based on the selection ID.
+   */
+  public readonly selectedLog = computed<ReadonlyDomainElement<Log> | null>(
+    () => {
+      const id = this.selectedLogId();
+      if (id === null) return null;
+      const data = this.inspectionDataStore.inspectionData();
+      if (!data) return null;
+      try {
+        return data.logStore.getLog(id);
+      } catch {
+        return null;
+      }
+    },
+  );
+
+  /**
+   * Computes the list of currently highlighted logs based on the highlight IDs.
+   */
+  public readonly highlightedLogs = computed<ReadonlyDomainElement<Log>[]>(
+    () => {
+      const data = this.inspectionDataStore.inspectionData();
+      if (!data) return [];
+      const ids = this.highlightedLogIds();
+      const result: ReadonlyDomainElement<Log>[] = [];
+      for (const id of ids) {
+        try {
+          result.push(data.logStore.getLog(id));
+        } catch {
+          // Ignore invalid IDs
+        }
+      }
+      return result;
+    },
+  );
+
+  /**
+   * Computes the index of the currently selected log.
+   * Returns -1 if no log is selected.
+   */
+  public readonly selectedLogIndex = computed<number>(() => {
+    const l = this.selectedLog();
+    return l !== null ? l.logIndex : -1;
+  });
+
+  /**
+   * Computes a set of indices of the currently highlighted logs.
+   */
+  public readonly highlightLogIndices = computed<Set<number>>(() => {
+    const data = this.inspectionDataStore.inspectionData();
+    if (!data) return new Set();
+    const ids = this.highlightedLogIds();
+    const indices = new Set<number>();
+    for (const id of ids) {
+      try {
+        indices.add(data.logStore.getIndex(id));
+      } catch {
+        // Ignore
+      }
+    }
+    return indices;
+  });
+
+  /**
+   * Computes the revisions on the current highlighted timeline that correspond to highlighted logs.
+   */
+  public readonly highlightedRevisionsOnCurrentTimeline = computed<
+    ReadonlyDomainElement<Revision>[]
+  >(() => {
+    const timeline = this.highlightedTimeline();
+    const logIndices = this.highlightLogIndices();
+    const result: ReadonlyDomainElement<Revision>[] = [];
+    if (timeline === null) return result;
+    for (const revision of timeline.revisions) {
+      if (logIndices.has(revision.logIndex)) {
+        result.push(revision);
+      }
+    }
+    return result;
+  });
+
+  /**
+   * Computes the revision that precedes the currently selected revision on the same timeline.
+   */
+  public readonly previousOfSelectedRevision =
+    computed<ReadonlyDomainElement<Revision> | null>(() => {
+      const revision = this.selectedRevision();
+      const timeline = this.selectedTimeline();
+      if (revision === null || timeline === null) return null;
+      const revisionIndex = timeline.revisions.indexOf(revision);
+      return revisionIndex > 0 ? timeline.revisions[revisionIndex - 1] : null;
+    });
+
+  /**
+   * Computes the list of selected timelines including their descendants if configured.
+   */
+  public readonly selectedTimelinesWithChildren = computed<
+    ReadonlyDomainElement<Timeline>[]
+  >(() => {
+    const selectedTimeline = this.selectedTimeline();
+    const shouldIncludeChild = this.timelineSelectionShouldIncludeChildren();
+    if (!selectedTimeline) return [];
+    if (!shouldIncludeChild) return [selectedTimeline];
+    return [selectedTimeline, ...selectedTimeline.descendants()];
+  });
+
+  /**
+   * Computes the set of descendant timelines of the selected timeline that should be highlighted.
+   */
+  public readonly highlightedChildrenOfSelectedTimeline = computed<
+    Set<ReadonlyDomainElement<Timeline>>
+  >(() => {
+    const selectedTimeline = this.selectedTimeline();
+    const includeChildren = this.timelineSelectionShouldIncludeChildren();
+    const allTimelines = this.filteredTimelines();
+    if (!includeChildren || selectedTimeline === null) return new Set();
+    for (const timeline of allTimelines) {
+      if (timeline === selectedTimeline) {
+        return new Set(timeline.descendants());
+      }
+    }
+    return new Set();
+  });
+
+  constructor() {
+    // Synchronize selection status when selected timeline changes.
+    effect(() => {
+      const timeline = this.selectedTimeline();
+      if (!timeline) return;
+
+      const log = this.selectedLog();
+      const revision = this.selectedRevision();
+
+      if (
+        log &&
+        timeline.lookupEventFromLog(log) === null &&
+        timeline.lookupRevisionFromLog(log) === null
+      ) {
+        // Clear log selection if it's not part of the newly selected timeline.
+        this.onSelectLog(null);
+      }
+
+      if (revision && timeline.lookupRevisionFromLog(revision.log) === null) {
+        this.selectedRevision.set(null);
+      }
+    });
+  }
+
+  /**
+   * Handles selection of a timeline.
+   * If the timeline is missing or null, the selection is cleared.
+   */
+  public onSelectTimeline(timeline?: ReadonlyDomainElement<Timeline> | null) {
+    this.selectedTimeline.set(timeline ?? null);
+  }
+
+  /**
+   * Handles highlighting of a timeline.
+   * If the timeline is missing or null, the highlight is cleared.
+   */
+  public onHighlightTimeline(
+    timeline?: ReadonlyDomainElement<Timeline> | null,
+  ) {
+    this.highlightedTimeline.set(timeline ?? null);
+  }
+
+  /**
+   * Highlights specific log entries.
+   */
+  public onHighlightLog(...logs: ReadonlyDomainElement<Log>[]) {
+    this.highlightedLogIds.set(new Set(logs.map((log) => log.id)));
+  }
+
+  /**
+   * Selects a log entry and updates dependent selections.
+   */
+  public onSelectLog(log: ReadonlyDomainElement<Log> | null) {
+    this.changeSelectionByLogInternal(log, false);
+  }
+
+  /**
+   * Selects an event and updates timeline and log selections.
+   */
+  public onSelectEvent(event: ReadonlyDomainElement<Event>) {
+    this.selectedTimeline.set(event.timeline);
+    this.changeSelectionByLogInternal(event.log, true);
+  }
+
+  /**
+   * Selects a revision and updates timeline and log selections.
+   */
+  public onSelectRevision(revision: ReadonlyDomainElement<Revision> | null) {
+    if (revision === null) {
+      this.selectedRevision.set(null);
+      return;
+    }
+    this.selectedRevision.set(revision);
+    this.selectedTimeline.set(revision.timeline);
+    this.changeSelectionByLogInternal(revision.log, true);
+  }
+
+  private changeSelectionByLogInternal(
+    log: ReadonlyDomainElement<Log> | null,
+    ignoreResourceSelect: boolean,
+  ) {
+    this.selectedLogId.set(log ? log.id : null);
+    if (ignoreResourceSelect) return;
+
+    const selectedLog = this.selectedLog();
+    if (!selectedLog) return;
+
+    const timelines = this.filteredTimelines();
+
+    // Find the timeline and the matching revision or event in a single pass using binary search
+    let relatedRevision: ReadonlyDomainElement<Revision> | null = null;
+    let relatedEvent: ReadonlyDomainElement<Event> | null = null;
+    let targetTimeline: ReadonlyDomainElement<Timeline> | null = null;
+    for (const timeline of timelines) {
+      relatedRevision = timeline.lookupRevisionFromLog(selectedLog);
+      if (relatedRevision !== null) {
+        targetTimeline = timeline;
+        break;
+      }
+      relatedEvent = timeline.lookupEventFromLog(selectedLog);
+      if (relatedEvent !== null) {
+        targetTimeline = timeline;
+        break;
+      }
+    }
+    if (!targetTimeline) return;
+
+    if (relatedRevision) {
+      this.selectedRevision.set(relatedRevision);
+      this.selectedTimeline.set(targetTimeline);
+      this.changeSelectionByLogInternal(relatedRevision.log, true);
+      return;
+    }
+
+    if (relatedEvent) {
+      this.selectedTimeline.set(targetTimeline);
+      this.changeSelectionByLogInternal(relatedEvent.log, true);
+      return;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds new `InspectionDataStoreV2` and `SelectionManagerV2` services that uses the new domain stores.
We'll replace all the components dependency with these V2 services and eventually remove the non suffixed services.