### PR TITLE
Allowed empty value in the filter builder

### DIFF
--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.html
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.html
@@ -36,7 +36,7 @@ limitations under the License.
       <mat-label>Timeline Type</mat-label>
       <input
         type="text"
-        placeholder="Any (*)"
+        placeholder="kind, namespace ...etc(leave empty to match all)"
         matInput
         [value]="typeInputQuery()"
         (input)="onTypeInputChange($any($event.target).value)"

--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.html
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.html
@@ -36,7 +36,7 @@ limitations under the License.
       <mat-label>Timeline Type</mat-label>
       <input
         type="text"
-        placeholder="kind, namespace ...etc(leave empty to match all)"
+        placeholder="kind, namespace, etc. (leave empty to match all)"
         matInput
         [value]="typeInputQuery()"
         (input)="onTypeInputChange($any($event.target).value)"

--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.spec.ts
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.spec.ts
@@ -71,6 +71,7 @@ describe('TimelineFilterBuilderComponent', () => {
     expect(component.filterMode()).toBe('regex');
     expect(component.regexValue()).toBe('');
     expect(component.selectedCandidates()).toEqual([]);
+    expect(component['typeInputQuery']()).toBe('');
   });
 
   it('should disable Add Filter button when input is empty in regex mode', () => {
@@ -259,5 +260,15 @@ describe('TimelineFilterBuilderComponent', () => {
     fixture.detectChanges();
 
     expect(component.selectedTimelineType()).toBe('*');
+  });
+
+  it('should sync selectedTimelineType to typeInputQuery when changed from parent', () => {
+    fixture.componentRef.setInput('selectedTimelineType', 'K8sResource');
+    fixture.detectChanges();
+    expect(component['typeInputQuery']()).toBe('K8sResource');
+
+    fixture.componentRef.setInput('selectedTimelineType', '*');
+    fixture.detectChanges();
+    expect(component['typeInputQuery']()).toBe('');
   });
 });

--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.ts
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.ts
@@ -81,7 +81,9 @@ export class TimelineFilterBuilderComponent {
   readonly selectedCandidates = model<string[]>([]);
 
   /** Holds the current text input query for autocomplete filtering. */
-  protected readonly typeInputQuery = signal<string>('*');
+  protected readonly typeInputQuery = signal<string>('');
+
+  private lastSyncedType = '*';
 
   /** Filters the timeline types case-insensitively based on the current text input query. */
   protected readonly filteredTimelineTypes = computed<TimelineType[]>(() => {
@@ -122,6 +124,10 @@ export class TimelineFilterBuilderComponent {
         this.filterMode.set('regex');
         this.selectedCandidates.set([]);
       }
+      if (currentType !== this.lastSyncedType) {
+        this.lastSyncedType = currentType;
+        this.typeInputQuery.set(currentType === '*' ? '' : currentType);
+      }
     });
   }
 
@@ -157,19 +163,16 @@ export class TimelineFilterBuilderComponent {
     const match = this.timelineTypes().find(
       (t) => t.label.toLowerCase() === value.trim().toLowerCase(),
     );
-    if (match) {
-      this.selectedTimelineType.set(match.label);
-    } else if (value.trim() === '') {
-      this.selectedTimelineType.set('*');
-    } else {
-      this.selectedTimelineType.set('*');
-    }
+    const newType = match ? match.label : '*';
+    this.lastSyncedType = newType;
+    this.selectedTimelineType.set(newType);
   }
 
   /**
    * Handles selection of a timeline type from the autocomplete dropdown.
    */
   protected onTimelineTypeSelected(value: string): void {
+    this.lastSyncedType = value;
     this.selectedTimelineType.set(value);
     this.typeInputQuery.set(value === '*' ? '' : value);
   }


### PR DESCRIPTION
This PR makes the filter builder to accept an empty value as the timeline type. This makes the autocomplete feature to show other timeline list by default, and it makes the control intuitive to find what is the other fillable items.