### PR TITLE
Change default listen host to 127.0.0.1 from localhost

### DIFF
--- a/pkg/parameters/server.go
+++ b/pkg/parameters/server.go
@@ -49,7 +49,7 @@ func (s *ServerParameters) PostProcess() error {
 func (s *ServerParameters) Prepare() error {
 	s.ViewerMode = flag.Bool("viewer-mode", false, "Limits the KHI feature to query logs with the backend. When it is true, KHI is only serve the frontend to open KHI files.", "KHI_VIEWER_MODE")
 	s.Port = flag.Int("port", 8080, "The port number where KHI server listens.", "PORT")
-	s.Host = flag.String("host", "localhost", "The host address where KHI server serves.", "HOST")
+	s.Host = flag.String("host", "127.0.0.1", "The host address where KHI server serves.", "HOST")
 	s.BasePath = flag.String("base-path", "/", "The base address of API endpoints.", "KHI_BASE_PATH")
 	s.FrontendResourceBasePath = flag.String("frontend-resource-base-path", "", "Another base address only for frontend assets. If this value is not set, this uses `--base-path` value by default.", "KHI_FRONTEND_RESOURCE_PATH")
 	s.FrontendAssetFolder = flag.String("frontend-asset-folder", "", "The root folder of the assets used in frontend including index.html. If this value is not set, the assets embedded into the executable are used.", "KHI_FRONTEND_ASSET_FOLDER")

--- a/pkg/parameters/server_test.go
+++ b/pkg/parameters/server_test.go
@@ -38,7 +38,7 @@ func TestServerParameters(t *testing.T) {
 			want: &ServerParameters{
 				ViewerMode:               testutil.P(false),
 				Port:                     testutil.P(8080),
-				Host:                     testutil.P("localhost"),
+				Host:                     testutil.P("127.0.0.1"),
 				BasePath:                 testutil.P("/"),
 				FrontendResourceBasePath: testutil.P("/"),
 				FrontendAssetFolder:      testutil.P(""),
@@ -54,7 +54,7 @@ func TestServerParameters(t *testing.T) {
 			want: &ServerParameters{
 				ViewerMode:               testutil.P(false),
 				Port:                     testutil.P(8080),
-				Host:                     testutil.P("localhost"),
+				Host:                     testutil.P("127.0.0.1"),
 				BasePath:                 testutil.P("/foo/bar/"),
 				FrontendResourceBasePath: testutil.P("/foo/bar/"),
 				FrontendAssetFolder:      testutil.P(""),
@@ -70,7 +70,7 @@ func TestServerParameters(t *testing.T) {
 			want: &ServerParameters{
 				ViewerMode:               testutil.P(false),
 				Port:                     testutil.P(8080),
-				Host:                     testutil.P("localhost"),
+				Host:                     testutil.P("127.0.0.1"),
 				BasePath:                 testutil.P("/foo/bar/"),
 				FrontendResourceBasePath: testutil.P("/foo/"),
 				FrontendAssetFolder:      testutil.P(""),


### PR DESCRIPTION
Changed the default server parameter to listen on 127.0.0.1:8080 instead of localhost:8080. This reduces behavioral differences depending on whether localhost resolves to an IPv4 or IPv6 loopback address.