### PR TITLE
Remove @type field contained in `request` and `respone` of the protoPayload in audit logs

### DIFF
--- a/pkg/common/structured/field_filter.go
+++ b/pkg/common/structured/field_filter.go
@@ -1,0 +1,61 @@
+package structured
+
+// fieldFilterNode wraps an existing Node and filters its children by ignoring specific keys.
+type fieldFilterNode struct {
+	original Node
+	ignored  map[string]struct{}
+}
+
+var _ Node = (*fieldFilterNode)(nil)
+
+// NewFieldFilterNode returns a filtered Node that wraps the original Node.
+// It filters out any map children whose keys are present in the ignored keys list.
+func NewFieldFilterNode(original Node, keys []string) Node {
+	ignored := make(map[string]struct{})
+	for _, key := range keys {
+		ignored[key] = struct{}{}
+	}
+	return &fieldFilterNode{
+		original: original,
+		ignored:  ignored,
+	}
+}
+
+// Type returns the NodeType of the wrapped original node.
+func (n *fieldFilterNode) Type() NodeType {
+	return n.original.Type()
+}
+
+// NodeScalarValue returns the scalar value of the wrapped original node, or an error if it is not a scalar node.
+func (n *fieldFilterNode) NodeScalarValue() (any, error) {
+	return n.original.NodeScalarValue()
+}
+
+// Children returns a filtered iterator of the original node's children.
+// Children whose keys are present in the ignored list are skipped.
+func (n *fieldFilterNode) Children() NodeChildrenIterator {
+	return func(callback func(key NodeChildrenKey, value Node) bool) {
+		index := 0
+		n.original.Children()(func(key NodeChildrenKey, value Node) bool {
+			if _, ok := n.ignored[key.Key]; ok {
+				return true
+			}
+			next := NodeChildrenKey{
+				Index: index,
+				Key:   key.Key,
+			}
+			index += 1
+			return callback(next, value)
+		})
+	}
+}
+
+// Len returns the number of children after filtering out ignored keys.
+func (n *fieldFilterNode) Len() int {
+	count := 0
+	n.Children()(func(key NodeChildrenKey, value Node) bool {
+		count += 1
+		return true
+	})
+	return count
+}

--- a/pkg/common/structured/field_filter.go
+++ b/pkg/common/structured/field_filter.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package structured
 
 // fieldFilterNode wraps an existing Node and filters its children by ignoring specific keys.

--- a/pkg/common/structured/field_filter.go
+++ b/pkg/common/structured/field_filter.go
@@ -25,6 +25,12 @@ var _ Node = (*fieldFilterNode)(nil)
 // NewFieldFilterNode returns a filtered Node that wraps the original Node.
 // It filters out any map children whose keys are present in the ignored keys list.
 func NewFieldFilterNode(original Node, keys []string) Node {
+	if original == nil {
+		return nil
+	}
+	if original.Type() != MapNodeType {
+		return original
+	}
 	ignored := make(map[string]struct{})
 	for _, key := range keys {
 		ignored[key] = struct{}{}

--- a/pkg/common/structured/field_filter_test.go
+++ b/pkg/common/structured/field_filter_test.go
@@ -111,27 +111,17 @@ func TestFieldFilterNode(t *testing.T) {
 			},
 		},
 		{
-			name:          "sequence node - ignored key is ignored on sequences",
-			originalVal:   []any{"x", "y"},
-			ignoredKeys:   []string{"x"},
-			wantType:      SequenceNodeType,
-			wantScalar:    nil,
-			wantScalarErr: true,
-			wantLen:       2,
-			wantChildren: []childItem{
-				{Index: 0, Key: "", Value: "x"},
-				{Index: 1, Key: "", Value: "y"},
-			},
-		},
-		{
 			name:          "sequence node - filter with empty key",
 			originalVal:   []any{"x", "y"},
 			ignoredKeys:   []string{""},
 			wantType:      SequenceNodeType,
 			wantScalar:    nil,
 			wantScalarErr: true,
-			wantLen:       0,
-			wantChildren:  nil,
+			wantLen:       2,
+			wantChildren: []childItem{
+				{Index: 0, Value: "x"},
+				{Index: 1, Value: "y"},
+			},
 		},
 	}
 

--- a/pkg/common/structured/field_filter_test.go
+++ b/pkg/common/structured/field_filter_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package structured
 
 import (

--- a/pkg/common/structured/field_filter_test.go
+++ b/pkg/common/structured/field_filter_test.go
@@ -1,0 +1,165 @@
+package structured
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type childItem struct {
+	Index int
+	Key   string
+	Value any
+}
+
+func getChildren(node Node) ([]childItem, error) {
+	var children []childItem
+	var err error
+	node.Children()(func(key NodeChildrenKey, value Node) bool {
+		var val any
+		if value.Type() == ScalarNodeType {
+			val, err = value.NodeScalarValue()
+			if err != nil {
+				return false
+			}
+		} else {
+			val = value.Type()
+		}
+		children = append(children, childItem{
+			Index: key.Index,
+			Key:   key.Key,
+			Value: val,
+		})
+		return true
+	})
+	return children, err
+}
+
+func TestFieldFilterNode(t *testing.T) {
+	orderProvider := &AlphabeticalGoMapKeyOrderProvider{}
+
+	testCases := []struct {
+		name          string
+		originalVal   any
+		ignoredKeys   []string
+		wantType      NodeType
+		wantScalar    any
+		wantScalarErr bool
+		wantLen       int
+		wantChildren  []childItem
+	}{
+		{
+			name:          "scalar node - no filtering",
+			originalVal:   "hello",
+			ignoredKeys:   []string{"hello"},
+			wantType:      ScalarNodeType,
+			wantScalar:    "hello",
+			wantScalarErr: false,
+			wantLen:       0,
+			wantChildren:  nil,
+		},
+		{
+			name:          "map node - filter one key",
+			originalVal:   map[string]any{"a": 1, "b": 2, "c": 3},
+			ignoredKeys:   []string{"b"},
+			wantType:      MapNodeType,
+			wantScalar:    nil,
+			wantScalarErr: true,
+			wantLen:       2,
+			wantChildren: []childItem{
+				{Index: 0, Key: "a", Value: 1},
+				{Index: 1, Key: "c", Value: 3},
+			},
+		},
+		{
+			name:          "map node - filter multiple keys",
+			originalVal:   map[string]any{"a": 1, "b": 2, "c": 3},
+			ignoredKeys:   []string{"a", "c"},
+			wantType:      MapNodeType,
+			wantScalar:    nil,
+			wantScalarErr: true,
+			wantLen:       1,
+			wantChildren: []childItem{
+				{Index: 0, Key: "b", Value: 2},
+			},
+		},
+		{
+			name:          "map node - filter non-existent key",
+			originalVal:   map[string]any{"a": 1, "b": 2},
+			ignoredKeys:   []string{"non-existent"},
+			wantType:      MapNodeType,
+			wantScalar:    nil,
+			wantScalarErr: true,
+			wantLen:       2,
+			wantChildren: []childItem{
+				{Index: 0, Key: "a", Value: 1},
+				{Index: 1, Key: "b", Value: 2},
+			},
+		},
+		{
+			name:          "sequence node - ignored key is ignored on sequences",
+			originalVal:   []any{"x", "y"},
+			ignoredKeys:   []string{"x"},
+			wantType:      SequenceNodeType,
+			wantScalar:    nil,
+			wantScalarErr: true,
+			wantLen:       2,
+			wantChildren: []childItem{
+				{Index: 0, Key: "", Value: "x"},
+				{Index: 1, Key: "", Value: "y"},
+			},
+		},
+		{
+			name:          "sequence node - filter with empty key",
+			originalVal:   []any{"x", "y"},
+			ignoredKeys:   []string{""},
+			wantType:      SequenceNodeType,
+			wantScalar:    nil,
+			wantScalarErr: true,
+			wantLen:       0,
+			wantChildren:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalNode, err := FromGoValue(tc.originalVal, orderProvider)
+			if err != nil {
+				t.Fatalf("FromGoValue failed: %v", err)
+			}
+
+			filterNode := NewFieldFilterNode(originalNode, tc.ignoredKeys)
+
+			if gotType := filterNode.Type(); gotType != tc.wantType {
+				t.Errorf("Type() mismatch: got %v, want %v", gotType, tc.wantType)
+			}
+
+			gotScalar, gotScalarErr := filterNode.NodeScalarValue()
+			if tc.wantScalarErr {
+				if gotScalarErr == nil {
+					t.Errorf("NodeScalarValue() expected error, got nil")
+				}
+			} else {
+				if gotScalarErr != nil {
+					t.Errorf("NodeScalarValue() unexpected error: %v", gotScalarErr)
+				}
+				if diff := cmp.Diff(tc.wantScalar, gotScalar); diff != "" {
+					t.Errorf("NodeScalarValue() mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			if gotLen := filterNode.Len(); gotLen != tc.wantLen {
+				t.Errorf("Len() mismatch: got %d, want %d", gotLen, tc.wantLen)
+			}
+
+			gotChildren, err := getChildren(filterNode)
+			if err != nil {
+				t.Fatalf("failed to get children: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantChildren, gotChildren); diff != "" {
+				t.Errorf("Children() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
@@ -138,7 +138,7 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 		}
 	}
 	// request or response may contain its proto type as @type. Removing it because its not a k8s field.
-	if currentBodyReader != nil{
+	if currentBodyReader != nil {
 		currentBodyReader = structured.NewNodeReader(structured.NewFieldFilterNode(currentBodyReader.Node, []string{"@type"}))
 	}
 	if currentBodyReader == nil {

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -72,8 +71,6 @@ var ManifestGeneratorTask = inspectiontaskbase.NewProgressReportableInspectionTa
 	grp.SetLimit(runtime.GOMAXPROCS(0))
 
 	for path, group := range logGroups {
-		path := path
-		group := group
 		grp.Go(func() error {
 			defer doneGroupCount.Add(1)
 			resourceLogs := []*commonlogk8saudit_contract.ResourceManifestLog{}
@@ -140,7 +137,10 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 			partial = true
 		}
 	}
-
+	// request or response may contain its proto type as @type. Removing it because its not a k8s field.
+	if currentBodyReader != nil{
+		currentBodyReader = structured.NewNodeReader(structured.NewFieldFilterNode(currentBodyReader.Node, []string{"@type"}))
+	}
 	if currentBodyReader == nil {
 		return &commonlogk8saudit_contract.ResourceManifestLog{
 			Log:                l,
@@ -203,7 +203,6 @@ kind: %s
 		slog.WarnContext(ctx, fmt.Sprintf("failed to serialize resource body to yaml\n%s", err.Error()))
 	}
 	currentRevisionBody := string(currentRevisionBodyRaw)
-	currentRevisionBody = removeAtType(currentRevisionBody)
 
 	if fieldSet.Verb == commonlogk8saudit_contract.VerbPatch && partial {
 		mergeConfigResolver := g.mergeConfigRegistry.Get(fieldSet.APIVersion, commonlogk8saudit_contract.GetSingularKindName(fieldSet.PluralKind))
@@ -212,7 +211,6 @@ kind: %s
 			ArrayMergeConfigResolver: mergeConfigResolver,
 		})
 		var mergedNodeReader *structured.NodeReader
-		var mergedYAML string
 		if err != nil {
 			slog.WarnContext(ctx, fmt.Sprintf("failed to merge resource body\n%s", err.Error()))
 			return &commonlogk8saudit_contract.ResourceManifestLog{
@@ -226,8 +224,7 @@ kind: %s
 			if err != nil {
 				slog.WarnContext(ctx, fmt.Sprintf("failed to read the merged resource body\n%s", err.Error()))
 			}
-			mergedYAML = removeAtType(string(mergedYAMLRaw))
-			g.prevRevisionBody = mergedYAML
+			g.prevRevisionBody = string(mergedYAMLRaw)
 			g.prevRevisionReader = mergedNodeReader
 			return &commonlogk8saudit_contract.ResourceManifestLog{
 				Log:                l,
@@ -253,17 +250,4 @@ kind: %s
 			ResourceBodyReader: g.prevRevisionReader,
 		}, nil
 	}
-}
-
-// removeAtType removes @type in response or request payload.
-func removeAtType(yamlString string) string {
-	lines := strings.Split(yamlString, "\n")
-	var result []string
-	for _, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), "'@type'") {
-			continue
-		}
-		result = append(result, line)
-	}
-	return strings.Join(result, "\n")
 }


### PR DESCRIPTION
Audit logs in Google Cloud may contain `@type` field under `request` or `response` of audit logs.
This can be included in the merged manifest result and even that is actually not included in the resource state at the past time. This PR removes the `@type` field from the merged struct.