### PR TITLE
extend memory limit for ng lint

### DIFF
--- a/scripts/make/hooks.mk
+++ b/scripts/make/hooks.mk
@@ -1,3 +1,4 @@
+export NODE_OPTIONS ?= --max-old-space-size=4096
 
 .PHONY: pre-commit
 pre-commit: ## Run pre-commit checks (internal)


### PR DESCRIPTION
`make pre-commit` command may fail due to the error written on the following article.
https://zenn.dev/yusuke_docha/articles/f8c3cd88302d16