### PR TITLE
Improve retry logic to consider temporal failure due to ECP issue

### DIFF
--- a/pkg/api/googlecloud/calloptions.go
+++ b/pkg/api/googlecloud/calloptions.go
@@ -15,7 +15,10 @@
 package googlecloud
 
 import (
+	"context"
+	"log/slog"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/googleapis/gax-go/v2"
@@ -28,7 +31,12 @@ var DefaultRetryPolicy = gax.WithRetry(NewDefaultRetryer)
 
 // NewDefaultRetryer returns the default retryer.
 func NewDefaultRetryer() gax.Retryer {
-	return gax.OnCodes([]codes.Code{
+	return NewDefaultRetryerWithContext(context.Background())
+}
+
+// NewDefaultRetryerWithContext returns the default retryer with context.
+func NewDefaultRetryerWithContext(ctx context.Context) gax.Retryer {
+	r := gax.OnCodes([]codes.Code{
 		codes.Aborted,
 		codes.Canceled,
 		codes.Internal,
@@ -36,11 +44,41 @@ func NewDefaultRetryer() gax.Retryer {
 		codes.Unknown,
 		codes.Unavailable,
 		codes.DeadlineExceeded,
+		codes.Unauthenticated, // Non per-RPC cred failures are not retried, see defaultRetryer.Retry.
 	}, gax.Backoff{
 		Initial:    100 * time.Millisecond,
 		Max:        5000 * time.Millisecond,
 		Multiplier: 1.30,
 	})
+	return &defaultRetryer{Retryer: r, ctx: ctx}
+}
+
+// defaultRetryer wraps a gax.Retryer to customize the retry behavior for specific codes like Unauthenticated.
+type defaultRetryer struct {
+	gax.Retryer
+	ctx context.Context
+}
+
+var _ gax.Retryer = (*defaultRetryer)(nil)
+
+// Retry overrides the underlying gax.Retryer's Retry method to filter Unauthenticated errors.
+func (r *defaultRetryer) Retry(err error) (time.Duration, bool) {
+	s, ok := status.FromError(err)
+	if !ok {
+		return 0, false
+	}
+	// Temporal issue on Enterprise Certificate Proxy may result in Unauthenticated errors.
+	// We retry on these errors since the root cause is likely a transient issue with ECP.
+	if s.Code() == codes.Unauthenticated {
+		if !strings.Contains(s.Message(), `per-RPC creds failed due to error:`) {
+			return 0, false
+		}
+	}
+	pause, shouldRetry := r.Retryer.Retry(err)
+	if shouldRetry && r.ctx != nil {
+		slog.DebugContext(r.ctx, "retrying Google Cloud API call due to transient error", "error", err, "pause", pause)
+	}
+	return pause, shouldRetry
 }
 
 // NeverTimeout is gax.CallOption that never reaches the timeout.
@@ -48,26 +86,26 @@ var NeverTimeout = gax.WithTimeout(1<<63 - 1)
 
 // retryWithCountBudget retries for specific error codes but with count limit.
 type retryWithCountBudget struct {
+	gax.Retryer
 	codes            []codes.Code
 	initialDuration  time.Duration
 	multiplier       float32
 	resetDuration    time.Duration
 	retryCount       int
 	retryCountBudget int
-	parentRetrier    gax.Retryer
 	lastRetry        time.Time
 }
 
 // NewRetryWithCountBudget returns the instance of retryWithCountBudget.
 func NewRetryWithCountBudget(codes []codes.Code, initialDuration time.Duration, multiplier float32, resetDuration time.Duration, retryCountBudget int, parentRetrier gax.Retryer) *retryWithCountBudget {
 	return &retryWithCountBudget{
+		Retryer:          parentRetrier,
 		codes:            codes,
 		initialDuration:  initialDuration,
 		multiplier:       multiplier,
 		resetDuration:    resetDuration,
 		retryCount:       0,
 		retryCountBudget: retryCountBudget,
-		parentRetrier:    parentRetrier,
 		lastRetry:        time.Time{},
 	}
 }
@@ -92,8 +130,8 @@ func (r *retryWithCountBudget) Retry(err error) (pause time.Duration, shouldRetr
 			return time.Duration(math.Pow(float64(r.multiplier), float64(r.retryCount-1)) * float64(r.initialDuration)), true
 		}
 	}
-	if r.parentRetrier != nil {
-		return r.parentRetrier.Retry(err)
+	if r.Retryer != nil {
+		return r.Retryer.Retry(err)
 	} else {
 		return 0, false
 	}

--- a/pkg/api/googlecloud/calloptions.go
+++ b/pkg/api/googlecloud/calloptions.go
@@ -63,14 +63,11 @@ var _ gax.Retryer = (*defaultRetryer)(nil)
 
 // Retry overrides the underlying gax.Retryer's Retry method to filter Unauthenticated errors.
 func (r *defaultRetryer) Retry(err error) (time.Duration, bool) {
-	s, ok := status.FromError(err)
-	if !ok {
-		return 0, false
-	}
 	// Temporal issue on Enterprise Certificate Proxy may result in Unauthenticated errors.
 	// We retry on these errors since the root cause is likely a transient issue with ECP.
-	if s.Code() == codes.Unauthenticated {
-		if !strings.Contains(s.Message(), `per-RPC creds failed due to error:`) {
+	if statusCode := status.Code(err); statusCode == codes.Unauthenticated {
+		s, ok := status.FromError(err)
+		if !ok || !strings.Contains(s.Message(), `per-RPC creds failed due to error:`) {
 			return 0, false
 		}
 	}

--- a/pkg/api/googlecloud/calloptions_test.go
+++ b/pkg/api/googlecloud/calloptions_test.go
@@ -198,6 +198,11 @@ func TestDefaultRetryer(t *testing.T) {
 			nextError: status.Error(codes.InvalidArgument, "invalid argument"),
 			wantRetry: false,
 		},
+		{
+			name:      "do not retry on non-gRPC error",
+			nextError: fmt.Errorf("generic network error"),
+			wantRetry: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/api/googlecloud/calloptions_test.go
+++ b/pkg/api/googlecloud/calloptions_test.go
@@ -165,3 +165,48 @@ func TestRetryWithCountBudget(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaultRetryer tests the custom default retry policy behavior.
+func TestDefaultRetryer(t *testing.T) {
+	testCases := []struct {
+		name      string
+		nextError error
+		wantRetry bool
+	}{
+		{
+			name:      "retry on unavailable",
+			nextError: status.Error(codes.Unavailable, "unavailable"),
+			wantRetry: true,
+		},
+		{
+			name:      "do not retry on standard unauthenticated",
+			nextError: status.Error(codes.Unauthenticated, "invalid credentials"),
+			wantRetry: false,
+		},
+		{
+			name:      "retry on specific mtls timeout unauthenticated error",
+			nextError: status.Error(codes.Unauthenticated, `transport: per-RPC creds failed due to error: Post "https://oauth2.mtls.googleapis.com/token": net/http: TLS handshake timeout`),
+			wantRetry: true,
+		},
+		{
+			name:      "retry on specific mtls pkcs11 sign failure error",
+			nextError: status.Error(codes.Unauthenticated, `transport: per-RPC creds failed due to error: Post "https://oauth2.mtls.googleapis.com/token": tls: failed to sign handshake: pkcs11: C_Sign() CKR_ARGUMENTS_BAD`),
+			wantRetry: true,
+		},
+		{
+			name:      "do not retry on other errors",
+			nextError: status.Error(codes.InvalidArgument, "invalid argument"),
+			wantRetry: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			retrier := NewDefaultRetryer()
+			_, gotRetry := retrier.Retry(tc.nextError)
+			if gotRetry != tc.wantRetry {
+				t.Errorf("Retry() got retry flag %v, want %v", gotRetry, tc.wantRetry)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudcommon/contract/logfetcher.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/logfetcher.go
@@ -65,7 +65,9 @@ func (l *logFetcherImpl) FetchLogs(dest chan<- *loggingpb.LogEntry, ctx context.
 		Filter:        filter,
 		OrderBy:       l.orderBy,
 		PageSize:      l.pageSize,
-	}, gax.WithRetry(newCloudLoggingRetrier), googlecloud.NeverTimeout)
+	}, gax.WithRetry(func() gax.Retryer {
+		return newCloudLoggingRetrier(ctx)
+	}), googlecloud.NeverTimeout)
 
 	for {
 		entry, err := iter.Next()
@@ -93,11 +95,11 @@ func (l *logFetcherImpl) FetchLogs(dest chan<- *loggingpb.LogEntry, ctx context.
 	return nil
 }
 
-func newCloudLoggingRetrier() gax.Retryer {
+func newCloudLoggingRetrier(ctx context.Context) gax.Retryer {
 	// Cloud Logging may return PermissionError even when caller has sufficient permission especially when the project contains many log views.
 	// Allow up to 5 Permission errors in series.
 	return googlecloud.NewRetryWithCountBudget([]codes.Code{
 		codes.PermissionDenied,
-	}, 100*time.Millisecond, 1.0, time.Second, 5, googlecloud.NewDefaultRetryer(),
+	}, 100*time.Millisecond, 1.0, time.Second, 5, googlecloud.NewDefaultRetryerWithContext(ctx),
 	)
 }


### PR DESCRIPTION
This change updates the custom default retry policy to handle transient `Unauthenticated` errors caused by temporary issues on the Enterprise Certificate Proxy (ECP) side.

**Key changes:**
- **Retry on Specific Unauthenticated Errors**: If an `Unauthenticated` error is returned due to transient ECP credential failures (indicated by `per-RPC creds failed due to error:`), the client will now retry the request.
- **Debug Logging**: Added debug logs during retries to improve observability when transient errors occur.
- **Tests**: Added unit tests to cover standard and ECP-specific authentication errors.