### PR TITLE
Optimized memory usage for searching

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,7 +63,19 @@ func redirectMiddleware(exactPath string, redirectTo string) gin.HandlerFunc {
 	}
 }
 
+func coepCoopMiddleware() gin.HandlerFunc {
+	// KHI uses SharedArrayBuffer to share memory between the main thread and worker threads.
+	// COOP and COEP headers are required for SharedArrayBuffer to work.
+	// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#api_availability
+	return func(ctx *gin.Context) {
+		ctx.Header("Cross-Origin-Opener-Policy", "same-origin")
+		ctx.Header("Cross-Origin-Embedder-Policy", "require-corp")
+		ctx.Next()
+	}
+}
+
 func CreateKHIServer(engine *gin.Engine, inspectionServer *coreinspection.InspectionTaskServer, serverConfig *ServerConfig) *gin.Engine {
+	engine.Use(coepCoopMiddleware())
 	basePathWithoutTrailingSlash := strings.TrimSuffix(serverConfig.ServerBasePath, "/")
 	engine.Use(redirectMiddleware(basePathWithoutTrailingSlash+"/", basePathWithoutTrailingSlash+"/session/0")) // Request for `/` shouldn't be handled by `static.Serve`, redirect `/session/0` to be handled by patternToString
 

--- a/web/src/app/services/search-worker-manager.service.ts
+++ b/web/src/app/services/search-worker-manager.service.ts
@@ -23,19 +23,30 @@ import {
   SearchWorkerRequest,
   SearchWorkerResponse,
 } from 'src/app/worker/search/search-types';
+import { SearchWorkerState } from 'src/app/worker/search/search-worker-state';
+import { handleSearchTimelines } from 'src/app/worker/search/handlers/search-timelines';
+import { handleSearchLogs } from 'src/app/worker/search/handlers/search-logs';
+import { isSharedArrayBufferSupported } from '../store/domain/types';
 import { CancellationError } from 'src/app/store/domain/filter/types';
 
 interface SearchSession {
-  readonly expectedResponses: number;
-  readonly matchedIds: number[];
-  receivedCount: number;
-  readonly workerProcessed: number[];
-  readonly workerTotals: number[];
+  readonly type: 'SEARCH_TIMELINES' | 'SEARCH_LOGS';
+  readonly celExpr: string;
+  readonly timelineIds: readonly number[];
+  nextIndex: number;
+  readonly matchedIds: Set<number>;
   readonly onProgress?: (current: number, total: number) => void;
-  readonly progressSab: SharedArrayBuffer;
-  resolve(matchedIds: number[]): void;
+  readonly progressSab: SharedArrayBuffer | ArrayBuffer;
+  activeWorkersCount: number;
+  resolve(matchedIds: Set<number>): void;
   reject(error: Error): void;
 }
+
+const MAX_REQUEST_ELEMENTS = 10_000; // 40KB
+const MAX_RESULT_ELEMENTS = 1_000_000; // 4MB
+const MAX_TIMELINES_PER_FRAME_ON_MAIN_THREAD = 10000;
+const MAX_LOGS_PER_FRAME_ON_MAIN_THREAD = 10000;
+const MAX_PROCESSING_TIME_MS_ON_MAIN_THREAD = 100;
 
 /**
  * Orchestrates a pool of WebWorkers to run CEL log and timeline searches concurrently.
@@ -50,20 +61,43 @@ export class SearchWorkerManager implements OnDestroy {
   private activeTimelineSearchRequestId: string | null = null;
   private activeLogSearchRequestId: string | null = null;
 
+  private readonly useWorker = isSharedArrayBufferSupported();
+  private readonly mainThreadState = new SearchWorkerState();
+
+  private readonly requestBufs: (SharedArrayBuffer | ArrayBuffer)[] = [];
+  private readonly resultBufs: (SharedArrayBuffer | ArrayBuffer)[] = [];
+
   constructor() {
-    this.numWorkers = 8; //Math.max(1, (navigator.hardwareConcurrency || 4) - 1);
+    const cores = Math.ceil((navigator.hardwareConcurrency || 4) / 2);
+    this.numWorkers = this.useWorker ? Math.max(1, cores - 1) : 1;
     for (let i = 0; i < this.numWorkers; i++) {
-      const worker = new Worker(
-        new URL('../worker/search/search.worker', import.meta.url),
-        { type: 'module' },
-      );
-      worker.addEventListener(
-        'message',
-        (event: MessageEvent<SearchWorkerResponse>) => {
-          this.handleWorkerMessage(event.data);
-        },
-      );
-      this.workers.push(worker);
+      if (this.useWorker) {
+        this.requestBufs.push(
+          new SharedArrayBuffer((MAX_REQUEST_ELEMENTS + 1) * 4),
+        );
+        this.resultBufs.push(
+          new SharedArrayBuffer((MAX_RESULT_ELEMENTS + 1) * 4),
+        );
+      } else {
+        this.requestBufs.push(new ArrayBuffer((MAX_REQUEST_ELEMENTS + 1) * 4));
+        this.resultBufs.push(new ArrayBuffer((MAX_RESULT_ELEMENTS + 1) * 4));
+      }
+    }
+
+    if (this.useWorker) {
+      for (let i = 0; i < this.numWorkers; i++) {
+        const worker = new Worker(
+          new URL('../worker/search/search.worker', import.meta.url),
+          { type: 'module' },
+        );
+        worker.addEventListener(
+          'message',
+          (event: MessageEvent<SearchWorkerResponse>) => {
+            this.handleWorkerMessage(event.data);
+          },
+        );
+        this.workers.push(worker);
+      }
     }
   }
 
@@ -77,6 +111,15 @@ export class SearchWorkerManager implements OnDestroy {
     styleStore: StyleStore,
   ): Promise<void[]> {
     this.activeTimelineStore = timelineStore;
+
+    if (!this.useWorker) {
+      this.mainThreadState.internPoolStore = internPoolStore;
+      this.mainThreadState.logStore = logStore;
+      this.mainThreadState.timelineStore = timelineStore;
+      this.mainThreadState.styleStore = styleStore;
+      return Promise.resolve([]);
+    }
+
     const internPoolSharedData = internPoolStore.getSharedData();
     const logStoreSharedData = logStore.getSharedData();
     const timelineStoreSharedData = timelineStore.getSharedData();
@@ -113,27 +156,47 @@ export class SearchWorkerManager implements OnDestroy {
   }
 
   /**
-   * Partitions timeline IDs and executes CEL timeline filtering concurrently across workers.
+   * Searches timeline IDs matching the CEL expression.
+   *
+   * Search is performed on Web Workers on the worker mode.
+   * Yields control to the main thread periodically if running in non-worker mode
+   * to avoid blocking the main UI thread during intensive log processing.
+   * @param celExpr The CEL expression to evaluate.
+   * @param onProgress Callback function to report progress.
+   * @returns A promise resolving to a Set of matched timeline IDs.
    */
   public async searchTimelines(
     celExpr: string,
     onProgress?: (current: number, total: number) => void,
   ): Promise<Set<number>> {
+    const allTimelineIds =
+      this.activeTimelineStore?.timelines.map((t) => t.id) ?? [];
     if (celExpr === '') {
-      const allIds = this.activeTimelineStore?.timelines.map((t) => t.id) ?? [];
-      return new Set(allIds);
+      return new Set(allTimelineIds);
     }
 
+    // Cancels current ongoing timeline search task if exists.
     if (this.activeTimelineSearchRequestId) {
       this.cancelSearch(this.activeTimelineSearchRequestId);
     }
 
-    const totalTimelines = this.activeTimelineStore?.timelines.length ?? 0;
+    const totalTimelines = allTimelineIds.length;
     const startTime = performance.now();
     const requestId = `search-t-${this.sessionCounter++}`;
     this.activeTimelineSearchRequestId = requestId;
 
-    const progressSab = new SharedArrayBuffer((this.workers.length + 1) * 64);
+    if (!this.useWorker) {
+      return this.searchTimelinesMainThread(
+        requestId,
+        celExpr,
+        allTimelineIds,
+        totalTimelines,
+        startTime,
+        onProgress,
+      );
+    }
+
+    const progressSab = new SharedArrayBuffer((this.workers.length + 1) * 4);
     const progressArray = new Int32Array(progressSab);
 
     let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -141,19 +204,20 @@ export class SearchWorkerManager implements OnDestroy {
       intervalId = setInterval(() => {
         let current = 0;
         for (let i = 0; i < this.workers.length; i++) {
-          current += progressArray[i * 16];
+          current += progressArray[i];
         }
         onProgress(current, totalTimelines);
       }, 50);
     }
 
-    const promise = new Promise<number[]>((resolve, reject) => {
+    const promise = new Promise<Set<number>>((resolve, reject) => {
       this.activeSessions.set(requestId, {
-        expectedResponses: this.workers.length,
-        matchedIds: [],
-        receivedCount: 0,
-        workerProcessed: Array.from({ length: this.workers.length }, () => 0),
-        workerTotals: Array.from({ length: this.workers.length }, () => 0),
+        type: 'SEARCH_TIMELINES',
+        celExpr,
+        timelineIds: allTimelineIds,
+        nextIndex: 0,
+        matchedIds: new Set<number>(),
+        activeWorkersCount: 0,
         onProgress,
         progressSab,
         resolve,
@@ -162,27 +226,16 @@ export class SearchWorkerManager implements OnDestroy {
     });
 
     const cleanup = () => {
-      if (intervalId !== null) {
-        clearInterval(intervalId);
-      }
+      if (intervalId !== null) clearInterval(intervalId);
     };
 
     for (let i = 0; i < this.workers.length; i++) {
-      this.workers[i].postMessage({
-        type: 'SEARCH_TIMELINES',
-        requestId,
-        workerIndex: i,
-        numWorkers: this.workers.length,
-        celExpr,
-        progressSab,
-      } as SearchWorkerRequest);
+      this.dispatchNextChunk(requestId, i);
     }
 
     try {
-      const matchedList = await promise;
-      if (onProgress) {
-        onProgress(totalTimelines, totalTimelines);
-      }
+      const matchedSet = await promise;
+      if (onProgress) onProgress(totalTimelines, totalTimelines);
       const elapsedMs = performance.now() - startTime;
       const speed = elapsedMs > 0 ? totalTimelines / (elapsedMs / 1000) : 0;
       console.debug(
@@ -191,7 +244,7 @@ export class SearchWorkerManager implements OnDestroy {
           `  Elapsed Time: ${elapsedMs.toFixed(2)}ms\n` +
           `  Search Speed: ${speed.toFixed(0)} timelines/sec`,
       );
-      return new Set(matchedList);
+      return matchedSet;
     } finally {
       if (this.activeTimelineSearchRequestId === requestId) {
         this.activeTimelineSearchRequestId = null;
@@ -201,7 +254,14 @@ export class SearchWorkerManager implements OnDestroy {
   }
 
   /**
-   * Partitions timeline IDs and executes CEL log filtering concurrently across workers.
+   * Searches log event IDs matching the CEL expression across specified timelines.
+   *
+   * Yields control to the main thread periodically if running in non-worker mode
+   * to avoid blocking the main UI thread during intensive log processing.
+   * @param celExpr The CEL expression to evaluate.
+   * @param timelineIds The list of timeline IDs to search within.
+   * @param onProgress Callback function to report progress.
+   * @returns A promise resolving to a Set of matched log event IDs.
    */
   public async searchLogs(
     celExpr: string,
@@ -228,7 +288,18 @@ export class SearchWorkerManager implements OnDestroy {
     const requestId = `search-l-${this.sessionCounter++}`;
     this.activeLogSearchRequestId = requestId;
 
-    const progressSab = new SharedArrayBuffer((this.workers.length + 1) * 64);
+    if (!this.useWorker) {
+      return this.searchLogsMainThread(
+        requestId,
+        celExpr,
+        timelineIds,
+        totalLogs,
+        startTime,
+        onProgress,
+      );
+    }
+
+    const progressSab = new SharedArrayBuffer((this.workers.length + 1) * 4);
     const progressArray = new Int32Array(progressSab);
 
     let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -236,19 +307,20 @@ export class SearchWorkerManager implements OnDestroy {
       intervalId = setInterval(() => {
         let current = 0;
         for (let i = 0; i < this.workers.length; i++) {
-          current += progressArray[i * 16];
+          current += progressArray[i];
         }
         onProgress(current, totalLogs);
       }, 50);
     }
 
-    const promise = new Promise<number[]>((resolve, reject) => {
+    const promise = new Promise<Set<number>>((resolve, reject) => {
       this.activeSessions.set(requestId, {
-        expectedResponses: this.workers.length,
-        matchedIds: [],
-        receivedCount: 0,
-        workerProcessed: Array.from({ length: this.workers.length }, () => 0),
-        workerTotals: Array.from({ length: this.workers.length }, () => 0),
+        type: 'SEARCH_LOGS',
+        celExpr,
+        timelineIds,
+        nextIndex: 0,
+        matchedIds: new Set<number>(),
+        activeWorkersCount: 0,
         onProgress,
         progressSab,
         resolve,
@@ -257,31 +329,16 @@ export class SearchWorkerManager implements OnDestroy {
     });
 
     const cleanup = () => {
-      if (intervalId !== null) {
-        clearInterval(intervalId);
-      }
+      if (intervalId !== null) clearInterval(intervalId);
     };
 
-    const chunks = this.partition(timelineIds, this.numWorkers);
-
     for (let i = 0; i < this.workers.length; i++) {
-      const chunk = chunks[i] || [];
-      this.workers[i].postMessage({
-        type: 'SEARCH_LOGS',
-        requestId,
-        workerIndex: i,
-        numWorkers: this.workers.length,
-        celExpr,
-        timelineIds: chunk,
-        progressSab,
-      } as SearchWorkerRequest);
+      this.dispatchNextChunk(requestId, i);
     }
 
     try {
-      const matchedList = await promise;
-      if (onProgress) {
-        onProgress(totalLogs, totalLogs);
-      }
+      const matchedSet = await promise;
+      if (onProgress) onProgress(totalLogs, totalLogs);
       const elapsedMs = performance.now() - startTime;
       const speed = elapsedMs > 0 ? totalLogs / (elapsedMs / 1000) : 0;
       console.debug(
@@ -290,7 +347,7 @@ export class SearchWorkerManager implements OnDestroy {
           `  Elapsed Time: ${elapsedMs.toFixed(2)}ms\n` +
           `  Search Speed: ${speed.toFixed(0)} logs/sec`,
       );
-      return new Set(matchedList);
+      return matchedSet;
     } finally {
       if (this.activeLogSearchRequestId === requestId) {
         this.activeLogSearchRequestId = null;
@@ -300,18 +357,12 @@ export class SearchWorkerManager implements OnDestroy {
   }
 
   private handleWorkerMessage(response: SearchWorkerResponse): void {
-    if (response.type === 'SYNC_COMPLETE') {
-      return; // Handled individually inside syncData() listeners
-    }
+    if (response.type === 'SYNC_COMPLETE') return;
 
-    if (!response.requestId) {
-      return;
-    }
+    if (!response.requestId) return;
 
     const session = this.activeSessions.get(response.requestId);
-    if (!session) {
-      return;
-    }
+    if (!session) return;
 
     if (response.type === 'ERROR') {
       session.reject(new Error(response.error));
@@ -320,13 +371,102 @@ export class SearchWorkerManager implements OnDestroy {
     }
 
     if (response.type === 'SEARCH_COMPLETE') {
-      session.matchedIds.push(...response.matchedIds);
-      session.receivedCount++;
+      const workerIndex = response.workerIndex;
+      session.activeWorkersCount--;
 
-      if (session.receivedCount === session.expectedResponses) {
-        session.resolve(session.matchedIds);
-        this.activeSessions.delete(response.requestId);
+      const resultView = new Int32Array(this.resultBufs[workerIndex]);
+      const matchCount = resultView[0];
+      for (let i = 1; i <= matchCount; i++) {
+        session.matchedIds.add(resultView[i]);
       }
+
+      this.dispatchNextChunk(response.requestId, workerIndex);
+    }
+  }
+
+  private dispatchNextChunk(sessionId: string, workerIndex: number): void {
+    const session = this.activeSessions.get(sessionId);
+    if (!session) return;
+
+    if (session.nextIndex >= session.timelineIds.length) {
+      if (session.activeWorkersCount === 0) {
+        session.resolve(session.matchedIds);
+        this.activeSessions.delete(sessionId);
+        if (this.activeTimelineSearchRequestId === sessionId)
+          this.activeTimelineSearchRequestId = null;
+        if (this.activeLogSearchRequestId === sessionId)
+          this.activeLogSearchRequestId = null;
+      }
+      return;
+    }
+
+    const remainingTimelines = session.timelineIds.length - session.nextIndex;
+    const availableWorkers = this.workers.length - session.activeWorkersCount;
+
+    session.activeWorkersCount++;
+
+    const requestView = new Int32Array(this.requestBufs[workerIndex]);
+    let count = 0;
+
+    switch (session.type) {
+      case 'SEARCH_TIMELINES': {
+        const targetChunkSize =
+          availableWorkers > 0
+            ? Math.ceil(remainingTimelines / availableWorkers)
+            : remainingTimelines;
+        const limit = Math.min(MAX_REQUEST_ELEMENTS, targetChunkSize);
+        while (
+          session.nextIndex < session.timelineIds.length &&
+          count < limit
+        ) {
+          requestView[++count] = session.timelineIds[session.nextIndex++];
+        }
+        break;
+      }
+      case 'SEARCH_LOGS': {
+        const targetTimelinesPerWorker =
+          availableWorkers > 0
+            ? Math.ceil(remainingTimelines / availableWorkers)
+            : remainingTimelines;
+        const limitTimelines = Math.min(
+          MAX_REQUEST_ELEMENTS,
+          targetTimelinesPerWorker,
+        );
+
+        let logsInChunk = 0;
+        while (
+          session.nextIndex < session.timelineIds.length &&
+          count < limitTimelines
+        ) {
+          const tId = session.timelineIds[session.nextIndex];
+          const t = this.activeTimelineStore?.getTimeline(tId);
+          const tLogs = t ? t.events.length + t.revisions.length : 0;
+
+          if (count > 0 && logsInChunk + tLogs > MAX_RESULT_ELEMENTS) {
+            break;
+          }
+
+          requestView[++count] = tId;
+          logsInChunk += tLogs;
+          session.nextIndex++;
+        }
+        break;
+      }
+    }
+
+    requestView[0] = count;
+
+    if (this.useWorker) {
+      this.workers[workerIndex].postMessage({
+        type: session.type,
+        requestId: sessionId,
+        workerIndex,
+        numWorkers: this.workers.length,
+        celExpr: session.celExpr,
+        requestBuf: this.requestBufs[workerIndex],
+        resultBuf: this.resultBufs[workerIndex],
+        progressSab: session.progressSab,
+      } as SearchWorkerRequest);
     }
   }
 
@@ -336,19 +476,204 @@ export class SearchWorkerManager implements OnDestroy {
       return;
     }
     const progressArray = new Int32Array(session.progressSab);
-    const cancellationIndex = this.workers.length * 16;
-    Atomics.store(progressArray, cancellationIndex, 1);
+    const cancellationIndex = this.numWorkers;
+    if (this.useWorker) {
+      Atomics.store(progressArray, cancellationIndex, 1);
+    } else {
+      progressArray[cancellationIndex] = 1;
+    }
 
     session.reject(new CancellationError('Search cancelled'));
     this.activeSessions.delete(requestId);
   }
 
-  private partition<T>(array: readonly T[], numParts: number): T[][] {
-    const result: T[][] = Array.from({ length: numParts }, () => []);
-    for (let i = 0; i < array.length; i++) {
-      result[i % numParts].push(array[i]);
+  private async searchTimelinesMainThread(
+    requestId: string,
+    celExpr: string,
+    allTimelineIds: readonly number[],
+    totalTimelines: number,
+    startTime: number,
+    onProgress?: (current: number, total: number) => void,
+  ): Promise<Set<number>> {
+    const progressSab = new ArrayBuffer(8);
+    const session: SearchSession = {
+      type: 'SEARCH_TIMELINES',
+      celExpr,
+      timelineIds: allTimelineIds,
+      nextIndex: 0,
+      matchedIds: new Set<number>(),
+      activeWorkersCount: 1, // acts as flag
+      progressSab,
+      resolve: () => {},
+      reject: () => {},
+    };
+    this.activeSessions.set(requestId, session);
+
+    try {
+      // Yield to allow synchronous follow-up searches to cancel this search before it starts.
+      await Promise.resolve();
+
+      let previousTime = performance.now();
+      while (session.nextIndex < session.timelineIds.length) {
+        if (!this.activeSessions.has(requestId))
+          throw new Error('Search cancelled');
+
+        const requestView = new Int32Array(this.requestBufs[0]);
+        let count = 0;
+        while (
+          session.nextIndex < session.timelineIds.length &&
+          count < MAX_TIMELINES_PER_FRAME_ON_MAIN_THREAD
+        ) {
+          requestView[++count] = session.timelineIds[session.nextIndex++];
+        }
+        requestView[0] = count;
+
+        handleSearchTimelines(
+          {
+            type: 'SEARCH_TIMELINES',
+            requestId,
+            workerIndex: 0,
+            numWorkers: 1,
+            celExpr,
+            requestBuf: this.requestBufs[0],
+            resultBuf: this.resultBufs[0],
+            progressSab,
+          },
+          this.mainThreadState,
+        );
+
+        const resultView = new Int32Array(this.resultBufs[0]);
+        const matchCount = resultView[0];
+        for (let i = 1; i <= matchCount; i++) {
+          session.matchedIds.add(resultView[i]);
+        }
+
+        if (onProgress) onProgress(session.nextIndex, totalTimelines);
+        previousTime = await this.waitIfExceedsFrame(previousTime);
+      }
+
+      if (onProgress) onProgress(totalTimelines, totalTimelines);
+      const elapsedMs = performance.now() - startTime;
+      console.debug(
+        `[SearchWorkerManager MainThread] searchTimelines finished:\n  Query: "${celExpr}"\n  Elapsed Time: ${elapsedMs.toFixed(2)}ms`,
+      );
+      return session.matchedIds;
+    } finally {
+      this.activeSessions.delete(requestId);
+      if (this.activeTimelineSearchRequestId === requestId) {
+        this.activeTimelineSearchRequestId = null;
+      }
     }
-    return result;
+  }
+
+  private async searchLogsMainThread(
+    requestId: string,
+    celExpr: string,
+    timelineIds: readonly number[],
+    totalLogs: number,
+    startTime: number,
+    onProgress?: (current: number, total: number) => void,
+  ): Promise<Set<number>> {
+    const progressSab = new ArrayBuffer(8);
+    const session: SearchSession = {
+      type: 'SEARCH_LOGS',
+      celExpr,
+      timelineIds,
+      nextIndex: 0,
+      matchedIds: new Set<number>(),
+      activeWorkersCount: 1,
+      progressSab,
+      resolve: () => {},
+      reject: () => {},
+    };
+    this.activeSessions.set(requestId, session);
+
+    try {
+      // Yield to allow synchronous follow-up searches to cancel this search before it starts.
+      await Promise.resolve();
+
+      let previousProcessed = 0;
+      let previousTime = performance.now();
+      while (session.nextIndex < session.timelineIds.length) {
+        if (!this.activeSessions.has(requestId))
+          throw new Error('Search cancelled');
+
+        const requestView = new Int32Array(this.requestBufs[0]);
+        let count = 0;
+        let logsInChunk = 0;
+        while (
+          session.nextIndex < session.timelineIds.length &&
+          count < MAX_TIMELINES_PER_FRAME_ON_MAIN_THREAD
+        ) {
+          const tId = session.timelineIds[session.nextIndex];
+          const t = this.activeTimelineStore?.getTimeline(tId);
+          const tLogs = t ? t.events.length + t.revisions.length : 0;
+          if (
+            count > 0 &&
+            logsInChunk + tLogs > MAX_LOGS_PER_FRAME_ON_MAIN_THREAD
+          ) {
+            break;
+          }
+          requestView[++count] = tId;
+          logsInChunk += tLogs;
+          session.nextIndex++;
+        }
+        requestView[0] = count;
+
+        const progressArray = new Int32Array(progressSab);
+        progressArray[0] = 0;
+
+        handleSearchLogs(
+          {
+            type: 'SEARCH_LOGS',
+            requestId,
+            workerIndex: 0,
+            numWorkers: 1,
+            celExpr,
+            requestBuf: this.requestBufs[0],
+            resultBuf: this.resultBufs[0],
+            progressSab,
+          },
+          this.mainThreadState,
+        );
+
+        const resultView = new Int32Array(this.resultBufs[0]);
+        const matchCount = resultView[0];
+        for (let i = 1; i <= matchCount; i++) {
+          session.matchedIds.add(resultView[i]);
+        }
+
+        previousProcessed += progressArray[0];
+        if (onProgress) onProgress(previousProcessed, totalLogs);
+
+        previousTime = await this.waitIfExceedsFrame(previousTime);
+      }
+
+      if (onProgress) onProgress(totalLogs, totalLogs);
+      const elapsedMs = performance.now() - startTime;
+      console.debug(
+        `[SearchWorkerManager MainThread] searchLogs finished:\n  Query: "${celExpr}"\n  Elapsed Time: ${elapsedMs.toFixed(2)}ms`,
+      );
+      return session.matchedIds;
+    } finally {
+      this.activeSessions.delete(requestId);
+      if (this.activeLogSearchRequestId === requestId) {
+        this.activeLogSearchRequestId = null;
+      }
+    }
+  }
+
+  private async waitIfExceedsFrame(
+    beginMsOfCurrentTask: number,
+  ): Promise<number> {
+    if (
+      performance.now() - beginMsOfCurrentTask >
+      MAX_PROCESSING_TIME_MS_ON_MAIN_THREAD
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return performance.now();
+    }
+    return beginMsOfCurrentTask;
   }
 
   ngOnDestroy(): void {

--- a/web/src/app/store/domain/filter/cel-filter.spec.ts
+++ b/web/src/app/store/domain/filter/cel-filter.spec.ts
@@ -130,7 +130,7 @@ describe('CelTimelineFilter', () => {
   it('should reset evaluator and return original context if an invalid expression is provided after a valid one', async () => {
     filter.updateFilter("t.name == 'T1'");
 
-    const res = filter.updateFilter("t.name == 'T1");
+    const res = filter.updateFilter("name == 'T1");
     expect(res.success).toBe(false);
 
     const context: LogTimelineFilterContext = {
@@ -202,7 +202,7 @@ describe('CelLogFilter', () => {
   it('should reset evaluator and return original context if an invalid expression is provided after a valid one', async () => {
     filter.updateFilter("l.summary == 'L1'");
 
-    const res = filter.updateFilter("l.summary == 'L1");
+    const res = filter.updateFilter("summary == 'L1");
     expect(res.success).toBe(false);
 
     const context: LogTimelineFilterContext = {

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -40,7 +40,7 @@ export interface LogStoreSharedData {
   readonly metadataSab: SharedArrayBuffer | ArrayBuffer;
   readonly bodyBufferSabs: readonly (SharedArrayBuffer | ArrayBuffer)[];
   readonly count: number;
-  readonly idToIndex: readonly (number | undefined)[];
+  readonly idToIndex: (number | undefined)[];
 }
 
 /**
@@ -106,7 +106,7 @@ export class LogStore {
       this.metadataSab = sharedData.metadataSab;
       this.bodyBufferSabs = Array.from(sharedData.bodyBufferSabs);
       this.bodyBuffers = this.bodyBufferSabs.map((sab) => new Uint8Array(sab));
-      this.idToIndex = Array.from(sharedData.idToIndex);
+      this.idToIndex = sharedData.idToIndex;
       this.mapMetadataViews(sharedData.count);
     }
   }

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -47,6 +47,8 @@ function align(offset: number, alignment: number): number {
 
 /**
  * Represents the shared memory structure of the timeline store.
+ * This is used to pass data to the worker threads.
+ * To prevent the main thread from OOM killing, the main contents are shared via SharedArrayBuffer.
  */
 export interface TimelineStoreSharedData {
   readonly metadataSab: SharedArrayBuffer | ArrayBuffer;
@@ -54,9 +56,8 @@ export interface TimelineStoreSharedData {
   readonly timelineCount: number;
   readonly revisionCount: number;
   readonly eventCount: number;
-  readonly timelineRevisionIds: readonly (readonly number[])[];
-  readonly timelineEventIds: readonly (readonly number[])[];
-  readonly timelineChildrenIds: readonly (readonly number[])[];
+  readonly timelineRevisionIds: Uint32Array[];
+  readonly timelineEventIds: Uint32Array[];
   readonly timelineIdToIndex: { readonly [tid: number]: number };
   readonly revisionIdToIndex: { readonly [rid: number]: number };
   readonly eventIdToIndex: { readonly [eid: number]: number };
@@ -169,25 +170,33 @@ export class TimelineStore {
         (sab) => new Uint8Array(sab),
       );
 
-      this.timelineRevisionIds = sharedData.timelineRevisionIds.map(
-        (arr) => new Uint32Array(arr),
-      );
-      this.timelineEventIds = sharedData.timelineEventIds.map(
-        (arr) => new Uint32Array(arr),
-      );
-      this.timelineChildrenIds = sharedData.timelineChildrenIds.map((arr) =>
-        Array.from(arr),
-      );
+      this.timelineRevisionIds = sharedData.timelineRevisionIds;
+      this.timelineEventIds = sharedData.timelineEventIds;
 
-      this.timelineIdToIndex = { ...sharedData.timelineIdToIndex };
-      this.revisionIdToIndex = { ...sharedData.revisionIdToIndex };
-      this.eventIdToIndex = { ...sharedData.eventIdToIndex };
+      this.timelineIdToIndex = sharedData.timelineIdToIndex;
+      this.revisionIdToIndex = sharedData.revisionIdToIndex;
+      this.eventIdToIndex = sharedData.eventIdToIndex;
 
       this.mapMetadataViews(
         sharedData.timelineCount,
         sharedData.revisionCount,
         sharedData.eventCount,
       );
+
+      this.timelineChildrenIds = [];
+      for (let i = 0; i < sharedData.timelineCount; i++) {
+        this.timelineChildrenIds[i] = [];
+      }
+
+      for (let i = 0; i < sharedData.timelineCount; i++) {
+        const parentId = this.timelineParentIds[i];
+        if (parentId !== 0) {
+          const parentIndex = this.timelineIdToIndex[parentId];
+          if (parentIndex !== undefined) {
+            this.timelineChildrenIds[parentIndex].push(this.timelineIds[i]);
+          }
+        }
+      }
 
       for (let i = 0; i < sharedData.timelineCount; i++) {
         this.timelinesList.push(new Timeline(this.timelineIds[i], this));
@@ -812,16 +821,11 @@ export class TimelineStore {
       timelineCount: this.timelineIds.length,
       revisionCount: this.revisionIds.length,
       eventCount: this.eventIds.length,
-      timelineRevisionIds: this.timelineRevisionIds.map((arr) =>
-        Array.from(arr),
-      ),
-      timelineEventIds: this.timelineEventIds.map((arr) => Array.from(arr)),
-      timelineChildrenIds: this.timelineChildrenIds.map((arr) =>
-        Array.from(arr),
-      ),
-      timelineIdToIndex: { ...this.timelineIdToIndex },
-      revisionIdToIndex: { ...this.revisionIdToIndex },
-      eventIdToIndex: { ...this.eventIdToIndex },
+      timelineRevisionIds: this.timelineRevisionIds,
+      timelineEventIds: this.timelineEventIds,
+      timelineIdToIndex: this.timelineIdToIndex,
+      revisionIdToIndex: this.revisionIdToIndex,
+      eventIdToIndex: this.eventIdToIndex,
     };
   }
 }

--- a/web/src/app/worker/search/handlers/search-logs.spec.ts
+++ b/web/src/app/worker/search/handlers/search-logs.spec.ts
@@ -81,20 +81,35 @@ describe('handleSearchLogs', () => {
     });
 
     const progressSab = new SharedArrayBuffer(1024);
+    const requestBuf = new SharedArrayBuffer(1024);
+    const resultBuf = new SharedArrayBuffer(1024);
+
+    const reqView = new Int32Array(requestBuf);
+    reqView[0] = 2;
+    reqView[1] = 0;
+    reqView[2] = 1;
 
     // Matching ERROR logs: log 11 and log 13
-    const matchedIds = handleSearchLogs(
+    handleSearchLogs(
       {
         type: 'SEARCH_LOGS',
         requestId: 'req-log-1',
         celExpr: 'severity == ERROR',
         workerIndex: 0,
         numWorkers: 1,
-        timelineIds: [0, 1],
+        requestBuf,
+        resultBuf,
         progressSab,
       },
       state,
     );
+
+    const resView = new Int32Array(resultBuf);
+    const matchedCount = resView[0];
+    const matchedIds = [];
+    for (let i = 1; i <= matchedCount; i++) {
+      matchedIds.push(resView[i]);
+    }
 
     expect(matchedIds.sort((a, b) => a - b)).toEqual([11, 13]);
   });

--- a/web/src/app/worker/search/handlers/search-logs.ts
+++ b/web/src/app/worker/search/handlers/search-logs.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+import { isSharedBuffer } from 'src/app/store/domain/types';
 import { SearchWorkerRequest } from 'src/app/worker/search/search-types';
 import { SearchWorkerState } from 'src/app/worker/search/search-worker-state';
 
 export function handleSearchLogs(
   request: Extract<SearchWorkerRequest, { type: 'SEARCH_LOGS' }>,
   state: SearchWorkerState,
-): number[] {
+): void {
   if (!state.timelineStore || !state.logStore) {
     throw new Error('Stores not initialized inside Worker');
   }
@@ -31,19 +32,33 @@ export function handleSearchLogs(
 
   const progressArray = new Int32Array(request.progressSab);
   const workerIndex = request.workerIndex;
-  const progressOffset = workerIndex * 16;
+  const progressOffset = workerIndex;
 
   const numWorkers = request.numWorkers;
-  const cancellationIndex = numWorkers * 16;
+  const cancellationIndex = numWorkers;
+  const isShared = isSharedBuffer(request.progressSab);
 
-  let count = 0;
+  let matchCount = 0;
+  const requestView = new Int32Array(request.requestBuf);
+  const resultView = new Int32Array(request.resultBuf);
+  const requestCount = requestView[0];
+
+  let count = isShared
+    ? Atomics.load(progressArray, progressOffset)
+    : progressArray[progressOffset];
   const matchedIdsSet = new Set<number>();
-  for (const tId of request.timelineIds) {
-    if (Atomics.load(progressArray, cancellationIndex) !== 0) {
+  for (let i = 1; i <= requestCount; i++) {
+    const tId = requestView[i];
+    const isCancelled = isShared
+      ? Atomics.load(progressArray, cancellationIndex) !== 0
+      : progressArray[cancellationIndex] !== 0;
+
+    if (isCancelled) {
       console.debug(
         `[SearchWorker #${workerIndex}] SEARCH_LOGS aborted (cancelled).`,
       );
-      return Array.from(matchedIdsSet);
+      resultView[0] = matchCount;
+      return;
     }
     const timeline = state.timelineStore.getTimeline(tId);
     for (const e of timeline.events) {
@@ -52,10 +67,16 @@ export function handleSearchLogs(
         const l = state.logStore.getLog(logId);
         if (state.logCelEnv.evaluate(l)) {
           matchedIdsSet.add(logId);
+          matchCount++;
+          resultView[matchCount] = logId;
         }
       }
       count++;
-      progressArray[progressOffset] = count;
+      if (isShared) {
+        Atomics.store(progressArray, progressOffset, count);
+      } else {
+        progressArray[progressOffset] = count;
+      }
     }
     for (const r of timeline.revisions) {
       const logId = r.log.id;
@@ -63,10 +84,16 @@ export function handleSearchLogs(
         const l = state.logStore.getLog(logId);
         if (state.logCelEnv.evaluate(l)) {
           matchedIdsSet.add(logId);
+          matchCount++;
+          resultView[matchCount] = logId;
         }
       }
       count++;
-      progressArray[progressOffset] = count;
+      if (isShared) {
+        Atomics.store(progressArray, progressOffset, count);
+      } else {
+        progressArray[progressOffset] = count;
+      }
     }
   }
 
@@ -75,5 +102,5 @@ export function handleSearchLogs(
       `Processed: ${count}, Matched: ${matchedIdsSet.size}`,
   );
 
-  return Array.from(matchedIdsSet);
+  resultView[0] = matchCount;
 }

--- a/web/src/app/worker/search/handlers/search-logs.ts
+++ b/web/src/app/worker/search/handlers/search-logs.ts
@@ -67,6 +67,11 @@ export function handleSearchLogs(
         const l = state.logStore.getLog(logId);
         if (state.logCelEnv.evaluate(l)) {
           matchedIdsSet.add(logId);
+          if (matchCount >= resultView.length - 1) {
+            throw new Error(
+              `[SearchWorker #${workerIndex}] result buffer overflow.`,
+            );
+          }
           matchCount++;
           resultView[matchCount] = logId;
         }
@@ -84,6 +89,11 @@ export function handleSearchLogs(
         const l = state.logStore.getLog(logId);
         if (state.logCelEnv.evaluate(l)) {
           matchedIdsSet.add(logId);
+          if (matchCount >= resultView.length - 1) {
+            throw new Error(
+              `[SearchWorker #${workerIndex}] result buffer overflow.`,
+            );
+          }
           matchCount++;
           resultView[matchCount] = logId;
         }

--- a/web/src/app/worker/search/handlers/search-timelines.spec.ts
+++ b/web/src/app/worker/search/handlers/search-timelines.spec.ts
@@ -49,22 +49,46 @@ describe('handleSearchTimelines', () => {
     Object.defineProperty(state.timelineStore, 'timelines', {
       get: () => mockTimelines,
     });
+    spyOn(state.timelineStore!, 'getTimeline').and.callFake((id: number) => {
+      const found = mockTimelines.find((t) => t.id === id);
+      if (!found) {
+        throw new Error(`Timeline ${id} not found`);
+      }
+      return found;
+    });
 
     const progressSab = new SharedArrayBuffer(1024);
+    const requestBuf = new SharedArrayBuffer(1024);
+    const resultBuf = new SharedArrayBuffer(1024);
+
+    const reqView = new Int32Array(requestBuf);
+    reqView[0] = 3;
+    reqView[1] = 1;
+    reqView[2] = 2;
+    reqView[3] = 3;
 
     // Test the logic directly
     // name == 'T1' will match id=1 and id=3
-    const matchedIds = handleSearchTimelines(
+    handleSearchTimelines(
       {
         type: 'SEARCH_TIMELINES',
         requestId: 'req-1',
         celExpr: "name == 'T1'",
         workerIndex: 0,
         numWorkers: 1,
+        requestBuf,
+        resultBuf,
         progressSab,
       },
       state,
     );
+
+    const resView = new Int32Array(resultBuf);
+    const matchedCount = resView[0];
+    const matchedIds = [];
+    for (let i = 1; i <= matchedCount; i++) {
+      matchedIds.push(resView[i]);
+    }
 
     expect(matchedIds).toEqual([1, 3]);
   });
@@ -80,37 +104,69 @@ describe('handleSearchTimelines', () => {
     Object.defineProperty(state.timelineStore, 'timelines', {
       get: () => mockTimelines,
     });
+    spyOn(state.timelineStore!, 'getTimeline').and.callFake((id: number) => {
+      const found = mockTimelines.find((t) => t.id === id);
+      if (!found) {
+        throw new Error(`Timeline ${id} not found`);
+      }
+      return found;
+    });
 
     const progressSab = new SharedArrayBuffer(1024);
 
-    const worker0Matches = handleSearchTimelines(
+    const requestBuf0 = new SharedArrayBuffer(1024);
+    const resultBuf0 = new SharedArrayBuffer(1024);
+    const reqView0 = new Int32Array(requestBuf0);
+    reqView0[0] = 3;
+    reqView0[1] = 0;
+    reqView0[2] = 2;
+    reqView0[3] = 4;
+
+    handleSearchTimelines(
       {
         type: 'SEARCH_TIMELINES',
         requestId: 'req-1',
         celExpr: "name == 'T1'",
         workerIndex: 0,
         numWorkers: 2, // Workers 0 and 1
+        requestBuf: requestBuf0,
+        resultBuf: resultBuf0,
         progressSab,
       },
       state,
     );
     // Worker 0 processes index 0, 2, 4
     // 0: match, 2: not match, 4: match
+    const resView0 = new Int32Array(resultBuf0);
+    const worker0Matches = [];
+    for (let i = 1; i <= resView0[0]; i++) worker0Matches.push(resView0[i]);
     expect(worker0Matches).toEqual([0, 4]);
 
-    const worker1Matches = handleSearchTimelines(
+    const requestBuf1 = new SharedArrayBuffer(1024);
+    const resultBuf1 = new SharedArrayBuffer(1024);
+    const reqView1 = new Int32Array(requestBuf1);
+    reqView1[0] = 2;
+    reqView1[1] = 1;
+    reqView1[2] = 3;
+
+    handleSearchTimelines(
       {
         type: 'SEARCH_TIMELINES',
         requestId: 'req-2',
         celExpr: "name == 'T1'",
         workerIndex: 1,
         numWorkers: 2,
+        requestBuf: requestBuf1,
+        resultBuf: resultBuf1,
         progressSab,
       },
       state,
     );
     // Worker 1 processes index 1, 3
     // 1: match, 3: match
+    const resView1 = new Int32Array(resultBuf1);
+    const worker1Matches = [];
+    for (let i = 1; i <= resView1[0]; i++) worker1Matches.push(resView1[i]);
     expect(worker1Matches).toEqual([1, 3]);
   });
 });

--- a/web/src/app/worker/search/handlers/search-timelines.ts
+++ b/web/src/app/worker/search/handlers/search-timelines.ts
@@ -60,6 +60,11 @@ export function handleSearchTimelines(
     }
     const t = state.timelineStore.getTimeline(tId);
     if (state.timelineCelEnv.evaluate(t, state.timelineStore)) {
+      if (matchCount >= resultView.length - 1) {
+        throw new Error(
+          `[SearchWorker #${workerIndex}] result buffer overflow.`,
+        );
+      }
       matchCount++;
       resultView[matchCount] = t.id;
     }

--- a/web/src/app/worker/search/handlers/search-timelines.ts
+++ b/web/src/app/worker/search/handlers/search-timelines.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+import { isSharedBuffer } from 'src/app/store/domain/types';
 import { SearchWorkerRequest } from 'src/app/worker/search/search-types';
 import { SearchWorkerState } from 'src/app/worker/search/search-worker-state';
 
 export function handleSearchTimelines(
   request: Extract<SearchWorkerRequest, { type: 'SEARCH_TIMELINES' }>,
   state: SearchWorkerState,
-): number[] {
+): void {
   if (!state.timelineStore) {
     throw new Error('TimelineStore not initialized inside Worker');
   }
@@ -29,36 +30,51 @@ export function handleSearchTimelines(
     throw compileRes.error ?? new Error(`Compile failed: ${request.celExpr}`);
   }
 
-  const matchedIds: number[] = [];
-  let processedCount = 0;
-  const timelines = state.timelineStore.timelines;
-  const totalTimelines = timelines.length;
+  let matchCount = 0;
+  const requestView = new Int32Array(request.requestBuf);
+  const resultView = new Int32Array(request.resultBuf);
+  const requestCount = requestView[0];
   const workerIndex = request.workerIndex;
   const numWorkers = request.numWorkers;
   const progressArray = new Int32Array(request.progressSab);
-  const progressOffset = workerIndex * 16;
+  const progressOffset = workerIndex;
+  const cancellationIndex = numWorkers;
+  const isShared = isSharedBuffer(request.progressSab);
 
-  const cancellationIndex = numWorkers * 16;
+  let processedCount = isShared
+    ? Atomics.load(progressArray, progressOffset)
+    : progressArray[progressOffset];
 
-  for (let i = workerIndex; i < totalTimelines; i += numWorkers) {
-    if (Atomics.load(progressArray, cancellationIndex) !== 0) {
+  for (let i = 1; i <= requestCount; i++) {
+    const tId = requestView[i];
+    const isCancelled = isShared
+      ? Atomics.load(progressArray, cancellationIndex) !== 0
+      : progressArray[cancellationIndex] !== 0;
+
+    if (isCancelled) {
       console.debug(
         `[SearchWorker #${workerIndex}] SEARCH_TIMELINES aborted (cancelled).`,
       );
-      return matchedIds;
+      resultView[0] = matchCount;
+      return;
     }
-    const t = timelines[i];
+    const t = state.timelineStore.getTimeline(tId);
     if (state.timelineCelEnv.evaluate(t, state.timelineStore)) {
-      matchedIds.push(t.id);
+      matchCount++;
+      resultView[matchCount] = t.id;
     }
     processedCount++;
-    progressArray[progressOffset] = processedCount;
+    if (isShared) {
+      Atomics.store(progressArray, progressOffset, processedCount);
+    } else {
+      progressArray[progressOffset] = processedCount;
+    }
   }
 
   console.debug(
     `[SearchWorker #${workerIndex}] SEARCH_TIMELINES complete. ` +
-      `Processed: ${processedCount}, Matched: ${matchedIds.length}`,
+      `Processed: ${processedCount}, Matched: ${matchCount}`,
   );
 
-  return matchedIds;
+  resultView[0] = matchCount;
 }

--- a/web/src/app/worker/search/search-types.ts
+++ b/web/src/app/worker/search/search-types.ts
@@ -21,6 +21,7 @@ import { StyleStoreSharedData } from 'src/app/store/domain/style';
 
 /**
  * Message request type sent from the manager (main thread) to SearchWorkers.
+ * To prvent OOMs by generating large request data, we reuse SharedArrayBuffers per worker.
  */
 export type SearchWorkerRequest =
   | {
@@ -38,6 +39,18 @@ export type SearchWorkerRequest =
       readonly workerIndex: number;
       readonly numWorkers: number;
       readonly celExpr: string;
+      /**
+       * Int32Array mapped over buffer.
+       * buffer[0] = count (N)
+       * buffer[1..N] = timeline IDs
+       */
+      readonly requestBuf: SharedArrayBuffer | ArrayBuffer;
+      /**
+       * Int32Array mapped over buffer.
+       * buffer[0] = count (M)
+       * buffer[1..M] = matched timeline IDs
+       */
+      readonly resultBuf: SharedArrayBuffer | ArrayBuffer;
       readonly progressSab: SharedArrayBuffer | ArrayBuffer;
     }
   | {
@@ -46,7 +59,18 @@ export type SearchWorkerRequest =
       readonly workerIndex: number;
       readonly numWorkers: number;
       readonly celExpr: string;
-      readonly timelineIds: readonly number[]; // timelines target for evaluating events & revisions
+      /**
+       * Int32Array mapped over buffer.
+       * buffer[0] = count (N)
+       * buffer[1..N] = timeline IDs to search logs in
+       */
+      readonly requestBuf: SharedArrayBuffer | ArrayBuffer;
+      /**
+       * Int32Array mapped over buffer.
+       * buffer[0] = count (M)
+       * buffer[1..M] = matched log IDs
+       */
+      readonly resultBuf: SharedArrayBuffer | ArrayBuffer;
       readonly progressSab: SharedArrayBuffer | ArrayBuffer;
     };
 
@@ -61,7 +85,7 @@ export type SearchWorkerResponse =
   | {
       readonly type: 'SEARCH_COMPLETE';
       readonly requestId: string;
-      readonly matchedIds: readonly number[];
+      readonly workerIndex: number;
     }
   | {
       readonly type: 'ERROR';

--- a/web/src/app/worker/search/search.worker.ts
+++ b/web/src/app/worker/search/search.worker.ts
@@ -32,20 +32,20 @@ addEventListener('message', (event: MessageEvent<SearchWorkerRequest>) => {
         handleSyncData(request, searchWorkerState);
         break;
       case 'SEARCH_TIMELINES': {
-        const matchedIds = handleSearchTimelines(request, searchWorkerState);
+        handleSearchTimelines(request, searchWorkerState);
         postMessage({
           type: 'SEARCH_COMPLETE',
           requestId: request.requestId,
-          matchedIds,
+          workerIndex: request.workerIndex,
         } as SearchWorkerResponse);
         break;
       }
       case 'SEARCH_LOGS': {
-        const matchedIds = handleSearchLogs(request, searchWorkerState);
+        handleSearchLogs(request, searchWorkerState);
         postMessage({
           type: 'SEARCH_COMPLETE',
           requestId: request.requestId,
-          matchedIds,
+          workerIndex: request.workerIndex,
         } as SearchWorkerResponse);
         break;
       }


### PR DESCRIPTION
# Description
Optimizes memory usage and mitigates Out-Of-Memory (OOM) risks and Garbage Collection (GC) overhead when running log and timeline searches inside WebWorkers.
Previously, search requests and responses allocated and copied massive arrays of timeline and log IDs across thread boundaries. This PR replaces those heavy array allocations with pre-allocated `SharedArrayBuffer` / `ArrayBuffer` instances (`requestBuf`, `resultBuf`).
## Key Changes
* **Buffer-Based IPC**: Updated `SearchWorkerRequest` to pass target timeline and log counts via shared memory buffers instead of standard JavaScript arrays.
* **Direct Match Recording**: Search handlers (`handleSearchTimelines`, `handleSearchLogs`) now record matching IDs directly into `resultBuf`.
* **Lightweight Responses**: Simplified the `SEARCH_COMPLETE` response to return only the worker index rather than copying large arrays of matched IDs back to the main thread.