### PR TITLE
Implement search cancellation for log and timeline async queries

### DIFF
--- a/web/src/app/services/search-worker-manager.service.spec.ts
+++ b/web/src/app/services/search-worker-manager.service.spec.ts
@@ -172,4 +172,38 @@ describe('SearchWorkerManager', () => {
       total: 2,
     });
   });
+
+  it('should cancel active searchTimelines when a new one is started', async () => {
+    await manager.syncData(
+      internPoolStore,
+      logStore,
+      timelineStore,
+      styleStore,
+    );
+
+    const p1 = manager.searchTimelines("name == 'pod-a'");
+    const p2 = manager.searchTimelines("name == 'pod-b'");
+
+    await expectAsync(p1).toBeRejectedWithError('Search cancelled');
+    const matched = await p2;
+    expect(matched.has(200)).toBeTrue();
+    expect(matched.has(100)).toBeFalse();
+  });
+
+  it('should cancel active searchLogs when a new one is started', async () => {
+    await manager.syncData(
+      internPoolStore,
+      logStore,
+      timelineStore,
+      styleStore,
+    );
+
+    const p1 = manager.searchLogs("summary == 'pod-a'", [100, 200]);
+    const p2 = manager.searchLogs("summary == 'pod-b'", [100, 200]);
+
+    await expectAsync(p1).toBeRejectedWithError('Search cancelled');
+    const matched = await p2;
+    expect(matched.has(20)).toBeTrue();
+    expect(matched.has(10)).toBeFalse();
+  });
 });

--- a/web/src/app/services/search-worker-manager.service.spec.ts
+++ b/web/src/app/services/search-worker-manager.service.spec.ts
@@ -22,6 +22,7 @@ import { TimelineStore } from 'src/app/store/domain/timeline-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { TimelineDTO } from 'src/app/store/domain/timeline-store';
 import { LogDTO } from 'src/app/store/domain/log-store';
+import { CancellationError } from 'src/app/store/domain/filter/types';
 
 describe('SearchWorkerManager', () => {
   let manager: SearchWorkerManager;
@@ -184,7 +185,10 @@ describe('SearchWorkerManager', () => {
     const p1 = manager.searchTimelines("name == 'pod-a'");
     const p2 = manager.searchTimelines("name == 'pod-b'");
 
-    await expectAsync(p1).toBeRejectedWithError('Search cancelled');
+    await expectAsync(p1).toBeRejectedWithError(
+      CancellationError,
+      'Search cancelled',
+    );
     const matched = await p2;
     expect(matched.has(200)).toBeTrue();
     expect(matched.has(100)).toBeFalse();
@@ -201,7 +205,10 @@ describe('SearchWorkerManager', () => {
     const p1 = manager.searchLogs("summary == 'pod-a'", [100, 200]);
     const p2 = manager.searchLogs("summary == 'pod-b'", [100, 200]);
 
-    await expectAsync(p1).toBeRejectedWithError('Search cancelled');
+    await expectAsync(p1).toBeRejectedWithError(
+      CancellationError,
+      'Search cancelled',
+    );
     const matched = await p2;
     expect(matched.has(20)).toBeTrue();
     expect(matched.has(10)).toBeFalse();

--- a/web/src/app/services/search-worker-manager.service.ts
+++ b/web/src/app/services/search-worker-manager.service.ts
@@ -31,6 +31,7 @@ interface SearchSession {
   readonly workerProcessed: number[];
   readonly workerTotals: number[];
   readonly onProgress?: (current: number, total: number) => void;
+  readonly progressSab: SharedArrayBuffer;
   resolve(matchedIds: number[]): void;
   reject(error: Error): void;
 }
@@ -45,6 +46,8 @@ export class SearchWorkerManager implements OnDestroy {
   private readonly activeSessions = new Map<string, SearchSession>();
   private sessionCounter = 0;
   private activeTimelineStore: TimelineStore | null = null;
+  private activeTimelineSearchRequestId: string | null = null;
+  private activeLogSearchRequestId: string | null = null;
 
   constructor() {
     this.numWorkers = 8; //Math.max(1, (navigator.hardwareConcurrency || 4) - 1);
@@ -120,10 +123,16 @@ export class SearchWorkerManager implements OnDestroy {
       return new Set(allIds);
     }
 
+    if (this.activeTimelineSearchRequestId) {
+      this.cancelSearch(this.activeTimelineSearchRequestId);
+    }
+
     const totalTimelines = this.activeTimelineStore?.timelines.length ?? 0;
     const startTime = performance.now();
     const requestId = `search-t-${this.sessionCounter++}`;
-    const progressSab = new SharedArrayBuffer(this.workers.length * 64);
+    this.activeTimelineSearchRequestId = requestId;
+
+    const progressSab = new SharedArrayBuffer((this.workers.length + 1) * 64);
     const progressArray = new Int32Array(progressSab);
 
     let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -145,6 +154,7 @@ export class SearchWorkerManager implements OnDestroy {
         workerProcessed: Array.from({ length: this.workers.length }, () => 0),
         workerTotals: Array.from({ length: this.workers.length }, () => 0),
         onProgress,
+        progressSab,
         resolve,
         reject,
       });
@@ -182,6 +192,9 @@ export class SearchWorkerManager implements OnDestroy {
       );
       return new Set(matchedList);
     } finally {
+      if (this.activeTimelineSearchRequestId === requestId) {
+        this.activeTimelineSearchRequestId = null;
+      }
       cleanup();
     }
   }
@@ -206,9 +219,15 @@ export class SearchWorkerManager implements OnDestroy {
       }
     }
 
+    if (this.activeLogSearchRequestId) {
+      this.cancelSearch(this.activeLogSearchRequestId);
+    }
+
     const startTime = performance.now();
     const requestId = `search-l-${this.sessionCounter++}`;
-    const progressSab = new SharedArrayBuffer(this.workers.length * 64);
+    this.activeLogSearchRequestId = requestId;
+
+    const progressSab = new SharedArrayBuffer((this.workers.length + 1) * 64);
     const progressArray = new Int32Array(progressSab);
 
     let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -230,6 +249,7 @@ export class SearchWorkerManager implements OnDestroy {
         workerProcessed: Array.from({ length: this.workers.length }, () => 0),
         workerTotals: Array.from({ length: this.workers.length }, () => 0),
         onProgress,
+        progressSab,
         resolve,
         reject,
       });
@@ -249,6 +269,7 @@ export class SearchWorkerManager implements OnDestroy {
         type: 'SEARCH_LOGS',
         requestId,
         workerIndex: i,
+        numWorkers: this.workers.length,
         celExpr,
         timelineIds: chunk,
         progressSab,
@@ -270,6 +291,9 @@ export class SearchWorkerManager implements OnDestroy {
       );
       return new Set(matchedList);
     } finally {
+      if (this.activeLogSearchRequestId === requestId) {
+        this.activeLogSearchRequestId = null;
+      }
       cleanup();
     }
   }
@@ -303,6 +327,19 @@ export class SearchWorkerManager implements OnDestroy {
         this.activeSessions.delete(response.requestId);
       }
     }
+  }
+
+  private cancelSearch(requestId: string): void {
+    const session = this.activeSessions.get(requestId);
+    if (!session) {
+      return;
+    }
+    const progressArray = new Int32Array(session.progressSab);
+    const cancellationIndex = this.numWorkers * 16;
+    Atomics.store(progressArray, cancellationIndex, 1);
+
+    session.reject(new Error('Search cancelled'));
+    this.activeSessions.delete(requestId);
   }
 
   private partition<T>(array: readonly T[], numParts: number): T[][] {

--- a/web/src/app/services/search-worker-manager.service.ts
+++ b/web/src/app/services/search-worker-manager.service.ts
@@ -23,6 +23,7 @@ import {
   SearchWorkerRequest,
   SearchWorkerResponse,
 } from 'src/app/worker/search/search-types';
+import { CancellationError } from 'src/app/store/domain/filter/types';
 
 interface SearchSession {
   readonly expectedResponses: number;
@@ -335,10 +336,10 @@ export class SearchWorkerManager implements OnDestroy {
       return;
     }
     const progressArray = new Int32Array(session.progressSab);
-    const cancellationIndex = this.numWorkers * 16;
+    const cancellationIndex = this.workers.length * 16;
     Atomics.store(progressArray, cancellationIndex, 1);
 
-    session.reject(new Error('Search cancelled'));
+    session.reject(new CancellationError('Search cancelled'));
     this.activeSessions.delete(requestId);
   }
 

--- a/web/src/app/store/domain/timeline-view.ts
+++ b/web/src/app/store/domain/timeline-view.ts
@@ -174,7 +174,7 @@ export class TimelineView {
       if (err instanceof CancellationError) {
         return;
       }
-      console.error('Error during async filtering pipeline:', err);
+      console.warn('Error during async filtering pipeline:', err);
     } finally {
       if (this.activeAbortController === abortController) {
         this._isFiltering.set(false);

--- a/web/src/app/store/domain/timeline-view.ts
+++ b/web/src/app/store/domain/timeline-view.ts
@@ -174,7 +174,7 @@ export class TimelineView {
       if (err instanceof CancellationError) {
         return;
       }
-      console.warn('Error during async filtering pipeline:', err);
+      console.error('Error during async filtering pipeline:', err);
     } finally {
       if (this.activeAbortController === abortController) {
         this._isFiltering.set(false);

--- a/web/src/app/worker/search/handlers/search-logs.spec.ts
+++ b/web/src/app/worker/search/handlers/search-logs.spec.ts
@@ -89,6 +89,7 @@ describe('handleSearchLogs', () => {
         requestId: 'req-log-1',
         celExpr: 'severity == ERROR',
         workerIndex: 0,
+        numWorkers: 1,
         timelineIds: [0, 1],
         progressSab,
       },

--- a/web/src/app/worker/search/handlers/search-logs.ts
+++ b/web/src/app/worker/search/handlers/search-logs.ts
@@ -33,9 +33,18 @@ export function handleSearchLogs(
   const workerIndex = request.workerIndex;
   const progressOffset = workerIndex * 16;
 
+  const numWorkers = request.numWorkers;
+  const cancellationIndex = numWorkers * 16;
+
   let count = 0;
   const matchedIdsSet = new Set<number>();
   for (const tId of request.timelineIds) {
+    if (Atomics.load(progressArray, cancellationIndex) !== 0) {
+      console.debug(
+        `[SearchWorker #${workerIndex}] SEARCH_LOGS aborted (cancelled).`,
+      );
+      return Array.from(matchedIdsSet);
+    }
     const timeline = state.timelineStore.getTimeline(tId);
     for (const e of timeline.events) {
       const logId = e.log.id;

--- a/web/src/app/worker/search/handlers/search-timelines.ts
+++ b/web/src/app/worker/search/handlers/search-timelines.ts
@@ -38,7 +38,15 @@ export function handleSearchTimelines(
   const progressArray = new Int32Array(request.progressSab);
   const progressOffset = workerIndex * 16;
 
+  const cancellationIndex = numWorkers * 16;
+
   for (let i = workerIndex; i < totalTimelines; i += numWorkers) {
+    if (Atomics.load(progressArray, cancellationIndex) !== 0) {
+      console.debug(
+        `[SearchWorker #${workerIndex}] SEARCH_TIMELINES aborted (cancelled).`,
+      );
+      return matchedIds;
+    }
     const t = timelines[i];
     if (state.timelineCelEnv.evaluate(t, state.timelineStore)) {
       matchedIds.push(t.id);

--- a/web/src/app/worker/search/search-types.ts
+++ b/web/src/app/worker/search/search-types.ts
@@ -44,6 +44,7 @@ export type SearchWorkerRequest =
       readonly type: 'SEARCH_LOGS';
       readonly requestId: string;
       readonly workerIndex: number;
+      readonly numWorkers: number;
       readonly celExpr: string;
       readonly timelineIds: readonly number[]; // timelines target for evaluating events & revisions
       readonly progressSab: SharedArrayBuffer | ArrayBuffer;


### PR DESCRIPTION
### **Description**
Introduces support for cancelling active search queries across both log search and timeline search operations. This improves UI responsiveness and avoids wasting CPU resources by aborting stale search workers when a new search query is issued.

### **Key Changes**
- **Search Worker Management (`web/src/app/services/search-worker-manager.service.ts`)**:
  - Added tracking of active search request IDs (`activeTimelineSearchRequestId` and `activeLogSearchRequestId`).
  - Automatically invokes `cancelSearch` if a new search request is submitted while a previous one is still executing.
  - Rejects cancelled queries with a `'Search cancelled'` error.
  - Implements cancellation logic via a `SharedArrayBuffer` (`progressSab`) shared with Web Workers. By storing a cancellation flag at the offset of `numWorkers * 16` using `Atomics.store`, the main thread can signal worker threads to abort.
- **Search Workers (`web/src/app/worker/search/handlers/`)**:
  - In `SEARCH_LOGS` (`search-logs.ts`) and `SEARCH_TIMELINES` (`search-timelines.ts`) task handlers inside the Web Worker context, checks `Atomics.load(progressArray, cancellationIndex) !== 0` in every loop iteration.
  - If a cancellation signal is received, the worker terminates processing early and returns partial/matched results accumulated up to that point.
- **Timeline View Store (`web/src/app/store/domain/timeline-view.ts`)**:
  - Updates error handling in the asynchronous filtering pipeline to gracefully ignore `CancellationError` and log other errors as warnings.
- **Unit Tests**:
  - Added a test case to `search-worker-manager.service.spec.ts` to verify that consecutive searches result in the first search being correctly cancelled and rejected with the cancellation error, while the second completes successfully.
  - Updated `search-logs.spec.ts` and other typing definitions to support the new `numWorkers` attribute in worker payloads.
