### PR TITLE
Implemented functions to copy a domain store data to the other worker with SharedArrayBuffer

### DIFF
--- a/web/angular-template.json
+++ b/web/angular-template.json
@@ -40,7 +40,11 @@
         "serve": {
           "builder": "@angular/build:dev-server",
           "options": {
-            "proxyConfig": "proxy.conf.mjs"
+            "proxyConfig": "proxy.conf.mjs",
+            "headers": {
+              "Cross-Origin-Opener-Policy": "same-origin",
+              "Cross-Origin-Embedder-Policy": "require-corp"
+            }
           },
           "configurations": {
             "dev": {

--- a/web/karma.conf.js
+++ b/web/karma.conf.js
@@ -19,6 +19,18 @@
 
 module.exports = function (config) {
   config.set({
+    customHeaders: [
+      {
+        match: '.*',
+        name: 'Cross-Origin-Opener-Policy',
+        value: 'same-origin',
+      },
+      {
+        match: '.*',
+        name: 'Cross-Origin-Embedder-Policy',
+        value: 'require-corp',
+      },
+    ],
     basePath: '',
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [

--- a/web/src/app/extensions/public/module.ts
+++ b/web/src/app/extensions/public/module.ts
@@ -16,17 +16,12 @@
 
 import { NgModule } from '@angular/core';
 import { KHIExtensionBundle } from '../extension-common/extension';
-import { NodeNameBindingWithPod } from './timeline-navigator-extensions';
 import { Reporter, ConsoleReporter } from 'src/app/common/reporter/reporter';
 
 @NgModule({
   providers: [
-    KHIExtensionBundle.forExtension(initExtension),
+    KHIExtensionBundle.forExtension(() => {}),
     { provide: Reporter, useClass: ConsoleReporter },
   ],
 })
 export class PublicKHIExtension {}
-
-function initExtension(extension: KHIExtensionBundle) {
-  extension.addTimelineNavigatorExtension(new NodeNameBindingWithPod());
-}

--- a/web/src/app/parser/core/builder.ts
+++ b/web/src/app/parser/core/builder.ts
@@ -63,8 +63,8 @@ export class InspectionDataBuilder {
   private iconAtlasPromise?: Promise<void>;
 
   constructor() {
-    this.logStore = new LogStore(this.internPool, this.styleStore);
-    this.timelineStore = new TimelineStore(
+    this.logStore = LogStore.create(this.internPool, this.styleStore);
+    this.timelineStore = TimelineStore.create(
       this.internPool,
       this.styleStore,
       this.logStore,

--- a/web/src/app/parser/core/builder.ts
+++ b/web/src/app/parser/core/builder.ts
@@ -46,7 +46,7 @@ import {
  * Collects components in a version-decoupled form.
  */
 export class InspectionDataBuilder {
-  private readonly internPool = new InternPoolStore();
+  private readonly internPool = InternPoolStore.create();
   private readonly styleStore = new StyleStore();
   private readonly logStore: LogStore;
   private readonly timelineStore: TimelineStore;

--- a/web/src/app/services/selection-manager-v2.service.spec.ts
+++ b/web/src/app/services/selection-manager-v2.service.spec.ts
@@ -39,8 +39,8 @@ describe('SelectionManagerV2', () => {
 
     const internPool = InternPoolStore.create();
     const styleStore = new StyleStore();
-    logStore = new LogStore(internPool, styleStore);
-    timelineStore = new TimelineStore(internPool, styleStore, logStore);
+    logStore = LogStore.create(internPool, styleStore);
+    timelineStore = TimelineStore.create(internPool, styleStore, logStore);
 
     styleStore.addSeverities([
       {

--- a/web/src/app/services/selection-manager-v2.service.spec.ts
+++ b/web/src/app/services/selection-manager-v2.service.spec.ts
@@ -37,7 +37,7 @@ describe('SelectionManagerV2', () => {
     dataStore = TestBed.inject(InspectionDataStoreV2);
     service = TestBed.inject(SelectionManagerV2);
 
-    const internPool = new InternPoolStore();
+    const internPool = InternPoolStore.create();
     const styleStore = new StyleStore();
     logStore = new LogStore(internPool, styleStore);
     timelineStore = new TimelineStore(internPool, styleStore, logStore);

--- a/web/src/app/store/domain/filter/cel-env.spec.ts
+++ b/web/src/app/store/domain/filter/cel-env.spec.ts
@@ -37,8 +37,8 @@ describe('CELTimelineFilterEnvironment', () => {
     env = new CELTimelineFilterEnvironment();
     internPool = InternPoolStore.create();
     styleStore = new StyleStore();
-    logStore = new LogStore(internPool, styleStore);
-    timelineStore = new TimelineStore(internPool, styleStore, logStore);
+    logStore = LogStore.create(internPool, styleStore);
+    timelineStore = TimelineStore.create(internPool, styleStore, logStore);
   });
 
   it('should successfully compile a valid CEL expression', () => {

--- a/web/src/app/store/domain/filter/cel-env.spec.ts
+++ b/web/src/app/store/domain/filter/cel-env.spec.ts
@@ -35,7 +35,7 @@ describe('CELTimelineFilterEnvironment', () => {
 
   beforeEach(() => {
     env = new CELTimelineFilterEnvironment();
-    internPool = new InternPoolStore();
+    internPool = InternPoolStore.create();
     styleStore = new StyleStore();
     logStore = new LogStore(internPool, styleStore);
     timelineStore = new TimelineStore(internPool, styleStore, logStore);

--- a/web/src/app/store/domain/intern-pool-store.spec.ts
+++ b/web/src/app/store/domain/intern-pool-store.spec.ts
@@ -209,4 +209,45 @@ describe('InternPoolStore', () => {
       sharedStore.addFieldPathSets([{ id: 200, fieldPathStringIds: [10] }]);
     }).toThrowError('Cannot write to a shared read-only InternPoolStore');
   });
+
+  describe('ArrayBuffer fallback when SharedArrayBuffer is unsupported', () => {
+    let originalSharedArrayBuffer: typeof SharedArrayBuffer | undefined;
+
+    beforeEach(() => {
+      originalSharedArrayBuffer = SharedArrayBuffer;
+      (
+        globalThis as unknown as Record<
+          string,
+          typeof SharedArrayBuffer | undefined
+        >
+      )['SharedArrayBuffer'] = undefined;
+    });
+
+    afterEach(() => {
+      (
+        globalThis as unknown as Record<
+          string,
+          typeof SharedArrayBuffer | undefined
+        >
+      )['SharedArrayBuffer'] = originalSharedArrayBuffer;
+    });
+
+    it('should allocate ArrayBuffer instead of SharedArrayBuffer and perform operations successfully', () => {
+      const fallbackStore = InternPoolStore.create();
+      fallbackStore.addStrings([
+        { id: 10, value: 'fallback-string-1' },
+        { id: 20, value: 'fallback-string-2' },
+      ]);
+
+      expect(fallbackStore.getString(10)).toBe('fallback-string-1');
+      expect(fallbackStore.getString(20)).toBe('fallback-string-2');
+
+      const sharedData = fallbackStore.getSharedData();
+      expect(sharedData.metadataSab instanceof ArrayBuffer).toBeTrue();
+      expect(sharedData.bufferSabs[0] instanceof ArrayBuffer).toBeTrue();
+
+      const reconstructedStore = InternPoolStore.fromSharedData(sharedData);
+      expect(reconstructedStore.getString(10)).toBe('fallback-string-1');
+    });
+  });
 });

--- a/web/src/app/store/domain/intern-pool-store.spec.ts
+++ b/web/src/app/store/domain/intern-pool-store.spec.ts
@@ -20,7 +20,7 @@ describe('InternPoolStore', () => {
   let store: InternPoolStore;
 
   beforeEach(() => {
-    store = new InternPoolStore();
+    store = InternPoolStore.create();
   });
 
   it('should add and get strings from the pool', () => {
@@ -61,5 +61,152 @@ describe('InternPoolStore', () => {
     expect(() => store.getFieldPathSet(999)).toThrowError(
       'FieldPathSet ID 999 not found in pool',
     );
+  });
+
+  it('should split buffer if the string size exceeds maxBufferSize', () => {
+    const smallStore = InternPoolStore.create(10);
+    smallStore.addStrings([
+      { id: 1, value: 'abcdefgh' }, // 8 bytes -> fits in 1st buffer
+      { id: 2, value: 'ijklmnop' }, // 8 bytes -> exceeds remaining 2 bytes, goes to 2nd buffer
+      { id: 3, value: 'qrstuvwxyz12345' }, // 15 bytes -> exceeds 10 bytes maxBufferSize, allocated standalone
+      { id: 4, value: 'abc' }, // 3 bytes -> fits in next buffer
+    ]);
+
+    expect(smallStore.getString(1)).toBe('abcdefgh');
+    expect(smallStore.getString(2)).toBe('ijklmnop');
+    expect(smallStore.getString(3)).toBe('qrstuvwxyz12345');
+    expect(smallStore.getString(4)).toBe('abc');
+  });
+
+  it('should resize metadata TypedArrays when string ID is large', () => {
+    store.addStrings([{ id: 2000, value: 'large-id-string' }]);
+
+    expect(store.getString(2000)).toBe('large-id-string');
+  });
+
+  it('should allow reconstructing string values from getSharedData() buffers', () => {
+    store.addStrings([
+      { id: 10, value: 'shared-string-1' },
+      { id: 20, value: 'shared-string-2' },
+    ]);
+
+    const sharedData = store.getSharedData();
+
+    const localIndices = new Uint16Array(
+      sharedData.metadataSab,
+      0,
+      sharedData.capacity,
+    );
+    const localOffsets = new Uint32Array(
+      sharedData.metadataSab,
+      sharedData.capacity * 2,
+      sharedData.capacity,
+    );
+    const localLengths = new Uint32Array(
+      sharedData.metadataSab,
+      sharedData.capacity * 6,
+      sharedData.capacity,
+    );
+
+    const index10 = localIndices[10] - 1;
+    const offset10 = localOffsets[10];
+    const length10 = localLengths[10];
+
+    const buffer10 = new Uint8Array(sharedData.bufferSabs[index10]);
+    const bytes10 = buffer10.subarray(offset10, offset10 + length10);
+    const nonSharedBytes10 = new Uint8Array(length10);
+    nonSharedBytes10.set(bytes10);
+    const decoder = new TextDecoder();
+
+    expect(decoder.decode(nonSharedBytes10)).toBe('shared-string-1');
+
+    const index20 = localIndices[20] - 1;
+    const offset20 = localOffsets[20];
+    const length20 = localLengths[20];
+
+    const buffer20 = new Uint8Array(sharedData.bufferSabs[index20]);
+    const bytes20 = buffer20.subarray(offset20, offset20 + length20);
+    const nonSharedBytes20 = new Uint8Array(length20);
+    nonSharedBytes20.set(bytes20);
+
+    expect(decoder.decode(nonSharedBytes20)).toBe('shared-string-2');
+  });
+
+  it('should be transmissible via postMessage and decodable inside a WebWorker', (done) => {
+    store.addStrings([{ id: 10, value: 'worker-shared-string' }]);
+
+    const sharedData = store.getSharedData();
+
+    const workerCode = `
+      self.onmessage = function(e) {
+        try {
+          const sharedData = e.data;
+          const localIndices = new Uint16Array(sharedData.metadataSab, 0, sharedData.capacity);
+          const localOffsets = new Uint32Array(sharedData.metadataSab, sharedData.capacity * 2, sharedData.capacity);
+          const localLengths = new Uint32Array(sharedData.metadataSab, sharedData.capacity * 6, sharedData.capacity);
+
+          const index = localIndices[10] - 1;
+          const offset = localOffsets[10];
+          const length = localLengths[10];
+
+          const buffer = new Uint8Array(sharedData.bufferSabs[index]);
+          const bytes = buffer.subarray(offset, offset + length);
+          const nonSharedBytes = new Uint8Array(length);
+          nonSharedBytes.set(bytes);
+          const decoded = new TextDecoder().decode(nonSharedBytes);
+
+          self.postMessage({ success: true, decoded });
+        } catch (err) {
+          self.postMessage({ success: false, error: err.toString() });
+        }
+      };
+    `;
+    const blob = new Blob([workerCode], { type: 'application/javascript' });
+    const worker = new Worker(URL.createObjectURL(blob));
+
+    worker.onmessage = (e) => {
+      const result = e.data;
+      if (result.success) {
+        expect(result.decoded).toBe('worker-shared-string');
+      } else {
+        fail('Worker failed with error: ' + result.error);
+      }
+      worker.terminate();
+      done();
+    };
+
+    worker.postMessage(sharedData);
+  });
+
+  it('should initialize successfully from sharedData using fromSharedData()', () => {
+    store.addStrings([
+      { id: 10, value: 'shared-string-1' },
+      { id: 20, value: 'shared-string-2' },
+    ]);
+    store.addFieldPathSets([{ id: 100, fieldPathStringIds: [10, 20] }]);
+
+    const sharedData = store.getSharedData();
+    const sharedStore = InternPoolStore.fromSharedData(sharedData);
+
+    expect(sharedStore.getString(10)).toBe('shared-string-1');
+    expect(sharedStore.getString(20)).toBe('shared-string-2');
+    expect(sharedStore.getFieldPathSet(100)).toEqual([
+      'shared-string-1',
+      'shared-string-2',
+    ]);
+  });
+
+  it('should throw an error on write attempts on a read-only instance created from sharedData', () => {
+    store.addStrings([{ id: 10, value: 'shared-string' }]);
+    const sharedData = store.getSharedData();
+    const sharedStore = InternPoolStore.fromSharedData(sharedData);
+
+    expect(() => {
+      sharedStore.addStrings([{ id: 11, value: 'fail' }]);
+    }).toThrowError('Cannot write to a shared read-only InternPoolStore');
+
+    expect(() => {
+      sharedStore.addFieldPathSets([{ id: 200, fieldPathStringIds: [10] }]);
+    }).toThrowError('Cannot write to a shared read-only InternPoolStore');
   });
 });

--- a/web/src/app/store/domain/intern-pool-store.ts
+++ b/web/src/app/store/domain/intern-pool-store.ts
@@ -28,6 +28,8 @@ export interface StringEntryDTO {
   readonly value: string;
 }
 
+import { allocateBuffer, isSharedBuffer } from 'src/app/store/domain/types';
+
 /**
  * Represents an entry defining a set of field path names.
  */
@@ -47,8 +49,8 @@ export interface FieldPathSetEntryDTO {
  * This can be transferred to a WebWorker via postMessage.
  */
 export interface InternPoolSharedData {
-  readonly bufferSabs: readonly SharedArrayBuffer[];
-  readonly metadataSab: SharedArrayBuffer;
+  readonly bufferSabs: readonly (SharedArrayBuffer | ArrayBuffer)[];
+  readonly metadataSab: SharedArrayBuffer | ArrayBuffer;
   readonly capacity: number;
   readonly fieldPathSets: readonly (readonly number[])[];
 }
@@ -65,7 +67,7 @@ export class InternPoolStore {
   /**
    * The SharedArrayBuffers backing the encoded string buffers.
    */
-  private readonly bufferSabs: SharedArrayBuffer[] = [];
+  private readonly bufferSabs: (SharedArrayBuffer | ArrayBuffer)[] = [];
 
   /**
    * Tracks the buffer index for each string ID (1-based index, 0 represents uninitialized).
@@ -85,7 +87,7 @@ export class InternPoolStore {
   /**
    * The single SharedArrayBuffer holding all metadata arrays.
    */
-  private metadataSab: SharedArrayBuffer;
+  private metadataSab: SharedArrayBuffer | ArrayBuffer;
 
   /**
    * Whether this store is read-only (for worker-side decoding).
@@ -121,7 +123,7 @@ export class InternPoolStore {
     this.readOnly = readOnly;
     if (typeof initialCapacityOrSharedData === 'number') {
       const initialCapacity = initialCapacityOrSharedData;
-      this.metadataSab = new SharedArrayBuffer(initialCapacity * 10);
+      this.metadataSab = allocateBuffer(initialCapacity * 10);
       this.bufferIndices = new Uint16Array(
         this.metadataSab,
         0,
@@ -208,7 +210,7 @@ export class InternPoolStore {
         this.maxBufferSize - this.currentOffset < encoded.length
       ) {
         const newSize = Math.max(this.maxBufferSize, encoded.length);
-        const sab = new SharedArrayBuffer(newSize);
+        const sab = allocateBuffer(newSize);
         this.bufferSabs.push(sab);
         this.buffers.push(new Uint8Array(sab));
         this.currentBufferIndex = this.buffers.length - 1;
@@ -261,9 +263,12 @@ export class InternPoolStore {
 
     const buffer = this.buffers[bufferIndex];
     const bytes = buffer.subarray(offset, offset + length);
-    const nonSharedBytes = new Uint8Array(length);
-    nonSharedBytes.set(bytes);
-    return this.decoder.decode(nonSharedBytes);
+    if (isSharedBuffer(bytes.buffer)) {
+      const nonSharedBytes = new Uint8Array(length);
+      nonSharedBytes.set(bytes);
+      return this.decoder.decode(nonSharedBytes);
+    }
+    return this.decoder.decode(bytes);
   }
 
   /**
@@ -310,7 +315,7 @@ export class InternPoolStore {
       newCapacity *= 2;
     }
 
-    const newMetadataSab = new SharedArrayBuffer(newCapacity * 10);
+    const newMetadataSab = allocateBuffer(newCapacity * 10);
     const newBufferIndices = new Uint16Array(newMetadataSab, 0, newCapacity);
     const newOffsets = new Uint32Array(
       newMetadataSab,

--- a/web/src/app/store/domain/intern-pool-store.ts
+++ b/web/src/app/store/domain/intern-pool-store.ts
@@ -43,13 +43,67 @@ export interface FieldPathSetEntryDTO {
 }
 
 /**
- * Manages the interned strings and field names used in structured data.
+ * Represents the shared memory structure of the intern pool.
+ * This can be transferred to a WebWorker via postMessage.
+ */
+export interface InternPoolSharedData {
+  readonly bufferSabs: readonly SharedArrayBuffer[];
+  readonly metadataSab: SharedArrayBuffer;
+  readonly capacity: number;
+  readonly fieldPathSets: readonly (readonly number[])[];
+}
+
+/**
+ * Manages the interned strings and field names used in structured data using SharedArrayBuffers.
  */
 export class InternPoolStore {
   /**
-   * The interned string directly referencable with string ID.
+   * Allocated buffers storing the encoded string data.
    */
-  private readonly strings: string[] = [];
+  private readonly buffers: Uint8Array[] = [];
+
+  /**
+   * The SharedArrayBuffers backing the encoded string buffers.
+   */
+  private readonly bufferSabs: SharedArrayBuffer[] = [];
+
+  /**
+   * Tracks the buffer index for each string ID (1-based index, 0 represents uninitialized).
+   */
+  private bufferIndices: Uint16Array;
+
+  /**
+   * Tracks the byte offset inside the buffer for each string ID.
+   */
+  private offsets: Uint32Array;
+
+  /**
+   * Tracks the byte length of the encoded string for each string ID.
+   */
+  private lengths: Uint32Array;
+
+  /**
+   * The single SharedArrayBuffer holding all metadata arrays.
+   */
+  private metadataSab: SharedArrayBuffer;
+
+  /**
+   * Whether this store is read-only (for worker-side decoding).
+   */
+  private readonly readOnly: boolean;
+
+  /**
+   * The index of the buffer currently being written to.
+   */
+  private currentBufferIndex = -1;
+
+  /**
+   * The current write offset in the active buffer.
+   */
+  private currentOffset = 0;
+
+  private readonly encoder = new TextEncoder();
+  private readonly decoder = new TextDecoder();
 
   /**
    * The interned structured data field path set.
@@ -58,13 +112,117 @@ export class InternPoolStore {
    */
   private readonly fieldPathSets: number[][] = [];
 
+  // Private constructor
+  private constructor(
+    private readonly maxBufferSize: number,
+    readOnly: boolean,
+    initialCapacityOrSharedData: number | InternPoolSharedData,
+  ) {
+    this.readOnly = readOnly;
+    if (typeof initialCapacityOrSharedData === 'number') {
+      const initialCapacity = initialCapacityOrSharedData;
+      this.metadataSab = new SharedArrayBuffer(initialCapacity * 10);
+      this.bufferIndices = new Uint16Array(
+        this.metadataSab,
+        0,
+        initialCapacity,
+      );
+      this.offsets = new Uint32Array(
+        this.metadataSab,
+        initialCapacity * 2,
+        initialCapacity,
+      );
+      this.lengths = new Uint32Array(
+        this.metadataSab,
+        initialCapacity * 6,
+        initialCapacity,
+      );
+    } else {
+      const sharedData = initialCapacityOrSharedData;
+      this.bufferSabs = Array.from(sharedData.bufferSabs);
+      this.buffers = this.bufferSabs.map((sab) => new Uint8Array(sab));
+      this.metadataSab = sharedData.metadataSab;
+      this.bufferIndices = new Uint16Array(
+        this.metadataSab,
+        0,
+        sharedData.capacity,
+      );
+      this.offsets = new Uint32Array(
+        this.metadataSab,
+        sharedData.capacity * 2,
+        sharedData.capacity,
+      );
+      this.lengths = new Uint32Array(
+        this.metadataSab,
+        sharedData.capacity * 6,
+        sharedData.capacity,
+      );
+      this.currentBufferIndex = this.buffers.length - 1;
+      this.currentOffset = 0;
+
+      for (let i = 0; i < sharedData.fieldPathSets.length; i++) {
+        const set = sharedData.fieldPathSets[i];
+        if (set !== undefined) {
+          this.fieldPathSets[i] = Array.from(set);
+        }
+      }
+    }
+  }
+
+  /**
+   * Creates a new writable InternPoolStore instance.
+   * @param maxBufferSize The maximum capacity of each buffer segment in bytes.
+   */
+  public static create(
+    maxBufferSize: number = 100 * 1024 * 1024,
+  ): InternPoolStore {
+    return new InternPoolStore(maxBufferSize, false, 1024);
+  }
+
+  /**
+   * Reconstructs a read-only InternPoolStore instance from shared memory data.
+   * @param sharedData The SharedArrayBuffers and capacity metadata.
+   * @param maxBufferSize The maximum capacity of each buffer segment in bytes.
+   */
+  public static fromSharedData(
+    sharedData: InternPoolSharedData,
+    maxBufferSize: number = 100 * 1024 * 1024,
+  ): InternPoolStore {
+    return new InternPoolStore(maxBufferSize, true, sharedData);
+  }
+
   /**
    * Adds multiple strings to the pool.
    * @param strings An iterable of objects containing id and value.
    */
   public addStrings(strings: Iterable<StringEntryDTO>): void {
+    if (this.readOnly) {
+      throw new Error('Cannot write to a shared read-only InternPoolStore');
+    }
     for (const { id, value } of strings) {
-      this.strings[id] = value;
+      const encoded = this.encoder.encode(value);
+      this.ensureCapacity(id + 1);
+
+      if (
+        this.currentBufferIndex === -1 ||
+        this.maxBufferSize - this.currentOffset < encoded.length
+      ) {
+        const newSize = Math.max(this.maxBufferSize, encoded.length);
+        const sab = new SharedArrayBuffer(newSize);
+        this.bufferSabs.push(sab);
+        this.buffers.push(new Uint8Array(sab));
+        this.currentBufferIndex = this.buffers.length - 1;
+        this.currentOffset = 0;
+      }
+
+      const activeBuffer = this.buffers[this.currentBufferIndex];
+      activeBuffer.set(encoded, this.currentOffset);
+
+      this.bufferIndices[id] = this.currentBufferIndex + 1;
+      this.offsets[id] = this.currentOffset;
+      this.lengths[id] = encoded.length;
+
+      this.currentOffset += encoded.length;
     }
   }
 
@@ -73,6 +231,9 @@ export class InternPoolStore {
    * @param sets An iterable of objects containing id and an array of string IDs.
    */
   public addFieldPathSets(sets: Iterable<FieldPathSetEntryDTO>): void {
+    if (this.readOnly) {
+      throw new Error('Cannot write to a shared read-only InternPoolStore');
+    }
     for (const { id, fieldPathStringIds: fieldNames } of sets) {
       this.fieldPathSets[id] = Array.from(fieldNames);
     }
@@ -85,11 +246,24 @@ export class InternPoolStore {
    * @throws Error if the ID is not found in the pool.
    */
   public getString(id: number): string {
-    const value = this.strings[id];
-    if (value === undefined) {
+    if (id < 0 || id >= this.bufferIndices.length) {
       throw new Error(`String ID ${id} not found in pool`);
     }
-    return value;
+
+    const bufferIndexPlusOne = this.bufferIndices[id];
+    if (bufferIndexPlusOne === 0) {
+      throw new Error(`String ID ${id} not found in pool`);
+    }
+
+    const bufferIndex = bufferIndexPlusOne - 1;
+    const offset = this.offsets[id];
+    const length = this.lengths[id];
+
+    const buffer = this.buffers[bufferIndex];
+    const bytes = buffer.subarray(offset, offset + length);
+    const nonSharedBytes = new Uint8Array(length);
+    nonSharedBytes.set(bytes);
+    return this.decoder.decode(nonSharedBytes);
   }
 
   /**
@@ -104,5 +278,58 @@ export class InternPoolStore {
       throw new Error(`FieldPathSet ID ${id} not found in pool`);
     }
     return set.map((strId) => this.getString(strId));
+  }
+
+  /**
+   * Transfers shared memory structure of this store.
+   * @returns The SharedArrayBuffers and metadata.
+   */
+  public getSharedData(): InternPoolSharedData {
+    return {
+      bufferSabs: this.bufferSabs,
+      metadataSab: this.metadataSab,
+      capacity: this.bufferIndices.length,
+      fieldPathSets: this.fieldPathSets,
+    };
+  }
+
+  /**
+   * Ensures the metadata TypedArrays can hold up to the given capacity by reallocating SharedArrayBuffers.
+   * @param minCapacity The required minimum capacity.
+   */
+  private ensureCapacity(minCapacity: number): void {
+    if (this.readOnly) {
+      throw new Error('Cannot resize a shared read-only InternPoolStore');
+    }
+    if (minCapacity <= this.bufferIndices.length) {
+      return;
+    }
+
+    let newCapacity = this.bufferIndices.length * 2;
+    while (newCapacity < minCapacity) {
+      newCapacity *= 2;
+    }
+
+    const newMetadataSab = new SharedArrayBuffer(newCapacity * 10);
+    const newBufferIndices = new Uint16Array(newMetadataSab, 0, newCapacity);
+    const newOffsets = new Uint32Array(
+      newMetadataSab,
+      newCapacity * 2,
+      newCapacity,
+    );
+    const newLengths = new Uint32Array(
+      newMetadataSab,
+      newCapacity * 6,
+      newCapacity,
+    );
+
+    newBufferIndices.set(this.bufferIndices);
+    newOffsets.set(this.offsets);
+    newLengths.set(this.lengths);
+
+    this.metadataSab = newMetadataSab;
+    this.bufferIndices = newBufferIndices;
+    this.offsets = newOffsets;
+    this.lengths = newLengths;
   }
 }

--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -31,7 +31,7 @@ describe('LogStore', () => {
   const mockColor = { r: 0, g: 0, b: 0, a: 1 };
 
   beforeEach(() => {
-    internPool = new InternPoolStore();
+    internPool = InternPoolStore.create();
     styleStore = new StyleStore();
     store = new LogStore(internPool, styleStore);
 

--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -33,7 +33,7 @@ describe('LogStore', () => {
   beforeEach(() => {
     internPool = InternPoolStore.create();
     styleStore = new StyleStore();
-    store = new LogStore(internPool, styleStore);
+    store = LogStore.create(internPool, styleStore);
 
     // Avoid errors of missing keys in basic tests
     styleStore.addSeverities([
@@ -315,5 +315,104 @@ describe('LogStore', () => {
     expect(iteratedLogs.length).toBe(2);
     expect(iteratedLogs[0].id).toBe(1);
     expect(iteratedLogs[1].id).toBe(2);
+  });
+
+  it('should restore from shared memory using fromSharedData and enforce readOnly guard', () => {
+    internPool.addStrings([
+      { id: 20, value: 'user' },
+      { id: 21, value: 'alice' },
+    ]);
+    internPool.addFieldPathSets([{ id: 2, fieldPathStringIds: [20] }]);
+    const struct = create(InternedStructSchema, {
+      fieldPathSetId: 2,
+      values: [
+        create(InternedValueSchema, {
+          kind: { case: 'stringValue', value: 21 },
+        }),
+      ],
+    });
+    const rawBody = toBinary(InternedStructSchema, struct);
+
+    const logs: LogDTO[] = [
+      {
+        id: 1,
+        ts: 1000n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+        body: rawBody,
+      },
+    ];
+
+    store.initialize(logs, 1);
+
+    const sharedData = store.getSharedData();
+    const restoredStore = LogStore.fromSharedData(
+      internPool,
+      styleStore,
+      sharedData,
+    );
+
+    expect(restoredStore.count).toBe(1);
+    const restoredLog = restoredStore.getLog(1);
+    expect(restoredLog.id).toBe(1);
+    expect(restoredLog.timestamp).toBe(1000n);
+    expect(restoredLog.body).toEqual({ user: 'alice' });
+
+    expect(() => {
+      restoredStore.initialize(logs, 1);
+    }).toThrowError('Cannot write to a shared read-only LogStore');
+  });
+
+  describe('ArrayBuffer fallback when SharedArrayBuffer is unsupported', () => {
+    let originalSharedArrayBuffer: typeof SharedArrayBuffer | undefined;
+
+    beforeEach(() => {
+      originalSharedArrayBuffer = SharedArrayBuffer;
+      (
+        globalThis as unknown as Record<
+          string,
+          typeof SharedArrayBuffer | undefined
+        >
+      )['SharedArrayBuffer'] = undefined;
+    });
+
+    afterEach(() => {
+      (
+        globalThis as unknown as Record<
+          string,
+          typeof SharedArrayBuffer | undefined
+        >
+      )['SharedArrayBuffer'] = originalSharedArrayBuffer;
+    });
+
+    it('should allocate ArrayBuffer instead of SharedArrayBuffer and perform operations successfully', () => {
+      const fallbackStore = LogStore.create(internPool, styleStore);
+      const logs: LogDTO[] = [
+        {
+          id: 1,
+          ts: 1000n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 1,
+        },
+      ];
+      fallbackStore.initialize(logs, 1);
+
+      expect(fallbackStore.count).toBe(1);
+      const log = fallbackStore.getLog(1);
+      expect(log.id).toBe(1);
+
+      const sharedData = fallbackStore.getSharedData();
+      expect(sharedData.metadataSab instanceof ArrayBuffer).toBeTrue();
+
+      const restoredStore = LogStore.fromSharedData(
+        internPool,
+        styleStore,
+        sharedData,
+      );
+      expect(restoredStore.count).toBe(1);
+      expect(restoredStore.getLog(1).id).toBe(1);
+    });
   });
 });

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -20,8 +20,29 @@ import { StyleStore } from 'src/app/store/domain/style-store';
 import { InternedStructDecoder } from 'src/app/store/domain/struct-decoder';
 import { InternedStructSchema } from 'src/app/generated/khifile/shared_pb';
 import { LogType, Severity } from 'src/app/store/domain/style';
-import { ReadonlyDomainElement, Undefinable } from 'src/app/store/domain/types';
+import {
+  ReadonlyDomainElement,
+  allocateBuffer,
+  isSharedBuffer,
+} from 'src/app/store/domain/types';
 import { fromBinary } from '@bufbuild/protobuf';
+
+/**
+ * Align the offset to the specified byte alignment.
+ */
+function align(offset: number, alignment: number): number {
+  return Math.ceil(offset / alignment) * alignment;
+}
+
+/**
+ * Represents the shared memory structure of the log store.
+ */
+export interface LogStoreSharedData {
+  readonly metadataSab: SharedArrayBuffer | ArrayBuffer;
+  readonly bodyBufferSabs: readonly (SharedArrayBuffer | ArrayBuffer)[];
+  readonly count: number;
+  readonly idToIndex: readonly (number | undefined)[];
+}
 
 /**
  * Raw Log object interface from the assembler.
@@ -42,24 +63,213 @@ export interface LogDTO {
  * Store for managing and retrieving logs efficiently.
  */
 export class LogStore {
-  private ids = new Uint32Array(0);
-  private timestamps = new BigUint64Array(0);
-  private logTypeIds = new Uint32Array(0);
-  private severityIds = new Uint32Array(0);
-  private summaryStringIds = new Uint32Array(0);
+  private readonly readOnly: boolean;
 
-  private bodies: Undefinable<Uint8Array>[] = [];
-  private decodedBodyCache: WeakRef<
+  private metadataSab!: SharedArrayBuffer | ArrayBuffer;
+  private ids!: Uint32Array;
+  private timestamps!: BigUint64Array;
+  private logTypeIds!: Uint32Array;
+  private severityIds!: Uint32Array;
+  private summaryStringIds!: Uint32Array;
+
+  // Packed body metadata
+  private bodyBufferIndices!: Uint16Array;
+  private bodyOffsets!: Uint32Array;
+  private bodyLengths!: Uint32Array;
+
+  private readonly bodyBufferSabs: (SharedArrayBuffer | ArrayBuffer)[] = [];
+  private readonly bodyBuffers: Uint8Array[] = [];
+
+  private currentBufferIndex = -1;
+  private currentOffset = 0;
+
+  private readonly decodedBodyCache: WeakRef<
     ReadonlyDomainElement<Record<string, unknown>>
   >[] = [];
-  private idToIndex: Undefinable<number>[] = [];
+  private idToIndex: (number | undefined)[] = [];
   private readonly decoder: InternedStructDecoder;
 
-  constructor(
+  private constructor(
     private readonly internPool: InternPoolStore,
     private readonly styleStore: StyleStore,
+    private readonly maxBufferSize: number,
+    readOnly: boolean,
+    initialData: number | LogStoreSharedData,
   ) {
+    this.readOnly = readOnly;
     this.decoder = new InternedStructDecoder(this.internPool);
+
+    if (typeof initialData === 'number') {
+      const initialCapacity = initialData;
+      this.allocateMetadata(initialCapacity);
+    } else {
+      const sharedData = initialData;
+      this.metadataSab = sharedData.metadataSab;
+      this.bodyBufferSabs = Array.from(sharedData.bodyBufferSabs);
+      this.bodyBuffers = this.bodyBufferSabs.map((sab) => new Uint8Array(sab));
+      this.idToIndex = Array.from(sharedData.idToIndex);
+      this.mapMetadataViews(sharedData.count);
+    }
+  }
+
+  /**
+   * Creates a new writable LogStore instance.
+   */
+  public static create(
+    internPool: InternPoolStore,
+    styleStore: StyleStore,
+    maxBufferSize: number = 100 * 1024 * 1024,
+  ): LogStore {
+    return new LogStore(internPool, styleStore, maxBufferSize, false, 1024);
+  }
+
+  /**
+   * Reconstructs a read-only LogStore instance from shared memory data.
+   */
+  public static fromSharedData(
+    internPool: InternPoolStore,
+    styleStore: StyleStore,
+    sharedData: LogStoreSharedData,
+    maxBufferSize: number = 100 * 1024 * 1024,
+  ): LogStore {
+    return new LogStore(
+      internPool,
+      styleStore,
+      maxBufferSize,
+      true,
+      sharedData,
+    );
+  }
+
+  private allocateMetadata(capacity: number): void {
+    let currentOffset = 0;
+    const idsOffset = currentOffset;
+    currentOffset += capacity * 4;
+
+    const logTypeIdsOffset = currentOffset;
+    currentOffset += capacity * 4;
+
+    const severityIdsOffset = currentOffset;
+    currentOffset += capacity * 4;
+
+    const summaryStringIdsOffset = currentOffset;
+    currentOffset += capacity * 4;
+
+    const timestampsOffset = align(currentOffset, 8);
+    currentOffset = timestampsOffset + capacity * 8;
+
+    const bodyBufferIndicesOffset = align(currentOffset, 2);
+    currentOffset = bodyBufferIndicesOffset + capacity * 2;
+
+    const bodyOffsetsOffset = align(currentOffset, 4);
+    currentOffset = bodyOffsetsOffset + capacity * 4;
+
+    const bodyLengthsOffset = align(currentOffset, 4);
+    currentOffset = bodyLengthsOffset + capacity * 4;
+
+    const totalBytes = currentOffset;
+    this.metadataSab = allocateBuffer(totalBytes);
+
+    this.ids = new Uint32Array(this.metadataSab, idsOffset, capacity);
+    this.logTypeIds = new Uint32Array(
+      this.metadataSab,
+      logTypeIdsOffset,
+      capacity,
+    );
+    this.severityIds = new Uint32Array(
+      this.metadataSab,
+      severityIdsOffset,
+      capacity,
+    );
+    this.summaryStringIds = new Uint32Array(
+      this.metadataSab,
+      summaryStringIdsOffset,
+      capacity,
+    );
+    this.timestamps = new BigUint64Array(
+      this.metadataSab,
+      timestampsOffset,
+      capacity,
+    );
+    this.bodyBufferIndices = new Uint16Array(
+      this.metadataSab,
+      bodyBufferIndicesOffset,
+      capacity,
+    );
+    this.bodyOffsets = new Uint32Array(
+      this.metadataSab,
+      bodyOffsetsOffset,
+      capacity,
+    );
+    this.bodyLengths = new Uint32Array(
+      this.metadataSab,
+      bodyLengthsOffset,
+      capacity,
+    );
+  }
+
+  private mapMetadataViews(capacity: number): void {
+    let currentOffset = 0;
+    const idsOffset = currentOffset;
+    currentOffset += capacity * 4;
+
+    const logTypeIdsOffset = currentOffset;
+    currentOffset += capacity * 4;
+
+    const severityIdsOffset = currentOffset;
+    currentOffset += capacity * 4;
+
+    const summaryStringIdsOffset = currentOffset;
+    currentOffset += capacity * 4;
+
+    const timestampsOffset = align(currentOffset, 8);
+    currentOffset = timestampsOffset + capacity * 8;
+
+    const bodyBufferIndicesOffset = align(currentOffset, 2);
+    currentOffset = bodyBufferIndicesOffset + capacity * 2;
+
+    const bodyOffsetsOffset = align(currentOffset, 4);
+    currentOffset = bodyOffsetsOffset + capacity * 4;
+
+    const bodyLengthsOffset = align(currentOffset, 4);
+    currentOffset = bodyLengthsOffset + capacity * 4;
+
+    this.ids = new Uint32Array(this.metadataSab, idsOffset, capacity);
+    this.logTypeIds = new Uint32Array(
+      this.metadataSab,
+      logTypeIdsOffset,
+      capacity,
+    );
+    this.severityIds = new Uint32Array(
+      this.metadataSab,
+      severityIdsOffset,
+      capacity,
+    );
+    this.summaryStringIds = new Uint32Array(
+      this.metadataSab,
+      summaryStringIdsOffset,
+      capacity,
+    );
+    this.timestamps = new BigUint64Array(
+      this.metadataSab,
+      timestampsOffset,
+      capacity,
+    );
+    this.bodyBufferIndices = new Uint16Array(
+      this.metadataSab,
+      bodyBufferIndicesOffset,
+      capacity,
+    );
+    this.bodyOffsets = new Uint32Array(
+      this.metadataSab,
+      bodyOffsetsOffset,
+      capacity,
+    );
+    this.bodyLengths = new Uint32Array(
+      this.metadataSab,
+      bodyLengthsOffset,
+      capacity,
+    );
   }
 
   /**
@@ -69,16 +279,13 @@ export class LogStore {
    * @param count The total number of logs.
    */
   public initialize(logs: Iterable<LogDTO>, count: number): void {
-    this.ids = new Uint32Array(count);
-    this.timestamps = new BigUint64Array(count);
-    this.logTypeIds = new Uint32Array(count);
-    this.severityIds = new Uint32Array(count);
-    this.summaryStringIds = new Uint32Array(count);
+    if (this.readOnly) {
+      throw new Error('Cannot write to a shared read-only LogStore');
+    }
 
-    this.bodies = new Array<Undefinable<Uint8Array>>(count);
-    this.decodedBodyCache = new Array<
-      WeakRef<ReadonlyDomainElement<Record<string, unknown>>>
-    >(count);
+    this.allocateMetadata(count);
+
+    this.decodedBodyCache.length = count;
     this.idToIndex = [];
 
     let index = 0;
@@ -96,10 +303,57 @@ export class LogStore {
       this.logTypeIds[index] = log.logTypeId;
       this.severityIds[index] = log.severityTypeId;
       this.summaryStringIds[index] = log.summaryStringId;
-      this.bodies[index] = log.body;
+
+      if (log.body !== undefined && log.body.length > 0) {
+        this.addBody(index, log.body);
+      } else {
+        this.bodyBufferIndices[index] = 0;
+        this.bodyOffsets[index] = 0;
+        this.bodyLengths[index] = 0;
+      }
+
       this.idToIndex[log.id] = index;
       index++;
     }
+  }
+
+  private addBody(index: number, bodyBytes: Uint8Array): void {
+    const length = bodyBytes.length;
+
+    if (length > this.maxBufferSize) {
+      const sab = allocateBuffer(length);
+      const buf = new Uint8Array(sab);
+      buf.set(bodyBytes);
+      this.bodyBufferSabs.push(sab);
+      this.bodyBuffers.push(buf);
+
+      const newBufIdx = this.bodyBuffers.length - 1;
+      this.bodyBufferIndices[index] = newBufIdx + 1;
+      this.bodyOffsets[index] = 0;
+      this.bodyLengths[index] = length;
+      return;
+    }
+
+    if (
+      this.currentBufferIndex === -1 ||
+      this.currentOffset + length > this.maxBufferSize
+    ) {
+      const sab = allocateBuffer(this.maxBufferSize);
+      const buf = new Uint8Array(sab);
+      this.bodyBufferSabs.push(sab);
+      this.bodyBuffers.push(buf);
+      this.currentBufferIndex = this.bodyBuffers.length - 1;
+      this.currentOffset = 0;
+    }
+
+    const currentBuf = this.bodyBuffers[this.currentBufferIndex];
+    currentBuf.set(bodyBytes, this.currentOffset);
+
+    this.bodyBufferIndices[index] = this.currentBufferIndex + 1;
+    this.bodyOffsets[index] = this.currentOffset;
+    this.bodyLengths[index] = length;
+
+    this.currentOffset += length;
   }
 
   /**
@@ -179,9 +433,22 @@ export class LogStore {
       return cached;
     }
 
-    const body = this.bodies[index];
-    if (!body) return null;
-    const struct = fromBinary(InternedStructSchema, body);
+    const bufIdx = this.bodyBufferIndices[index];
+    if (bufIdx === 0) return null;
+
+    const offset = this.bodyOffsets[index];
+    const length = this.bodyLengths[index];
+
+    const buffer = this.bodyBuffers[bufIdx - 1];
+    const bytes = buffer.subarray(offset, offset + length);
+    let decodeTarget = bytes;
+    if (isSharedBuffer(bytes.buffer)) {
+      const nonSharedBytes = new Uint8Array(length);
+      nonSharedBytes.set(bytes);
+      decodeTarget = nonSharedBytes;
+    }
+
+    const struct = fromBinary(InternedStructSchema, decodeTarget);
     const decoded = this.decoder.decode(struct);
     this.decodedBodyCache[index] = new WeakRef(decoded);
     return decoded;
@@ -198,5 +465,17 @@ export class LogStore {
       throw new Error(`Log ID ${id} not found`);
     }
     return index;
+  }
+
+  /**
+   * Returns the shared memory representation of this LogStore.
+   */
+  public getSharedData(): LogStoreSharedData {
+    return {
+      metadataSab: this.metadataSab,
+      bodyBufferSabs: this.bodyBufferSabs,
+      count: this.ids.length,
+      idToIndex: this.idToIndex,
+    };
   }
 }

--- a/web/src/app/store/domain/struct-decoder.spec.ts
+++ b/web/src/app/store/domain/struct-decoder.spec.ts
@@ -29,7 +29,7 @@ describe('InternedStructDecoder', () => {
   let decoder: InternedStructDecoder;
 
   beforeEach(() => {
-    store = new InternPoolStore();
+    store = InternPoolStore.create();
     decoder = new InternedStructDecoder(store);
   });
 

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -22,7 +22,7 @@ import {
 } from 'src/app/store/domain/timeline-store';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
-import { LogStore } from 'src/app/store/domain/log-store';
+import { LogStore, LogDTO } from 'src/app/store/domain/log-store';
 import { create, toBinary } from '@bufbuild/protobuf';
 import {
   InternedStructSchema,
@@ -40,8 +40,8 @@ describe('TimelineStore', () => {
   beforeEach(() => {
     internPool = InternPoolStore.create();
     styleStore = new StyleStore();
-    logStore = new LogStore(internPool, styleStore);
-    store = new TimelineStore(internPool, styleStore, logStore);
+    logStore = LogStore.create(internPool, styleStore);
+    store = TimelineStore.create(internPool, styleStore, logStore);
 
     styleStore.addTimelineTypes([
       {
@@ -610,5 +610,132 @@ describe('TimelineStore', () => {
     expect(body3).toEqual({ user: 'alice' });
     expect(body3).not.toBe(body1);
     expect(spyDecoderDecode).toHaveBeenCalledTimes(1);
+  });
+
+  it('should restore from shared memory using fromSharedData and enforce readOnly guard', () => {
+    internPool.addStrings([
+      { id: 20, value: 'user' },
+      { id: 21, value: 'alice' },
+    ]);
+    internPool.addFieldPathSets([{ id: 2, fieldPathStringIds: [20] }]);
+    const struct = create(InternedStructSchema, {
+      fieldPathSetId: 2,
+      values: [
+        create(InternedValueSchema, {
+          kind: { case: 'stringValue', value: 21 },
+        }),
+      ],
+    });
+    const rawBody = toBinary(InternedStructSchema, struct);
+
+    const timelines: TimelineDTO[] = [
+      {
+        id: 1,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [1],
+        eventIds: [],
+      },
+    ];
+
+    const revisions: RevisionDTO[] = [
+      {
+        id: 1,
+        logId: 1,
+        changedTime: 1000n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+        body: rawBody,
+      },
+    ];
+
+    // Mock logs initialization needed by severity indexing
+    const logs: LogDTO[] = [
+      { id: 1, ts: 1000n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
+    ];
+    logStore.initialize(logs, 1);
+
+    store.initialize(timelines, 1, revisions, 1, [], 0);
+
+    const sharedData = store.getSharedData();
+    const restoredStore = TimelineStore.fromSharedData(
+      internPool,
+      styleStore,
+      logStore,
+      sharedData,
+    );
+
+    expect(restoredStore.timelines.length).toBe(1);
+    const restoredTimeline = restoredStore.getTimeline(1);
+    expect(restoredTimeline.id).toBe(1);
+
+    const restoredRevisions = restoredTimeline.revisions;
+    expect(restoredRevisions.length).toBe(1);
+    expect(restoredRevisions[0].id).toBe(1);
+    expect(restoredRevisions[0].body).toEqual({ user: 'alice' });
+
+    expect(() => {
+      restoredStore.initialize(timelines, 1, revisions, 1, [], 0);
+    }).toThrowError('Cannot write to a shared read-only TimelineStore');
+  });
+
+  describe('ArrayBuffer fallback when SharedArrayBuffer is unsupported', () => {
+    let originalSharedArrayBuffer: typeof SharedArrayBuffer | undefined;
+
+    beforeEach(() => {
+      originalSharedArrayBuffer = SharedArrayBuffer;
+      (
+        globalThis as unknown as Record<
+          string,
+          typeof SharedArrayBuffer | undefined
+        >
+      )['SharedArrayBuffer'] = undefined;
+    });
+
+    afterEach(() => {
+      (
+        globalThis as unknown as Record<
+          string,
+          typeof SharedArrayBuffer | undefined
+        >
+      )['SharedArrayBuffer'] = originalSharedArrayBuffer;
+    });
+
+    it('should allocate ArrayBuffer instead of SharedArrayBuffer and perform operations successfully', () => {
+      const fallbackStore = TimelineStore.create(
+        internPool,
+        styleStore,
+        logStore,
+      );
+      const timelines: TimelineDTO[] = [
+        {
+          id: 1,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
+      ];
+      fallbackStore.initialize(timelines, 1, [], 0, [], 0);
+
+      expect(fallbackStore.timelines.length).toBe(1);
+      const timeline = fallbackStore.getTimeline(1);
+      expect(timeline.id).toBe(1);
+
+      const sharedData = fallbackStore.getSharedData();
+      expect(sharedData.metadataSab instanceof ArrayBuffer).toBeTrue();
+
+      const restoredStore = TimelineStore.fromSharedData(
+        internPool,
+        styleStore,
+        logStore,
+        sharedData,
+      );
+      expect(restoredStore.timelines.length).toBe(1);
+      expect(restoredStore.getTimeline(1).id).toBe(1);
+    });
   });
 });

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -38,7 +38,7 @@ describe('TimelineStore', () => {
   const mockColor = { r: 0, g: 0, b: 0, a: 1 };
 
   beforeEach(() => {
-    internPool = new InternPoolStore();
+    internPool = InternPoolStore.create();
     styleStore = new StyleStore();
     logStore = new LogStore(internPool, styleStore);
     store = new TimelineStore(internPool, styleStore, logStore);

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -31,8 +31,36 @@ import {
   Verb,
 } from 'src/app/store/domain/style';
 import { LogStore } from 'src/app/store/domain/log-store';
-import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import {
+  ReadonlyDomainElement,
+  allocateBuffer,
+  isSharedBuffer,
+} from 'src/app/store/domain/types';
 import { fromBinary } from '@bufbuild/protobuf';
+
+/**
+ * Align the offset to the specified byte alignment.
+ */
+function align(offset: number, alignment: number): number {
+  return Math.ceil(offset / alignment) * alignment;
+}
+
+/**
+ * Represents the shared memory structure of the timeline store.
+ */
+export interface TimelineStoreSharedData {
+  readonly metadataSab: SharedArrayBuffer | ArrayBuffer;
+  readonly bodyBufferSabs: readonly (SharedArrayBuffer | ArrayBuffer)[];
+  readonly timelineCount: number;
+  readonly revisionCount: number;
+  readonly eventCount: number;
+  readonly timelineRevisionIds: readonly (readonly number[])[];
+  readonly timelineEventIds: readonly (readonly number[])[];
+  readonly timelineChildrenIds: readonly (readonly number[])[];
+  readonly timelineIdToIndex: { readonly [tid: number]: number };
+  readonly revisionIdToIndex: { readonly [rid: number]: number };
+  readonly eventIdToIndex: { readonly [eid: number]: number };
+}
 
 /**
  * Raw timeline object interface from the assembler.
@@ -71,44 +99,296 @@ export interface EventDTO {
  * Store for managing and retrieving timelines, revisions, and events efficiently.
  */
 export class TimelineStore {
-  // Timeline metadata
-  private timelineIds = new Uint32Array(0);
-  private timelineTypeIds = new Uint32Array(0);
-  private timelineNameStringIds = new Uint32Array(0);
-  private timelineParentIds = new Uint32Array(0);
-  private timelineSeverities = new Uint8Array(0);
+  private readonly readOnly: boolean;
+
+  private metadataSab!: SharedArrayBuffer | ArrayBuffer;
+
+  // Timeline views
+  private timelineIds!: Uint32Array;
+  private timelineTypeIds!: Uint32Array;
+  private timelineNameStringIds!: Uint32Array;
+  private timelineParentIds!: Uint32Array;
+  private timelineSeverities!: Uint8Array;
+
   private readonly timelineRevisionIds: Uint32Array[] = [];
   private readonly timelineEventIds: Uint32Array[] = [];
   private readonly timelineChildrenIds: number[][] = [];
   private readonly timelinesList: ReadonlyDomainElement<Timeline>[] = [];
   private timelineIdToIndex: { [tid: number]: number } = {};
 
-  // Revision metadata stored in packed arrays
-  private revisionIds = new Uint32Array(0);
-  private revisionLogIds = new Uint32Array(0);
-  private revisionChangedTimes = new BigUint64Array(0);
-  private revisionPrincipalStringIds = new Uint32Array(0);
-  private revisionVerbTypeIds = new Uint32Array(0);
-  private revisionStateTypeIds = new Uint32Array(0);
-  private readonly revisionBodies: Uint8Array[] = [];
+  // Revision views
+  private revisionIds!: Uint32Array;
+  private revisionLogIds!: Uint32Array;
+  private revisionChangedTimes!: BigUint64Array;
+  private revisionPrincipalStringIds!: Uint32Array;
+  private revisionVerbTypeIds!: Uint32Array;
+  private revisionStateTypeIds!: Uint32Array;
+
+  // Packed revision bodies
+  private revisionBodyBufferIndices!: Uint16Array;
+  private revisionBodyOffsets!: Uint32Array;
+  private revisionBodyLengths!: Uint32Array;
+
+  private readonly revisionBodyBufferSabs: (SharedArrayBuffer | ArrayBuffer)[] =
+    [];
+  private readonly revisionBodyBuffers: Uint8Array[] = [];
+
+  private currentBufferIndex = -1;
+  private currentOffset = 0;
+
   private readonly revisionDecodedBodyCache: WeakRef<
     ReadonlyDomainElement<Record<string, unknown>>
   >[] = [];
   private revisionIdToIndex: { [rid: number]: number } = {};
 
-  // Event metadata
-  private eventIds = new Uint32Array(0);
-  private eventLogIds = new Uint32Array(0);
+  // Event views
+  private eventIds!: Uint32Array;
+  private eventLogIds!: Uint32Array;
   private eventIdToIndex: { [eid: number]: number } = {};
 
   private readonly decoder: InternedStructDecoder;
 
-  constructor(
+  private constructor(
     private readonly internPool: InternPoolStore,
     public readonly styleStore: StyleStore,
     public readonly logStore: LogStore,
+    private readonly maxBufferSize: number,
+    readOnly: boolean,
+    initialData:
+      | { timelineCount: number; revisionCount: number; eventCount: number }
+      | TimelineStoreSharedData,
   ) {
+    this.readOnly = readOnly;
     this.decoder = new InternedStructDecoder(this.internPool);
+
+    if ('metadataSab' in initialData) {
+      const sharedData = initialData;
+      this.metadataSab = sharedData.metadataSab;
+      this.revisionBodyBufferSabs = Array.from(sharedData.bodyBufferSabs);
+      this.revisionBodyBuffers = this.revisionBodyBufferSabs.map(
+        (sab) => new Uint8Array(sab),
+      );
+
+      this.timelineRevisionIds = sharedData.timelineRevisionIds.map(
+        (arr) => new Uint32Array(arr),
+      );
+      this.timelineEventIds = sharedData.timelineEventIds.map(
+        (arr) => new Uint32Array(arr),
+      );
+      this.timelineChildrenIds = sharedData.timelineChildrenIds.map((arr) =>
+        Array.from(arr),
+      );
+
+      this.timelineIdToIndex = { ...sharedData.timelineIdToIndex };
+      this.revisionIdToIndex = { ...sharedData.revisionIdToIndex };
+      this.eventIdToIndex = { ...sharedData.eventIdToIndex };
+
+      this.mapMetadataViews(
+        sharedData.timelineCount,
+        sharedData.revisionCount,
+        sharedData.eventCount,
+      );
+
+      for (let i = 0; i < sharedData.timelineCount; i++) {
+        this.timelinesList.push(new Timeline(this.timelineIds[i], this));
+      }
+    } else {
+      const counts = initialData;
+      this.allocateMetadata(
+        counts.timelineCount,
+        counts.revisionCount,
+        counts.eventCount,
+      );
+    }
+  }
+
+  /**
+   * Creates a new writable TimelineStore instance.
+   */
+  public static create(
+    internPool: InternPoolStore,
+    styleStore: StyleStore,
+    logStore: LogStore,
+    maxBufferSize: number = 100 * 1024 * 1024,
+  ): TimelineStore {
+    return new TimelineStore(
+      internPool,
+      styleStore,
+      logStore,
+      maxBufferSize,
+      false,
+      { timelineCount: 1024, revisionCount: 1024, eventCount: 1024 },
+    );
+  }
+
+  /**
+   * Reconstructs a read-only TimelineStore instance from shared memory data.
+   */
+  public static fromSharedData(
+    internPool: InternPoolStore,
+    styleStore: StyleStore,
+    logStore: LogStore,
+    sharedData: TimelineStoreSharedData,
+    maxBufferSize: number = 100 * 1024 * 1024,
+  ): TimelineStore {
+    return new TimelineStore(
+      internPool,
+      styleStore,
+      logStore,
+      maxBufferSize,
+      true,
+      sharedData,
+    );
+  }
+
+  private allocateMetadata(tCap: number, rCap: number, eCap: number): void {
+    const layout = this.calculateOffsets(tCap, rCap, eCap);
+    this.metadataSab = allocateBuffer(layout.totalBytes);
+    this.applyViews(layout, tCap, rCap, eCap);
+  }
+
+  private mapMetadataViews(tCap: number, rCap: number, eCap: number): void {
+    const layout = this.calculateOffsets(tCap, rCap, eCap);
+    this.applyViews(layout, tCap, rCap, eCap);
+  }
+
+  private calculateOffsets(tCap: number, rCap: number, eCap: number) {
+    let offset = 0;
+
+    const timelineIds = offset;
+    offset += tCap * 4;
+
+    const timelineTypeIds = offset;
+    offset += tCap * 4;
+
+    const timelineNameStringIds = offset;
+    offset += tCap * 4;
+
+    const timelineParentIds = offset;
+    offset += tCap * 4;
+
+    const timelineSeverities = offset;
+    offset += tCap * 1;
+
+    const revisionIds = align(offset, 4);
+    offset = revisionIds + rCap * 4;
+
+    const revisionLogIds = offset;
+    offset += rCap * 4;
+
+    const revisionChangedTimes = align(offset, 8);
+    offset = revisionChangedTimes + rCap * 8;
+
+    const revisionPrincipalStringIds = offset;
+    offset += rCap * 4;
+
+    const revisionVerbTypeIds = offset;
+    offset += rCap * 4;
+
+    const revisionStateTypeIds = offset;
+    offset += rCap * 4;
+
+    const revisionBodyBufferIndices = align(offset, 2);
+    offset = revisionBodyBufferIndices + rCap * 2;
+
+    const revisionBodyOffsets = align(offset, 4);
+    offset = revisionBodyOffsets + rCap * 4;
+
+    const revisionBodyLengths = align(offset, 4);
+    offset = revisionBodyLengths + rCap * 4;
+
+    const eventIds = align(offset, 4);
+    offset = eventIds + eCap * 4;
+
+    const eventLogIds = offset;
+    offset += eCap * 4;
+
+    return {
+      timelineIds,
+      timelineTypeIds,
+      timelineNameStringIds,
+      timelineParentIds,
+      timelineSeverities,
+      revisionIds,
+      revisionLogIds,
+      revisionChangedTimes,
+      revisionPrincipalStringIds,
+      revisionVerbTypeIds,
+      revisionStateTypeIds,
+      revisionBodyBufferIndices,
+      revisionBodyOffsets,
+      revisionBodyLengths,
+      eventIds,
+      eventLogIds,
+      totalBytes: offset,
+    };
+  }
+
+  private applyViews(
+    layout: ReturnType<typeof TimelineStore.prototype.calculateOffsets>,
+    tCap: number,
+    rCap: number,
+    eCap: number,
+  ): void {
+    const sab = this.metadataSab;
+    this.timelineIds = new Uint32Array(sab, layout.timelineIds, tCap);
+    this.timelineTypeIds = new Uint32Array(sab, layout.timelineTypeIds, tCap);
+    this.timelineNameStringIds = new Uint32Array(
+      sab,
+      layout.timelineNameStringIds,
+      tCap,
+    );
+    this.timelineParentIds = new Uint32Array(
+      sab,
+      layout.timelineParentIds,
+      tCap,
+    );
+    this.timelineSeverities = new Uint8Array(
+      sab,
+      layout.timelineSeverities,
+      tCap,
+    );
+
+    this.revisionIds = new Uint32Array(sab, layout.revisionIds, rCap);
+    this.revisionLogIds = new Uint32Array(sab, layout.revisionLogIds, rCap);
+    this.revisionChangedTimes = new BigUint64Array(
+      sab,
+      layout.revisionChangedTimes,
+      rCap,
+    );
+    this.revisionPrincipalStringIds = new Uint32Array(
+      sab,
+      layout.revisionPrincipalStringIds,
+      rCap,
+    );
+    this.revisionVerbTypeIds = new Uint32Array(
+      sab,
+      layout.revisionVerbTypeIds,
+      rCap,
+    );
+    this.revisionStateTypeIds = new Uint32Array(
+      sab,
+      layout.revisionStateTypeIds,
+      rCap,
+    );
+    this.revisionBodyBufferIndices = new Uint16Array(
+      sab,
+      layout.revisionBodyBufferIndices,
+      rCap,
+    );
+    this.revisionBodyOffsets = new Uint32Array(
+      sab,
+      layout.revisionBodyOffsets,
+      rCap,
+    );
+    this.revisionBodyLengths = new Uint32Array(
+      sab,
+      layout.revisionBodyLengths,
+      rCap,
+    );
+
+    this.eventIds = new Uint32Array(sab, layout.eventIds, eCap);
+    this.eventLogIds = new Uint32Array(sab, layout.eventLogIds, eCap);
   }
 
   /**
@@ -128,20 +408,24 @@ export class TimelineStore {
     events: Iterable<EventDTO>,
     eventCount: number,
   ): void {
-    this.timelineIds = new Uint32Array(timelineCount);
-    this.timelineTypeIds = new Uint32Array(timelineCount);
-    this.timelineNameStringIds = new Uint32Array(timelineCount);
-    this.timelineParentIds = new Uint32Array(timelineCount);
-    this.timelineSeverities = new Uint8Array(timelineCount);
+    if (this.readOnly) {
+      throw new Error('Cannot write to a shared read-only TimelineStore');
+    }
+
+    this.allocateMetadata(timelineCount, revisionCount, eventCount);
 
     this.timelineRevisionIds.length = 0;
     this.timelineEventIds.length = 0;
-    this.revisionBodies.length = 0;
+    this.revisionBodyBufferSabs.length = 0;
+    this.revisionBodyBuffers.length = 0;
     this.timelinesList.length = 0;
     this.timelineChildrenIds.length = 0;
     this.timelineIdToIndex = {};
     this.revisionIdToIndex = {};
     this.eventIdToIndex = {};
+
+    this.currentBufferIndex = -1;
+    this.currentOffset = 0;
 
     // Load timelines
     let tIndex = 0;
@@ -168,12 +452,6 @@ export class TimelineStore {
       }
     }
 
-    this.revisionIds = new Uint32Array(revisionCount);
-    this.revisionLogIds = new Uint32Array(revisionCount);
-    this.revisionChangedTimes = new BigUint64Array(revisionCount);
-    this.revisionPrincipalStringIds = new Uint32Array(revisionCount);
-    this.revisionVerbTypeIds = new Uint32Array(revisionCount);
-    this.revisionStateTypeIds = new Uint32Array(revisionCount);
     this.revisionDecodedBodyCache.length = revisionCount;
 
     // Load revisions
@@ -186,16 +464,18 @@ export class TimelineStore {
       this.revisionVerbTypeIds[rIndex] = r.verbTypeId;
       this.revisionStateTypeIds[rIndex] = r.stateTypeId;
 
-      if (r.body !== undefined) {
-        this.revisionBodies[rIndex] = r.body;
+      if (r.body !== undefined && r.body.length > 0) {
+        this.addRevisionBody(rIndex, r.body);
+      } else {
+        this.revisionBodyBufferIndices[rIndex] = 0;
+        this.revisionBodyOffsets[rIndex] = 0;
+        this.revisionBodyLengths[rIndex] = 0;
       }
       this.revisionIdToIndex[r.id] = rIndex;
       rIndex++;
     }
 
     // load events
-    this.eventIds = new Uint32Array(eventCount);
-    this.eventLogIds = new Uint32Array(eventCount);
     let eIndex = 0;
     for (const e of events) {
       this.eventIds[eIndex] = e.id;
@@ -231,6 +511,45 @@ export class TimelineStore {
       }
       this.timelineSeverities[i] = mask;
     }
+  }
+
+  private addRevisionBody(index: number, bodyBytes: Uint8Array): void {
+    const length = bodyBytes.length;
+
+    if (length > this.maxBufferSize) {
+      const sab = allocateBuffer(length);
+      const buf = new Uint8Array(sab);
+      buf.set(bodyBytes);
+      this.revisionBodyBufferSabs.push(sab);
+      this.revisionBodyBuffers.push(buf);
+
+      const newBufIdx = this.revisionBodyBuffers.length - 1;
+      this.revisionBodyBufferIndices[index] = newBufIdx + 1;
+      this.revisionBodyOffsets[index] = 0;
+      this.revisionBodyLengths[index] = length;
+      return;
+    }
+
+    if (
+      this.currentBufferIndex === -1 ||
+      this.currentOffset + length > this.maxBufferSize
+    ) {
+      const sab = allocateBuffer(this.maxBufferSize);
+      const buf = new Uint8Array(sab);
+      this.revisionBodyBufferSabs.push(sab);
+      this.revisionBodyBuffers.push(buf);
+      this.currentBufferIndex = this.revisionBodyBuffers.length - 1;
+      this.currentOffset = 0;
+    }
+
+    const currentBuf = this.revisionBodyBuffers[this.currentBufferIndex];
+    currentBuf.set(bodyBytes, this.currentOffset);
+
+    this.revisionBodyBufferIndices[index] = this.currentBufferIndex + 1;
+    this.revisionBodyOffsets[index] = this.currentOffset;
+    this.revisionBodyLengths[index] = length;
+
+    this.currentOffset += length;
   }
 
   // --- Timeline Accessors ---
@@ -436,9 +755,22 @@ export class TimelineStore {
       return cached;
     }
 
-    const body = this.revisionBodies[index];
-    if (!body) return null;
-    const struct = fromBinary(InternedStructSchema, body);
+    const bufIdx = this.revisionBodyBufferIndices[index];
+    if (bufIdx === 0) return null;
+
+    const offset = this.revisionBodyOffsets[index];
+    const length = this.revisionBodyLengths[index];
+
+    const buffer = this.revisionBodyBuffers[bufIdx - 1];
+    const bytes = buffer.subarray(offset, offset + length);
+    let decodeTarget = bytes;
+    if (isSharedBuffer(bytes.buffer)) {
+      const nonSharedBytes = new Uint8Array(length);
+      nonSharedBytes.set(bytes);
+      decodeTarget = nonSharedBytes;
+    }
+
+    const struct = fromBinary(InternedStructSchema, decodeTarget);
     const decoded = this.decoder.decode(struct);
     this.revisionDecodedBodyCache[index] = new WeakRef(decoded);
     return decoded;
@@ -468,5 +800,28 @@ export class TimelineStore {
       throw new Error(`Event ID ${id} not found`);
     }
     return index;
+  }
+
+  /**
+   * Returns the shared memory representation of this TimelineStore.
+   */
+  public getSharedData(): TimelineStoreSharedData {
+    return {
+      metadataSab: this.metadataSab,
+      bodyBufferSabs: this.revisionBodyBufferSabs,
+      timelineCount: this.timelineIds.length,
+      revisionCount: this.revisionIds.length,
+      eventCount: this.eventIds.length,
+      timelineRevisionIds: this.timelineRevisionIds.map((arr) =>
+        Array.from(arr),
+      ),
+      timelineEventIds: this.timelineEventIds.map((arr) => Array.from(arr)),
+      timelineChildrenIds: this.timelineChildrenIds.map((arr) =>
+        Array.from(arr),
+      ),
+      timelineIdToIndex: { ...this.timelineIdToIndex },
+      revisionIdToIndex: { ...this.revisionIdToIndex },
+      eventIdToIndex: { ...this.eventIdToIndex },
+    };
   }
 }

--- a/web/src/app/store/domain/timeline.spec.ts
+++ b/web/src/app/store/domain/timeline.spec.ts
@@ -38,7 +38,7 @@ describe('Timeline', () => {
   const mockColor = { r: 0, g: 0, b: 0, a: 1 };
 
   beforeEach(() => {
-    internPool = new InternPoolStore();
+    internPool = InternPoolStore.create();
     styleStore = new StyleStore();
     logStore = new LogStore(internPool, styleStore);
     timelineStore = new TimelineStore(internPool, styleStore, logStore);

--- a/web/src/app/store/domain/timeline.spec.ts
+++ b/web/src/app/store/domain/timeline.spec.ts
@@ -40,8 +40,8 @@ describe('Timeline', () => {
   beforeEach(() => {
     internPool = InternPoolStore.create();
     styleStore = new StyleStore();
-    logStore = new LogStore(internPool, styleStore);
-    timelineStore = new TimelineStore(internPool, styleStore, logStore);
+    logStore = LogStore.create(internPool, styleStore);
+    timelineStore = TimelineStore.create(internPool, styleStore, logStore);
 
     styleStore.addTimelineTypes([
       {

--- a/web/src/app/store/domain/types.ts
+++ b/web/src/app/store/domain/types.ts
@@ -30,3 +30,28 @@ export type ReadonlyDomainElement<T> = T extends Function
  * Type representing a value that can be undefined.
  */
 export type Undefinable<T> = T | undefined;
+
+/**
+ * Checks if SharedArrayBuffer is supported in the current environment.
+ */
+export function isSharedArrayBufferSupported(): boolean {
+  return typeof SharedArrayBuffer !== 'undefined';
+}
+
+/**
+ * Helper to allocate a SharedArrayBuffer if supported, otherwise fallback to ArrayBuffer.
+ */
+export function allocateBuffer(size: number): SharedArrayBuffer | ArrayBuffer {
+  return isSharedArrayBufferSupported()
+    ? new SharedArrayBuffer(size)
+    : new ArrayBuffer(size);
+}
+
+/**
+ * Checks if the given buffer is a SharedArrayBuffer.
+ */
+export function isSharedBuffer(
+  buffer: ArrayBuffer | SharedArrayBuffer,
+): boolean {
+  return isSharedArrayBufferSupported() && buffer instanceof SharedArrayBuffer;
+}

--- a/web/src/app/store/mock/inspection-data.mock.ts
+++ b/web/src/app/store/mock/inspection-data.mock.ts
@@ -46,7 +46,7 @@ import {
  * @returns A promise resolving to a populated mock inspection data instance.
  */
 export async function createMockInspectionDataV2(): Promise<InspectionDataV2> {
-  const internPool = new InternPoolStore();
+  const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
   const logStore = new LogStore(internPool, styleStore);
   const timelineStore = new TimelineStore(internPool, styleStore, logStore);

--- a/web/src/app/store/mock/inspection-data.mock.ts
+++ b/web/src/app/store/mock/inspection-data.mock.ts
@@ -48,8 +48,8 @@ import {
 export async function createMockInspectionDataV2(): Promise<InspectionDataV2> {
   const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
-  const logStore = new LogStore(internPool, styleStore);
-  const timelineStore = new TimelineStore(internPool, styleStore, logStore);
+  const logStore = LogStore.create(internPool, styleStore);
+  const timelineStore = TimelineStore.create(internPool, styleStore, logStore);
 
   const idState: MockInternIdState = {
     nextStringId: 1,

--- a/web/src/app/store/mock/mock-util.spec.ts
+++ b/web/src/app/store/mock/mock-util.spec.ts
@@ -65,7 +65,7 @@ describe('mock-util', () => {
 
   describe('objectToInternedStruct', () => {
     it('should successfully convert plain object to InternedStruct and decode back', () => {
-      const internPool = new InternPoolStore();
+      const internPool = InternPoolStore.create();
       const idState = { nextStringId: 1, nextFieldSetId: 1 };
 
       const original = {

--- a/web/src/app/timeline/components/misc/demo-builder.ts
+++ b/web/src/app/timeline/components/misc/demo-builder.ts
@@ -43,7 +43,7 @@ import { getMinTimeSpanForHistogram } from '../calculator/human-friendly-tick';
  * specifically for testing and Storybook demonstrations using the V2 domain stores.
  */
 export class DemoViewModelBuilder {
-  private readonly internPool = new InternPoolStore();
+  private readonly internPool = InternPoolStore.create();
   private readonly styleStore = new StyleStore();
   private readonly logStore = new LogStore(this.internPool, this.styleStore);
   private readonly timelineStore = new TimelineStore(

--- a/web/src/app/timeline/components/misc/demo-builder.ts
+++ b/web/src/app/timeline/components/misc/demo-builder.ts
@@ -45,8 +45,8 @@ import { getMinTimeSpanForHistogram } from '../calculator/human-friendly-tick';
 export class DemoViewModelBuilder {
   private readonly internPool = InternPoolStore.create();
   private readonly styleStore = new StyleStore();
-  private readonly logStore = new LogStore(this.internPool, this.styleStore);
-  private readonly timelineStore = new TimelineStore(
+  private readonly logStore = LogStore.create(this.internPool, this.styleStore);
+  private readonly timelineStore = TimelineStore.create(
     this.internPool,
     this.styleStore,
     this.logStore,

--- a/web/src/app/timeline/components/misc/histogram-cache.spec.ts
+++ b/web/src/app/timeline/components/misc/histogram-cache.spec.ts
@@ -33,7 +33,7 @@ function createCacheWithLogs(
   minTimeMs?: number,
   maxTimeMs?: number,
 ): HistogramCache {
-  const internPool = new InternPoolStore();
+  const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
   const logStore = new LogStore(internPool, styleStore);
 

--- a/web/src/app/timeline/components/misc/histogram-cache.spec.ts
+++ b/web/src/app/timeline/components/misc/histogram-cache.spec.ts
@@ -35,7 +35,7 @@ function createCacheWithLogs(
 ): HistogramCache {
   const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
-  const logStore = new LogStore(internPool, styleStore);
+  const logStore = LogStore.create(internPool, styleStore);
 
   styleStore.addSeverities([
     {

--- a/web/src/app/timeline/components/timeline-index.stories.ts
+++ b/web/src/app/timeline/components/timeline-index.stories.ts
@@ -131,8 +131,8 @@ function createTimelines(): Timeline[] {
       height: 0.5,
     },
   ]);
-  const logStore = new LogStore(internPool, styleStore);
-  const timelineStore = new TimelineStore(internPool, styleStore, logStore);
+  const logStore = LogStore.create(internPool, styleStore);
+  const timelineStore = TimelineStore.create(internPool, styleStore, logStore);
 
   internPool.addStrings([
     { id: 1, value: 'core/v1' },

--- a/web/src/app/timeline/components/timeline-index.stories.ts
+++ b/web/src/app/timeline/components/timeline-index.stories.ts
@@ -57,7 +57,7 @@ export default meta;
 type Story = StoryObj<TimelineIndexComponent>;
 
 function createTimelines(): Timeline[] {
-  const internPool = new InternPoolStore();
+  const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
   styleStore.addTimelineTypes([
     {

--- a/web/src/app/timeline/components/timeline-legend.stories.ts
+++ b/web/src/app/timeline/components/timeline-legend.stories.ts
@@ -37,7 +37,7 @@ export default meta;
 type Story = StoryObj<TimelineLegendComponent>;
 
 function createMockTimeline(isKind: boolean): Timeline {
-  const internPool = new InternPoolStore();
+  const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
   const logStore = new LogStore(internPool, styleStore);
   const timelineStore = new TimelineStore(internPool, styleStore, logStore);

--- a/web/src/app/timeline/components/timeline-legend.stories.ts
+++ b/web/src/app/timeline/components/timeline-legend.stories.ts
@@ -39,8 +39,8 @@ type Story = StoryObj<TimelineLegendComponent>;
 function createMockTimeline(isKind: boolean): Timeline {
   const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
-  const logStore = new LogStore(internPool, styleStore);
-  const timelineStore = new TimelineStore(internPool, styleStore, logStore);
+  const logStore = LogStore.create(internPool, styleStore);
+  const timelineStore = TimelineStore.create(internPool, styleStore, logStore);
 
   internPool.addStrings([
     { id: 1, value: 'core/v1#default' },

--- a/web/src/app/timeline/components/timeline-ruler.stories.ts
+++ b/web/src/app/timeline/components/timeline-ruler.stories.ts
@@ -144,7 +144,7 @@ function generateMockLogs(
   severityRatio: { [severity in Severity]?: number },
 ): Log[] {
   const internPool = InternPoolStore.create();
-  const logStore = new LogStore(internPool, sharedStyleStore);
+  const logStore = LogStore.create(internPool, sharedStyleStore);
 
   const culmativeRatios: number[] = [];
   const severitiesList = [

--- a/web/src/app/timeline/components/timeline-ruler.stories.ts
+++ b/web/src/app/timeline/components/timeline-ruler.stories.ts
@@ -143,7 +143,7 @@ function generateMockLogs(
   count: number,
   severityRatio: { [severity in Severity]?: number },
 ): Log[] {
-  const internPool = new InternPoolStore();
+  const internPool = InternPoolStore.create();
   const logStore = new LogStore(internPool, sharedStyleStore);
 
   const culmativeRatios: number[] = [];


### PR DESCRIPTION
This PR introduces several methods on domain stores. Methods like `getSharedData`  implemented each domain store creates transferable object from the store and implemented another contructor to initialize stores from the shared data.

These changes are base of up coming WebWorker based search approach.