### PR TITLE
Index severity field with timeline filter

### DIFF
--- a/web/src/app/store/domain/filter/cel-env.spec.ts
+++ b/web/src/app/store/domain/filter/cel-env.spec.ts
@@ -21,12 +21,24 @@ import {
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { Timeline } from 'src/app/store/domain/timeline';
 import { Log } from 'src/app/store/domain/log';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { LogStore } from 'src/app/store/domain/log-store';
 
 describe('CELTimelineFilterEnvironment', () => {
   let env: CELTimelineFilterEnvironment;
+  let internPool: InternPoolStore;
+  let styleStore: StyleStore;
+  let logStore: LogStore;
+  let timelineStore: TimelineStore;
 
   beforeEach(() => {
     env = new CELTimelineFilterEnvironment();
+    internPool = new InternPoolStore();
+    styleStore = new StyleStore();
+    logStore = new LogStore(internPool, styleStore);
+    timelineStore = new TimelineStore(internPool, styleStore, logStore);
   });
 
   it('should successfully compile a valid CEL expression', () => {
@@ -51,7 +63,7 @@ describe('CELTimelineFilterEnvironment', () => {
       revisions: [],
     } as unknown as ReadonlyDomainElement<Timeline>;
 
-    expect(env.evaluate(mockTimeline)).toBe(true);
+    expect(env.evaluate(mockTimeline, timelineStore)).toBe(true);
   });
 
   it('should return failure for syntactically invalid CEL expression', () => {
@@ -79,8 +91,8 @@ describe('CELTimelineFilterEnvironment', () => {
 
     env.compile("name == 'T1' && timelineType == 'pod'");
 
-    expect(env.evaluate(timeline1)).toBe(true);
-    expect(env.evaluate(timeline2)).toBe(false);
+    expect(env.evaluate(timeline1, timelineStore)).toBe(true);
+    expect(env.evaluate(timeline2, timelineStore)).toBe(false);
   });
 
   it('should resolve timeline path map correctly', () => {
@@ -96,10 +108,10 @@ describe('CELTimelineFilterEnvironment', () => {
     } as unknown as ReadonlyDomainElement<Timeline>;
 
     env.compile("path['namespace'] == 'default' && path['name'] == 'pod-a'");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("path['namespace'] == 'kube-system'");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
   });
 
   it('should support severity constants during evaluation', () => {
@@ -114,7 +126,7 @@ describe('CELTimelineFilterEnvironment', () => {
       revisions: [],
     } as unknown as ReadonlyDomainElement<Timeline>;
 
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
   });
 
   it('should support match() and M() functions with a single pattern', () => {
@@ -131,17 +143,17 @@ describe('CELTimelineFilterEnvironment', () => {
 
     // Match with key and pattern
     env.compile("match('Namespace', 'kube-.*')");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("M('Namespace', 'default')");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
 
     // Wildcard match
     env.compile("match('apiserver')");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("M('default')");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
   });
 
   it('should support match() and M() functions with a list of patterns', () => {
@@ -154,16 +166,16 @@ describe('CELTimelineFilterEnvironment', () => {
     } as unknown as ReadonlyDomainElement<Timeline>;
 
     env.compile("match('Namespace', ['default', 'kube-.*'])");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("M('Namespace', ['default', 'non-matching'])");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
 
     env.compile("match(['default', 'system'])");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("M(['default', 'non-matching'])");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
   });
 
   it('should support revision_body() and RB() functions with a single pattern', () => {
@@ -194,17 +206,17 @@ describe('CELTimelineFilterEnvironment', () => {
     } as unknown as ReadonlyDomainElement<Timeline>;
 
     env.compile("revision_body('spec.replicas', '3')");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("RB('spec.replicas', '5')");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
 
     // Wildcard match
     env.compile("revision_body('replicas')");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("RB('non-existent')");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
   });
 
   it('should support revision_body() and RB() functions with a list of patterns', () => {
@@ -235,17 +247,103 @@ describe('CELTimelineFilterEnvironment', () => {
     } as unknown as ReadonlyDomainElement<Timeline>;
 
     env.compile("revision_body('spec.replicas', ['1', '3'])");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("RB('spec.replicas', ['1', '5'])");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
 
     // Wildcard list match
     env.compile("revision_body(['replicas', 'other'])");
-    expect(env.evaluate(timeline)).toBe(true);
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
 
     env.compile("RB(['other', 'non-matching'])");
-    expect(env.evaluate(timeline)).toBe(false);
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
+  });
+
+  it('should support minSeverity() function correctly', () => {
+    internPool.addStrings([{ id: 1, value: 'timeline-name' }]);
+
+    const mockColor = { r: 0, g: 0, b: 0, a: 1 };
+    styleStore.addTimelineTypes([
+      {
+        id: 1,
+        label: 'type-a',
+        description: 'desc',
+        icon: '',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        typeChipBackgroundColor: mockColor,
+        visible: true,
+        sortPriority: 0,
+        height: 1,
+      },
+    ]);
+
+    styleStore.addSeverities([
+      {
+        id: 1,
+        label: 'INFO',
+        shortLabel: 'I',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 1,
+      },
+      {
+        id: 2,
+        label: 'WARNING',
+        shortLabel: 'W',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 2,
+      },
+      {
+        id: 3,
+        label: 'ERROR',
+        shortLabel: 'E',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 3,
+      },
+    ]);
+
+    const logs = [
+      { id: 1, ts: 10n, logTypeId: 1, severityTypeId: 2, summaryStringId: 1 },
+    ];
+    logStore.initialize(logs, 1);
+
+    const rawTimelines = [
+      {
+        id: 10,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [100],
+        eventIds: [],
+      },
+    ];
+    const rawRevisions = [
+      {
+        id: 100,
+        logId: 1,
+        changedTime: 10n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+      },
+    ];
+
+    timelineStore.initialize(rawTimelines, 1, rawRevisions, 1, [], 0);
+
+    const timeline = timelineStore.getTimeline(10);
+
+    env.compile('minSeverity(WARNING)');
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
+
+    env.compile('minSeverity(ERROR)');
+    expect(env.evaluate(timeline, timelineStore)).toBe(false);
+
+    env.compile('minSeverity(INFO)');
+    expect(env.evaluate(timeline, timelineStore)).toBe(true);
   });
 });
 

--- a/web/src/app/store/domain/filter/cel-env.ts
+++ b/web/src/app/store/domain/filter/cel-env.ts
@@ -18,6 +18,7 @@ import { Environment } from '@marcbachmann/cel-js';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { Timeline } from 'src/app/store/domain/timeline';
 import { Log } from 'src/app/store/domain/log';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
 import {
   CELLog,
   CELTimeline,
@@ -46,6 +47,8 @@ export class CELTimelineFilterEnvironment {
   private readonly environment: Environment;
   private evaluator?: (ctx: CELTimeline) => boolean;
   private currentTimeline?: CELTimeline;
+  private currentTimelineStore?: TimelineStore;
+  private currentRawTimeline?: ReadonlyDomainElement<Timeline>;
 
   /**
    * Initializes the CEL Environment with unlistedVariablesAreDyn disabled to enforce strict variable registration.
@@ -150,6 +153,9 @@ export class CELTimelineFilterEnvironment {
       )
       .registerFunction('RB(list): bool', (v) =>
         matchTimelineRevisionBodyField(this.currentTimeline, '*', v),
+      )
+      .registerFunction('minSeverity(int): bool', (minOrder) =>
+        this.evaluateMinSeverity(Number(minOrder)),
       );
   }
 
@@ -189,21 +195,39 @@ export class CELTimelineFilterEnvironment {
   /**
    * Evaluates a raw Timeline element against the compiled CEL expression.
    *
-   * @param timeline - Raw Timeline element
-   * @returns True if the timeline passes the filter
+   * @param timeline - Raw Timeline element.
+   * @param timelineStore - The store managing timelines and severities.
+   * @returns True if the timeline passes the filter.
    */
-  public evaluate(timeline: ReadonlyDomainElement<Timeline>): boolean {
+  public evaluate(
+    timeline: ReadonlyDomainElement<Timeline>,
+    timelineStore: TimelineStore,
+  ): boolean {
     if (!this.evaluator) {
       return true; // Pass-through if no active expression
     }
 
     const celTimeline = toCelTimeline(timeline);
     this.currentTimeline = celTimeline;
+    this.currentTimelineStore = timelineStore;
+    this.currentRawTimeline = timeline;
     try {
       return this.evaluator(celTimeline);
     } finally {
       this.currentTimeline = undefined;
+      this.currentTimelineStore = undefined;
+      this.currentRawTimeline = undefined;
     }
+  }
+
+  private evaluateMinSeverity(minOrder: number): boolean {
+    if (!this.currentRawTimeline || !this.currentTimelineStore) {
+      return false;
+    }
+    const severities = this.currentTimelineStore.styleStore.severities.filter(
+      (s) => s.order >= minOrder,
+    );
+    return this.currentRawTimeline.hasSeverity(...severities);
   }
 }
 

--- a/web/src/app/store/domain/filter/cel-env.ts
+++ b/web/src/app/store/domain/filter/cel-env.ts
@@ -31,6 +31,7 @@ import {
   matchTimelinePath,
   matchTimelineRevisionBodyField,
 } from 'src/app/store/domain/filter/cel-functions';
+import { Severity } from 'src/app/store/domain/style';
 
 const SEVERITY_LEVELS = {
   UNKNOWN: 0n,
@@ -49,6 +50,10 @@ export class CELTimelineFilterEnvironment {
   private currentTimeline?: CELTimeline;
   private currentTimelineStore?: TimelineStore;
   private currentRawTimeline?: ReadonlyDomainElement<Timeline>;
+  private readonly minSeverityCache = new Map<
+    number,
+    readonly ReadonlyDomainElement<ReadonlyDomainElement<Severity>>[]
+  >();
 
   /**
    * Initializes the CEL Environment with unlistedVariablesAreDyn disabled to enforce strict variable registration.
@@ -224,9 +229,13 @@ export class CELTimelineFilterEnvironment {
     if (!this.currentRawTimeline || !this.currentTimelineStore) {
       return false;
     }
-    const severities = this.currentTimelineStore.styleStore.severities.filter(
-      (s) => s.order >= minOrder,
-    );
+    let severities = this.minSeverityCache.get(minOrder);
+    if (!severities) {
+      severities = this.currentTimelineStore.styleStore.severities.filter(
+        (s) => s.order >= minOrder,
+      );
+      this.minSeverityCache.set(minOrder, severities);
+    }
     return this.currentRawTimeline.hasSeverity(...severities);
   }
 }

--- a/web/src/app/store/domain/filter/cel-filter.ts
+++ b/web/src/app/store/domain/filter/cel-filter.ts
@@ -92,7 +92,7 @@ export class CelTimelineFilter implements LogTimelineFilter {
         throw new CancellationError();
       }
       const t = timelineStore.getTimeline(id);
-      if (this.celEnv.evaluate(t)) {
+      if (this.celEnv.evaluate(t, timelineStore)) {
         passedTimelineIds.add(id);
       }
       count++;

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -107,6 +107,11 @@ describe('TimelineStore', () => {
       { id: 2, value: 'principal-y' },
     ]);
 
+    const logs = [
+      { id: 1, ts: 10n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+    ];
+    logStore.initialize(logs, 1);
+
     const rawTimelines: TimelineDTO[] = [
       {
         id: 10,
@@ -147,6 +152,227 @@ describe('TimelineStore', () => {
     const all = store.timelines;
     expect(all.length).toBe(1);
     expect(all[0].id).toBe(10);
+  });
+
+  it('should correctly build severity index for timelines', () => {
+    internPool.addStrings([
+      { id: 1, value: 'timeline-x' },
+      { id: 2, value: 'principal-y' },
+    ]);
+
+    // Severity 1: Info, Severity 2: Warning
+    styleStore.addSeverities([
+      {
+        id: 1,
+        label: 'Info',
+        shortLabel: 'I',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 1,
+      },
+      {
+        id: 2,
+        label: 'Warning',
+        shortLabel: 'W',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 2,
+      },
+    ]);
+
+    const logs = [
+      { id: 1, ts: 10n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+      { id: 2, ts: 20n, logTypeId: 1, severityTypeId: 2, summaryStringId: 1 },
+    ];
+    logStore.initialize(logs, 2);
+
+    const rawTimelines: TimelineDTO[] = [
+      {
+        id: 10,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [100],
+        eventIds: [],
+      },
+      {
+        id: 20,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [200],
+      },
+      {
+        id: 30,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [],
+      },
+    ];
+
+    const rawRevisions: RevisionDTO[] = [
+      {
+        id: 100,
+        logId: 1,
+        changedTime: 10n,
+        principalStringId: 2,
+        verbTypeId: 1,
+        stateTypeId: 1,
+      },
+    ];
+
+    const rawEvents: EventDTO[] = [
+      {
+        id: 200,
+        logId: 2,
+      },
+    ];
+
+    store.initialize(rawTimelines, 3, rawRevisions, 1, rawEvents, 1);
+
+    const s1 = styleStore.getSeverity(1);
+    const s2 = styleStore.getSeverity(2);
+
+    const t1 = store.getTimeline(10);
+    expect(t1.hasSeverity(s1)).toBeTrue();
+    expect(t1.hasSeverity(s2)).toBeFalse();
+
+    const t2 = store.getTimeline(20);
+    expect(t2.hasSeverity(s1)).toBeFalse();
+    expect(t2.hasSeverity(s2)).toBeTrue();
+
+    const t3 = store.getTimeline(30);
+    expect(t3.hasSeverity(s1)).toBeFalse();
+    expect(t3.hasSeverity(s2)).toBeFalse();
+
+    // Invalid severity ID
+    expect(
+      t1.hasSeverity({
+        id: 99,
+        label: 'invalid',
+        shortLabel: 'inv',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 99,
+      }),
+    ).toBeFalse();
+  });
+
+  it('should correctly check if timeline has severities', () => {
+    internPool.addStrings([
+      { id: 1, value: 'timeline-x' },
+      { id: 2, value: 'principal-y' },
+    ]);
+
+    // Severity 1: Info (order 1), Severity 2: Warning (order 2), Severity 3: Error (order 3)
+    styleStore.addSeverities([
+      {
+        id: 1,
+        label: 'Info',
+        shortLabel: 'I',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 1,
+      },
+      {
+        id: 2,
+        label: 'Warning',
+        shortLabel: 'W',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 2,
+      },
+      {
+        id: 3,
+        label: 'Error',
+        shortLabel: 'E',
+        backgroundColor: mockColor,
+        foregroundColor: mockColor,
+        order: 3,
+      },
+    ]);
+
+    const logs = [
+      { id: 1, ts: 10n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+      { id: 2, ts: 20n, logTypeId: 1, severityTypeId: 2, summaryStringId: 1 },
+      { id: 3, ts: 30n, logTypeId: 1, severityTypeId: 3, summaryStringId: 1 },
+    ];
+    logStore.initialize(logs, 3);
+
+    const rawTimelines: TimelineDTO[] = [
+      {
+        id: 10,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [100],
+        eventIds: [],
+      },
+      {
+        id: 20,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [200],
+      },
+      {
+        id: 30,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [300],
+      },
+    ];
+
+    const rawRevisions: RevisionDTO[] = [
+      {
+        id: 100,
+        logId: 1,
+        changedTime: 10n,
+        principalStringId: 2,
+        verbTypeId: 1,
+        stateTypeId: 1,
+      },
+    ];
+
+    const rawEvents: EventDTO[] = [
+      {
+        id: 200,
+        logId: 2,
+      },
+      {
+        id: 300,
+        logId: 3,
+      },
+    ];
+
+    store.initialize(rawTimelines, 3, rawRevisions, 1, rawEvents, 2);
+
+    const s1 = styleStore.getSeverity(1);
+    const s2 = styleStore.getSeverity(2);
+    const s3 = styleStore.getSeverity(3);
+
+    const t1 = store.getTimeline(10);
+    const t2 = store.getTimeline(20);
+    const t3 = store.getTimeline(30);
+
+    // Single severity checks
+    expect(t1.hasSeverity(s1)).toBeTrue();
+    expect(t1.hasSeverity(s2)).toBeFalse();
+
+    // Multiple severity checks
+    expect(t1.hasSeverity(s1, s2)).toBeTrue();
+    expect(t2.hasSeverity(s2, s3)).toBeTrue();
+    expect(t3.hasSeverity(s1, s2)).toBeFalse();
+    expect(t3.hasSeverity(s3)).toBeTrue();
+
+    // Empty severities list
+    expect(t1.hasSeverity()).toBeFalse();
   });
 
   it('should correctly decode timeline traversal path', () => {

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -24,7 +24,12 @@ import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { InternedStructDecoder } from 'src/app/store/domain/struct-decoder';
 import { InternedStructSchema } from 'src/app/generated/khifile/shared_pb';
-import { RevisionState, TimelineType, Verb } from 'src/app/store/domain/style';
+import {
+  RevisionState,
+  Severity,
+  TimelineType,
+  Verb,
+} from 'src/app/store/domain/style';
 import { LogStore } from 'src/app/store/domain/log-store';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { fromBinary } from '@bufbuild/protobuf';
@@ -71,6 +76,7 @@ export class TimelineStore {
   private timelineTypeIds = new Uint32Array(0);
   private timelineNameStringIds = new Uint32Array(0);
   private timelineParentIds = new Uint32Array(0);
+  private timelineSeverities = new Uint8Array(0);
   private readonly timelineRevisionIds: Uint32Array[] = [];
   private readonly timelineEventIds: Uint32Array[] = [];
   private readonly timelineChildrenIds: number[][] = [];
@@ -99,7 +105,7 @@ export class TimelineStore {
 
   constructor(
     private readonly internPool: InternPoolStore,
-    private readonly styleStore: StyleStore,
+    public readonly styleStore: StyleStore,
     public readonly logStore: LogStore,
   ) {
     this.decoder = new InternedStructDecoder(this.internPool);
@@ -126,6 +132,7 @@ export class TimelineStore {
     this.timelineTypeIds = new Uint32Array(timelineCount);
     this.timelineNameStringIds = new Uint32Array(timelineCount);
     this.timelineParentIds = new Uint32Array(timelineCount);
+    this.timelineSeverities = new Uint8Array(timelineCount);
 
     this.timelineRevisionIds.length = 0;
     this.timelineEventIds.length = 0;
@@ -195,6 +202,34 @@ export class TimelineStore {
       this.eventLogIds[eIndex] = e.logId;
       this.eventIdToIndex[e.id] = eIndex;
       eIndex++;
+    }
+
+    // Build severity index for timelines
+    for (let i = 0; i < timelineCount; i++) {
+      let mask = 0;
+      const revIds = this.timelineRevisionIds[i];
+      for (let j = 0; j < revIds.length; j++) {
+        const rIndex = this.revisionIdToIndex[revIds[j]];
+        if (rIndex !== undefined) {
+          const logId = this.revisionLogIds[rIndex];
+          const severityId = this.logStore._getSeverity(logId).id;
+          if (severityId >= 0 && severityId < 8) {
+            mask |= 1 << severityId;
+          }
+        }
+      }
+      const eventIds = this.timelineEventIds[i];
+      for (let j = 0; j < eventIds.length; j++) {
+        const eIndex = this.eventIdToIndex[eventIds[j]];
+        if (eIndex !== undefined) {
+          const logId = this.eventLogIds[eIndex];
+          const severityId = this.logStore._getSeverity(logId).id;
+          if (severityId >= 0 && severityId < 8) {
+            mask |= 1 << severityId;
+          }
+        }
+      }
+      this.timelineSeverities[i] = mask;
     }
   }
 
@@ -311,6 +346,25 @@ export class TimelineStore {
    */
   public _getChildIdsForTimeline(id: number): readonly number[] {
     return this.timelineChildrenIds[this.getTimelineIndex(id)] ?? [];
+  }
+
+  /**
+   * Checks if the timeline with the specified ID has any logs with any of the specified severities.
+   *
+   * @note Intended solely for internal retrieval inside the {@link Timeline} domain adapter.
+   */
+  public _hasSeverities(
+    id: number,
+    severities: readonly ReadonlyDomainElement<Severity>[],
+  ): boolean {
+    const index = this.getTimelineIndex(id);
+    let severityMask = 0;
+    for (const s of severities) {
+      if (s.id >= 0 && s.id < 8) {
+        severityMask |= 1 << s.id;
+      }
+    }
+    return (this.timelineSeverities[index] & severityMask) !== 0;
   }
 
   private getTimelineIndex(id: number): number {

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { RevisionState, TimelineType, Verb } from 'src/app/store/domain/style';
+import {
+  Severity,
+  RevisionState,
+  TimelineType,
+  Verb,
+} from 'src/app/store/domain/style';
 import { TimelineStore } from 'src/app/store/domain/timeline-store';
 import * as yaml from 'js-yaml';
 
@@ -281,6 +286,15 @@ export class Timeline {
       this._events = this.timelineStore._getEventsForTimeline(this.id);
     }
     return this._events;
+  }
+
+  /**
+   * Checks if this timeline has any logs with any of the specified severities.
+   */
+  public hasSeverity(
+    ...severities: readonly ReadonlyDomainElement<Severity>[]
+  ): boolean {
+    return this.timelineStore._hasSeverities(this.id, severities);
   }
 
   /**

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.spec.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.spec.ts
@@ -144,5 +144,23 @@ describe('TimelineToolbarSmart compilation helpers', () => {
         'match("K8sResource", "pod-.*") && match("^(?:ns-1|ns-2)$")',
       );
     });
+
+    it('should prepend minSeverity when severity is not ANY', () => {
+      const filters: TimelineFilterConfig[] = [
+        {
+          id: '1',
+          timelineType: '*',
+          mode: 'regex',
+          value: 'pod-.*',
+        },
+      ];
+      expect(compileFiltersToCel(filters, 'ERROR')).toBe(
+        'minSeverity(ERROR) && match("pod-.*")',
+      );
+    });
+
+    it('should return minSeverity only when filters is empty and severity is not ANY', () => {
+      expect(compileFiltersToCel([], 'ERROR')).toBe('minSeverity(ERROR)');
+    });
   });
 });

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
@@ -246,6 +246,7 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
 
     const hypotheticalTimelineCel = compileFiltersToCel(
       viewState.standardTimelineFilters(),
+      viewState.standardSelectedSeverity(),
     );
     const hypotheticalLogCel = compileLogFiltersToCel(
       viewState.standardSelectedSeverity(),
@@ -267,7 +268,8 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
     effect(() => {
       if (!this.isAdvancedMode()) {
         const filters = this.timelineFilters();
-        const celExpr = compileFiltersToCel(filters);
+        const severity = this.selectedSeverity();
+        const celExpr = compileFiltersToCel(filters, severity);
         this.celTimelineFilter.updateFilter(celExpr);
       }
     });
@@ -405,29 +407,37 @@ export function compileLogFiltersToCel(
 }
 
 /**
- * Compiles a list of standard timeline filters into a CEL expression.
+ * Compiles a list of standard timeline filters and a severity level into a CEL expression.
  */
-export function compileFiltersToCel(filters: TimelineFilterConfig[]): string {
-  if (filters.length === 0) {
-    return '';
+export function compileFiltersToCel(
+  filters: TimelineFilterConfig[],
+  severity: string = 'ANY',
+): string {
+  const parts: string[] = [];
+  if (severity && severity !== 'ANY') {
+    parts.push(`minSeverity(${severity})`);
   }
-  return filters
-    .map((f) => {
-      let celValue = f.value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      if (f.mode === 'selection') {
-        const escapedParts = f.value.split('|').map((val) =>
-          val
-            .replace(/\\/g, '\\\\')
-            .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-            .replace(/"/g, '\\"'),
-        );
-        celValue = `^(?:${escapedParts.join('|')})$`;
-      }
-      if (f.timelineType === '*') {
-        return `match("${celValue}")`;
-      } else {
-        return `match("${f.timelineType}", "${celValue}")`;
-      }
-    })
-    .join(' && ');
+  if (filters.length > 0) {
+    const filtersCel = filters
+      .map((f) => {
+        let celValue = f.value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        if (f.mode === 'selection') {
+          const escapedParts = f.value.split('|').map((val) =>
+            val
+              .replace(/\\/g, '\\\\')
+              .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+              .replace(/"/g, '\\"'),
+          );
+          celValue = `^(?:${escapedParts.join('|')})$`;
+        }
+        if (f.timelineType === '*') {
+          return `match("${celValue}")`;
+        } else {
+          return `match("${f.timelineType}", "${celValue}")`;
+        }
+      })
+      .join(' && ');
+    parts.push(filtersCel);
+  }
+  return parts.join(' && ');
 }


### PR DESCRIPTION
Filtering logs/timelines with severity is common scenario but it can be very slow for KHI. This PR optimize the timeline store to support severity based filter.