### PR TITLE
Migrate log/timeline searching to WebWorker

### DIFF
--- a/web/src/app/services/inspection-data-store-v2.service.ts
+++ b/web/src/app/services/inspection-data-store-v2.service.ts
@@ -26,6 +26,7 @@ import {
   ExcludeNoLogsFilter,
   IncludeDescendantsFilter,
 } from 'src/app/store/domain/filter/other-filter';
+import { SearchWorkerManager } from 'src/app/services/search-worker-manager.service';
 
 /**
  * Service to store and manage the active InspectionDataV2 domain model.
@@ -38,6 +39,7 @@ export class InspectionDataStoreV2 {
   private readonly celTimelineFilter = inject(CelTimelineFilter);
   private readonly celLogFilter = inject(CelLogFilter);
   private readonly excludeNoLogsFilter = inject(ExcludeNoLogsFilter);
+  private readonly searchWorkerManager = inject(SearchWorkerManager);
 
   /**
    * Holds the active inspection data. Emits null if no data has been loaded.
@@ -65,6 +67,14 @@ export class InspectionDataStoreV2 {
       this._timelineView.set(null);
       return;
     }
+
+    void this.searchWorkerManager.syncData(
+      data.internPool,
+      data.logStore,
+      data.timelineStore,
+      data.styleStore,
+    );
+
     const view = new TimelineView(data.timelineStore);
     view.addFilter(this.celTimelineFilter);
     view.addFilter(new IncludeDescendantsFilter());

--- a/web/src/app/services/search-worker-manager.service.spec.ts
+++ b/web/src/app/services/search-worker-manager.service.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { SearchWorkerManager } from 'src/app/services/search-worker-manager.service';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { TimelineDTO } from 'src/app/store/domain/timeline-store';
+import { LogDTO } from 'src/app/store/domain/log-store';
+
+describe('SearchWorkerManager', () => {
+  let manager: SearchWorkerManager;
+  let styleStore: StyleStore;
+  let internPoolStore: InternPoolStore;
+  let logStore: LogStore;
+  let timelineStore: TimelineStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    manager = TestBed.inject(SearchWorkerManager);
+
+    styleStore = new StyleStore();
+    styleStore.addSeverities([
+      {
+        id: 1,
+        label: 'INFO',
+        shortLabel: 'I',
+        backgroundColor: { r: 0, g: 0, b: 0, a: 1 },
+        foregroundColor: { r: 0, g: 0, b: 0, a: 1 },
+        order: 1,
+      },
+    ]);
+    styleStore.addLogTypes([
+      {
+        id: 1,
+        label: 'k8s',
+        description: '',
+        backgroundColor: { r: 0, g: 0, b: 0, a: 1 },
+        foregroundColor: { r: 0, g: 0, b: 0, a: 1 },
+      },
+    ]);
+    styleStore.addTimelineTypes([
+      {
+        id: 1,
+        label: 'Pod',
+        description: '',
+        icon: '',
+        backgroundColor: { r: 0, g: 0, b: 0, a: 1 },
+        foregroundColor: { r: 0, g: 0, b: 0, a: 1 },
+        typeChipBackgroundColor: { r: 0, g: 0, b: 0, a: 1 },
+        typeChipForegroundColor: { r: 0, g: 0, b: 0, a: 1 },
+        visible: true,
+        sortPriority: 1,
+        height: 20,
+      },
+    ]);
+
+    internPoolStore = InternPoolStore.create();
+    internPoolStore.addStrings([
+      { id: 1, value: 'pod-a' },
+      { id: 2, value: 'pod-b' },
+    ]);
+
+    logStore = LogStore.create(internPoolStore, styleStore);
+    const logs: LogDTO[] = [
+      {
+        id: 10,
+        ts: 1000n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+      },
+      {
+        id: 20,
+        ts: 2000n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 2,
+      },
+    ];
+    logStore.initialize(logs, 2);
+
+    timelineStore = TimelineStore.create(internPoolStore, styleStore, logStore);
+    const timelines: TimelineDTO[] = [
+      {
+        id: 100,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [10],
+      },
+      {
+        id: 200,
+        timelineTypeId: 1,
+        nameStringId: 2,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [20],
+      },
+    ];
+    timelineStore.initialize(
+      timelines,
+      2,
+      [],
+      0,
+      [
+        { id: 10, logId: 10 },
+        { id: 20, logId: 20 },
+      ],
+      2,
+    );
+  });
+
+  afterEach(() => {
+    manager.ngOnDestroy();
+  });
+
+  it('should sync stores and run parallel searches correctly', async () => {
+    await manager.syncData(
+      internPoolStore,
+      logStore,
+      timelineStore,
+      styleStore,
+    );
+
+    // Timeline search: name == 'pod-a' should match timeline 100
+    const timelineProgressCalls: { current: number; total: number }[] = [];
+    const matchedTimelines = await manager.searchTimelines(
+      "name == 'pod-a'",
+      (current, total) => {
+        timelineProgressCalls.push({ current, total });
+      },
+    );
+    expect(matchedTimelines.has(100)).toBeTrue();
+    expect(matchedTimelines.has(200)).toBeFalse();
+    expect(timelineProgressCalls.length).toBeGreaterThan(0);
+    expect(timelineProgressCalls[timelineProgressCalls.length - 1]).toEqual({
+      current: 2,
+      total: 2,
+    });
+
+    // Log search: summary == 'pod-b' should match log 20
+    const logProgressCalls: { current: number; total: number }[] = [];
+    const matchedLogs = await manager.searchLogs(
+      "summary == 'pod-b'",
+      [100, 200],
+      (current, total) => {
+        logProgressCalls.push({ current, total });
+      },
+    );
+    expect(matchedLogs.has(20)).toBeTrue();
+    expect(matchedLogs.has(10)).toBeFalse();
+    expect(logProgressCalls.length).toBeGreaterThan(0);
+    expect(logProgressCalls[logProgressCalls.length - 1]).toEqual({
+      current: 2,
+      total: 2,
+    });
+  });
+});

--- a/web/src/app/services/search-worker-manager.service.ts
+++ b/web/src/app/services/search-worker-manager.service.ts
@@ -83,7 +83,7 @@ export class SearchWorkerManager implements OnDestroy {
         const tempSessionId = `sync-${this.sessionCounter++}`;
         const handleSync = (event: MessageEvent<SearchWorkerResponse>) => {
           const res = event.data;
-          if (res.type === 'SYNC_COMPLETE') {
+          if (res.type === 'SYNC_COMPLETE' && res.requestId === tempSessionId) {
             worker.removeEventListener('message', handleSync);
             resolve();
           } else if (res.type === 'ERROR' && res.requestId === tempSessionId) {
@@ -95,6 +95,7 @@ export class SearchWorkerManager implements OnDestroy {
 
         worker.postMessage({
           type: 'SYNC_DATA',
+          requestId: tempSessionId,
           workerIndex: index,
           internPoolSharedData,
           logStoreSharedData,

--- a/web/src/app/services/search-worker-manager.service.ts
+++ b/web/src/app/services/search-worker-manager.service.ts
@@ -1,0 +1,320 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable, OnDestroy } from '@angular/core';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import {
+  SearchWorkerRequest,
+  SearchWorkerResponse,
+} from 'src/app/worker/search/search-types';
+
+interface SearchSession {
+  readonly expectedResponses: number;
+  readonly matchedIds: number[];
+  receivedCount: number;
+  readonly workerProcessed: number[];
+  readonly workerTotals: number[];
+  readonly onProgress?: (current: number, total: number) => void;
+  resolve(matchedIds: number[]): void;
+  reject(error: Error): void;
+}
+
+/**
+ * Orchestrates a pool of WebWorkers to run CEL log and timeline searches concurrently.
+ */
+@Injectable({ providedIn: 'root' })
+export class SearchWorkerManager implements OnDestroy {
+  private readonly workers: Worker[] = [];
+  private readonly numWorkers: number;
+  private readonly activeSessions = new Map<string, SearchSession>();
+  private sessionCounter = 0;
+  private activeTimelineStore: TimelineStore | null = null;
+
+  constructor() {
+    this.numWorkers = 8; //Math.max(1, (navigator.hardwareConcurrency || 4) - 1);
+    for (let i = 0; i < this.numWorkers; i++) {
+      const worker = new Worker(
+        new URL('../worker/search/search.worker', import.meta.url),
+        { type: 'module' },
+      );
+      worker.addEventListener(
+        'message',
+        (event: MessageEvent<SearchWorkerResponse>) => {
+          this.handleWorkerMessage(event.data);
+        },
+      );
+      this.workers.push(worker);
+    }
+  }
+
+  /**
+   * Synchronizes shared store data arrays across all active WebWorkers.
+   */
+  public syncData(
+    internPoolStore: InternPoolStore,
+    logStore: LogStore,
+    timelineStore: TimelineStore,
+    styleStore: StyleStore,
+  ): Promise<void[]> {
+    this.activeTimelineStore = timelineStore;
+    const internPoolSharedData = internPoolStore.getSharedData();
+    const logStoreSharedData = logStore.getSharedData();
+    const timelineStoreSharedData = timelineStore.getSharedData();
+    const styleStoreSharedData = styleStore.getSharedData();
+
+    const promises = this.workers.map((worker, index) => {
+      return new Promise<void>((resolve, reject) => {
+        const tempSessionId = `sync-${this.sessionCounter++}`;
+        const handleSync = (event: MessageEvent<SearchWorkerResponse>) => {
+          const res = event.data;
+          if (res.type === 'SYNC_COMPLETE') {
+            worker.removeEventListener('message', handleSync);
+            resolve();
+          } else if (res.type === 'ERROR' && res.requestId === tempSessionId) {
+            worker.removeEventListener('message', handleSync);
+            reject(new Error(res.error));
+          }
+        };
+        worker.addEventListener('message', handleSync);
+
+        worker.postMessage({
+          type: 'SYNC_DATA',
+          workerIndex: index,
+          internPoolSharedData,
+          logStoreSharedData,
+          timelineStoreSharedData,
+          styleStoreSharedData,
+        } as SearchWorkerRequest);
+      });
+    });
+
+    return Promise.all(promises);
+  }
+
+  /**
+   * Partitions timeline IDs and executes CEL timeline filtering concurrently across workers.
+   */
+  public async searchTimelines(
+    celExpr: string,
+    onProgress?: (current: number, total: number) => void,
+  ): Promise<Set<number>> {
+    if (celExpr === '') {
+      const allIds = this.activeTimelineStore?.timelines.map((t) => t.id) ?? [];
+      return new Set(allIds);
+    }
+
+    const totalTimelines = this.activeTimelineStore?.timelines.length ?? 0;
+    const startTime = performance.now();
+    const requestId = `search-t-${this.sessionCounter++}`;
+    const progressSab = new SharedArrayBuffer(this.workers.length * 64);
+    const progressArray = new Int32Array(progressSab);
+
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    if (onProgress) {
+      intervalId = setInterval(() => {
+        let current = 0;
+        for (let i = 0; i < this.workers.length; i++) {
+          current += progressArray[i * 16];
+        }
+        onProgress(current, totalTimelines);
+      }, 50);
+    }
+
+    const promise = new Promise<number[]>((resolve, reject) => {
+      this.activeSessions.set(requestId, {
+        expectedResponses: this.workers.length,
+        matchedIds: [],
+        receivedCount: 0,
+        workerProcessed: Array.from({ length: this.workers.length }, () => 0),
+        workerTotals: Array.from({ length: this.workers.length }, () => 0),
+        onProgress,
+        resolve,
+        reject,
+      });
+    });
+
+    const cleanup = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+      }
+    };
+
+    for (let i = 0; i < this.workers.length; i++) {
+      this.workers[i].postMessage({
+        type: 'SEARCH_TIMELINES',
+        requestId,
+        workerIndex: i,
+        numWorkers: this.workers.length,
+        celExpr,
+        progressSab,
+      } as SearchWorkerRequest);
+    }
+
+    try {
+      const matchedList = await promise;
+      if (onProgress) {
+        onProgress(totalTimelines, totalTimelines);
+      }
+      const elapsedMs = performance.now() - startTime;
+      const speed = elapsedMs > 0 ? totalTimelines / (elapsedMs / 1000) : 0;
+      console.debug(
+        `[SearchWorkerManager] searchTimelines finished:\n` +
+          `  Query: "${celExpr}"\n` +
+          `  Elapsed Time: ${elapsedMs.toFixed(2)}ms\n` +
+          `  Search Speed: ${speed.toFixed(0)} timelines/sec`,
+      );
+      return new Set(matchedList);
+    } finally {
+      cleanup();
+    }
+  }
+
+  /**
+   * Partitions timeline IDs and executes CEL log filtering concurrently across workers.
+   */
+  public async searchLogs(
+    celExpr: string,
+    timelineIds: readonly number[],
+    onProgress?: (current: number, total: number) => void,
+  ): Promise<Set<number>> {
+    if (timelineIds.length === 0 || celExpr === '') {
+      return new Set();
+    }
+
+    let totalLogs = 0;
+    for (const tId of timelineIds) {
+      const timeline = this.activeTimelineStore?.getTimeline(tId);
+      if (timeline) {
+        totalLogs += timeline.events.length + timeline.revisions.length;
+      }
+    }
+
+    const startTime = performance.now();
+    const requestId = `search-l-${this.sessionCounter++}`;
+    const progressSab = new SharedArrayBuffer(this.workers.length * 64);
+    const progressArray = new Int32Array(progressSab);
+
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    if (onProgress) {
+      intervalId = setInterval(() => {
+        let current = 0;
+        for (let i = 0; i < this.workers.length; i++) {
+          current += progressArray[i * 16];
+        }
+        onProgress(current, totalLogs);
+      }, 50);
+    }
+
+    const promise = new Promise<number[]>((resolve, reject) => {
+      this.activeSessions.set(requestId, {
+        expectedResponses: this.workers.length,
+        matchedIds: [],
+        receivedCount: 0,
+        workerProcessed: Array.from({ length: this.workers.length }, () => 0),
+        workerTotals: Array.from({ length: this.workers.length }, () => 0),
+        onProgress,
+        resolve,
+        reject,
+      });
+    });
+
+    const cleanup = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+      }
+    };
+
+    const chunks = this.partition(timelineIds, this.numWorkers);
+
+    for (let i = 0; i < this.workers.length; i++) {
+      const chunk = chunks[i] || [];
+      this.workers[i].postMessage({
+        type: 'SEARCH_LOGS',
+        requestId,
+        workerIndex: i,
+        celExpr,
+        timelineIds: chunk,
+        progressSab,
+      } as SearchWorkerRequest);
+    }
+
+    try {
+      const matchedList = await promise;
+      if (onProgress) {
+        onProgress(totalLogs, totalLogs);
+      }
+      const elapsedMs = performance.now() - startTime;
+      const speed = elapsedMs > 0 ? totalLogs / (elapsedMs / 1000) : 0;
+      console.debug(
+        `[SearchWorkerManager] searchLogs finished:\n` +
+          `  Query: "${celExpr}"\n` +
+          `  Elapsed Time: ${elapsedMs.toFixed(2)}ms\n` +
+          `  Search Speed: ${speed.toFixed(0)} logs/sec`,
+      );
+      return new Set(matchedList);
+    } finally {
+      cleanup();
+    }
+  }
+
+  private handleWorkerMessage(response: SearchWorkerResponse): void {
+    if (response.type === 'SYNC_COMPLETE') {
+      return; // Handled individually inside syncData() listeners
+    }
+
+    if (!response.requestId) {
+      return;
+    }
+
+    const session = this.activeSessions.get(response.requestId);
+    if (!session) {
+      return;
+    }
+
+    if (response.type === 'ERROR') {
+      session.reject(new Error(response.error));
+      this.activeSessions.delete(response.requestId);
+      return;
+    }
+
+    if (response.type === 'SEARCH_COMPLETE') {
+      session.matchedIds.push(...response.matchedIds);
+      session.receivedCount++;
+
+      if (session.receivedCount === session.expectedResponses) {
+        session.resolve(session.matchedIds);
+        this.activeSessions.delete(response.requestId);
+      }
+    }
+  }
+
+  private partition<T>(array: readonly T[], numParts: number): T[][] {
+    const result: T[][] = Array.from({ length: numParts }, () => []);
+    for (let i = 0; i < array.length; i++) {
+      result[i % numParts].push(array[i]);
+    }
+    return result;
+  }
+
+  ngOnDestroy(): void {
+    for (const worker of this.workers) {
+      worker.terminate();
+    }
+  }
+}

--- a/web/src/app/store/domain/filter/cel-env.ts
+++ b/web/src/app/store/domain/filter/cel-env.ts
@@ -33,14 +33,6 @@ import {
 } from 'src/app/store/domain/filter/cel-functions';
 import { Severity } from 'src/app/store/domain/style';
 
-const SEVERITY_LEVELS = {
-  UNKNOWN: 0n,
-  INFO: 1n,
-  WARNING: 2n,
-  ERROR: 3n,
-  FATAL: 4n,
-};
-
 /**
  * Manages the CEL Environment, compiles expressions, and evaluates raw Timelines.
  */
@@ -188,8 +180,7 @@ export class CELTimelineFilterEnvironment {
 
     try {
       const parsed = this.environment.parse(celExpr);
-      this.evaluator = (ctx) =>
-        Boolean(parsed({ t: ctx, ...ctx, ...SEVERITY_LEVELS }));
+      this.evaluator = (ctx) => Boolean(parsed(ctx));
       return { success: true };
     } catch (err) {
       this.evaluator = undefined;
@@ -325,8 +316,7 @@ export class CELLogFilterEnvironment {
 
     try {
       const parsed = this.environment.parse(celExpr);
-      this.evaluator = (ctx) =>
-        Boolean(parsed({ l: ctx, ...ctx, ...SEVERITY_LEVELS }));
+      this.evaluator = (ctx) => Boolean(parsed(ctx));
       return { success: true };
     } catch (err) {
       this.evaluator = undefined;

--- a/web/src/app/store/domain/filter/cel-filter.spec.ts
+++ b/web/src/app/store/domain/filter/cel-filter.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { TestBed } from '@angular/core/testing';
 import {
   CelTimelineFilter,
   CelLogFilter,
@@ -22,8 +23,28 @@ import { LogTimelineFilterContext } from 'src/app/store/domain/filter/types';
 import { TimelineStore } from 'src/app/store/domain/timeline-store';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { Timeline } from 'src/app/store/domain/timeline';
+import { SearchWorkerManager } from 'src/app/services/search-worker-manager.service';
 
 describe('CelTimelineFilter', () => {
+  let filter: CelTimelineFilter;
+  let searchWorkerManagerSpy: jasmine.SpyObj<SearchWorkerManager>;
+
+  beforeEach(() => {
+    searchWorkerManagerSpy = jasmine.createSpyObj<SearchWorkerManager>(
+      'SearchWorkerManager',
+      ['searchTimelines', 'searchLogs'],
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        CelTimelineFilter,
+        { provide: SearchWorkerManager, useValue: searchWorkerManagerSpy },
+      ],
+    });
+
+    filter = TestBed.inject(CelTimelineFilter);
+  });
+
   it('should filter timelines based on configured CEL expression', async () => {
     const timelines = [
       {
@@ -53,7 +74,10 @@ describe('CelTimelineFilter', () => {
       return found as unknown as ReadonlyDomainElement<Timeline>;
     });
 
-    const filter = new CelTimelineFilter();
+    searchWorkerManagerSpy.searchTimelines.and.returnValue(
+      Promise.resolve(new Set([1])),
+    );
+
     const res = filter.updateFilter("t.name == 'T1'");
     expect(res.success).toBe(true);
 
@@ -65,10 +89,13 @@ describe('CelTimelineFilter', () => {
     const result = await filter.process(context, timelineStoreSpy);
     expect(result.timelineIds.size).toBe(1);
     expect(result.timelineIds.has(1)).toBe(true);
+    expect(searchWorkerManagerSpy.searchTimelines).toHaveBeenCalledWith(
+      "t.name == 'T1'",
+      undefined,
+    );
   });
 
   it('should return original context if filter is not updated with an expression', async () => {
-    const filter = new CelTimelineFilter();
     const context: LogTimelineFilterContext = {
       timelineIds: new Set([1, 2]),
       logIds: new Set(),
@@ -83,7 +110,6 @@ describe('CelTimelineFilter', () => {
   });
 
   it('should return error and not filter context when updateFilter is called with an invalid expression', async () => {
-    const filter = new CelTimelineFilter();
     const res = filter.updateFilter("t.name == 'T1");
     expect(res.success).toBe(false);
     expect(res.error).toBeDefined();
@@ -102,7 +128,6 @@ describe('CelTimelineFilter', () => {
   });
 
   it('should reset evaluator and return original context if an invalid expression is provided after a valid one', async () => {
-    const filter = new CelTimelineFilter();
     filter.updateFilter("t.name == 'T1'");
 
     const res = filter.updateFilter("t.name == 'T1");
@@ -123,8 +148,26 @@ describe('CelTimelineFilter', () => {
 });
 
 describe('CelLogFilter', () => {
+  let filter: CelLogFilter;
+  let searchWorkerManagerSpy: jasmine.SpyObj<SearchWorkerManager>;
+
+  beforeEach(() => {
+    searchWorkerManagerSpy = jasmine.createSpyObj<SearchWorkerManager>(
+      'SearchWorkerManager',
+      ['searchTimelines', 'searchLogs'],
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        CelLogFilter,
+        { provide: SearchWorkerManager, useValue: searchWorkerManagerSpy },
+      ],
+    });
+
+    filter = TestBed.inject(CelLogFilter);
+  });
+
   it('should return original context if filter is not updated with an expression', async () => {
-    const filter = new CelLogFilter();
     const context: LogTimelineFilterContext = {
       timelineIds: new Set(),
       logIds: new Set([1, 2]),
@@ -139,7 +182,6 @@ describe('CelLogFilter', () => {
   });
 
   it('should return error and not filter context when updateFilter is called with an invalid expression', async () => {
-    const filter = new CelLogFilter();
     const res = filter.updateFilter("l.summary == 'L1");
     expect(res.success).toBe(false);
     expect(res.error).toBeDefined();
@@ -158,7 +200,6 @@ describe('CelLogFilter', () => {
   });
 
   it('should reset evaluator and return original context if an invalid expression is provided after a valid one', async () => {
-    const filter = new CelLogFilter();
     filter.updateFilter("l.summary == 'L1'");
 
     const res = filter.updateFilter("l.summary == 'L1");

--- a/web/src/app/store/domain/filter/cel-filter.ts
+++ b/web/src/app/store/domain/filter/cel-filter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Injectable, signal } from '@angular/core';
+import { Injectable, signal, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 import {
   CancellationError,
@@ -27,6 +27,7 @@ import {
   CELTimelineFilterEnvironment,
   CELLogFilterEnvironment,
 } from 'src/app/store/domain/filter/cel-env';
+import { SearchWorkerManager } from 'src/app/services/search-worker-manager.service';
 
 /**
  * Filters timelines based on the configured CEL expression.
@@ -35,6 +36,7 @@ import {
 export class CelTimelineFilter implements LogTimelineFilter {
   readonly displayName = 'Timeline CEL filter';
   readonly priority = 10;
+  private readonly searchWorkerManager = inject(SearchWorkerManager);
   private readonly celEnv = new CELTimelineFilterEnvironment();
   private readonly _celExpr = signal<string>('');
   private readonly _onChanged = new Subject<void>();
@@ -84,25 +86,30 @@ export class CelTimelineFilter implements LogTimelineFilter {
     if (this.celExpr() === '') {
       return context;
     }
-    const passedTimelineIds = new Set<number>();
-    let count = 0;
-    const total = context.timelineIds.size;
+    if (signal?.aborted) {
+      throw new CancellationError();
+    }
+
+    onProgress?.(0, context.timelineIds.size);
+
+    const passedTimelineIds = await this.searchWorkerManager.searchTimelines(
+      this.celExpr(),
+      onProgress,
+    );
+
+    if (signal?.aborted) {
+      throw new CancellationError();
+    }
+
+    const filteredIds = new Set<number>();
     for (const id of context.timelineIds) {
-      if (signal?.aborted) {
-        throw new CancellationError();
-      }
-      const t = timelineStore.getTimeline(id);
-      if (this.celEnv.evaluate(t, timelineStore)) {
-        passedTimelineIds.add(id);
-      }
-      count++;
-      if (count % 500 === 0 || count === total) {
-        onProgress?.(count, total);
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      if (passedTimelineIds.has(id)) {
+        filteredIds.add(id);
       }
     }
+
     return {
-      timelineIds: passedTimelineIds,
+      timelineIds: filteredIds,
       logIds: context.logIds,
     };
   }
@@ -115,6 +122,7 @@ export class CelTimelineFilter implements LogTimelineFilter {
 export class CelLogFilter implements LogTimelineFilter {
   readonly displayName = 'Log CEL Filter';
   readonly priority = 30;
+  private readonly searchWorkerManager = inject(SearchWorkerManager);
   private readonly celEnv = new CELLogFilterEnvironment();
   private readonly _celExpr = signal<string>('');
   private readonly _onChanged = new Subject<void>();
@@ -164,47 +172,19 @@ export class CelLogFilter implements LogTimelineFilter {
     if (this.celExpr() === '') {
       return context;
     }
-    const passedLogIds = new Set<number>();
-    let count = 0;
-    let total = 0;
-    for (const tId of context.timelineIds) {
-      const timeline = timelineStore.getTimeline(tId);
-      total += timeline.events.length + timeline.revisions.length;
+    if (signal?.aborted) {
+      throw new CancellationError();
     }
-    for (const tId of context.timelineIds) {
-      if (signal?.aborted) {
-        throw new CancellationError();
-      }
-      const timeline = timelineStore.getTimeline(tId);
-      for (const e of timeline.events) {
-        if (signal?.aborted) {
-          throw new CancellationError();
-        }
-        const l = timelineStore.logStore.getLog(e.log.id);
-        if (!passedLogIds.has(e.log.id) && this.celEnv.evaluate(l)) {
-          passedLogIds.add(e.log.id);
-        }
-        count++;
-        if (count % 1000 === 0 || count === total) {
-          onProgress?.(count, total);
-          await new Promise((resolve) => setTimeout(resolve, 0));
-        }
-      }
-      for (const r of timeline.revisions) {
-        if (signal?.aborted) {
-          throw new CancellationError();
-        }
-        const l = timelineStore.logStore.getLog(r.log.id);
-        if (!passedLogIds.has(r.log.id) && this.celEnv.evaluate(l)) {
-          passedLogIds.add(r.log.id);
-        }
-        count++;
-        if (count % 1000 === 0 || count === total) {
-          onProgress?.(count, total);
-          await new Promise((resolve) => setTimeout(resolve, 0));
-        }
-      }
+    const passedLogIds = await this.searchWorkerManager.searchLogs(
+      this.celExpr(),
+      Array.from(context.timelineIds),
+      onProgress,
+    );
+
+    if (signal?.aborted) {
+      throw new CancellationError();
     }
+
     return {
       timelineIds: context.timelineIds,
       logIds: passedLogIds,

--- a/web/src/app/store/domain/filter/cel-functions.spec.ts
+++ b/web/src/app/store/domain/filter/cel-functions.spec.ts
@@ -60,7 +60,7 @@ describe('cel-functions', () => {
   });
 
   describe('matchTimelinePath', () => {
-    const mockTimeline: CELTimeline = {
+    const mockTimeline = {
       name: 'test-timeline',
       timelineType: 'pod',
       path: {
@@ -70,7 +70,7 @@ describe('cel-functions', () => {
       },
       events: [],
       revisions: [],
-    };
+    } as unknown as CELTimeline;
 
     it('should return false if timeline is undefined', () => {
       expect(matchTimelinePath(undefined, 'namespace', 'kube-system')).toBe(
@@ -130,7 +130,7 @@ describe('cel-functions', () => {
   });
 
   describe('matchLogField', () => {
-    const mockLog: CELLog = {
+    const mockLog = {
       logType: 'k8s',
       severity: 1n,
       summary: 'test-log',
@@ -149,7 +149,7 @@ describe('cel-functions', () => {
         },
       },
       bodyYAML: 'verb: CREATE\nobject:\n  metadata:\n    name: test-pod\n',
-    };
+    } as unknown as CELLog;
 
     it('should return false if log is undefined', () => {
       expect(matchLogField(undefined, 'verb', 'CREATE')).toBe(false);
@@ -222,7 +222,7 @@ describe('cel-functions', () => {
           summary: 'rev-1',
           body: {},
           bodyYAML: '',
-        },
+        } as unknown as CELLog,
         changedTime: 1000n,
         principal: 'user-1',
         verb: 'CREATE',
@@ -241,7 +241,7 @@ describe('cel-functions', () => {
           summary: 'rev-2',
           body: {},
           bodyYAML: '',
-        },
+        } as unknown as CELLog,
         changedTime: 2000n,
         principal: 'user-2',
         verb: 'UPDATE',
@@ -255,13 +255,13 @@ describe('cel-functions', () => {
       },
     ];
 
-    const mockTimeline: CELTimeline = {
+    const mockTimeline = {
       name: 'test-timeline',
       timelineType: 'pod',
       path: {},
       events: [],
       revisions: mockRevisions,
-    };
+    } as unknown as CELTimeline;
 
     it('should return false if timeline is undefined', () => {
       expect(

--- a/web/src/app/store/domain/filter/cel-types.ts
+++ b/web/src/app/store/domain/filter/cel-types.ts
@@ -28,6 +28,11 @@ export interface CELLog {
   readonly summary: string;
   readonly body: Record<string, unknown>;
   readonly bodyYAML: string;
+  readonly UNKNOWN: bigint;
+  readonly INFO: bigint;
+  readonly WARNING: bigint;
+  readonly ERROR: bigint;
+  readonly FATAL: bigint;
 }
 
 /**
@@ -59,6 +64,11 @@ export interface CELTimeline {
   readonly path: Record<string, string>;
   readonly events: readonly CELEvent[];
   readonly revisions: readonly CELRevision[];
+  readonly UNKNOWN: bigint;
+  readonly INFO: bigint;
+  readonly WARNING: bigint;
+  readonly ERROR: bigint;
+  readonly FATAL: bigint;
 }
 
 /**
@@ -99,6 +109,11 @@ export function toCelLog(log: ReadonlyDomainElement<Log>): CELLog {
     get bodyYAML(): string {
       return log.bodyYAML ?? '';
     },
+    UNKNOWN: 0n,
+    INFO: 1n,
+    WARNING: 2n,
+    ERROR: 3n,
+    FATAL: 4n,
   };
 }
 
@@ -172,5 +187,10 @@ export function toCelTimeline(
     get revisions(): readonly CELRevision[] {
       return timeline.revisions.map((r) => toCelRevision(r));
     },
+    UNKNOWN: 0n,
+    INFO: 1n,
+    WARNING: 2n,
+    ERROR: 3n,
+    FATAL: 4n,
   };
 }

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -16,10 +16,9 @@
 
 import { Log } from 'src/app/store/domain/log';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
-import { StyleStore } from 'src/app/store/domain/style-store';
 import { InternedStructDecoder } from 'src/app/store/domain/struct-decoder';
 import { InternedStructSchema } from 'src/app/generated/khifile/shared_pb';
-import { LogType, Severity } from 'src/app/store/domain/style';
+import { LogType, Severity, StyleProvider } from 'src/app/store/domain/style';
 import {
   ReadonlyDomainElement,
   allocateBuffer,
@@ -91,7 +90,7 @@ export class LogStore {
 
   private constructor(
     private readonly internPool: InternPoolStore,
-    private readonly styleStore: StyleStore,
+    private readonly styleStore: StyleProvider,
     private readonly maxBufferSize: number,
     readOnly: boolean,
     initialData: number | LogStoreSharedData,
@@ -117,7 +116,7 @@ export class LogStore {
    */
   public static create(
     internPool: InternPoolStore,
-    styleStore: StyleStore,
+    styleStore: StyleProvider,
     maxBufferSize: number = 100 * 1024 * 1024,
   ): LogStore {
     return new LogStore(internPool, styleStore, maxBufferSize, false, 1024);
@@ -128,7 +127,7 @@ export class LogStore {
    */
   public static fromSharedData(
     internPool: InternPoolStore,
-    styleStore: StyleStore,
+    styleStore: StyleProvider,
     sharedData: LogStoreSharedData,
     maxBufferSize: number = 100 * 1024 * 1024,
   ): LogStore {

--- a/web/src/app/store/domain/style-store.ts
+++ b/web/src/app/store/domain/style-store.ts
@@ -23,6 +23,8 @@ import {
   Severity,
   TimelineType,
   Verb,
+  StyleProvider,
+  StyleStoreSharedData,
 } from 'src/app/store/domain/style';
 import { ReadonlyDomainElement } from './types';
 
@@ -70,18 +72,13 @@ export interface IconAtlasDTO {
  * Interface representing a provider of style configurations (severities, log types, etc.).
  * Structurally matches StyleStore and StyleOverrideService.
  */
-export interface StyleStoreLike {
-  readonly severities: ReadonlyDomainElement<Severity[]>;
-  readonly logTypes: ReadonlyDomainElement<LogType[]>;
-  readonly verbs: ReadonlyDomainElement<Verb[]>;
-  readonly revisionStates: ReadonlyDomainElement<RevisionState[]>;
-  readonly timelineTypes: ReadonlyDomainElement<TimelineType[]>;
+export interface StyleStoreLike extends StyleProvider {
+  /** Signal that emits when styles are updated. */
   readonly stylesUpdated?: Signal<number>;
-  getSeverity(id: number): ReadonlyDomainElement<Severity>;
-  getLogType(id: number): ReadonlyDomainElement<LogType>;
-  getVerb(id: number): ReadonlyDomainElement<Verb>;
-  getRevisionState(id: number): ReadonlyDomainElement<RevisionState>;
-  getTimelineType(id: number): ReadonlyDomainElement<TimelineType>;
+
+  /**
+   * Retrieves the parsed and initialized icon atlas.
+   */
   getIconAtlas(): IconAtlas | undefined;
 }
 
@@ -291,5 +288,31 @@ export class StyleStore implements StyleStoreLike {
    */
   public getIconAtlas(): IconAtlas | undefined {
     return this.iconAtlas;
+  }
+
+  /**
+   * Returns a shared representation of the style store data.
+   */
+  public getSharedData(): StyleStoreSharedData {
+    return {
+      severities: this.severities,
+      logTypes: this.logTypes,
+      verbs: this.verbs,
+      revisionStates: this.revisionStates,
+      timelineTypes: this.timelineTypes,
+    };
+  }
+
+  /**
+   * Reconstructs StyleStore from shared data.
+   */
+  public static fromSharedData(sharedData: StyleStoreSharedData): StyleStore {
+    const store = new StyleStore();
+    store.addSeverities(sharedData.severities);
+    store.addLogTypes(sharedData.logTypes);
+    store.addVerbs(sharedData.verbs);
+    store.addRevisionStates(sharedData.revisionStates);
+    store.addTimelineTypes(sharedData.timelineTypes);
+    return store;
   }
 }

--- a/web/src/app/store/domain/style.ts
+++ b/web/src/app/store/domain/style.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 
 /**
  * Represents a high dynamic range color.
@@ -147,4 +148,67 @@ export interface IconAtlas {
   readonly msdfIconImage: TexImageSource[];
   readonly bmfontJson: BMFontConfig;
   readonly nameToCodepoints: Map<string, string>;
+}
+
+/**
+ * Interface representing a provider of style configurations (severities, log types, etc.).
+ * Structurally matches StyleStore and StyleOverrideService, but has no DOM/Angular dependencies.
+ */
+export interface StyleProvider {
+  /** The collection of severity level configurations. */
+  readonly severities: ReadonlyDomainElement<Severity[]>;
+  /** The collection of log category/source configurations. */
+  readonly logTypes: ReadonlyDomainElement<LogType[]>;
+  /** The collection of action verb configurations. */
+  readonly verbs: ReadonlyDomainElement<Verb[]>;
+  /** The collection of revision status configurations. */
+  readonly revisionStates: ReadonlyDomainElement<RevisionState[]>;
+  /** The collection of timeline presentation styles. */
+  readonly timelineTypes: ReadonlyDomainElement<TimelineType[]>;
+
+  /**
+   * Retrieves a severity configuration by its ID.
+   * @param id The severity level ID.
+   */
+  getSeverity(id: number): ReadonlyDomainElement<Severity>;
+
+  /**
+   * Retrieves a log type configuration by its ID.
+   * @param id The log category ID.
+   */
+  getLogType(id: number): ReadonlyDomainElement<LogType>;
+
+  /**
+   * Retrieves an action verb configuration by its ID.
+   * @param id The action verb ID.
+   */
+  getVerb(id: number): ReadonlyDomainElement<Verb>;
+
+  /**
+   * Retrieves a revision state configuration by its ID.
+   * @param id The revision status ID.
+   */
+  getRevisionState(id: number): ReadonlyDomainElement<RevisionState>;
+
+  /**
+   * Retrieves a timeline presentation style by its ID.
+   * @param id The timeline type ID.
+   */
+  getTimelineType(id: number): ReadonlyDomainElement<TimelineType>;
+}
+
+/**
+ * Interface representing shared StyleStore data.
+ */
+export interface StyleStoreSharedData {
+  /** List of all severity level configurations. */
+  readonly severities: readonly Severity[];
+  /** List of all log category/source configurations. */
+  readonly logTypes: readonly LogType[];
+  /** List of all action verb configurations. */
+  readonly verbs: readonly Verb[];
+  /** List of all revision status configurations. */
+  readonly revisionStates: readonly RevisionState[];
+  /** List of all timeline presentation styles. */
+  readonly timelineTypes: readonly TimelineType[];
 }

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -21,7 +21,6 @@ import {
   Timeline,
 } from 'src/app/store/domain/timeline';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
-import { StyleStore } from 'src/app/store/domain/style-store';
 import { InternedStructDecoder } from 'src/app/store/domain/struct-decoder';
 import { InternedStructSchema } from 'src/app/generated/khifile/shared_pb';
 import {
@@ -29,6 +28,7 @@ import {
   Severity,
   TimelineType,
   Verb,
+  StyleProvider,
 } from 'src/app/store/domain/style';
 import { LogStore } from 'src/app/store/domain/log-store';
 import {
@@ -150,7 +150,7 @@ export class TimelineStore {
 
   private constructor(
     private readonly internPool: InternPoolStore,
-    public readonly styleStore: StyleStore,
+    public readonly styleStore: StyleProvider,
     public readonly logStore: LogStore,
     private readonly maxBufferSize: number,
     readOnly: boolean,
@@ -207,7 +207,7 @@ export class TimelineStore {
    */
   public static create(
     internPool: InternPoolStore,
-    styleStore: StyleStore,
+    styleStore: StyleProvider,
     logStore: LogStore,
     maxBufferSize: number = 100 * 1024 * 1024,
   ): TimelineStore {
@@ -226,7 +226,7 @@ export class TimelineStore {
    */
   public static fromSharedData(
     internPool: InternPoolStore,
-    styleStore: StyleStore,
+    styleStore: StyleProvider,
     logStore: LogStore,
     sharedData: TimelineStoreSharedData,
     maxBufferSize: number = 100 * 1024 * 1024,

--- a/web/src/app/worker/search/handlers/search-logs.spec.ts
+++ b/web/src/app/worker/search/handlers/search-logs.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SearchWorkerState } from 'src/app/worker/search/search-worker-state';
+import { handleSearchLogs } from 'src/app/worker/search/handlers/search-logs';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import { Timeline } from 'src/app/store/domain/timeline';
+import { Log } from 'src/app/store/domain/log';
+
+describe('handleSearchLogs', () => {
+  let state: SearchWorkerState;
+
+  beforeEach(() => {
+    state = new SearchWorkerState();
+    const internPool = InternPoolStore.create();
+    const styleStore = new StyleStore();
+    state.styleStore = styleStore;
+    state.internPoolStore = internPool;
+    state.logStore = LogStore.create(internPool, styleStore);
+    state.timelineStore = TimelineStore.create(
+      internPool,
+      styleStore,
+      state.logStore,
+    );
+  });
+
+  it('should return matched log ids using the provided CEL expression', () => {
+    const mockTimelines = [
+      {
+        id: 0,
+        events: [{ log: { id: 10 } }, { log: { id: 11 } }],
+        revisions: [{ log: { id: 12 } }],
+      } as unknown as Timeline,
+      {
+        id: 1,
+        events: [{ log: { id: 13 } }],
+        revisions: [],
+      } as unknown as Timeline,
+    ];
+    spyOn(state.timelineStore!, 'getTimeline').and.callFake((id: number) => {
+      return mockTimelines[id] as unknown as Timeline;
+    });
+
+    const mockLogs: Record<number, Partial<Log>> = {
+      10: {
+        severity: { label: 'INFO' } as unknown as Log['severity'],
+        summary: 'test 10',
+      },
+      11: {
+        severity: { label: 'ERROR' } as unknown as Log['severity'],
+        summary: 'test 11',
+      },
+      12: {
+        severity: { label: 'INFO' } as unknown as Log['severity'],
+        summary: 'test 12',
+      },
+      13: {
+        severity: { label: 'ERROR' } as unknown as Log['severity'],
+        summary: 'test 13',
+      },
+    };
+
+    spyOn(state.logStore!, 'getLog').and.callFake((id: number) => {
+      return mockLogs[id] as unknown as Log;
+    });
+
+    const progressSab = new SharedArrayBuffer(1024);
+
+    // Matching ERROR logs: log 11 and log 13
+    const matchedIds = handleSearchLogs(
+      {
+        type: 'SEARCH_LOGS',
+        requestId: 'req-log-1',
+        celExpr: 'severity == ERROR',
+        workerIndex: 0,
+        timelineIds: [0, 1],
+        progressSab,
+      },
+      state,
+    );
+
+    expect(matchedIds.sort((a, b) => a - b)).toEqual([11, 13]);
+  });
+});

--- a/web/src/app/worker/search/handlers/search-logs.ts
+++ b/web/src/app/worker/search/handlers/search-logs.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SearchWorkerRequest } from 'src/app/worker/search/search-types';
+import { SearchWorkerState } from 'src/app/worker/search/search-worker-state';
+
+export function handleSearchLogs(
+  request: Extract<SearchWorkerRequest, { type: 'SEARCH_LOGS' }>,
+  state: SearchWorkerState,
+): number[] {
+  if (!state.timelineStore || !state.logStore) {
+    throw new Error('Stores not initialized inside Worker');
+  }
+  const compileRes = state.logCelEnv.compile(request.celExpr);
+  if (!compileRes.success) {
+    throw compileRes.error ?? new Error(`Compile failed: ${request.celExpr}`);
+  }
+
+  const progressArray = new Int32Array(request.progressSab);
+  const workerIndex = request.workerIndex;
+  const progressOffset = workerIndex * 16;
+
+  let count = 0;
+  const matchedIdsSet = new Set<number>();
+  for (const tId of request.timelineIds) {
+    const timeline = state.timelineStore.getTimeline(tId);
+    for (const e of timeline.events) {
+      const logId = e.log.id;
+      if (!matchedIdsSet.has(logId)) {
+        const l = state.logStore.getLog(logId);
+        if (state.logCelEnv.evaluate(l)) {
+          matchedIdsSet.add(logId);
+        }
+      }
+      count++;
+      progressArray[progressOffset] = count;
+    }
+    for (const r of timeline.revisions) {
+      const logId = r.log.id;
+      if (!matchedIdsSet.has(logId)) {
+        const l = state.logStore.getLog(logId);
+        if (state.logCelEnv.evaluate(l)) {
+          matchedIdsSet.add(logId);
+        }
+      }
+      count++;
+      progressArray[progressOffset] = count;
+    }
+  }
+
+  console.debug(
+    `[SearchWorker #${workerIndex}] SEARCH_LOGS complete. ` +
+      `Processed: ${count}, Matched: ${matchedIdsSet.size}`,
+  );
+
+  return Array.from(matchedIdsSet);
+}

--- a/web/src/app/worker/search/handlers/search-timelines.spec.ts
+++ b/web/src/app/worker/search/handlers/search-timelines.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SearchWorkerState } from 'src/app/worker/search/search-worker-state';
+import { handleSearchTimelines } from 'src/app/worker/search/handlers/search-timelines';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { StyleStore } from 'src/app/store/domain/style-store';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import { Timeline } from 'src/app/store/domain/timeline';
+
+describe('handleSearchTimelines', () => {
+  let state: SearchWorkerState;
+
+  beforeEach(() => {
+    state = new SearchWorkerState();
+    const internPool = InternPoolStore.create();
+    const styleStore = new StyleStore();
+    state.styleStore = styleStore;
+    state.internPoolStore = internPool;
+    state.logStore = LogStore.create(internPool, styleStore);
+    state.timelineStore = TimelineStore.create(
+      internPool,
+      styleStore,
+      state.logStore,
+    );
+  });
+
+  it('should return matched timeline ids using the provided CEL expression', () => {
+    // We will bypass Timeline creation complexity by forcing the timeline data in the store
+    const mockTimelines = [
+      { id: 1, name: 'T1' } as unknown as Timeline,
+      { id: 2, name: 'T2' } as unknown as Timeline,
+      { id: 3, name: 'T1' } as unknown as Timeline,
+    ];
+    Object.defineProperty(state.timelineStore, 'timelines', {
+      get: () => mockTimelines,
+    });
+
+    const progressSab = new SharedArrayBuffer(1024);
+
+    // Test the logic directly
+    // name == 'T1' will match id=1 and id=3
+    const matchedIds = handleSearchTimelines(
+      {
+        type: 'SEARCH_TIMELINES',
+        requestId: 'req-1',
+        celExpr: "name == 'T1'",
+        workerIndex: 0,
+        numWorkers: 1,
+        progressSab,
+      },
+      state,
+    );
+
+    expect(matchedIds).toEqual([1, 3]);
+  });
+
+  it('should process partitions correctly based on workerIndex and numWorkers', () => {
+    const mockTimelines = [
+      { id: 0, name: 'T1' } as unknown as Timeline,
+      { id: 1, name: 'T1' } as unknown as Timeline,
+      { id: 2, name: 'T2' } as unknown as Timeline, // Does not match
+      { id: 3, name: 'T1' } as unknown as Timeline,
+      { id: 4, name: 'T1' } as unknown as Timeline,
+    ];
+    Object.defineProperty(state.timelineStore, 'timelines', {
+      get: () => mockTimelines,
+    });
+
+    const progressSab = new SharedArrayBuffer(1024);
+
+    const worker0Matches = handleSearchTimelines(
+      {
+        type: 'SEARCH_TIMELINES',
+        requestId: 'req-1',
+        celExpr: "name == 'T1'",
+        workerIndex: 0,
+        numWorkers: 2, // Workers 0 and 1
+        progressSab,
+      },
+      state,
+    );
+    // Worker 0 processes index 0, 2, 4
+    // 0: match, 2: not match, 4: match
+    expect(worker0Matches).toEqual([0, 4]);
+
+    const worker1Matches = handleSearchTimelines(
+      {
+        type: 'SEARCH_TIMELINES',
+        requestId: 'req-2',
+        celExpr: "name == 'T1'",
+        workerIndex: 1,
+        numWorkers: 2,
+        progressSab,
+      },
+      state,
+    );
+    // Worker 1 processes index 1, 3
+    // 1: match, 3: match
+    expect(worker1Matches).toEqual([1, 3]);
+  });
+});

--- a/web/src/app/worker/search/handlers/search-timelines.ts
+++ b/web/src/app/worker/search/handlers/search-timelines.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SearchWorkerRequest } from 'src/app/worker/search/search-types';
+import { SearchWorkerState } from 'src/app/worker/search/search-worker-state';
+
+export function handleSearchTimelines(
+  request: Extract<SearchWorkerRequest, { type: 'SEARCH_TIMELINES' }>,
+  state: SearchWorkerState,
+): number[] {
+  if (!state.timelineStore) {
+    throw new Error('TimelineStore not initialized inside Worker');
+  }
+  const compileRes = state.timelineCelEnv.compile(request.celExpr);
+  if (!compileRes.success) {
+    throw compileRes.error ?? new Error(`Compile failed: ${request.celExpr}`);
+  }
+
+  const matchedIds: number[] = [];
+  let processedCount = 0;
+  const timelines = state.timelineStore.timelines;
+  const totalTimelines = timelines.length;
+  const workerIndex = request.workerIndex;
+  const numWorkers = request.numWorkers;
+  const progressArray = new Int32Array(request.progressSab);
+  const progressOffset = workerIndex * 16;
+
+  for (let i = workerIndex; i < totalTimelines; i += numWorkers) {
+    const t = timelines[i];
+    if (state.timelineCelEnv.evaluate(t, state.timelineStore)) {
+      matchedIds.push(t.id);
+    }
+    processedCount++;
+    progressArray[progressOffset] = processedCount;
+  }
+
+  console.debug(
+    `[SearchWorker #${workerIndex}] SEARCH_TIMELINES complete. ` +
+      `Processed: ${processedCount}, Matched: ${matchedIds.length}`,
+  );
+
+  return matchedIds;
+}

--- a/web/src/app/worker/search/handlers/sync-data.ts
+++ b/web/src/app/worker/search/handlers/sync-data.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  SearchWorkerRequest,
+  SearchWorkerResponse,
+} from 'src/app/worker/search/search-types';
+import { SearchWorkerState } from 'src/app/worker/search/search-worker-state';
+import { WorkerStyleStore } from 'src/app/worker/worker-style-store';
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+
+export function handleSyncData(
+  request: Extract<SearchWorkerRequest, { type: 'SYNC_DATA' }>,
+  state: SearchWorkerState,
+): void {
+  const styleStore = new WorkerStyleStore(request.styleStoreSharedData);
+  const internPoolStore = InternPoolStore.fromSharedData(
+    request.internPoolSharedData,
+  );
+  const logStore = LogStore.fromSharedData(
+    internPoolStore,
+    styleStore,
+    request.logStoreSharedData,
+  );
+  const timelineStore = TimelineStore.fromSharedData(
+    internPoolStore,
+    styleStore,
+    logStore,
+    request.timelineStoreSharedData,
+  );
+
+  state.styleStore = styleStore;
+  state.internPoolStore = internPoolStore;
+  state.logStore = logStore;
+  state.timelineStore = timelineStore;
+
+  console.debug(`[SearchWorker #${request.workerIndex}] SYNC_DATA complete.`);
+
+  postMessage({
+    type: 'SYNC_COMPLETE',
+  } as SearchWorkerResponse);
+}

--- a/web/src/app/worker/search/handlers/sync-data.ts
+++ b/web/src/app/worker/search/handlers/sync-data.ts
@@ -53,5 +53,6 @@ export function handleSyncData(
 
   postMessage({
     type: 'SYNC_COMPLETE',
+    requestId: request.requestId,
   } as SearchWorkerResponse);
 }

--- a/web/src/app/worker/search/search-types.ts
+++ b/web/src/app/worker/search/search-types.ts
@@ -25,6 +25,7 @@ import { StyleStoreSharedData } from 'src/app/store/domain/style';
 export type SearchWorkerRequest =
   | {
       readonly type: 'SYNC_DATA';
+      readonly requestId: string;
       readonly workerIndex: number;
       readonly internPoolSharedData: InternPoolSharedData;
       readonly logStoreSharedData: LogStoreSharedData;
@@ -54,6 +55,7 @@ export type SearchWorkerRequest =
 export type SearchWorkerResponse =
   | {
       readonly type: 'SYNC_COMPLETE';
+      readonly requestId: string;
     }
   | {
       readonly type: 'SEARCH_COMPLETE';

--- a/web/src/app/worker/search/search-types.ts
+++ b/web/src/app/worker/search/search-types.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InternPoolSharedData } from 'src/app/store/domain/intern-pool-store';
+import { LogStoreSharedData } from 'src/app/store/domain/log-store';
+import { TimelineStoreSharedData } from 'src/app/store/domain/timeline-store';
+import { StyleStoreSharedData } from 'src/app/store/domain/style';
+
+/**
+ * Message request type sent from the manager (main thread) to SearchWorkers.
+ */
+export type SearchWorkerRequest =
+  | {
+      readonly type: 'SYNC_DATA';
+      readonly workerIndex: number;
+      readonly internPoolSharedData: InternPoolSharedData;
+      readonly logStoreSharedData: LogStoreSharedData;
+      readonly timelineStoreSharedData: TimelineStoreSharedData;
+      readonly styleStoreSharedData: StyleStoreSharedData;
+    }
+  | {
+      readonly type: 'SEARCH_TIMELINES';
+      readonly requestId: string;
+      readonly workerIndex: number;
+      readonly numWorkers: number;
+      readonly celExpr: string;
+      readonly progressSab: SharedArrayBuffer | ArrayBuffer;
+    }
+  | {
+      readonly type: 'SEARCH_LOGS';
+      readonly requestId: string;
+      readonly workerIndex: number;
+      readonly celExpr: string;
+      readonly timelineIds: readonly number[]; // timelines target for evaluating events & revisions
+      readonly progressSab: SharedArrayBuffer | ArrayBuffer;
+    };
+
+/**
+ * Message response type sent from SearchWorkers back to the manager.
+ */
+export type SearchWorkerResponse =
+  | {
+      readonly type: 'SYNC_COMPLETE';
+    }
+  | {
+      readonly type: 'SEARCH_COMPLETE';
+      readonly requestId: string;
+      readonly matchedIds: readonly number[];
+    }
+  | {
+      readonly type: 'ERROR';
+      readonly requestId?: string;
+      readonly error: string;
+    };

--- a/web/src/app/worker/search/search-worker-state.ts
+++ b/web/src/app/worker/search/search-worker-state.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import { StyleProvider } from 'src/app/store/domain/style';
+import {
+  CELTimelineFilterEnvironment,
+  CELLogFilterEnvironment,
+} from 'src/app/store/domain/filter/cel-env';
+
+export class SearchWorkerState {
+  styleStore: StyleProvider | null = null;
+  internPoolStore: InternPoolStore | null = null;
+  logStore: LogStore | null = null;
+  timelineStore: TimelineStore | null = null;
+
+  readonly timelineCelEnv = new CELTimelineFilterEnvironment();
+  readonly logCelEnv = new CELLogFilterEnvironment();
+}
+
+export const searchWorkerState = new SearchWorkerState();

--- a/web/src/app/worker/search/search.worker.ts
+++ b/web/src/app/worker/search/search.worker.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/// <reference lib="webworker" />
 
 import {
   SearchWorkerRequest,
@@ -54,13 +53,9 @@ addEventListener('message', (event: MessageEvent<SearchWorkerRequest>) => {
         throw new Error(`Unknown request type`);
     }
   } catch (error) {
-    let requestId: string | undefined;
-    if (request.type !== 'SYNC_DATA') {
-      requestId = request.requestId;
-    }
     postMessage({
       type: 'ERROR',
-      requestId,
+      requestId: request.requestId,
       error: error instanceof Error ? error.message : String(error),
     } as SearchWorkerResponse);
   }

--- a/web/src/app/worker/search/search.worker.ts
+++ b/web/src/app/worker/search/search.worker.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// <reference lib="webworker" />
+
+import {
+  SearchWorkerRequest,
+  SearchWorkerResponse,
+} from 'src/app/worker/search/search-types';
+import { searchWorkerState } from 'src/app/worker/search/search-worker-state';
+import { handleSyncData } from 'src/app/worker/search/handlers/sync-data';
+import { handleSearchTimelines } from 'src/app/worker/search/handlers/search-timelines';
+import { handleSearchLogs } from 'src/app/worker/search/handlers/search-logs';
+
+addEventListener('message', (event: MessageEvent<SearchWorkerRequest>) => {
+  const request = event.data;
+
+  try {
+    switch (request.type) {
+      case 'SYNC_DATA':
+        handleSyncData(request, searchWorkerState);
+        break;
+      case 'SEARCH_TIMELINES': {
+        const matchedIds = handleSearchTimelines(request, searchWorkerState);
+        postMessage({
+          type: 'SEARCH_COMPLETE',
+          requestId: request.requestId,
+          matchedIds,
+        } as SearchWorkerResponse);
+        break;
+      }
+      case 'SEARCH_LOGS': {
+        const matchedIds = handleSearchLogs(request, searchWorkerState);
+        postMessage({
+          type: 'SEARCH_COMPLETE',
+          requestId: request.requestId,
+          matchedIds,
+        } as SearchWorkerResponse);
+        break;
+      }
+      default:
+        throw new Error(`Unknown request type`);
+    }
+  } catch (error) {
+    let requestId: string | undefined;
+    if (request.type !== 'SYNC_DATA') {
+      requestId = request.requestId;
+    }
+    postMessage({
+      type: 'ERROR',
+      requestId,
+      error: error instanceof Error ? error.message : String(error),
+    } as SearchWorkerResponse);
+  }
+});

--- a/web/src/app/worker/worker-style-store.ts
+++ b/web/src/app/worker/worker-style-store.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import {
+  Severity,
+  LogType,
+  Verb,
+  RevisionState,
+  TimelineType,
+  StyleProvider,
+  StyleStoreSharedData,
+} from 'src/app/store/domain/style';
+
+/**
+ * Lightweight StyleStore implementation for WebWorkers.
+ * Implements StyleProvider using maps populated from StyleStoreSharedData.
+ */
+export class WorkerStyleStore implements StyleProvider {
+  /** The collection of severity level configurations. */
+  public readonly severities: ReadonlyDomainElement<Severity[]>;
+  /** The collection of log category/source configurations. */
+  public readonly logTypes: ReadonlyDomainElement<LogType[]>;
+  /** The collection of action verb configurations. */
+  public readonly verbs: ReadonlyDomainElement<Verb[]>;
+  /** The collection of revision status configurations. */
+  public readonly revisionStates: ReadonlyDomainElement<RevisionState[]>;
+  /** The collection of timeline presentation styles. */
+  public readonly timelineTypes: ReadonlyDomainElement<TimelineType[]>;
+
+  private readonly severityMap = new Map<number, Severity>();
+  private readonly logTypeMap = new Map<number, LogType>();
+  private readonly verbMap = new Map<number, Verb>();
+  private readonly revisionStateMap = new Map<number, RevisionState>();
+  private readonly timelineTypeMap = new Map<number, TimelineType>();
+
+  /**
+   * Constructs a WorkerStyleStore from serialized shared data.
+   * @param sharedData The serialized style store data.
+   */
+  constructor(sharedData: StyleStoreSharedData) {
+    this.severities = sharedData.severities;
+    this.logTypes = sharedData.logTypes;
+    this.verbs = sharedData.verbs;
+    this.revisionStates = sharedData.revisionStates;
+    this.timelineTypes = sharedData.timelineTypes;
+    for (const s of sharedData.severities) {
+      this.severityMap.set(s.id, s);
+    }
+    for (const l of sharedData.logTypes) {
+      this.logTypeMap.set(l.id, l);
+    }
+    for (const v of sharedData.verbs) {
+      this.verbMap.set(v.id, v);
+    }
+    for (const r of sharedData.revisionStates) {
+      this.revisionStateMap.set(r.id, r);
+    }
+    for (const t of sharedData.timelineTypes) {
+      this.timelineTypeMap.set(t.id, t);
+    }
+  }
+
+  /**
+   * Retrieves a severity configuration by its ID.
+   * @param id The severity level ID.
+   */
+  public getSeverity(id: number): ReadonlyDomainElement<Severity> {
+    const s = this.severityMap.get(id);
+    if (!s) {
+      throw new Error(`Severity not found: ${id}`);
+    }
+    return s as ReadonlyDomainElement<Severity>;
+  }
+
+  /**
+   * Retrieves a log type configuration by its ID.
+   * @param id The log category ID.
+   */
+  public getLogType(id: number): ReadonlyDomainElement<LogType> {
+    const l = this.logTypeMap.get(id);
+    if (!l) {
+      throw new Error(`LogType not found: ${id}`);
+    }
+    return l as ReadonlyDomainElement<LogType>;
+  }
+
+  /**
+   * Retrieves an action verb configuration by its ID.
+   * @param id The action verb ID.
+   */
+  public getVerb(id: number): ReadonlyDomainElement<Verb> {
+    const v = this.verbMap.get(id);
+    if (!v) {
+      throw new Error(`Verb not found: ${id}`);
+    }
+    return v as ReadonlyDomainElement<Verb>;
+  }
+
+  /**
+   * Retrieves a revision state configuration by its ID.
+   * @param id The revision status ID.
+   */
+  public getRevisionState(id: number): ReadonlyDomainElement<RevisionState> {
+    const r = this.revisionStateMap.get(id);
+    if (!r) {
+      throw new Error(`RevisionState not found: ${id}`);
+    }
+    return r as ReadonlyDomainElement<RevisionState>;
+  }
+
+  /**
+   * Retrieves a timeline presentation style by its ID.
+   * @param id The timeline type ID.
+   */
+  public getTimelineType(id: number): ReadonlyDomainElement<TimelineType> {
+    const t = this.timelineTypeMap.get(id);
+    if (!t) {
+      throw new Error(`TimelineType not found: ${id}`);
+    }
+    return t as ReadonlyDomainElement<TimelineType>;
+  }
+}

--- a/web/tsconfig.worker.json
+++ b/web/tsconfig.worker.json
@@ -3,7 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/worker",
-    "lib": ["es2018", "webworker"],
+    "lib": ["es2022", "webworker"],
     "types": []
   },
   "include": ["src/**/*.worker.ts"]


### PR DESCRIPTION
This PR moves the log/timeline searching logics to run in WebWorker. KHI uses multiple WebWorkers concurrently to gain the profit of multi core.