### PR TITLE
Added style override dialog to preview timeline styles easier

### DIFF
--- a/web/src/app/dialogs/style-override/components/log-type-override-list.component.html
+++ b/web/src/app/dialogs/style-override/components/log-type-override-list.component.html
@@ -1,0 +1,99 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div class="states-list">
+  @for (state of logTypes(); track state.id) {
+    <div class="log-type-card">
+      <div class="preview-area">
+        <div class="log-container-preview">
+          <div
+            class="log-type-preview"
+            [style.background-color]="state.hexColor"
+            [style.color]="state.hexForegroundColor"
+          >
+            Type: <span class="value">{{ state.label }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="controls-area">
+        <div class="control-row">
+          <span class="control-label">Background Color</span>
+          <div class="control-actions">
+            <div
+              class="color-picker-wrapper"
+              [style.background-color]="state.hexColor"
+            >
+              <input
+                type="color"
+                class="color-picker-input"
+                [value]="state.hexColor"
+                (input)="onColorChange(state.id, 'backgroundColor', $event)"
+              />
+            </div>
+            <button
+              mat-icon-button
+              class="copy-button"
+              (click)="copyToClipboard(getGoColorCode(state.hexColor))"
+              title="Copy Go color code"
+            >
+              <mat-icon>content_copy</mat-icon>
+            </button>
+          </div>
+        </div>
+
+        <div class="control-row">
+          <span class="control-label">Foreground Color</span>
+          <div class="control-actions">
+            <div
+              class="color-picker-wrapper"
+              [style.background-color]="state.hexForegroundColor"
+            >
+              <input
+                type="color"
+                class="color-picker-input"
+                [value]="state.hexForegroundColor"
+                (input)="onColorChange(state.id, 'foregroundColor', $event)"
+              />
+            </div>
+            <button
+              mat-icon-button
+              class="copy-button"
+              (click)="
+                copyToClipboard(getGoColorCode(state.hexForegroundColor))
+              "
+              title="Copy Go color code"
+            >
+              <mat-icon>content_copy</mat-icon>
+            </button>
+            <button
+              mat-icon-button
+              color="warn"
+              class="reset-button"
+              [disabled]="!state.isOverridden"
+              (click)="resetColor.emit(state.id)"
+              title="Reset to default styles"
+            >
+              <mat-icon>restart_alt</mat-icon>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  } @empty {
+    <div class="empty-state">No log types found.</div>
+  }
+</div>

--- a/web/src/app/dialogs/style-override/components/log-type-override-list.component.scss
+++ b/web/src/app/dialogs/style-override/components/log-type-override-list.component.scss
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+@use '../../../common.scss' as common;
+
+$border-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 300);
+$bg-color-row: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 50);
+$text-color-primary: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 900);
+$text-color-secondary: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 600);
+$picker-border-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 400);
+$picker-border-hover: mat.m2-get-color-from-palette(mat.$m2-blue-palette, 400);
+
+.states-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.log-type-card {
+  display: grid;
+  grid-template:
+    'preview' auto
+    'controls' auto
+    / 1fr;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 8px;
+  background-color: $bg-color-row;
+  border: 1px solid $border-color;
+}
+
+.preview-area {
+  grid-area: preview;
+  border: 1px solid $border-color;
+  border-radius: 4px;
+  overflow: hidden;
+  background-color: #fff;
+}
+
+.log-container-preview {
+  box-sizing: border-box;
+  display: grid;
+  align-items: center;
+  overflow: hidden;
+  position: relative;
+  min-width: 0;
+}
+
+.log-type-preview {
+  padding: 0 8px;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-radius: 2px;
+  line-height: 20px;
+  display: inline-block;
+
+  .value {
+    font-weight: 600;
+  }
+}
+
+.controls-area {
+  grid-area: controls;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.control-row {
+  display: grid;
+  grid-template:
+    'label actions' 1fr
+    / 1fr auto;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.control-label {
+  grid-area: label;
+  font-size: 13px;
+  font-weight: 500;
+  color: $text-color-secondary;
+}
+
+.control-actions {
+  grid-area: actions;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.color-picker-wrapper {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid $picker-border-color;
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    transform: scale(1.1);
+    border-color: $picker-border-hover;
+  }
+}
+
+.color-picker-input {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+}
+
+.reset-button {
+  margin-left: auto;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 32px;
+  font-style: italic;
+  color: $text-color-secondary;
+}

--- a/web/src/app/dialogs/style-override/components/log-type-override-list.component.spec.ts
+++ b/web/src/app/dialogs/style-override/components/log-type-override-list.component.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LogTypeOverrideListComponent } from 'src/app/dialogs/style-override/components/log-type-override-list.component';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { LogTypeOverrideEvent } from 'src/app/dialogs/style-override/types/style-override-viewmodel';
+
+describe('LogTypeOverrideListComponent', () => {
+  let component: LogTypeOverrideListComponent;
+  let fixture: ComponentFixture<LogTypeOverrideListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LogTypeOverrideListComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LogTypeOverrideListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.componentRef.setInput('logTypes', []);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should list log types', () => {
+    fixture.componentRef.setInput('logTypes', [
+      {
+        id: 1,
+        label: 'Audit',
+        description: 'Audit log events',
+        hexColor: '#3f51b5',
+        hexForegroundColor: '#ffffff',
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.247, G: 0.318, B: 0.710, A: 1.0}',
+      },
+    ]);
+    fixture.detectChanges();
+
+    const valueEl = fixture.debugElement.query(
+      By.css('.log-type-preview .value'),
+    );
+    expect(valueEl.nativeElement.innerText).toContain('Audit');
+  });
+
+  it('should emit propertyChange on color input', () => {
+    fixture.componentRef.setInput('logTypes', [
+      {
+        id: 1,
+        label: 'Audit',
+        description: 'Audit log events',
+        hexColor: '#3f51b5',
+        hexForegroundColor: '#ffffff',
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.247, G: 0.318, B: 0.710, A: 1.0}',
+      },
+    ]);
+    fixture.detectChanges();
+
+    let emitted: LogTypeOverrideEvent | undefined;
+    component.propertyChange.subscribe((event) => (emitted = event));
+
+    const colorInput = fixture.debugElement.query(
+      By.css('.color-picker-input'),
+    );
+    colorInput.nativeElement.value = '#ff0000';
+    colorInput.nativeElement.dispatchEvent(new Event('input'));
+
+    expect(emitted).toEqual({ id: 1, backgroundColor: '#ff0000' });
+  });
+});

--- a/web/src/app/dialogs/style-override/components/log-type-override-list.component.ts
+++ b/web/src/app/dialogs/style-override/components/log-type-override-list.component.ts
@@ -85,6 +85,6 @@ export class LogTypeOverrideListComponent {
    * @param text The text to copy.
    */
   protected copyToClipboard(text: string): void {
-    navigator.clipboard.writeText(text);
+    navigator.clipboard?.writeText(text);
   }
 }

--- a/web/src/app/dialogs/style-override/components/log-type-override-list.component.ts
+++ b/web/src/app/dialogs/style-override/components/log-type-override-list.component.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+import {
+  LogTypeStyleOverrideViewModel,
+  LogTypeOverrideEvent,
+} from 'src/app/dialogs/style-override/types/style-override-viewmodel';
+
+/**
+ * Dumb component that presents a list of log types and allows overriding their background and foreground colors.
+ */
+@Component({
+  selector: 'khi-log-type-override-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    KHIIconRegistrationModule,
+  ],
+  templateUrl: './log-type-override-list.component.html',
+  styleUrls: ['./log-type-override-list.component.scss'],
+})
+export class LogTypeOverrideListComponent {
+  /** List of log type view models to display. */
+  readonly logTypes = input.required<LogTypeStyleOverrideViewModel[]>();
+
+  /** Emitted when a log type property is overridden. */
+  readonly propertyChange = output<LogTypeOverrideEvent>();
+
+  /** Emitted when a log type's styles are reset. */
+  readonly resetColor = output<number>();
+
+  /**
+   * Handles color picker changes for a specific color property.
+   * @param id The ID of the log type.
+   * @param prop The property to override ('backgroundColor' | 'foregroundColor').
+   * @param event The native input event from the color picker.
+   */
+  protected onColorChange(
+    id: number,
+    prop: 'backgroundColor' | 'foregroundColor',
+    event: Event,
+  ): void {
+    const inputElement = event.target as HTMLInputElement;
+    if (inputElement) {
+      this.propertyChange.emit({
+        id,
+        [prop]: inputElement.value,
+      });
+    }
+  }
+
+  /**
+   * Converts a hex color string to Go style.Color code format.
+   * @param hex The hex color string (e.g. '#ff0000').
+   */
+  protected getGoColorCode(hex: string): string {
+    const r = parseInt(hex.substring(1, 3), 16) / 255;
+    const g = parseInt(hex.substring(3, 5), 16) / 255;
+    const b = parseInt(hex.substring(5, 7), 16) / 255;
+    return `style.Color{R: ${r.toFixed(3)}, G: ${g.toFixed(3)}, B: ${b.toFixed(3)}, A: 1.0}`;
+  }
+
+  /**
+   * Copies the provided text to the clipboard.
+   * @param text The text to copy.
+   */
+  protected copyToClipboard(text: string): void {
+    navigator.clipboard.writeText(text);
+  }
+}

--- a/web/src/app/dialogs/style-override/components/revision-state-override-list.component.html
+++ b/web/src/app/dialogs/style-override/components/revision-state-override-list.component.html
@@ -1,0 +1,76 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div class="states-list">
+  @for (state of revisionStates(); track state.id) {
+    <div class="state-row">
+      <div class="state-info">
+        <div
+          class="revision-rect"
+          [style.--revision-color]="state.hexColor"
+          [ngClass]="{
+            'style-normal': state.style === RevisionStateStyle.NORMAL,
+            'style-partial-info':
+              state.style === RevisionStateStyle.PARTIAL_INFO,
+            'style-deleted': state.style === RevisionStateStyle.DELETED,
+          }"
+        >
+          <mat-icon class="material-icons-outlined">{{ state.icon }}</mat-icon>
+        </div>
+        <div class="state-details">
+          <span class="state-label">{{ state.label }}</span>
+          <span class="state-description">{{ state.description }}</span>
+        </div>
+      </div>
+
+      <div class="state-actions">
+        <div
+          class="color-picker-wrapper"
+          [style.background-color]="state.hexColor"
+        >
+          <input
+            type="color"
+            class="color-picker-input"
+            [value]="state.hexColor"
+            (input)="onColorPickerChange(state.id, $event)"
+          />
+        </div>
+
+        <button
+          mat-icon-button
+          class="copy-button"
+          (click)="copyToClipboard(state.goColorCode)"
+          title="Copy Go color code"
+        >
+          <mat-icon>content_copy</mat-icon>
+        </button>
+
+        <button
+          mat-icon-button
+          color="warn"
+          class="reset-button"
+          [disabled]="!state.isOverridden"
+          (click)="resetColor.emit(state.id)"
+          title="Reset to default color"
+        >
+          <mat-icon>restart_alt</mat-icon>
+        </button>
+      </div>
+    </div>
+  } @empty {
+    <div class="empty-state">No revision states found.</div>
+  }
+</div>

--- a/web/src/app/dialogs/style-override/components/revision-state-override-list.component.scss
+++ b/web/src/app/dialogs/style-override/components/revision-state-override-list.component.scss
@@ -1,0 +1,229 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+
+$border-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 300);
+$bg-color-row: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 50);
+$bg-color-row-hover: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 100);
+$text-color-primary: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 900);
+$text-color-secondary: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 600);
+$picker-border-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 400);
+$picker-border-hover: mat.m2-get-color-from-palette(mat.$m2-blue-palette, 400);
+
+.states-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+.state-row {
+  display: grid;
+  grid-template:
+    'info actions' 1fr
+    / 1fr auto;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background-color: $bg-color-row;
+  border: 1px solid $border-color;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+
+  &:hover {
+    background-color: $bg-color-row-hover;
+    border-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 400);
+  }
+}
+
+.state-info {
+  grid-area: info;
+  display: grid;
+  grid-template:
+    'icon details' 1fr
+    / auto 1fr;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+}
+
+@mixin dashed-border($dash-size, $gap-size, $border-width, $color) {
+  $bg-size: $dash-size + $gap-size;
+  background-image:
+    linear-gradient(to right, $color $dash-size, transparent $dash-size),
+    linear-gradient(to bottom, $color $dash-size, transparent $dash-size),
+    linear-gradient(to right, $color $dash-size, transparent $dash-size),
+    linear-gradient(to bottom, $color $dash-size, transparent $dash-size);
+
+  background-position:
+    top left,
+    top right,
+    bottom left,
+    top left;
+
+  background-size:
+    $bg-size $border-width,
+    $border-width $bg-size,
+    $bg-size $border-width,
+    $border-width $bg-size;
+
+  background-repeat: repeat-x, repeat-y, repeat-x, repeat-y;
+}
+
+@mixin revision-style-box($revisionColor, $borderThickness) {
+  box-sizing: border-box;
+  $revision-background-color: color-mix(
+    in display-p3,
+    $revisionColor 40%,
+    transparent
+  );
+  $revision-darker-color: $revisionColor;
+
+  mat-icon {
+    color: $revision-darker-color;
+  }
+
+  &.style-normal {
+    background-color: $revision-background-color;
+    border: $borderThickness solid $revision-darker-color;
+  }
+
+  &.style-partial-info {
+    $stripe-brighter: color-mix(
+      in display-p3,
+      $revision-background-color 50%,
+      transparent
+    );
+    background-image: repeating-linear-gradient(
+      45deg,
+      $stripe-brighter,
+      $stripe-brighter 5px,
+      $revision-background-color 5px,
+      $revision-background-color 10px
+    );
+    border: $borderThickness solid $revision-darker-color;
+  }
+
+  &.style-deleted {
+    background-color: $revision-background-color;
+    @include dashed-border(2px, 2px, $borderThickness, $revision-darker-color);
+  }
+}
+
+.revision-rect {
+  grid-area: icon;
+  width: 30px;
+  height: 30px;
+  @include revision-style-box(var(--revision-color), 3px);
+  display: grid;
+  place-items: center;
+  color: var(--revision-color);
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.state-details {
+  grid-area: details;
+  display: grid;
+  grid-template:
+    'label' auto
+    'desc' auto
+    / 1fr;
+  min-width: 0;
+}
+
+.state-label {
+  grid-area: label;
+  font-size: 14px;
+  font-weight: 500;
+  color: $text-color-primary;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.state-description {
+  grid-area: desc;
+  font-size: 12px;
+  color: $text-color-secondary;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.state-actions {
+  grid-area: actions;
+  display: grid;
+  grid-template:
+    'picker copy reset' 1fr
+    / auto auto auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.copy-button {
+  grid-area: copy;
+}
+
+.color-picker-wrapper {
+  grid-area: picker;
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid $picker-border-color;
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    transform: scale(1.1);
+    border-color: $picker-border-hover;
+  }
+}
+
+.color-picker-input {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 48px;
+  height: 48px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+}
+
+.reset-button {
+  grid-area: reset;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 32px;
+  font-style: italic;
+  color: $text-color-secondary;
+}

--- a/web/src/app/dialogs/style-override/components/revision-state-override-list.component.spec.ts
+++ b/web/src/app/dialogs/style-override/components/revision-state-override-list.component.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RevisionStateOverrideListComponent } from './revision-state-override-list.component';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RevisionStateStyle } from 'src/app/store/domain/style';
+
+describe('RevisionStateOverrideListComponent', () => {
+  let component: RevisionStateOverrideListComponent;
+  let fixture: ComponentFixture<RevisionStateOverrideListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RevisionStateOverrideListComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RevisionStateOverrideListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.componentRef.setInput('revisionStates', []);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should list states', () => {
+    fixture.componentRef.setInput('revisionStates', [
+      {
+        id: 1,
+        label: 'Running',
+        icon: 'play_arrow',
+        description: 'Resource is running',
+        hexColor: '#00ff00',
+        isOverridden: false,
+        style: RevisionStateStyle.NORMAL,
+        goColorCode: 'style.Color{R: 0.000, G: 1.000, B: 0.000, A: 1.0}',
+      },
+    ]);
+    fixture.detectChanges();
+
+    const labelEl = fixture.debugElement.query(By.css('.state-label'));
+    expect(labelEl.nativeElement.innerText).toBe('Running');
+  });
+
+  it('should emit colorChange on input', () => {
+    fixture.componentRef.setInput('revisionStates', [
+      {
+        id: 1,
+        label: 'Running',
+        icon: 'play_arrow',
+        description: 'Resource is running',
+        hexColor: '#00ff00',
+        isOverridden: false,
+        style: RevisionStateStyle.NORMAL,
+        goColorCode: 'style.Color{R: 0.000, G: 1.000, B: 0.000, A: 1.0}',
+      },
+    ]);
+    fixture.detectChanges();
+
+    let emitted: { id: number; hexColor: string } | undefined;
+    component.colorChange.subscribe((event) => (emitted = event));
+
+    const colorInput = fixture.debugElement.query(
+      By.css('.color-picker-input'),
+    );
+    colorInput.nativeElement.value = '#0000ff';
+    colorInput.nativeElement.dispatchEvent(new Event('input'));
+
+    expect(emitted).toEqual({ id: 1, hexColor: '#0000ff' });
+  });
+});

--- a/web/src/app/dialogs/style-override/components/revision-state-override-list.component.ts
+++ b/web/src/app/dialogs/style-override/components/revision-state-override-list.component.ts
@@ -70,6 +70,6 @@ export class RevisionStateOverrideListComponent {
    * @param text The text to copy.
    */
   protected copyToClipboard(text: string): void {
-    navigator.clipboard.writeText(text);
+    navigator.clipboard?.writeText(text);
   }
 }

--- a/web/src/app/dialogs/style-override/components/revision-state-override-list.component.ts
+++ b/web/src/app/dialogs/style-override/components/revision-state-override-list.component.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+import { RevisionStateStyle } from 'src/app/store/domain/style';
+import { RevisionStateStyleOverrideViewModel } from 'src/app/dialogs/style-override/types/style-override-viewmodel';
+
+/**
+ * Dumb component that presents a list of revision states and allows overriding their colors.
+ */
+@Component({
+  selector: 'khi-revision-state-override-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    KHIIconRegistrationModule,
+  ],
+  templateUrl: './revision-state-override-list.component.html',
+  styleUrls: ['./revision-state-override-list.component.scss'],
+})
+export class RevisionStateOverrideListComponent {
+  protected readonly RevisionStateStyle = RevisionStateStyle;
+
+  /** List of revision state view models to display. */
+  readonly revisionStates =
+    input.required<RevisionStateStyleOverrideViewModel[]>();
+
+  /** Emitted when a revision state's color is overridden. */
+  readonly colorChange = output<{
+    readonly id: number;
+    readonly hexColor: string;
+  }>();
+
+  /** Emitted when a revision state's color override is reset. */
+  readonly resetColor = output<number>();
+
+  /**
+   * Handles native color input element changes.
+   * @param id The ID of the revision state.
+   * @param event The native input event from color picker.
+   */
+  protected onColorPickerChange(id: number, event: Event): void {
+    const inputElement = event.target as HTMLInputElement;
+    if (inputElement) {
+      this.colorChange.emit({ id, hexColor: inputElement.value });
+    }
+  }
+
+  /**
+   * Copies the provided text to the clipboard.
+   * @param text The text to copy.
+   */
+  protected copyToClipboard(text: string): void {
+    navigator.clipboard.writeText(text);
+  }
+}

--- a/web/src/app/dialogs/style-override/components/style-override-layout.component.html
+++ b/web/src/app/dialogs/style-override/components/style-override-layout.component.html
@@ -1,0 +1,63 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<h2 mat-dialog-title class="dialog-title">
+  <mat-icon class="title-icon">palette</mat-icon>
+  <span class="title-text">
+    Style Override Settings
+    <span class="title-badge">For developers</span>
+  </span>
+</h2>
+
+<mat-dialog-content class="dialog-content">
+  <div class="subtitle">
+    This UI is for currently for developers to adjust styles interactively.
+  </div>
+
+  <mat-tab-group mat-stretch-tabs="false" animationDuration="150ms">
+    <mat-tab label="Revision States">
+      <div class="tab-body-container">
+        <khi-revision-state-override-list
+          [revisionStates]="revisionStates()"
+          (colorChange)="revisionStateColorChange.emit($event)"
+          (resetColor)="revisionStateResetColor.emit($event)"
+        ></khi-revision-state-override-list>
+      </div>
+    </mat-tab>
+    <mat-tab label="Timeline Types">
+      <div class="tab-body-container">
+        <khi-timeline-type-override-list
+          [timelineTypes]="timelineTypes()"
+          (propertyChange)="timelineTypePropertyChange.emit($event)"
+          (resetColor)="timelineTypeResetColor.emit($event)"
+        ></khi-timeline-type-override-list>
+      </div>
+    </mat-tab>
+    <mat-tab label="Log Types">
+      <div class="tab-body-container">
+        <khi-log-type-override-list
+          [logTypes]="logTypes()"
+          (propertyChange)="logTypePropertyChange.emit($event)"
+          (resetColor)="logTypeResetColor.emit($event)"
+        ></khi-log-type-override-list>
+      </div>
+    </mat-tab>
+  </mat-tab-group>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="dialog-actions">
+  <button mat-button mat-dialog-close color="primary">Close</button>
+</mat-dialog-actions>

--- a/web/src/app/dialogs/style-override/components/style-override-layout.component.scss
+++ b/web/src/app/dialogs/style-override/components/style-override-layout.component.scss
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+
+$border-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 300);
+$text-color-primary: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 900);
+$text-color-secondary: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 600);
+
+:host {
+  display: grid;
+  height: 100%;
+  box-sizing: border-box;
+  grid-template:
+    'title' auto
+    'content' 1fr
+    'actions' auto
+    / 1fr;
+}
+
+.dialog-title {
+  grid-area: title;
+  display: flex;
+  align-items: center;
+  font-family: 'Google Sans', 'Roboto', sans-serif;
+  font-size: 20px;
+  font-weight: 500;
+  color: $text-color-primary;
+  padding: 5px;
+  border-bottom: 1px solid $border-color;
+}
+
+.title-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.title-text {
+  flex: 1;
+  text-align: center;
+}
+
+.title-badge {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 8px;
+  background-color: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 100);
+  color: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 900);
+  vertical-align: middle;
+}
+
+.dialog-content {
+  grid-area: content;
+  padding: 20px 24px;
+  overflow: hidden;
+  max-height: none !important;
+  color: $text-color-primary;
+  display: grid;
+  grid-template:
+    'subtitle' auto
+    'tabs' 1fr
+    / 1fr;
+}
+
+.subtitle {
+  grid-area: subtitle;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 16px;
+  color: $text-color-secondary;
+}
+
+mat-tab-group {
+  grid-area: tabs;
+  height: 100%;
+  display: grid;
+  grid-template:
+    'header' auto
+    'body-wrapper' 1fr
+    / 1fr;
+  min-height: 0;
+
+  ::ng-deep {
+    .mat-mdc-tab-header {
+      grid-area: header;
+    }
+
+    .mat-mdc-tab-body-wrapper {
+      grid-area: body-wrapper;
+      height: 100%;
+      min-height: 0;
+    }
+
+    .mat-mdc-tab-body {
+      height: 100%;
+    }
+  }
+}
+
+.tab-body-container {
+  padding-top: 16px;
+  height: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.dialog-actions {
+  grid-area: actions;
+  border-top: 1px solid $border-color;
+  padding: 12px 24px;
+  margin: 0 !important;
+}

--- a/web/src/app/dialogs/style-override/components/style-override-layout.component.spec.ts
+++ b/web/src/app/dialogs/style-override/components/style-override-layout.component.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StyleOverrideLayoutComponent } from 'src/app/dialogs/style-override/components/style-override-layout.component';
+import { By } from '@angular/platform-browser';
+import { MatDialogModule } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RevisionStateStyle } from 'src/app/store/domain/style';
+import { RevisionStateOverrideListComponent } from 'src/app/dialogs/style-override/components/revision-state-override-list.component';
+import { TimelineTypeOverrideListComponent } from 'src/app/dialogs/style-override/components/timeline-type-override-list.component';
+import { LogTypeOverrideListComponent } from 'src/app/dialogs/style-override/components/log-type-override-list.component';
+import {
+  TimelineTypeOverrideEvent,
+  LogTypeOverrideEvent,
+} from 'src/app/dialogs/style-override/types/style-override-viewmodel';
+
+describe('StyleOverrideLayoutComponent', () => {
+  let component: StyleOverrideLayoutComponent;
+  let fixture: ComponentFixture<StyleOverrideLayoutComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        StyleOverrideLayoutComponent,
+        MatDialogModule,
+        NoopAnimationsModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StyleOverrideLayoutComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.componentRef.setInput('revisionStates', []);
+    fixture.componentRef.setInput('timelineTypes', []);
+    fixture.componentRef.setInput('logTypes', []);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should render mat-tab-group and pass inputs down', () => {
+    fixture.componentRef.setInput('revisionStates', [
+      {
+        id: 1,
+        label: 'Running',
+        icon: 'play_arrow',
+        description: 'Resource is running',
+        hexColor: '#00ff00',
+        isOverridden: false,
+        style: RevisionStateStyle.NORMAL,
+        goColorCode: 'style.Color{R: 0.000, G: 1.000, B: 0.000, A: 1.0}',
+      },
+    ]);
+    fixture.componentRef.setInput('timelineTypes', [
+      {
+        id: 1,
+        label: 'Pod',
+        icon: 'pod',
+        description: 'Pod type',
+        hexColor: '#3f51b5',
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.247, G: 0.318, B: 0.710, A: 1.0}',
+      },
+    ]);
+    fixture.componentRef.setInput('logTypes', [
+      {
+        id: 1,
+        label: 'Audit',
+        description: 'Audit log events',
+        hexColor: '#3f51b5',
+        hexForegroundColor: '#ffffff',
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.247, G: 0.318, B: 0.710, A: 1.0}',
+      },
+    ]);
+    fixture.detectChanges();
+
+    const tabs = fixture.debugElement.queryAll(By.css('.mat-mdc-tab'));
+    expect(tabs.length).toBe(3);
+
+    const revisionList = fixture.debugElement.query(
+      By.directive(RevisionStateOverrideListComponent),
+    );
+    expect(revisionList).toBeTruthy();
+    expect(revisionList.componentInstance.revisionStates()).toEqual(
+      component.revisionStates(),
+    );
+
+    // Select and detect changes for Timeline Types tab
+    const tabGroup = fixture.debugElement.query(
+      By.css('mat-tab-group'),
+    ).componentInstance;
+    tabGroup.selectedIndex = 1;
+    fixture.detectChanges();
+
+    const timelineTypeList = fixture.debugElement.query(
+      By.directive(TimelineTypeOverrideListComponent),
+    );
+    expect(timelineTypeList).toBeTruthy();
+    expect(timelineTypeList.componentInstance.timelineTypes()).toEqual(
+      component.timelineTypes(),
+    );
+
+    // Select and detect changes for Log Types tab
+    tabGroup.selectedIndex = 2;
+    fixture.detectChanges();
+
+    const logTypeList = fixture.debugElement.query(
+      By.directive(LogTypeOverrideListComponent),
+    );
+    expect(logTypeList).toBeTruthy();
+    expect(logTypeList.componentInstance.logTypes()).toEqual(
+      component.logTypes(),
+    );
+  });
+
+  it('should forward revisionStateColorChange and revisionStateResetColor', () => {
+    fixture.componentRef.setInput('revisionStates', []);
+    fixture.componentRef.setInput('timelineTypes', []);
+    fixture.componentRef.setInput('logTypes', []);
+    fixture.detectChanges();
+
+    let colorChangeEmitted: { id: number; hexColor: string } | undefined;
+    component.revisionStateColorChange.subscribe(
+      (event) => (colorChangeEmitted = event),
+    );
+
+    let resetColorEmitted: number | undefined;
+    component.revisionStateResetColor.subscribe(
+      (id) => (resetColorEmitted = id),
+    );
+
+    const revisionList = fixture.debugElement.query(
+      By.directive(RevisionStateOverrideListComponent),
+    ).componentInstance as RevisionStateOverrideListComponent;
+
+    revisionList.colorChange.emit({ id: 2, hexColor: '#ffffff' });
+    expect(colorChangeEmitted).toEqual({ id: 2, hexColor: '#ffffff' });
+
+    revisionList.resetColor.emit(3);
+    expect(resetColorEmitted).toBe(3);
+  });
+
+  it('should forward timelineTypePropertyChange and timelineTypeResetColor', () => {
+    fixture.componentRef.setInput('revisionStates', []);
+    fixture.componentRef.setInput('timelineTypes', []);
+    fixture.componentRef.setInput('logTypes', []);
+    fixture.detectChanges();
+
+    const tabGroup = fixture.debugElement.query(
+      By.css('mat-tab-group'),
+    ).componentInstance;
+    tabGroup.selectedIndex = 1;
+    fixture.detectChanges();
+
+    let propertyChangeEmitted: TimelineTypeOverrideEvent | undefined;
+    component.timelineTypePropertyChange.subscribe(
+      (event) => (propertyChangeEmitted = event),
+    );
+
+    let resetColorEmitted: number | undefined;
+    component.timelineTypeResetColor.subscribe(
+      (id) => (resetColorEmitted = id),
+    );
+
+    const timelineList = fixture.debugElement.query(
+      By.directive(TimelineTypeOverrideListComponent),
+    ).componentInstance as TimelineTypeOverrideListComponent;
+
+    timelineList.propertyChange.emit({ id: 5, backgroundColor: '#000000' });
+    expect(propertyChangeEmitted).toEqual({
+      id: 5,
+      backgroundColor: '#000000',
+    });
+
+    timelineList.resetColor.emit(6);
+    expect(resetColorEmitted).toBe(6);
+  });
+
+  it('should forward logTypePropertyChange and logTypeResetColor', () => {
+    fixture.componentRef.setInput('revisionStates', []);
+    fixture.componentRef.setInput('timelineTypes', []);
+    fixture.componentRef.setInput('logTypes', []);
+    fixture.detectChanges();
+
+    const tabGroup = fixture.debugElement.query(
+      By.css('mat-tab-group'),
+    ).componentInstance;
+    tabGroup.selectedIndex = 2;
+    fixture.detectChanges();
+
+    let propertyChangeEmitted: LogTypeOverrideEvent | undefined;
+    component.logTypePropertyChange.subscribe(
+      (event) => (propertyChangeEmitted = event),
+    );
+
+    let resetColorEmitted: number | undefined;
+    component.logTypeResetColor.subscribe((id) => (resetColorEmitted = id));
+
+    const logList = fixture.debugElement.query(
+      By.directive(LogTypeOverrideListComponent),
+    ).componentInstance as LogTypeOverrideListComponent;
+
+    logList.propertyChange.emit({ id: 5, backgroundColor: '#000000' });
+    expect(propertyChangeEmitted).toEqual({
+      id: 5,
+      backgroundColor: '#000000',
+    });
+
+    logList.resetColor.emit(6);
+    expect(resetColorEmitted).toBe(6);
+  });
+});

--- a/web/src/app/dialogs/style-override/components/style-override-layout.component.stories.ts
+++ b/web/src/app/dialogs/style-override/components/style-override-layout.component.stories.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryObj } from '@storybook/angular';
+import { StyleOverrideLayoutComponent } from 'src/app/dialogs/style-override/components/style-override-layout.component';
+import { RevisionStateStyle } from 'src/app/store/domain/style';
+
+const meta: Meta<StyleOverrideLayoutComponent> = {
+  title: 'Dialogs/StyleOverrideLayout',
+  component: StyleOverrideLayoutComponent,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<StyleOverrideLayoutComponent>;
+
+export const Default: Story = {
+  args: {
+    revisionStates: [
+      {
+        id: 1,
+        label: 'State is "True"',
+        icon: 'lightbulb',
+        description: 'Resource condition is true',
+        hexColor: '#004400',
+        isOverridden: false,
+        style: RevisionStateStyle.NORMAL,
+        goColorCode: 'style.Color{R: 0.000, G: 0.267, B: 0.000, A: 1.0}',
+      },
+      {
+        id: 2,
+        label: 'State is "False"',
+        icon: 'light_off',
+        description: 'Resource condition is false',
+        hexColor: '#ee4400',
+        isOverridden: true,
+        style: RevisionStateStyle.NORMAL,
+        goColorCode: 'style.Color{R: 0.933, G: 0.267, B: 0.000, A: 1.0}',
+      },
+      {
+        id: 3,
+        label: 'State is "Unknown"',
+        icon: 'siren_question',
+        description: 'Resource condition is unknown',
+        hexColor: '#663366',
+        isOverridden: false,
+        style: RevisionStateStyle.NORMAL,
+        goColorCode: 'style.Color{R: 0.400, G: 0.200, B: 0.400, A: 1.0}',
+      },
+    ],
+    timelineTypes: [
+      {
+        id: 1,
+        label: 'Pod',
+        icon: 'pod',
+        description: 'Kubernetes Pod resources',
+        hexColor: '#3f51b5',
+        hexForegroundColor: '#ffffff',
+        hexChipBackgroundColor: '#1a237e',
+        hexChipForegroundColor: '#ffffff',
+        height: 1.2,
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.247, G: 0.318, B: 0.710, A: 1.0}',
+      },
+    ],
+    logTypes: [
+      {
+        id: 1,
+        label: 'Audit',
+        description: 'Kubernetes Audit Logs',
+        hexColor: '#00bcd4',
+        hexForegroundColor: '#ffffff',
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.000, G: 0.737, B: 0.831, A: 1.0}',
+      },
+    ],
+  },
+};

--- a/web/src/app/dialogs/style-override/components/style-override-layout.component.ts
+++ b/web/src/app/dialogs/style-override/components/style-override-layout.component.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatTabsModule } from '@angular/material/tabs';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+import {
+  RevisionStateStyleOverrideViewModel,
+  TimelineTypeStyleOverrideViewModel,
+  TimelineTypeOverrideEvent,
+  LogTypeStyleOverrideViewModel,
+  LogTypeOverrideEvent,
+} from 'src/app/dialogs/style-override/types/style-override-viewmodel';
+import { RevisionStateOverrideListComponent } from 'src/app/dialogs/style-override/components/revision-state-override-list.component';
+import { TimelineTypeOverrideListComponent } from 'src/app/dialogs/style-override/components/timeline-type-override-list.component';
+import { LogTypeOverrideListComponent } from 'src/app/dialogs/style-override/components/log-type-override-list.component';
+
+/**
+ * Dumb component that presents a tabbed panel for overriding styles (Revision States, Timeline Types).
+ */
+@Component({
+  selector: 'khi-style-override-layout',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    MatTabsModule,
+    KHIIconRegistrationModule,
+    RevisionStateOverrideListComponent,
+    TimelineTypeOverrideListComponent,
+    LogTypeOverrideListComponent,
+  ],
+  templateUrl: './style-override-layout.component.html',
+  styleUrls: ['./style-override-layout.component.scss'],
+})
+export class StyleOverrideLayoutComponent {
+  /** List of revision state view models to display. */
+  readonly revisionStates =
+    input.required<RevisionStateStyleOverrideViewModel[]>();
+
+  /** List of timeline type view models to display. */
+  readonly timelineTypes =
+    input.required<TimelineTypeStyleOverrideViewModel[]>();
+
+  /** List of log type view models to display. */
+  readonly logTypes = input.required<LogTypeStyleOverrideViewModel[]>();
+
+  /** Emitted when a revision state's color is overridden. */
+  readonly revisionStateColorChange = output<{
+    readonly id: number;
+    readonly hexColor: string;
+  }>();
+
+  /** Emitted when a revision state's color override is reset. */
+  readonly revisionStateResetColor = output<number>();
+
+  /** Emitted when a timeline type style property is overridden. */
+  readonly timelineTypePropertyChange = output<TimelineTypeOverrideEvent>();
+
+  /** Emitted when a timeline type's color override is reset. */
+  readonly timelineTypeResetColor = output<number>();
+
+  /** Emitted when a log type style property is overridden. */
+  readonly logTypePropertyChange = output<LogTypeOverrideEvent>();
+
+  /** Emitted when a log type's color override is reset. */
+  readonly logTypeResetColor = output<number>();
+}

--- a/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.html
+++ b/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.html
@@ -1,0 +1,186 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div class="states-list">
+  @for (state of timelineTypes(); track state.id) {
+    <div class="timeline-type-card">
+      <!-- Live Preview matching TimelineIndexComponent -->
+      <div class="preview-area">
+        <div
+          class="index-container-preview"
+          [style.--timeline-bg-color]="state.hexColor"
+          [style.--timeline-fg-color]="state.hexForegroundColor"
+          [style.--timeline-chip-bg-color]="state.hexChipBackgroundColor"
+          [style.--timeline-chip-fg-color]="state.hexChipForegroundColor"
+          [style.--timeline-height]="state.height * 25 + 'px'"
+        >
+          @if (state.icon) {
+            <mat-icon class="icon">{{ state.icon }}</mat-icon>
+          }
+          <div class="index-text">
+            <p class="main-name">Preview {{ state.label }} Name</p>
+            <span class="layer-name">{{ state.label }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Controls Area -->
+      <div class="controls-area">
+        <!-- Background Color -->
+        <div class="control-row">
+          <span class="control-label">Background Color</span>
+          <div class="control-actions">
+            <div
+              class="color-picker-wrapper"
+              [style.background-color]="state.hexColor"
+            >
+              <input
+                type="color"
+                class="color-picker-input"
+                [value]="state.hexColor"
+                (input)="onColorChange(state.id, 'backgroundColor', $event)"
+              />
+            </div>
+            <button
+              mat-icon-button
+              class="copy-button"
+              (click)="copyToClipboard(getGoColorCode(state.hexColor))"
+              title="Copy Go color code"
+            >
+              <mat-icon>content_copy</mat-icon>
+            </button>
+          </div>
+        </div>
+
+        <!-- Foreground Color -->
+        <div class="control-row">
+          <span class="control-label">Foreground Color</span>
+          <div class="control-actions">
+            <div
+              class="color-picker-wrapper"
+              [style.background-color]="state.hexForegroundColor"
+            >
+              <input
+                type="color"
+                class="color-picker-input"
+                [value]="state.hexForegroundColor"
+                (input)="onColorChange(state.id, 'foregroundColor', $event)"
+              />
+            </div>
+            <button
+              mat-icon-button
+              class="copy-button"
+              (click)="
+                copyToClipboard(getGoColorCode(state.hexForegroundColor))
+              "
+              title="Copy Go color code"
+            >
+              <mat-icon>content_copy</mat-icon>
+            </button>
+          </div>
+        </div>
+
+        <!-- Type Chip Background Color -->
+        <div class="control-row">
+          <span class="control-label">Chip Background Color</span>
+          <div class="control-actions">
+            <div
+              class="color-picker-wrapper"
+              [style.background-color]="state.hexChipBackgroundColor"
+            >
+              <input
+                type="color"
+                class="color-picker-input"
+                [value]="state.hexChipBackgroundColor"
+                (input)="
+                  onColorChange(state.id, 'typeChipBackgroundColor', $event)
+                "
+              />
+            </div>
+            <button
+              mat-icon-button
+              class="copy-button"
+              (click)="
+                copyToClipboard(getGoColorCode(state.hexChipBackgroundColor))
+              "
+              title="Copy Go color code"
+            >
+              <mat-icon>content_copy</mat-icon>
+            </button>
+          </div>
+        </div>
+
+        <!-- Type Chip Foreground Color -->
+        <div class="control-row">
+          <span class="control-label">Chip Foreground Color</span>
+          <div class="control-actions">
+            <div
+              class="color-picker-wrapper"
+              [style.background-color]="state.hexChipForegroundColor"
+            >
+              <input
+                type="color"
+                class="color-picker-input"
+                [value]="state.hexChipForegroundColor"
+                (input)="
+                  onColorChange(state.id, 'typeChipForegroundColor', $event)
+                "
+              />
+            </div>
+            <button
+              mat-icon-button
+              class="copy-button"
+              (click)="
+                copyToClipboard(getGoColorCode(state.hexChipForegroundColor))
+              "
+              title="Copy Go color code"
+            >
+              <mat-icon>content_copy</mat-icon>
+            </button>
+          </div>
+        </div>
+
+        <!-- Height & Reset -->
+        <div class="control-row">
+          <span class="control-label">Row Height Multiplier</span>
+          <div class="control-actions">
+            <input
+              type="number"
+              class="height-input"
+              [value]="state.height"
+              min="0.5"
+              max="5.0"
+              step="0.1"
+              (change)="onHeightChange(state.id, $event)"
+            />
+            <button
+              mat-icon-button
+              color="warn"
+              class="reset-button"
+              [disabled]="!state.isOverridden"
+              (click)="resetColor.emit(state.id)"
+              title="Reset to default styles"
+            >
+              <mat-icon>restart_alt</mat-icon>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  } @empty {
+    <div class="empty-state">No timeline types found.</div>
+  }
+</div>

--- a/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.scss
+++ b/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.scss
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+@use '../../../common.scss' as common;
+
+$border-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 300);
+$bg-color-row: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 50);
+$text-color-primary: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 900);
+$text-color-secondary: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 600);
+$picker-border-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 400);
+$picker-border-hover: mat.m2-get-color-from-palette(mat.$m2-blue-palette, 400);
+
+.states-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.timeline-type-card {
+  display: grid;
+  grid-template:
+    'preview' auto
+    'controls' auto
+    / 1fr;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 8px;
+  background-color: $bg-color-row;
+  border: 1px solid $border-color;
+}
+
+.preview-area {
+  grid-area: preview;
+  border: 1px solid $border-color;
+  border-radius: 4px;
+  overflow: hidden;
+  background-color: #fff;
+}
+
+.index-container-preview {
+  box-sizing: border-box;
+  display: grid;
+  align-items: center;
+  overflow: hidden;
+  position: relative;
+  min-width: 0;
+
+  --icon-size: clamp(12px, calc(0.64 * var(--timeline-height)), 18px);
+
+  height: var(--timeline-height);
+  background-color: var(--timeline-bg-color);
+  color: var(--timeline-fg-color);
+  padding-left: 12px;
+  padding-right: 12px;
+  font-weight: 400;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.35);
+
+  grid-template:
+    'icon label' 1fr
+    / var(--icon-size) 1fr;
+  gap: 0 8px;
+
+  .icon {
+    grid-area: icon;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--timeline-fg-color);
+    @include common.adjust-mat-icon-size(var(--icon-size));
+  }
+
+  .index-text {
+    grid-area: label;
+    text-wrap: nowrap;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    font-size: clamp(10px, 52cqh, 14px);
+
+    .main-name {
+      flex-shrink: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      margin: 0;
+    }
+
+    .layer-name {
+      flex-shrink: 2;
+      min-width: 24px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: clamp(8px, 40cqh, 10px);
+      font-weight: 500;
+      margin-left: auto;
+      margin-right: 2px;
+      padding: 1px 5px;
+      border-radius: 3px;
+      background-color: var(--timeline-chip-bg-color);
+      box-shadow:
+        inset 0 1px 2px rgba(0, 0, 0, 0.15),
+        inset 0 -0.5px 0 rgba(255, 255, 255, 0.2);
+      color: var(--timeline-chip-fg-color);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      user-select: none;
+      text-align: center;
+    }
+  }
+}
+
+.controls-area {
+  grid-area: controls;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.control-row {
+  display: grid;
+  grid-template:
+    'label actions' 1fr
+    / 1fr auto;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.control-label {
+  grid-area: label;
+  font-size: 13px;
+  font-weight: 500;
+  color: $text-color-secondary;
+}
+
+.control-actions {
+  grid-area: actions;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.color-picker-wrapper {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid $picker-border-color;
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    transform: scale(1.1);
+    border-color: $picker-border-hover;
+  }
+}
+
+.color-picker-input {
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+}
+
+.height-input {
+  width: 60px;
+  padding: 4px 8px;
+  font-size: 13px;
+  border-radius: 4px;
+  border: 1px solid $picker-border-color;
+  background-color: #fff;
+  color: $text-color-primary;
+
+  &:focus {
+    border-color: $picker-border-hover;
+    outline: none;
+  }
+}
+
+.reset-button {
+  margin-left: auto;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 32px;
+  font-style: italic;
+  color: $text-color-secondary;
+}

--- a/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.spec.ts
+++ b/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TimelineTypeOverrideListComponent } from './timeline-type-override-list.component';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TimelineTypeOverrideEvent } from 'src/app/dialogs/style-override/types/style-override-viewmodel';
+
+describe('TimelineTypeOverrideListComponent', () => {
+  let component: TimelineTypeOverrideListComponent;
+  let fixture: ComponentFixture<TimelineTypeOverrideListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TimelineTypeOverrideListComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TimelineTypeOverrideListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.componentRef.setInput('timelineTypes', []);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should list timeline types', () => {
+    fixture.componentRef.setInput('timelineTypes', [
+      {
+        id: 1,
+        label: 'Pod',
+        icon: 'pod',
+        description: 'Pod type',
+        hexColor: '#3f51b5',
+        hexForegroundColor: '#ffffff',
+        hexChipBackgroundColor: '#1a237e',
+        height: 1.2,
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.247, G: 0.318, B: 0.710, A: 1.0}',
+      },
+    ]);
+    fixture.detectChanges();
+
+    const nameEl = fixture.debugElement.query(By.css('.main-name'));
+    expect(nameEl.nativeElement.innerText).toContain('Pod');
+  });
+
+  it('should emit propertyChange on color input', () => {
+    fixture.componentRef.setInput('timelineTypes', [
+      {
+        id: 1,
+        label: 'Pod',
+        icon: 'pod',
+        description: 'Pod type',
+        hexColor: '#3f51b5',
+        hexForegroundColor: '#ffffff',
+        hexChipBackgroundColor: '#1a237e',
+        height: 1.2,
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.247, G: 0.318, B: 0.710, A: 1.0}',
+      },
+    ]);
+    fixture.detectChanges();
+
+    let emitted: TimelineTypeOverrideEvent | undefined;
+    component.propertyChange.subscribe((event) => (emitted = event));
+
+    const colorInput = fixture.debugElement.query(
+      By.css('.color-picker-input'),
+    );
+    colorInput.nativeElement.value = '#ff0000';
+    colorInput.nativeElement.dispatchEvent(new Event('input'));
+
+    expect(emitted).toEqual({ id: 1, backgroundColor: '#ff0000' });
+  });
+
+  it('should emit propertyChange on height input change', () => {
+    fixture.componentRef.setInput('timelineTypes', [
+      {
+        id: 1,
+        label: 'Pod',
+        icon: 'pod',
+        description: 'Pod type',
+        hexColor: '#3f51b5',
+        hexForegroundColor: '#ffffff',
+        hexChipBackgroundColor: '#1a237e',
+        height: 1.2,
+        isOverridden: false,
+        goColorCode: 'style.Color{R: 0.247, G: 0.318, B: 0.710, A: 1.0}',
+      },
+    ]);
+    fixture.detectChanges();
+
+    let emitted: TimelineTypeOverrideEvent | undefined;
+    component.propertyChange.subscribe((event) => (emitted = event));
+
+    const heightInput = fixture.debugElement.query(By.css('.height-input'));
+    heightInput.nativeElement.value = '1.5';
+    heightInput.nativeElement.dispatchEvent(new Event('change'));
+
+    expect(emitted).toEqual({ id: 1, height: 1.5 });
+  });
+});

--- a/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.ts
+++ b/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+import {
+  TimelineTypeStyleOverrideViewModel,
+  TimelineTypeOverrideEvent,
+} from 'src/app/dialogs/style-override/types/style-override-viewmodel';
+
+/**
+ * Dumb component that presents a list of timeline types and allows overriding their styles (3 colors and height).
+ */
+@Component({
+  selector: 'khi-timeline-type-override-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    KHIIconRegistrationModule,
+  ],
+  templateUrl: './timeline-type-override-list.component.html',
+  styleUrls: ['./timeline-type-override-list.component.scss'],
+})
+export class TimelineTypeOverrideListComponent {
+  /** List of timeline type view models to display. */
+  readonly timelineTypes =
+    input.required<TimelineTypeStyleOverrideViewModel[]>();
+
+  /** Emitted when a timeline type property is overridden. */
+  readonly propertyChange = output<TimelineTypeOverrideEvent>();
+
+  /** Emitted when a timeline type's styles are reset. */
+  readonly resetColor = output<number>();
+
+  /**
+   * Handles color picker changes for a specific color property.
+   * @param id The ID of the timeline type.
+   * @param prop The property to override ('backgroundColor' | 'foregroundColor' | 'typeChipBackgroundColor').
+   * @param event The native input event from the color picker.
+   */
+  protected onColorChange(
+    id: number,
+    prop:
+      | 'backgroundColor'
+      | 'foregroundColor'
+      | 'typeChipBackgroundColor'
+      | 'typeChipForegroundColor',
+    event: Event,
+  ): void {
+    const inputElement = event.target as HTMLInputElement;
+    if (inputElement) {
+      this.propertyChange.emit({
+        id,
+        [prop]: inputElement.value,
+      });
+    }
+  }
+
+  /**
+   * Handles height input changes.
+   * @param id The ID of the timeline type.
+   * @param event The native change event.
+   */
+  protected onHeightChange(id: number, event: Event): void {
+    const inputElement = event.target as HTMLInputElement;
+    if (inputElement) {
+      const height = parseFloat(inputElement.value);
+      if (!isNaN(height) && height >= 0.1) {
+        this.propertyChange.emit({
+          id,
+          height,
+        });
+      }
+    }
+  }
+
+  /**
+   * Converts a hex color string to Go style.Color code format.
+   * @param hex The hex color string (e.g. '#ff0000').
+   */
+  protected getGoColorCode(hex: string): string {
+    const r = parseInt(hex.substring(1, 3), 16) / 255;
+    const g = parseInt(hex.substring(3, 5), 16) / 255;
+    const b = parseInt(hex.substring(5, 7), 16) / 255;
+    return `style.Color{R: ${r.toFixed(3)}, G: ${g.toFixed(3)}, B: ${b.toFixed(3)}, A: 1.0}`;
+  }
+
+  /**
+   * Copies the provided text to the clipboard.
+   * @param text The text to copy.
+   */
+  protected copyToClipboard(text: string): void {
+    navigator.clipboard.writeText(text);
+  }
+}

--- a/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.ts
+++ b/web/src/app/dialogs/style-override/components/timeline-type-override-list.component.ts
@@ -108,6 +108,6 @@ export class TimelineTypeOverrideListComponent {
    * @param text The text to copy.
    */
   protected copyToClipboard(text: string): void {
-    navigator.clipboard.writeText(text);
+    navigator.clipboard?.writeText(text);
   }
 }

--- a/web/src/app/dialogs/style-override/style-override-smart.component.html
+++ b/web/src/app/dialogs/style-override/style-override-smart.component.html
@@ -1,0 +1,27 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<khi-style-override-layout
+  [revisionStates]="revisionStateViewModels()"
+  [timelineTypes]="timelineTypeViewModels()"
+  [logTypes]="logTypeViewModels()"
+  (revisionStateColorChange)="onRevisionStateColorChange($event)"
+  (revisionStateResetColor)="onRevisionStateResetColor($event)"
+  (timelineTypePropertyChange)="onTimelineTypePropertyChange($event)"
+  (timelineTypeResetColor)="onTimelineTypeResetColor($event)"
+  (logTypePropertyChange)="onLogTypePropertyChange($event)"
+  (logTypeResetColor)="onLogTypeResetColor($event)"
+></khi-style-override-layout>

--- a/web/src/app/dialogs/style-override/style-override-smart.component.scss
+++ b/web/src/app/dialogs/style-override/style-override-smart.component.scss
@@ -14,14 +14,6 @@
  * limitations under the License.
  */
 
-import { Timeline } from 'src/app/store/domain/timeline';
-import { ReadonlyDomainElement } from 'src/app/store/domain/types';
-import { StyleStoreLike } from 'src/app/store/domain/style-store';
-
-export interface TimelineChartViewModel {
-  inspectionDataUniqueID: string;
-  timelinesInDrawArea: ReadonlyDomainElement<Timeline>[];
-  logBeginTime: number;
-  logEndTime: number;
-  styleStore: StyleStoreLike;
+:host {
+  display: contents;
 }

--- a/web/src/app/dialogs/style-override/style-override-smart.component.spec.ts
+++ b/web/src/app/dialogs/style-override/style-override-smart.component.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StyleOverrideService } from 'src/app/services/style-override.service';
+import { StyleOverrideSmartComponent } from 'src/app/dialogs/style-override/style-override-smart.component';
+import {
+  RevisionStateStyle,
+  TimelineType,
+  LogType,
+} from 'src/app/store/domain/style';
+import { MatDialogModule } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('StyleOverrideSmartComponent', () => {
+  let component: StyleOverrideSmartComponent;
+  let fixture: ComponentFixture<StyleOverrideSmartComponent>;
+  let mockStyleOverrideService: jasmine.SpyObj<StyleOverrideService>;
+
+  const originalColor = { r: 1, g: 0, b: 0, a: 1 };
+  const mockState = {
+    id: 1,
+    label: 'State 1',
+    icon: 'check',
+    description: 'First State',
+    backgroundColor: originalColor,
+    style: RevisionStateStyle.NORMAL,
+  };
+
+  const mockTimelineType: TimelineType = {
+    id: 1,
+    label: 'Pod',
+    description: 'Pod resources',
+    icon: 'pod',
+    backgroundColor: originalColor,
+    foregroundColor: originalColor,
+    typeChipBackgroundColor: originalColor,
+    typeChipForegroundColor: originalColor,
+    visible: true,
+    sortPriority: 10,
+    height: 1.2,
+  };
+
+  const mockLogType: LogType = {
+    id: 1,
+    label: 'Audit',
+    description: 'Audit events',
+    backgroundColor: originalColor,
+    foregroundColor: originalColor,
+  };
+
+  beforeEach(async () => {
+    mockStyleOverrideService = jasmine.createSpyObj<StyleOverrideService>(
+      'StyleOverrideService',
+      [
+        'overrideRevisionState',
+        'resetRevisionState',
+        'isRevisionStateOverridden',
+        'getRevisionState',
+        'overrideTimelineType',
+        'resetTimelineType',
+        'isTimelineTypeOverridden',
+        'getTimelineType',
+        'overrideLogType',
+        'resetLogType',
+        'isLogTypeOverridden',
+        'getLogType',
+      ],
+      {
+        stylesUpdated: signal(0),
+        revisionStates: [mockState],
+        timelineTypes: [mockTimelineType],
+        logTypes: [mockLogType],
+      },
+    );
+
+    mockStyleOverrideService.getRevisionState.and.returnValue(mockState);
+    mockStyleOverrideService.getTimelineType.and.returnValue(mockTimelineType);
+    mockStyleOverrideService.getLogType.and.returnValue(mockLogType);
+    mockStyleOverrideService.isRevisionStateOverridden.and.returnValue(false);
+    mockStyleOverrideService.isTimelineTypeOverridden.and.returnValue(false);
+    mockStyleOverrideService.isLogTypeOverridden.and.returnValue(false);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        StyleOverrideSmartComponent,
+        MatDialogModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        {
+          provide: StyleOverrideService,
+          useValue: mockStyleOverrideService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StyleOverrideSmartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should map revision states to view models correctly', () => {
+    const vms = component['revisionStateViewModels']();
+    expect(vms.length).toBe(1);
+    expect(vms[0]).toEqual({
+      id: 1,
+      label: 'State 1',
+      icon: 'check',
+      description: 'First State',
+      hexColor: '#ff0000',
+      isOverridden: false,
+      style: RevisionStateStyle.NORMAL,
+      goColorCode: 'style.Color{R: 1.000, G: 0.000, B: 0.000, A: 1.0}',
+    });
+  });
+
+  it('should map timeline types to view models correctly', () => {
+    const vms = component['timelineTypeViewModels']();
+    expect(vms.length).toBe(1);
+    expect(vms[0]).toEqual({
+      id: 1,
+      label: 'Pod',
+      icon: 'pod',
+      description: 'Pod resources',
+      hexColor: '#ff0000',
+      hexForegroundColor: '#ff0000',
+      hexChipBackgroundColor: '#ff0000',
+      hexChipForegroundColor: '#ff0000',
+      height: 1.2,
+      isOverridden: false,
+      goColorCode: 'style.Color{R: 1.000, G: 0.000, B: 0.000, A: 1.0}',
+    });
+  });
+
+  it('should map log types to view models correctly', () => {
+    const vms = component['logTypeViewModels']();
+    expect(vms.length).toBe(1);
+    expect(vms[0]).toEqual({
+      id: 1,
+      label: 'Audit',
+      description: 'Audit events',
+      hexColor: '#ff0000',
+      hexForegroundColor: '#ff0000',
+      isOverridden: false,
+      goColorCode: 'style.Color{R: 1.000, G: 0.000, B: 0.000, A: 1.0}',
+    });
+  });
+
+  it('should call overrideRevisionState onRevisionStateColorChange', () => {
+    component['onRevisionStateColorChange']({ id: 1, hexColor: '#00ff00' });
+    expect(mockStyleOverrideService.overrideRevisionState).toHaveBeenCalledWith(
+      {
+        ...mockState,
+        backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+      },
+    );
+  });
+
+  it('should call resetRevisionState onRevisionStateResetColor', () => {
+    component['onRevisionStateResetColor'](1);
+    expect(mockStyleOverrideService.resetRevisionState).toHaveBeenCalledWith(1);
+  });
+
+  it('should call overrideTimelineType onTimelineTypePropertyChange', () => {
+    component['onTimelineTypePropertyChange']({
+      id: 1,
+      backgroundColor: '#00ff00',
+      height: 1.5,
+    });
+    expect(mockStyleOverrideService.overrideTimelineType).toHaveBeenCalledWith({
+      ...mockTimelineType,
+      backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+      height: 1.5,
+    });
+  });
+
+  it('should call resetTimelineType onTimelineTypeResetColor', () => {
+    component['onTimelineTypeResetColor'](1);
+    expect(mockStyleOverrideService.resetTimelineType).toHaveBeenCalledWith(1);
+  });
+
+  it('should call overrideLogType onLogTypePropertyChange', () => {
+    component['onLogTypePropertyChange']({
+      id: 1,
+      backgroundColor: '#00ff00',
+    });
+    expect(mockStyleOverrideService.overrideLogType).toHaveBeenCalledWith({
+      ...mockLogType,
+      backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+    });
+  });
+
+  it('should call resetLogType onLogTypeResetColor', () => {
+    component['onLogTypeResetColor'](1);
+    expect(mockStyleOverrideService.resetLogType).toHaveBeenCalledWith(1);
+  });
+});

--- a/web/src/app/dialogs/style-override/style-override-smart.component.ts
+++ b/web/src/app/dialogs/style-override/style-override-smart.component.ts
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, computed, inject } from '@angular/core';
+import { StyleOverrideService } from 'src/app/services/style-override.service';
+import { StyleOverrideLayoutComponent } from 'src/app/dialogs/style-override/components/style-override-layout.component';
+import { HDRColor4 } from 'src/app/store/domain/style';
+import {
+  RevisionStateStyleOverrideViewModel,
+  TimelineTypeStyleOverrideViewModel,
+  TimelineTypeOverrideEvent,
+  LogTypeStyleOverrideViewModel,
+  LogTypeOverrideEvent,
+} from 'src/app/dialogs/style-override/types/style-override-viewmodel';
+
+/**
+ * Smart component for the style override dialog.
+ * Connects the StyleOverrideService color override logic with the presentation layout component.
+ */
+@Component({
+  selector: 'khi-style-override-smart',
+  standalone: true,
+  imports: [StyleOverrideLayoutComponent],
+  templateUrl: './style-override-smart.component.html',
+  styleUrls: ['./style-override-smart.component.scss'],
+})
+export class StyleOverrideSmartComponent {
+  private readonly styleOverrideService = inject(StyleOverrideService);
+
+  /** Computes the list of revision state view models with overridden flags and hex colors. */
+  protected readonly revisionStateViewModels = computed<
+    RevisionStateStyleOverrideViewModel[]
+  >(() => {
+    // Track signal to trigger computed updates when styles are overridden
+    this.styleOverrideService.stylesUpdated();
+
+    return this.styleOverrideService.revisionStates.map((state) => {
+      const color = state.backgroundColor;
+      const goColorCode = `style.Color{R: ${color.r.toFixed(3)}, G: ${color.g.toFixed(3)}, B: ${color.b.toFixed(3)}, A: ${color.a.toFixed(1)}}`;
+      return {
+        id: state.id,
+        label: state.label,
+        icon: state.icon,
+        description: state.description,
+        hexColor: this.hdrColorToHex(state.backgroundColor),
+        isOverridden: this.styleOverrideService.isRevisionStateOverridden(
+          state.id,
+        ),
+        style: state.style,
+        goColorCode,
+      };
+    });
+  });
+
+  /** Computes the list of timeline type view models with overridden flags and hex colors. */
+  protected readonly timelineTypeViewModels = computed<
+    TimelineTypeStyleOverrideViewModel[]
+  >(() => {
+    // Track signal to trigger computed updates when styles are overridden
+    this.styleOverrideService.stylesUpdated();
+
+    return this.styleOverrideService.timelineTypes.map((type) => {
+      const bg = type.backgroundColor;
+      const fg = type.foregroundColor;
+      const chipBg = type.typeChipBackgroundColor;
+      const chipFg = type.typeChipForegroundColor;
+      const goColorCode = `style.Color{R: ${bg.r.toFixed(3)}, G: ${bg.g.toFixed(3)}, B: ${bg.b.toFixed(3)}, A: ${bg.a.toFixed(1)}}`;
+      return {
+        id: type.id,
+        label: type.label,
+        icon: type.icon,
+        description: type.description,
+        hexColor: this.hdrColorToHex(bg),
+        hexForegroundColor: this.hdrColorToHex(fg),
+        hexChipBackgroundColor: this.hdrColorToHex(chipBg),
+        hexChipForegroundColor: this.hdrColorToHex(chipFg),
+        height: type.height,
+        isOverridden: this.styleOverrideService.isTimelineTypeOverridden(
+          type.id,
+        ),
+        goColorCode,
+      };
+    });
+  });
+
+  /** Computes the list of log type view models with overridden flags and hex colors. */
+  protected readonly logTypeViewModels = computed<
+    LogTypeStyleOverrideViewModel[]
+  >(() => {
+    // Track signal to trigger computed updates when styles are overridden
+    this.styleOverrideService.stylesUpdated();
+
+    return this.styleOverrideService.logTypes.map((type) => {
+      const bg = type.backgroundColor;
+      const fg = type.foregroundColor;
+      const goColorCode = `style.Color{R: ${bg.r.toFixed(3)}, G: ${bg.g.toFixed(3)}, B: ${bg.b.toFixed(3)}, A: ${bg.a.toFixed(1)}}`;
+      return {
+        id: type.id,
+        label: type.label,
+        description: type.description,
+        hexColor: this.hdrColorToHex(bg),
+        hexForegroundColor: this.hdrColorToHex(fg),
+        isOverridden: this.styleOverrideService.isLogTypeOverridden(type.id),
+        goColorCode,
+      };
+    });
+  });
+
+  /**
+   * Handles revision state color override emission.
+   * @param event The event payload containing state ID and hex color.
+   */
+  protected onRevisionStateColorChange(event: {
+    readonly id: number;
+    readonly hexColor: string;
+  }): void {
+    const originalState = this.styleOverrideService.getRevisionState(event.id);
+    this.styleOverrideService.overrideRevisionState({
+      ...originalState,
+      backgroundColor: this.hexToHDRColor(event.hexColor),
+    });
+  }
+
+  /**
+   * Handles resetting revision state color override emission.
+   * @param id The ID of the revision state to reset.
+   */
+  protected onRevisionStateResetColor(id: number): void {
+    this.styleOverrideService.resetRevisionState(id);
+  }
+
+  /**
+   * Handles timeline type property override emission.
+   * @param event The event payload containing timeline type ID and modified style properties.
+   */
+  protected onTimelineTypePropertyChange(
+    event: TimelineTypeOverrideEvent,
+  ): void {
+    const originalType = this.styleOverrideService.getTimelineType(event.id);
+    const updatedType = {
+      ...originalType,
+    };
+    if (event.backgroundColor !== undefined) {
+      updatedType.backgroundColor = this.hexToHDRColor(event.backgroundColor);
+    }
+    if (event.foregroundColor !== undefined) {
+      updatedType.foregroundColor = this.hexToHDRColor(event.foregroundColor);
+    }
+    if (event.typeChipBackgroundColor !== undefined) {
+      updatedType.typeChipBackgroundColor = this.hexToHDRColor(
+        event.typeChipBackgroundColor,
+      );
+    }
+    if (event.typeChipForegroundColor !== undefined) {
+      updatedType.typeChipForegroundColor = this.hexToHDRColor(
+        event.typeChipForegroundColor,
+      );
+    }
+    if (event.height !== undefined) {
+      updatedType.height = event.height;
+    }
+    this.styleOverrideService.overrideTimelineType(updatedType);
+  }
+
+  /**
+   * Handles resetting timeline type color override emission.
+   * @param id The ID of the timeline type to reset.
+   */
+  protected onTimelineTypeResetColor(id: number): void {
+    this.styleOverrideService.resetTimelineType(id);
+  }
+
+  /**
+   * Handles log type property override emission.
+   * @param event The event payload containing log type ID and modified style properties.
+   */
+  protected onLogTypePropertyChange(event: LogTypeOverrideEvent): void {
+    const originalType = this.styleOverrideService.getLogType(event.id);
+    const updatedType = {
+      ...originalType,
+    };
+    if (event.backgroundColor !== undefined) {
+      updatedType.backgroundColor = this.hexToHDRColor(event.backgroundColor);
+    }
+    if (event.foregroundColor !== undefined) {
+      updatedType.foregroundColor = this.hexToHDRColor(event.foregroundColor);
+    }
+    this.styleOverrideService.overrideLogType(updatedType);
+  }
+
+  /**
+   * Handles resetting log type color override emission.
+   * @param id The ID of the log type to reset.
+   */
+  protected onLogTypeResetColor(id: number): void {
+    this.styleOverrideService.resetLogType(id);
+  }
+
+  private hdrColorToHex(color: HDRColor4): string {
+    const r = Math.round(color.r * 255)
+      .toString(16)
+      .padStart(2, '0');
+    const g = Math.round(color.g * 255)
+      .toString(16)
+      .padStart(2, '0');
+    const b = Math.round(color.b * 255)
+      .toString(16)
+      .padStart(2, '0');
+    return `#${r}${g}${b}`;
+  }
+
+  private hexToHDRColor(hex: string): HDRColor4 {
+    const r = parseInt(hex.substring(1, 3), 16) / 255;
+    const g = parseInt(hex.substring(3, 5), 16) / 255;
+    const b = parseInt(hex.substring(5, 7), 16) / 255;
+    return { r, g, b, a: 1.0 };
+  }
+}

--- a/web/src/app/dialogs/style-override/types/style-override-viewmodel.ts
+++ b/web/src/app/dialogs/style-override/types/style-override-viewmodel.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RevisionStateStyle } from 'src/app/store/domain/style';
+
+/**
+ * ViewModel for a revision state style override row.
+ */
+export interface RevisionStateStyleOverrideViewModel {
+  readonly id: number;
+  readonly label: string;
+  readonly icon: string;
+  readonly description: string;
+  readonly hexColor: string;
+  readonly isOverridden: boolean;
+  readonly style: RevisionStateStyle;
+  readonly goColorCode: string;
+}
+
+/**
+ * ViewModel for a timeline type style override row.
+ */
+export interface TimelineTypeStyleOverrideViewModel {
+  readonly id: number;
+  readonly label: string;
+  readonly icon: string;
+  readonly description: string;
+  readonly hexColor: string;
+  readonly hexForegroundColor: string;
+  readonly hexChipBackgroundColor: string;
+  readonly hexChipForegroundColor: string;
+  readonly height: number;
+  readonly isOverridden: boolean;
+  readonly goColorCode: string;
+}
+
+/**
+ * Event payload structure when overriding a timeline type.
+ */
+export interface TimelineTypeOverrideEvent {
+  readonly id: number;
+  readonly backgroundColor?: string;
+  readonly foregroundColor?: string;
+  readonly typeChipBackgroundColor?: string;
+  readonly typeChipForegroundColor?: string;
+  readonly height?: number;
+}
+
+/**
+ * ViewModel for a log type style override card.
+ */
+export interface LogTypeStyleOverrideViewModel {
+  readonly id: number;
+  readonly label: string;
+  readonly description: string;
+  readonly hexColor: string;
+  readonly hexForegroundColor: string;
+  readonly isOverridden: boolean;
+  readonly goColorCode: string;
+}
+
+/**
+ * Event payload structure when overriding a log type.
+ */
+export interface LogTypeOverrideEvent {
+  readonly id: number;
+  readonly backgroundColor?: string;
+  readonly foregroundColor?: string;
+}

--- a/web/src/app/services/layout/layout.service.ts
+++ b/web/src/app/services/layout/layout.service.ts
@@ -21,6 +21,7 @@ import {
   signal,
   ViewContainerRef,
 } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import {
   GoldenLayout,
   ComponentContainer,
@@ -31,6 +32,7 @@ import { TimelineSmartComponent } from '../../timeline/timeline-smart.component'
 import { LogSmartComponent } from '../../log/log-smart.component';
 import { DiffSmartComponent } from '../../diff/diff-smart.component';
 import { MenuManager, MenuItemType } from '../menu/menu-manager.service';
+import { StyleOverrideSmartComponent } from 'src/app/dialogs/style-override/style-override-smart.component';
 
 /**
  * LayoutService manages the GoldenLayout instance and component registration.
@@ -38,6 +40,9 @@ import { MenuManager, MenuItemType } from '../menu/menu-manager.service';
 @Injectable()
 export class LayoutService implements OnDestroy {
   private readonly menuManager = inject(MenuManager);
+  private readonly dialog = inject(MatDialog);
+  private styleOverrideDialogRef: MatDialogRef<StyleOverrideSmartComponent> | null =
+    null;
   /** The GoldenLayout instance. */
   private goldenLayout!: GoldenLayout;
 
@@ -221,6 +226,38 @@ export class LayoutService implements OnDestroy {
       action: () => {
         this.loadDefaultLayout();
       },
+    });
+    this.menuManager.addItem('view', {
+      id: 'style-override',
+      label: 'Style override Settings',
+      type: MenuItemType.Button,
+      icon: 'palette',
+      priority: 6,
+      action: () => {
+        this.openStyleOverrideDialog();
+      },
+    });
+  }
+
+  private openStyleOverrideDialog() {
+    if (this.styleOverrideDialogRef) {
+      return;
+    }
+    this.styleOverrideDialogRef = this.dialog.open(
+      StyleOverrideSmartComponent,
+      {
+        width: '400px',
+        height: '100vh',
+        maxHeight: '100vh',
+        position: {
+          right: '0px',
+          top: '0px',
+        },
+        hasBackdrop: false,
+      },
+    );
+    this.styleOverrideDialogRef.afterClosed().subscribe(() => {
+      this.styleOverrideDialogRef = null;
     });
   }
 

--- a/web/src/app/services/style-override.service.spec.ts
+++ b/web/src/app/services/style-override.service.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { InspectionDataStoreV2 } from 'src/app/services/inspection-data-store-v2.service';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { StyleOverrideService } from 'src/app/services/style-override.service';
+import { RevisionStateStyle } from 'src/app/store/domain/style';
+
+import { InspectionDataV2 } from 'src/app/store/domain/inspection-data';
+
+describe('StyleOverrideService', () => {
+  let service: StyleOverrideService;
+  let mockInspectionDataStore: jasmine.SpyObj<InspectionDataStoreV2>;
+  let styleStore: StyleStore;
+
+  const originalColor = { r: 1, g: 0, b: 0, a: 1 };
+  const mockState = {
+    id: 1,
+    label: 'Terminated',
+    icon: 'cancel',
+    description: 'Resource instance terminated',
+    backgroundColor: originalColor,
+    style: RevisionStateStyle.NORMAL,
+  };
+
+  const mockTimelineType = {
+    id: 1,
+    label: 'Pod',
+    description: 'Pod resources',
+    icon: 'pod',
+    backgroundColor: originalColor,
+    foregroundColor: originalColor,
+    typeChipBackgroundColor: originalColor,
+    typeChipForegroundColor: originalColor,
+    visible: true,
+    sortPriority: 10,
+    height: 30,
+  };
+
+  const mockLogType = {
+    id: 1,
+    label: 'Audit',
+    description: 'Audit log events',
+    backgroundColor: originalColor,
+    foregroundColor: originalColor,
+  };
+
+  beforeEach(() => {
+    styleStore = new StyleStore();
+    styleStore.addRevisionStates([mockState]);
+    styleStore.addTimelineTypes([mockTimelineType]);
+    styleStore.addLogTypes([mockLogType]);
+
+    mockInspectionDataStore = jasmine.createSpyObj<InspectionDataStoreV2>(
+      'InspectionDataStoreV2',
+      [],
+      {
+        inspectionData: signal({
+          styleStore,
+        } as unknown as InspectionDataV2),
+      },
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        StyleOverrideService,
+        {
+          provide: InspectionDataStoreV2,
+          useValue: mockInspectionDataStore,
+        },
+      ],
+    });
+
+    service = TestBed.inject(StyleOverrideService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return base styles when no overrides are applied', () => {
+    expect(service.revisionStates.length).toBe(1);
+    expect(service.revisionStates[0]).toEqual(mockState);
+    expect(service.getRevisionState(1)).toEqual(mockState);
+    expect(service.isRevisionStateOverridden(1)).toBeFalse();
+
+    expect(service.timelineTypes.length).toBe(1);
+    expect(service.timelineTypes[0]).toEqual(mockTimelineType);
+    expect(service.getTimelineType(1)).toEqual(mockTimelineType);
+    expect(service.isTimelineTypeOverridden(1)).toBeFalse();
+
+    expect(service.logTypes.length).toBe(1);
+    expect(service.logTypes[0]).toEqual(mockLogType);
+    expect(service.getLogType(1)).toEqual(mockLogType);
+    expect(service.isLogTypeOverridden(1)).toBeFalse();
+  });
+
+  it('should override and reset revision state styles correctly', () => {
+    const overriddenState = {
+      ...mockState,
+      backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+    };
+
+    service.overrideRevisionState(overriddenState);
+
+    expect(service.isRevisionStateOverridden(1)).toBeTrue();
+    expect(service.revisionStates[0]).toEqual(overriddenState);
+    expect(service.getRevisionState(1)).toEqual(overriddenState);
+    expect(service.stylesUpdated()).toBe(1);
+
+    service.resetRevisionState(1);
+
+    expect(service.isRevisionStateOverridden(1)).toBeFalse();
+    expect(service.revisionStates[0]).toEqual(mockState);
+    expect(service.getRevisionState(1)).toEqual(mockState);
+    expect(service.stylesUpdated()).toBe(2);
+  });
+
+  it('should override and reset timeline type styles correctly', () => {
+    const overriddenType = {
+      ...mockTimelineType,
+      backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+    };
+
+    service.overrideTimelineType(overriddenType);
+
+    expect(service.isTimelineTypeOverridden(1)).toBeTrue();
+    expect(service.timelineTypes[0]).toEqual(overriddenType);
+    expect(service.getTimelineType(1)).toEqual(overriddenType);
+    expect(service.stylesUpdated()).toBe(1);
+
+    service.resetTimelineType(1);
+
+    expect(service.isTimelineTypeOverridden(1)).toBeFalse();
+    expect(service.timelineTypes[0]).toEqual(mockTimelineType);
+    expect(service.getTimelineType(1)).toEqual(mockTimelineType);
+    expect(service.stylesUpdated()).toBe(2);
+  });
+
+  it('should override and reset log type styles correctly', () => {
+    const overriddenType = {
+      ...mockLogType,
+      backgroundColor: { r: 0, g: 1, b: 0, a: 1 },
+      foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
+    };
+
+    service.overrideLogType(overriddenType);
+
+    expect(service.isLogTypeOverridden(1)).toBeTrue();
+    expect(service.logTypes[0]).toEqual(overriddenType);
+    expect(service.getLogType(1)).toEqual(overriddenType);
+    expect(service.stylesUpdated()).toBe(1);
+
+    service.resetLogType(1);
+
+    expect(service.isLogTypeOverridden(1)).toBeFalse();
+    expect(service.logTypes[0]).toEqual(mockLogType);
+    expect(service.getLogType(1)).toEqual(mockLogType);
+    expect(service.stylesUpdated()).toBe(2);
+  });
+});

--- a/web/src/app/services/style-override.service.ts
+++ b/web/src/app/services/style-override.service.ts
@@ -1,0 +1,353 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { inject, Injectable, computed, signal } from '@angular/core';
+import { InspectionDataStoreV2 } from 'src/app/services/inspection-data-store-v2.service';
+import {
+  IconAtlas,
+  LogType,
+  RevisionState,
+  Severity,
+  TimelineType,
+  Verb,
+} from 'src/app/store/domain/style';
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
+
+/**
+ * Service to override timeline element style configurations dynamically.
+ * Injects InspectionDataStoreV2 to fetch baseline StyleStore settings.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class StyleOverrideService implements StyleStoreLike {
+  private readonly inspectionDataStore = inject(InspectionDataStoreV2);
+
+  /** Map of overridden revision states. Key is the state ID. */
+  private readonly _revisionStateOverrides = signal<Map<number, RevisionState>>(
+    new Map(),
+  );
+
+  /** Map of overridden timeline types. Key is the timeline type ID. */
+  private readonly _timelineTypeOverrides = signal<Map<number, TimelineType>>(
+    new Map(),
+  );
+
+  /** Map of overridden log types. Key is the log type ID. */
+  private readonly _logTypeOverrides = signal<Map<number, LogType>>(new Map());
+
+  /** Caches of the original baseline configurations to support resetting. */
+  private readonly _originalRevisionStates = new Map<number, RevisionState>();
+  private readonly _originalTimelineTypes = new Map<number, TimelineType>();
+  private readonly _originalLogTypes = new Map<number, LogType>();
+
+  /** Signal triggered/incremented whenever styles are updated. */
+  public readonly stylesUpdated = signal(0);
+
+  /** Base style store from current active inspection data. */
+  protected readonly baseStyleStore = computed(() => {
+    return this.inspectionDataStore.inspectionData()?.styleStore ?? null;
+  });
+
+  /**
+   * Overrides the style configuration of a revision state.
+   * @param s The new revision state config DTO to override with.
+   */
+  public overrideRevisionState(s: RevisionState): void {
+    const store = this.baseStyleStore();
+    if (store) {
+      if (!this._originalRevisionStates.has(s.id)) {
+        this._originalRevisionStates.set(s.id, store.getRevisionState(s.id));
+      }
+      store.addRevisionStates([s]);
+    }
+
+    this._revisionStateOverrides.update((map) => {
+      const newMap = new Map(map);
+      newMap.set(s.id, s);
+      return newMap;
+    });
+    this.stylesUpdated.update((v) => v + 1);
+  }
+
+  /**
+   * Resets the override for a specific revision state.
+   * @param id The ID of the revision state.
+   */
+  public resetRevisionState(id: number): void {
+    const store = this.baseStyleStore();
+    const original = this._originalRevisionStates.get(id);
+    if (store && original) {
+      store.addRevisionStates([original]);
+      this._originalRevisionStates.delete(id);
+    }
+
+    this._revisionStateOverrides.update((map) => {
+      if (map.has(id)) {
+        const newMap = new Map(map);
+        newMap.delete(id);
+        return newMap;
+      }
+      return map;
+    });
+    this.stylesUpdated.update((v) => v + 1);
+  }
+
+  /**
+   * Checks if a revision state's color has been overridden.
+   * @param id The ID of the revision state.
+   * @returns True if overridden, false otherwise.
+   */
+  public isRevisionStateOverridden(id: number): boolean {
+    return this._revisionStateOverrides().has(id);
+  }
+
+  /**
+   * Overrides the style configuration of a timeline type.
+   * @param t The new timeline type config DTO to override with.
+   */
+  public overrideTimelineType(t: TimelineType): void {
+    const store = this.baseStyleStore();
+    if (store) {
+      if (!this._originalTimelineTypes.has(t.id)) {
+        this._originalTimelineTypes.set(t.id, store.getTimelineType(t.id));
+      }
+      store.addTimelineTypes([t]);
+    }
+
+    this._timelineTypeOverrides.update((map) => {
+      const newMap = new Map(map);
+      newMap.set(t.id, t);
+      return newMap;
+    });
+    this.stylesUpdated.update((v) => v + 1);
+  }
+
+  /**
+   * Resets the override for a specific timeline type.
+   * @param id The ID of the timeline type.
+   */
+  public resetTimelineType(id: number): void {
+    const store = this.baseStyleStore();
+    const original = this._originalTimelineTypes.get(id);
+    if (store && original) {
+      store.addTimelineTypes([original]);
+      this._originalTimelineTypes.delete(id);
+    }
+
+    this._timelineTypeOverrides.update((map) => {
+      if (map.has(id)) {
+        const newMap = new Map(map);
+        newMap.delete(id);
+        return newMap;
+      }
+      return map;
+    });
+    this.stylesUpdated.update((v) => v + 1);
+  }
+
+  /**
+   * Checks if a timeline type's color has been overridden.
+   * @param id The ID of the timeline type.
+   * @returns True if overridden, false otherwise.
+   */
+  public isTimelineTypeOverridden(id: number): boolean {
+    return this._timelineTypeOverrides().has(id);
+  }
+
+  /**
+   * Overrides the style configuration of a log type.
+   * @param l The new log type config DTO to override with.
+   */
+  public overrideLogType(l: LogType): void {
+    const store = this.baseStyleStore();
+    if (store) {
+      if (!this._originalLogTypes.has(l.id)) {
+        this._originalLogTypes.set(l.id, store.getLogType(l.id));
+      }
+      store.addLogTypes([l]);
+    }
+
+    this._logTypeOverrides.update((map) => {
+      const newMap = new Map(map);
+      newMap.set(l.id, l);
+      return newMap;
+    });
+    this.stylesUpdated.update((v) => v + 1);
+  }
+
+  /**
+   * Resets the override for a specific log type.
+   * @param id The ID of the log type.
+   */
+  public resetLogType(id: number): void {
+    const store = this.baseStyleStore();
+    const original = this._originalLogTypes.get(id);
+    if (store && original) {
+      store.addLogTypes([original]);
+      this._originalLogTypes.delete(id);
+    }
+
+    this._logTypeOverrides.update((map) => {
+      if (map.has(id)) {
+        const newMap = new Map(map);
+        newMap.delete(id);
+        return newMap;
+      }
+      return map;
+    });
+    this.stylesUpdated.update((v) => v + 1);
+  }
+
+  /**
+   * Checks if a log type's style has been overridden.
+   * @param id The ID of the log type.
+   * @returns True if overridden, false otherwise.
+   */
+  public isLogTypeOverridden(id: number): boolean {
+    return this._logTypeOverrides().has(id);
+  }
+
+  /**
+   * Returns all severities defined in the base store.
+   */
+  public get severities(): ReadonlyDomainElement<Severity[]> {
+    return this.baseStyleStore()?.severities ?? [];
+  }
+
+  /**
+   * Returns all log types, applying overrides if they exist.
+   */
+  public get logTypes(): ReadonlyDomainElement<LogType[]> {
+    const originalTypes = this.baseStyleStore()?.logTypes ?? [];
+    const overrides = this._logTypeOverrides();
+    if (overrides.size === 0) {
+      return originalTypes;
+    }
+    return originalTypes.map((type) => overrides.get(type.id) ?? type);
+  }
+
+  /**
+   * Returns all verbs defined in the base store.
+   */
+  public get verbs(): ReadonlyDomainElement<Verb[]> {
+    return this.baseStyleStore()?.verbs ?? [];
+  }
+
+  /**
+   * Returns all revision states, applying overrides if they exist.
+   */
+  public get revisionStates(): ReadonlyDomainElement<RevisionState[]> {
+    const originalStates = this.baseStyleStore()?.revisionStates ?? [];
+    const overrides = this._revisionStateOverrides();
+    if (overrides.size === 0) {
+      return originalStates;
+    }
+    return originalStates.map((state) => overrides.get(state.id) ?? state);
+  }
+
+  /**
+   * Returns all timeline types, applying overrides if they exist.
+   */
+  public get timelineTypes(): ReadonlyDomainElement<TimelineType[]> {
+    const originalTypes = this.baseStyleStore()?.timelineTypes ?? [];
+    const overrides = this._timelineTypeOverrides();
+    if (overrides.size === 0) {
+      return originalTypes;
+    }
+    return originalTypes.map((type) => overrides.get(type.id) ?? type);
+  }
+
+  /**
+   * Resolves severity by ID from the base store.
+   * @param id The ID of the severity.
+   */
+  public getSeverity(id: number): ReadonlyDomainElement<Severity> {
+    const store = this.baseStyleStore();
+    if (!store) {
+      throw new Error('StyleStore is not loaded');
+    }
+    return store.getSeverity(id);
+  }
+
+  /**
+   * Resolves log type by ID, applying override if set.
+   * @param id The ID of the log type.
+   */
+  public getLogType(id: number): ReadonlyDomainElement<LogType> {
+    const override = this._logTypeOverrides().get(id);
+    if (override) {
+      return override;
+    }
+    const store = this.baseStyleStore();
+    if (!store) {
+      throw new Error('StyleStore is not loaded');
+    }
+    return store.getLogType(id);
+  }
+
+  /**
+   * Resolves verb by ID from the base store.
+   * @param id The ID of the verb.
+   */
+  public getVerb(id: number): ReadonlyDomainElement<Verb> {
+    const store = this.baseStyleStore();
+    if (!store) {
+      throw new Error('StyleStore is not loaded');
+    }
+    return store.getVerb(id);
+  }
+
+  /**
+   * Resolves revision state by ID, applying override if set.
+   * @param id The ID of the revision state.
+   */
+  public getRevisionState(id: number): ReadonlyDomainElement<RevisionState> {
+    const override = this._revisionStateOverrides().get(id);
+    if (override) {
+      return override;
+    }
+    const store = this.baseStyleStore();
+    if (!store) {
+      throw new Error('StyleStore is not loaded');
+    }
+    return store.getRevisionState(id);
+  }
+
+  /**
+   * Resolves timeline type by ID, applying override if set.
+   * @param id The ID of the timeline type.
+   */
+  public getTimelineType(id: number): ReadonlyDomainElement<TimelineType> {
+    const override = this._timelineTypeOverrides().get(id);
+    if (override) {
+      return override;
+    }
+    const store = this.baseStyleStore();
+    if (!store) {
+      throw new Error('StyleStore is not loaded');
+    }
+    return store.getTimelineType(id);
+  }
+
+  /**
+   * Resolves loaded icon atlas.
+   */
+  public getIconAtlas(): IconAtlas | undefined {
+    return this.baseStyleStore()?.getIconAtlas();
+  }
+}

--- a/web/src/app/services/style-override.service.ts
+++ b/web/src/app/services/style-override.service.ts
@@ -50,11 +50,6 @@ export class StyleOverrideService implements StyleStoreLike {
   /** Map of overridden log types. Key is the log type ID. */
   private readonly _logTypeOverrides = signal<Map<number, LogType>>(new Map());
 
-  /** Caches of the original baseline configurations to support resetting. */
-  private readonly _originalRevisionStates = new Map<number, RevisionState>();
-  private readonly _originalTimelineTypes = new Map<number, TimelineType>();
-  private readonly _originalLogTypes = new Map<number, LogType>();
-
   /** Signal triggered/incremented whenever styles are updated. */
   public readonly stylesUpdated = signal(0);
 
@@ -68,14 +63,6 @@ export class StyleOverrideService implements StyleStoreLike {
    * @param s The new revision state config DTO to override with.
    */
   public overrideRevisionState(s: RevisionState): void {
-    const store = this.baseStyleStore();
-    if (store) {
-      if (!this._originalRevisionStates.has(s.id)) {
-        this._originalRevisionStates.set(s.id, store.getRevisionState(s.id));
-      }
-      store.addRevisionStates([s]);
-    }
-
     this._revisionStateOverrides.update((map) => {
       const newMap = new Map(map);
       newMap.set(s.id, s);
@@ -89,13 +76,6 @@ export class StyleOverrideService implements StyleStoreLike {
    * @param id The ID of the revision state.
    */
   public resetRevisionState(id: number): void {
-    const store = this.baseStyleStore();
-    const original = this._originalRevisionStates.get(id);
-    if (store && original) {
-      store.addRevisionStates([original]);
-      this._originalRevisionStates.delete(id);
-    }
-
     this._revisionStateOverrides.update((map) => {
       if (map.has(id)) {
         const newMap = new Map(map);
@@ -121,14 +101,6 @@ export class StyleOverrideService implements StyleStoreLike {
    * @param t The new timeline type config DTO to override with.
    */
   public overrideTimelineType(t: TimelineType): void {
-    const store = this.baseStyleStore();
-    if (store) {
-      if (!this._originalTimelineTypes.has(t.id)) {
-        this._originalTimelineTypes.set(t.id, store.getTimelineType(t.id));
-      }
-      store.addTimelineTypes([t]);
-    }
-
     this._timelineTypeOverrides.update((map) => {
       const newMap = new Map(map);
       newMap.set(t.id, t);
@@ -142,13 +114,6 @@ export class StyleOverrideService implements StyleStoreLike {
    * @param id The ID of the timeline type.
    */
   public resetTimelineType(id: number): void {
-    const store = this.baseStyleStore();
-    const original = this._originalTimelineTypes.get(id);
-    if (store && original) {
-      store.addTimelineTypes([original]);
-      this._originalTimelineTypes.delete(id);
-    }
-
     this._timelineTypeOverrides.update((map) => {
       if (map.has(id)) {
         const newMap = new Map(map);
@@ -174,14 +139,6 @@ export class StyleOverrideService implements StyleStoreLike {
    * @param l The new log type config DTO to override with.
    */
   public overrideLogType(l: LogType): void {
-    const store = this.baseStyleStore();
-    if (store) {
-      if (!this._originalLogTypes.has(l.id)) {
-        this._originalLogTypes.set(l.id, store.getLogType(l.id));
-      }
-      store.addLogTypes([l]);
-    }
-
     this._logTypeOverrides.update((map) => {
       const newMap = new Map(map);
       newMap.set(l.id, l);
@@ -195,13 +152,6 @@ export class StyleOverrideService implements StyleStoreLike {
    * @param id The ID of the log type.
    */
   public resetLogType(id: number): void {
-    const store = this.baseStyleStore();
-    const original = this._originalLogTypes.get(id);
-    if (store && original) {
-      store.addLogTypes([original]);
-      this._originalLogTypes.delete(id);
-    }
-
     this._logTypeOverrides.update((map) => {
       if (map.has(id)) {
         const newMap = new Map(map);

--- a/web/src/app/timeline/components/canvas/timeline-events-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-events-renderer.ts
@@ -26,7 +26,7 @@ import {
   getEventStyleForHeight,
 } from '../style-model-v2';
 import { RendererConvertUtil } from './convertutil';
-import { StyleStore } from 'src/app/store/domain/style-store';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
 
 /**
  * Renders timeline events (points in time) using WebGL.
@@ -380,7 +380,7 @@ export class TimelineEventsSharedResources {
   beforeRender(
     gl: WebGL2RenderingContext,
     tmpBuffer: SharedTmpBuffer,
-    styleStore: StyleStore,
+    styleStore: StyleStoreLike,
   ) {
     if (this.styleUpdated) {
       const logTypes = styleStore.logTypes;

--- a/web/src/app/timeline/components/canvas/timeline-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-renderer.ts
@@ -268,6 +268,13 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
   }
 
   /**
+   * Invalidates cached styles, forcing UBOs to rebuild on next frame.
+   */
+  public invalidateStyles() {
+    this.revisionSharedResource.invalidateStyles();
+  }
+
+  /**
    * Requests a hit test at the specified coordinates.
    *
    * @param x The x-coordinate for the hit test.

--- a/web/src/app/timeline/components/canvas/timeline-revisions-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-revisions-renderer.ts
@@ -29,7 +29,7 @@ import {
   getRevisionStyleForHeight,
 } from '../style-model-v2';
 import { RendererConvertUtil } from './convertutil';
-import { StyleStore } from 'src/app/store/domain/style-store';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
 
 /**
  * Renders timeline revisions (horizontal bars representing resource states) using WebGL.
@@ -438,7 +438,7 @@ export class TimelineRevisionsSharedResources {
   beforeRender(
     gl: WebGL2RenderingContext,
     tmpBuffer: SharedTmpBuffer,
-    styleStore: StyleStore,
+    styleStore: StyleStoreLike,
   ) {
     if (this.styleUpdated) {
       const revisionStates = styleStore.revisionStates;
@@ -594,6 +594,13 @@ export class TimelineRevisionsSharedResources {
    */
   updateChartStyle(style: TimelineChartStyle) {
     this.chartStyle = style;
+    this.styleUpdated = true;
+  }
+
+  /**
+   * Invalidates cached styles, forcing UBOs to rebuild on next frame.
+   */
+  invalidateStyles() {
     this.styleUpdated = true;
   }
 }

--- a/web/src/app/timeline/components/canvas/timeline-shared-resource.ts
+++ b/web/src/app/timeline/components/canvas/timeline-shared-resource.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { StyleStore } from 'src/app/store/domain/style-store';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
 import { RendererConvertUtil } from './convertutil';
 import { WebGLContextLostException } from './glcontextmanager';
 import { SharedTmpBuffer, WebGLUtil } from './glutil';
@@ -164,7 +164,7 @@ export class TimelineRendererSharedResource {
    * @param gl The WebGL2 rendering context.
    * @param styleStore The style store containing the icon atlas.
    */
-  updateIconAtlas(gl: WebGL2RenderingContext, styleStore: StyleStore) {
+  updateIconAtlas(gl: WebGL2RenderingContext, styleStore: StyleStoreLike) {
     const iconAtlas = styleStore.getIconAtlas();
     if (!iconAtlas) {
       // If no inspection data has been loaded yet, there will be no icon atlas.

--- a/web/src/app/timeline/components/misc/demo-builder.ts
+++ b/web/src/app/timeline/components/misc/demo-builder.ts
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-import {
-  LogType,
-  RevisionState,
-  RevisionVerb,
-  Severity,
-} from 'src/app/zzz-generated';
+type LogType = number;
+type RevisionState = number;
+type RevisionVerb = number;
+type Severity = number;
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { LogStore, LogDTO } from 'src/app/store/domain/log-store';
@@ -82,7 +80,7 @@ export class DemoViewModelBuilder {
     // Setup standard severities
     this.styleStore.addSeverities([
       {
-        id: Severity.SeverityUnknown,
+        id: 0, // SeverityUnknown
         label: 'Unknown',
         shortLabel: 'U',
         backgroundColor: { r: 0.502, g: 0.502, b: 0.502, a: 1 },
@@ -90,7 +88,7 @@ export class DemoViewModelBuilder {
         order: 0,
       },
       {
-        id: Severity.SeverityInfo,
+        id: 1, // SeverityInfo
         label: 'Info',
         shortLabel: 'I',
         backgroundColor: { r: 0, g: 0, b: 1, a: 1 },
@@ -98,7 +96,7 @@ export class DemoViewModelBuilder {
         order: 1,
       },
       {
-        id: Severity.SeverityWarning,
+        id: 2, // SeverityWarning
         label: 'Warning',
         shortLabel: 'W',
         backgroundColor: { r: 1, g: 0.667, b: 0.267, a: 1 },
@@ -106,7 +104,7 @@ export class DemoViewModelBuilder {
         order: 2,
       },
       {
-        id: Severity.SeverityError,
+        id: 3, // SeverityError
         label: 'Error',
         shortLabel: 'E',
         backgroundColor: { r: 1, g: 0.224, b: 0.208, a: 1 },
@@ -114,7 +112,7 @@ export class DemoViewModelBuilder {
         order: 3,
       },
       {
-        id: Severity.SeverityFatal,
+        id: 4, // SeverityFatal
         label: 'Fatal',
         shortLabel: 'F',
         backgroundColor: { r: 0.667, g: 0.4, b: 0.667, a: 1 },
@@ -126,21 +124,21 @@ export class DemoViewModelBuilder {
     // Setup standard log types
     this.styleStore.addLogTypes([
       {
-        id: LogType.LogTypeUnknown,
+        id: 0, // LogTypeUnknown
         label: 'Unknown',
         description: 'Unknown log type',
         backgroundColor: { r: 0.502, g: 0.502, b: 0.502, a: 1 },
         foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
       },
       {
-        id: LogType.LogTypeAudit,
+        id: 1, // LogTypeAudit
         label: 'Audit',
         description: 'Audit log entry',
         backgroundColor: { r: 0, g: 0.502, b: 0, a: 1 },
         foregroundColor: { r: 1, g: 1, b: 1, a: 1 },
       },
       {
-        id: LogType.LogTypeEvent,
+        id: 2, // LogTypeEvent
         label: 'Event',
         description: 'Kubernetes Event',
         backgroundColor: { r: 1, g: 0.647, b: 0, a: 1 },
@@ -174,6 +172,7 @@ export class DemoViewModelBuilder {
           backgroundColor: { r: 33, g: 150, b: 243, a: 255 },
           foregroundColor: { r: 255, g: 255, b: 255, a: 255 },
           typeChipBackgroundColor: { r: 33, g: 150, b: 243, a: 255 },
+          typeChipForegroundColor: { r: 255, g: 255, b: 255, a: 255 },
           visible: true,
           sortPriority: id,
           height: 20,
@@ -219,8 +218,8 @@ export class DemoViewModelBuilder {
     this.logDTOs.push({
       id: logId,
       ts: BigInt(Math.floor(logTime)) * 1000000n,
-      logTypeId: LogType.LogTypeAudit,
-      severityTypeId: Severity.SeverityInfo,
+      logTypeId: 1, // LogTypeAudit
+      severityTypeId: 1, // SeverityInfo
       summaryStringId: this.getStringId(''),
       body: undefined,
     });

--- a/web/src/app/timeline/components/style-model-v2.ts
+++ b/web/src/app/timeline/components/style-model-v2.ts
@@ -24,7 +24,7 @@ import {
   TimelineHighlightType,
 } from 'src/app/timeline/components/interaction-model';
 import { RevisionStateStyle, Severity } from 'src/app/store/domain/style';
-import { StyleStore } from 'src/app/store/domain/style-store';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
 
 /**
  * Baseline height of a timeline row in pixels.
@@ -357,7 +357,7 @@ export function generateDefaultChartStyle(): TimelineChartStyle {
  * Generates the default style configuration for the timeline ruler.
  */
 export function generateDefaultRulerStyle(
-  styleStore: StyleStore,
+  styleStore: StyleStoreLike,
 ): TimelineRulerStyle {
   const severities = styleStore.severities;
   const severityColors: { [severityId: number]: HDRColor4 } = {};

--- a/web/src/app/timeline/components/timeline-chart.component.ts
+++ b/web/src/app/timeline/components/timeline-chart.component.ts
@@ -174,6 +174,12 @@ export class TimelineChartComponent implements AfterViewInit {
 
   constructor() {
     effect(() => {
+      const chartViewModel = this.chartViewModel();
+      if (chartViewModel) {
+        chartViewModel.styleStore.stylesUpdated?.();
+        this.timelineRenderer.invalidateStyles();
+      }
+      this.invalidate.set(true);
       this.updateRendererParams();
     });
   }

--- a/web/src/app/timeline/components/timeline-frame.component.html
+++ b/web/src/app/timeline/components/timeline-frame.component.html
@@ -77,6 +77,7 @@
         <khi-timeline-index
           class="index-content"
           [timelines]="visibleTimelines()"
+          [styleStore]="styleStore()"
           (hoverOnTimeline)="
             handleTimelineEventForIndex($event, hoverOnTimeline)
           "
@@ -153,6 +154,7 @@
           <khi-timeline-index
             class="index-content"
             [timelines]="stickyTimelines()"
+            [styleStore]="styleStore()"
             (hoverOnTimeline)="
               handleTimelineEventForIndex($event, hoverOnTimeline)
             "

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -66,7 +66,7 @@ import {
   TimelineHighlightType,
   TimelineChartItemHighlightType,
 } from './interaction-model';
-import { StyleStore } from 'src/app/store/domain/style-store';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
 import {
   BASE_ROW_HEIGHT,
   TimelineChartStyle,
@@ -172,7 +172,7 @@ export class TimelineFrameComponent implements AfterViewInit {
   /**
    * The StyleStore containing all color and layout styling definitions.
    */
-  readonly styleStore = input.required<StyleStore>();
+  readonly styleStore = input.required<StyleStoreLike>();
 
   /**
    * The minimum time in milliseconds for the query range.

--- a/web/src/app/timeline/components/timeline-index.component.scss
+++ b/web/src/app/timeline/components/timeline-index.component.scss
@@ -156,10 +156,7 @@ $tint-border-color: mat.m2-get-color-from-palette(mat.$m2-green-palette, 600);
       box-shadow:
         inset 0 1px 2px rgba(0, 0, 0, 0.15),
         inset 0 -0.5px 0 rgba(255, 255, 255, 0.2);
-      color: hsl(
-        from var(--timeline-chip-bg-color) h 0%
-          calc(clamp(13.3, (60 - l) * 1000, 100) * 1%)
-      );
+      color: var(--timeline-chip-fg-color);
       text-transform: uppercase;
       letter-spacing: 0.5px;
       user-select: none;

--- a/web/src/app/timeline/components/timeline-index.component.ts
+++ b/web/src/app/timeline/components/timeline-index.component.ts
@@ -24,6 +24,7 @@ import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registrati
 import { TimelineHighlight, TimelineHighlightType } from './interaction-model';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { BASE_ROW_HEIGHT } from 'src/app/timeline/components/style-model-v2';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
 
 export interface TreeGuideViewModel {
   readonly level: number;
@@ -85,8 +86,12 @@ export class TimelineIndexComponent {
   /** Current highlight state for timelines, keyed by timeline ID. */
   highlights = input<TimelineHighlight>({});
 
+  /** The StyleStore containing all color and layout styling definitions. */
+  styleStore = input<StyleStoreLike>();
+
   /** Computed view models for rendering the timeline index rows. */
   timelineVMs = computed<TimelineIndexViewModel[]>(() => {
+    this.styleStore()?.stylesUpdated?.();
     return this.toViewModelType(this.timelines());
   });
 
@@ -165,6 +170,12 @@ export class TimelineIndexComponent {
           chipBg.g,
           chipBg.b,
           chipBg.a,
+        ]),
+        '--timeline-chip-fg-color': RendererConvertUtil.hdrColorToCSSColor([
+          timeline.type.typeChipForegroundColor.r,
+          timeline.type.typeChipForegroundColor.g,
+          timeline.type.typeChipForegroundColor.b,
+          timeline.type.typeChipForegroundColor.a,
         ]),
         '--timeline-height': `${height}px`,
         '--timeline-layer': `${timeline.layer}`,

--- a/web/src/app/timeline/timeline-smart.component.ts
+++ b/web/src/app/timeline/timeline-smart.component.ts
@@ -32,7 +32,8 @@ import {
 import { Timeline } from 'src/app/store/domain/timeline';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { InspectionDataV2 } from 'src/app/store/domain/inspection-data';
-import { StyleStore } from 'src/app/store/domain/style-store';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
+import { StyleOverrideService } from 'src/app/services/style-override.service';
 import {
   TimelineChartStyle,
   TimelineRulerStyle,
@@ -66,6 +67,8 @@ export class TimelineSmartComponent {
   private readonly inspectionDataStore = inject(InspectionDataStoreV2);
 
   private readonly selectionManager = inject(SelectionManagerV2);
+
+  private readonly styleOverrideService = inject(StyleOverrideService);
 
   private readonly inspectionData = computed(() => {
     return this.inspectionDataStore.inspectionData();
@@ -108,8 +111,8 @@ export class TimelineSmartComponent {
   /**
    * The StyleStore containing all color and layout styling definitions.
    */
-  protected readonly styleStore = computed(() => {
-    return this.inspectionData()?.styleStore ?? new StyleStore();
+  protected readonly styleStore = computed<StyleStoreLike>(() => {
+    return this.styleOverrideService;
   });
 
   /**


### PR DESCRIPTION
This PR adds a developer tool for us to preview timeline style and revision style easier.

<img width="3840" height="1926" alt="image" src="https://github.com/user-attachments/assets/951b1560-7cac-42b5-93e1-606fb16b963f" />
<img width="3840" height="1926" alt="image" src="https://github.com/user-attachments/assets/549e668a-eac6-4984-87dc-e25d44ed06e8" />
<img width="3840" height="1926" alt="image" src="https://github.com/user-attachments/assets/c9b055fc-d51d-4269-8898-2e57d7651933" />
