### PR TITLE
Improved search feature on diffs/logs

### DIFF
--- a/web/src/app/diff/components/diff-content.component.html
+++ b/web/src/app/diff/components/diff-content.component.html
@@ -21,9 +21,23 @@ limitations under the License.
       [(showManagedFields)]="showManagedFields"
       (openInNewTab)="_openInNewTab()"
       (copyContent)="copyContent()"
+      (openSearch)="openSearch()"
     >
     </khi-diff-toolbar>
-    <div class="diff-inner">
+    @if (isSearchOpen()) {
+      <div class="search-bar-container">
+        <khi-search-bar
+          [query]="searchQuery()"
+          [matchCount]="matchCount()"
+          [currentMatchIndex]="currentMatchIndex()"
+          (queryChange)="updateSearchQuery($event)"
+          (nextMatch)="nextMatch()"
+          (prevMatch)="prevMatch()"
+          (closeSearch)="closeSearch()"
+        ></khi-search-bar>
+      </div>
+    }
+    <div #diffContainer class="diff-inner">
       @let currentContent = currentRevisionContent();
       @let previousContent = previousRevisionContent();
       @if (previousContent !== undefined && previousContent !== null) {

--- a/web/src/app/diff/components/diff-content.component.scss
+++ b/web/src/app/diff/components/diff-content.component.scss
@@ -14,6 +14,21 @@
  * limitations under the License.
  */
 
+@use '@angular/material' as mat;
+
+$search-highlight-bg-color: mat.m2-get-color-from-palette(
+  mat.$m2-yellow-palette,
+  200
+);
+$search-highlight-active-bg-color: mat.m2-get-color-from-palette(
+  mat.$m2-orange-palette,
+  500
+);
+$search-highlight-active-text-color: mat.m2-get-color-from-palette(
+  mat.$m2-gray-palette,
+  50
+);
+
 .empty-message {
   margin: 16px;
   color: var(--md-sys-color-on-surface-variant);
@@ -25,9 +40,22 @@
   height: 100%;
 }
 
+.search-bar-container {
+  margin: 0 16px 4px;
+}
+
 .diff-inner {
   overflow-y: auto;
   flex: 1;
+
+  .search-highlight {
+    background-color: $search-highlight-bg-color;
+
+    &.active {
+      background-color: $search-highlight-active-bg-color;
+      color: $search-highlight-active-text-color;
+    }
+  }
 }
 
 .log-body-container {

--- a/web/src/app/diff/components/diff-content.component.ts
+++ b/web/src/app/diff/components/diff-content.component.ts
@@ -14,7 +14,18 @@
  * limitations under the License.
  */
 
-import { Component, inject, input, model, output } from '@angular/core';
+import {
+  Component,
+  effect,
+  ElementRef,
+  HostListener,
+  inject,
+  input,
+  model,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DiffToolbarComponent } from './diff-toolbar.component';
 import { UnifiedDiffComponent } from 'ngx-diff';
@@ -23,6 +34,23 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { Revision } from 'src/app/store/domain/timeline';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import { SearchBarComponent } from 'src/app/shared/components/search-bar/search-bar.component';
+import { SearchScope } from 'src/app/services/view-state.service';
+
+interface TextNodeSpan {
+  node: Text;
+  start: number;
+  end: number;
+}
+
+interface TextRange {
+  start: number;
+  end: number;
+}
+
+interface MatchGroup {
+  marks: HTMLElement[];
+}
 
 /**
  * Component for displaying the unified diff of a resource revision.
@@ -36,6 +64,7 @@ import { ReadonlyDomainElement } from 'src/app/store/domain/types';
     DiffToolbarComponent,
     UnifiedDiffComponent,
     HighlightModule,
+    SearchBarComponent,
   ],
 })
 export class DiffContentComponent {
@@ -69,6 +98,130 @@ export class DiffContentComponent {
   readonly openInNewTab = output<void>();
 
   /**
+   * Emitted when the mouse hovers over or focus enters/leaves the diff content area.
+   */
+  readonly scopeActiveChange = output<boolean>();
+
+  /**
+   * Reference to the diff inner container element to search within.
+   */
+  public readonly diffContainer =
+    viewChild<ElementRef<HTMLElement>>('diffContainer');
+
+  /**
+   * Reference to the search bar component for focus management.
+   */
+  public readonly searchBar = viewChild(SearchBarComponent);
+
+  /**
+   * Signal indicating whether the search bar is currently open.
+   */
+  public readonly isSearchOpen = signal(false);
+
+  /**
+   * Signal holding the current search query string.
+   */
+  public readonly searchQuery = signal('');
+
+  /**
+   * Signal holding the total count of matches found.
+   */
+  public readonly matchCount = signal(0);
+
+  /**
+   * Signal holding the 1-based index of the active match.
+   */
+  public readonly currentMatchIndex = signal(0);
+
+  /** Holds the current active search scope. */
+  public readonly activeSearchScope = input<SearchScope>(SearchScope.Global);
+
+  private matchGroups: MatchGroup[] = [];
+
+  /**
+   * Initializes the component and registers an effect to sync search highlights.
+   */
+  constructor() {
+    effect(() => {
+      const query = this.searchQuery();
+      this.applyHighlights(query);
+    });
+  }
+
+  /**
+   * Intercepts keyboard shortcuts to trigger in-diff search when active.
+   * @param event The keyboard event.
+   */
+  @HostListener('window:keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    if (this.activeSearchScope() !== SearchScope.Diff) {
+      return;
+    }
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'f') {
+      event.preventDefault();
+      this.openSearch();
+    } else if (event.key === 'Escape' && this.isSearchOpen()) {
+      event.preventDefault();
+      this.closeSearch();
+    }
+  }
+
+  /**
+   * Opens the search bar and focuses the input field.
+   */
+  public openSearch() {
+    this.isSearchOpen.set(true);
+    setTimeout(() => {
+      this.searchBar()?.focus();
+    });
+  }
+
+  /**
+   * Closes the search bar and clears the query string.
+   */
+  public closeSearch() {
+    this.isSearchOpen.set(false);
+    this.searchQuery.set('');
+  }
+
+  /**
+   * Updates the search query string.
+   * @param query The new query string.
+   */
+  public updateSearchQuery(query: string) {
+    this.searchQuery.set(query);
+  }
+
+  /**
+   * Navigates to the next search match.
+   */
+  public nextMatch() {
+    const count = this.matchCount();
+    if (count === 0) {
+      return;
+    }
+    const next = (this.currentMatchIndex() % count) + 1;
+    this.currentMatchIndex.set(next);
+    this.updateActiveHighlight();
+  }
+
+  /**
+   * Navigates to the previous search match.
+   */
+  public prevMatch() {
+    const count = this.matchCount();
+    if (count === 0) {
+      return;
+    }
+    let prev = this.currentMatchIndex() - 1;
+    if (prev <= 0) {
+      prev = count;
+    }
+    this.currentMatchIndex.set(prev);
+    this.updateActiveHighlight();
+  }
+
+  /**
    * Triggers the openInNewTab output event.
    */
   protected _openInNewTab() {
@@ -85,5 +238,194 @@ export class DiffContentComponent {
       snackbarMessage = 'Copied!';
     }
     this.snackBar.open(snackbarMessage, undefined, { duration: 1000 });
+  }
+
+  /**
+   * Removes all search highlights and restores original text nodes.
+   */
+  private removeHighlights() {
+    const root = this.diffContainer()?.nativeElement;
+    if (!root) {
+      return;
+    }
+    const marks = root.querySelectorAll('mark.search-highlight');
+    marks.forEach((mark) => {
+      const parent = mark.parentNode;
+      if (parent) {
+        while (mark.firstChild) {
+          parent.insertBefore(mark.firstChild, mark);
+        }
+        parent.removeChild(mark);
+      }
+    });
+    root.normalize();
+  }
+
+  /**
+   * Applies search highlights to the diff body matching the given query across text nodes.
+   * @param query The search query string.
+   */
+  private applyHighlights(query: string) {
+    this.removeHighlights();
+    this.matchGroups = [];
+    if (!query) {
+      this.matchCount.set(0);
+      this.currentMatchIndex.set(0);
+      return;
+    }
+
+    const root = this.diffContainer()?.nativeElement;
+    if (!root) {
+      return;
+    }
+
+    const { textNodes, fullText } = this.extractTextNodes(root);
+    const matchRanges = this.findMatchRanges(fullText, query);
+    const marksForMatch = this.applyHighlightsToNodes(textNodes, matchRanges);
+
+    this.matchGroups = marksForMatch.map((marks) => ({ marks }));
+    const count = this.matchGroups.length;
+    this.matchCount.set(count);
+    if (count > 0) {
+      this.currentMatchIndex.set(1);
+      this.updateActiveHighlight();
+    } else {
+      this.currentMatchIndex.set(0);
+    }
+  }
+
+  /**
+   * Extracts text nodes and their global offsets from the root element.
+   * @param root The root element to scan.
+   * @returns An object containing text nodes spans and cumulative full text.
+   */
+  private extractTextNodes(root: HTMLElement): {
+    textNodes: TextNodeSpan[];
+    fullText: string;
+  } {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+    const textNodes: TextNodeSpan[] = [];
+    let fullText = '';
+
+    let node = walker.nextNode();
+    while (node) {
+      const text = node.nodeValue || '';
+      const start = fullText.length;
+      fullText += text;
+      textNodes.push({ node: node as Text, start, end: fullText.length });
+      node = walker.nextNode();
+    }
+
+    return { textNodes, fullText };
+  }
+
+  /**
+   * Finds all matching index ranges within the scanned text for the given query.
+   * @param text The full text string to search within.
+   * @param query The search query string.
+   * @returns An array of start and end match ranges.
+   */
+  private findMatchRanges(text: string, query: string): TextRange[] {
+    const lowerQuery = query.toLowerCase();
+    const queryLen = query.length;
+    const matchRanges: TextRange[] = [];
+    let matchPos = text.toLowerCase().indexOf(lowerQuery);
+
+    while (matchPos !== -1) {
+      matchRanges.push({ start: matchPos, end: matchPos + queryLen });
+      matchPos = text.toLowerCase().indexOf(lowerQuery, matchPos + queryLen);
+    }
+
+    return matchRanges;
+  }
+
+  /**
+   * Applies mark elements to matching text nodes and groups them by match index.
+   * @param textNodes The scanned text node spans.
+   * @param matchRanges The matched search query ranges.
+   * @returns A grouped array of created mark elements per match range.
+   */
+  private applyHighlightsToNodes(
+    textNodes: TextNodeSpan[],
+    matchRanges: TextRange[],
+  ): HTMLElement[][] {
+    const marksForMatch: HTMLElement[][] = matchRanges.map(() => []);
+
+    for (const item of textNodes) {
+      const highlights: {
+        localStart: number;
+        localEnd: number;
+        matchIdx: number;
+      }[] = [];
+
+      matchRanges.forEach((m, matchIdx) => {
+        const oStart = Math.max(item.start, m.start);
+        const oEnd = Math.min(item.end, m.end);
+        if (oStart < oEnd) {
+          highlights.push({
+            localStart: oStart - item.start,
+            localEnd: oEnd - item.start,
+            matchIdx,
+          });
+        }
+      });
+
+      highlights.sort((a, b) => b.localStart - a.localStart);
+
+      for (const h of highlights) {
+        const middleNode = item.node.splitText(h.localStart);
+        middleNode.splitText(h.localEnd - h.localStart);
+
+        const mark = document.createElement('mark');
+        mark.className = 'search-highlight';
+        mark.textContent = middleNode.nodeValue;
+
+        if (middleNode.parentNode) {
+          middleNode.parentNode.replaceChild(mark, middleNode);
+        }
+
+        marksForMatch[h.matchIdx].unshift(mark);
+      }
+    }
+
+    return marksForMatch;
+  }
+
+  /**
+   * Updates the visual active state of the current match and scrolls it into view.
+   */
+  private updateActiveHighlight() {
+    const index = this.currentMatchIndex() - 1;
+    this.matchGroups.forEach((group, idx) => {
+      const isActive = idx === index;
+      group.marks.forEach((mark) => {
+        if (isActive) {
+          mark.classList.add('active');
+        } else {
+          mark.classList.remove('active');
+        }
+      });
+      if (isActive && group.marks.length > 0) {
+        group.marks[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    });
+  }
+
+  /**
+   * Sets the active search scope when mouse enters or focus enters.
+   */
+  @HostListener('mouseenter')
+  @HostListener('focusin')
+  public onScopeEnter(): void {
+    this.scopeActiveChange.emit(true);
+  }
+
+  /**
+   * Clears the active search scope when mouse leaves or focus leaves.
+   */
+  @HostListener('mouseleave')
+  @HostListener('focusout')
+  public onScopeLeave(): void {
+    this.scopeActiveChange.emit(false);
   }
 }

--- a/web/src/app/diff/components/diff-content.component.ts
+++ b/web/src/app/diff/components/diff-content.component.ts
@@ -144,7 +144,19 @@ export class DiffContentComponent {
   constructor() {
     effect(() => {
       const query = this.searchQuery();
-      this.applyHighlights(query);
+      this.currentRevisionContent();
+      this.previousRevisionContent();
+      const isOpen = this.isSearchOpen();
+      setTimeout(() => {
+        // applyHighlights read DOM contents that can be updated by the signals above.
+        // applyHighlights can update a signal and effects shouldn't update signals.
+        // This setTimeout is a workaround to avoid this issue.
+        if (isOpen && query) {
+          this.applyHighlights(query);
+        } else {
+          this.removeHighlights();
+        }
+      });
     });
   }
 

--- a/web/src/app/diff/components/diff-toolbar.component.html
+++ b/web/src/app/diff/components/diff-toolbar.component.html
@@ -29,6 +29,14 @@
     >
   </div>
   <div class="right">
+    <button
+      matIconButton
+      class="toolbar-button"
+      matTooltip="Search in diff (Ctrl+F)"
+      (click)="openSearch.emit()"
+    >
+      <mat-icon>search</mat-icon>
+    </button>
     <button matIconButton class="toolbar-button" (click)="copyContent.emit()">
       <mat-icon>content_paste</mat-icon>
     </button>

--- a/web/src/app/diff/components/diff-toolbar.component.ts
+++ b/web/src/app/diff/components/diff-toolbar.component.ts
@@ -58,4 +58,9 @@ export class DiffToolbarComponent {
    * Emitted when the open in new tab button is clicked.
    */
   openInNewTab = output<void>();
+
+  /**
+   * Emitted when the open search button is clicked.
+   */
+  openSearch = output<void>();
 }

--- a/web/src/app/diff/diff-smart.component.html
+++ b/web/src/app/diff/diff-smart.component.html
@@ -42,6 +42,8 @@ limitations under the License.
           [previousRevisionContent]="previousRevisionContent()"
           [(showManagedFields)]="showManagedFields"
           (openInNewTab)="openDiffInAnotherWindow()"
+          (scopeActiveChange)="onScopeActiveChange($event)"
+          [activeSearchScope]="activeSearchScope()"
         ></khi-diff-content>
       }
     </as-split-area>

--- a/web/src/app/diff/diff-smart.component.ts
+++ b/web/src/app/diff/diff-smart.component.ts
@@ -25,7 +25,7 @@ import {
 import { Subject, takeUntil } from 'rxjs';
 import { InspectionDataStoreV2 } from '../services/inspection-data-store-v2.service';
 import { SelectionManagerV2 } from '../services/selection-manager-v2.service';
-import { ViewStateService } from '../services/view-state.service';
+import { SearchScope, ViewStateService } from '../services/view-state.service';
 import { DiffListHeaderComponent } from './components/diff-list-header.component';
 import { DiffListComponent } from './components/diff-list.component';
 import { DiffContentComponent } from './components/diff-content.component';
@@ -66,6 +66,9 @@ export class DiffSmartComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroyed.next();
   }
+
+  /** Holds the active search scope. */
+  public readonly activeSearchScope = this.viewState.activeSearchScope;
 
   /**
    * Signal containing the timezone shift in hours from the view state.
@@ -221,6 +224,17 @@ export class DiffSmartComponent implements OnInit, OnDestroy {
     } catch (e) {
       console.warn(`failed to process frontend yaml: ${e}`);
       return content;
+    }
+  }
+
+  /**
+   * Sets the active search scope in the ViewStateService based on whether Diff Content is hovered or focused.
+   */
+  protected onScopeActiveChange(active: boolean): void {
+    if (active) {
+      this.viewState.activeSearchScope.set(SearchScope.Diff);
+    } else if (this.viewState.activeSearchScope() === SearchScope.Diff) {
+      this.viewState.activeSearchScope.set(SearchScope.Global);
     }
   }
 }

--- a/web/src/app/log/components/log-content.component.html
+++ b/web/src/app/log/components/log-content.component.html
@@ -30,6 +30,14 @@ limitations under the License.
       <button
         class="toolbar-button"
         matIconButton
+        matTooltip="Search in body (Ctrl+F)"
+        (click)="openSearch()"
+      >
+        <mat-icon>search</mat-icon>
+      </button>
+      <button
+        class="toolbar-button"
+        matIconButton
         matTooltip="Copy the log to clipboard"
         (click)="copyLog()"
       >
@@ -46,9 +54,22 @@ limitations under the License.
         </button>
       }
     </div>
+    @if (isSearchOpen()) {
+      <div class="search-bar-container">
+        <khi-search-bar
+          [query]="searchQuery()"
+          [matchCount]="matchCount()"
+          [currentMatchIndex]="currentMatchIndex()"
+          (queryChange)="updateSearchQuery($event)"
+          (nextMatch)="nextMatch()"
+          (prevMatch)="prevMatch()"
+          (closeSearch)="closeSearch()"
+        ></khi-search-bar>
+      </div>
+    }
     <div class="log-body-container">
       <div class="log-body">
-        <pre><code [highlight]="viewModel.logBody" language="yaml" lineNumbers></code></pre>
+        <pre><code #codeElement [highlight]="viewModel.logBody" language="yaml" lineNumbers></code></pre>
       </div>
     </div>
   } @else {

--- a/web/src/app/log/components/log-content.component.scss
+++ b/web/src/app/log/components/log-content.component.scss
@@ -17,12 +17,29 @@
 @use '@angular/material' as mat;
 @use '../../common.scss' as common;
 
+$search-highlight-bg-color: mat.m2-get-color-from-palette(
+  mat.$m2-yellow-palette,
+  200
+);
+$search-highlight-active-bg-color: mat.m2-get-color-from-palette(
+  mat.$m2-orange-palette,
+  500
+);
+$search-highlight-active-text-color: mat.m2-get-color-from-palette(
+  mat.$m2-gray-palette,
+  50
+);
+
 .log-body-view-root {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-areas: 'header' 'toolbar' 'logbody';
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template:
+    'header' auto
+    'toolbar' auto
+    'searchbar' auto
+    'logbody' minmax(0, 1fr)
+    / 1fr;
 
   khi-log-header {
     grid: 'header';
@@ -54,6 +71,11 @@
   }
 }
 
+.search-bar-container {
+  grid: 'searchbar';
+  margin: 0 10px 4px;
+}
+
 .log-body-container {
   grid: 'logbody';
   margin: 0 10px;
@@ -62,6 +84,15 @@
   code {
     white-space: pre;
     font-family: common.$font-code;
+
+    .search-highlight {
+      background-color: $search-highlight-bg-color;
+
+      &.active {
+        background-color: $search-highlight-active-bg-color;
+        color: $search-highlight-active-text-color;
+      }
+    }
   }
 }
 

--- a/web/src/app/log/components/log-content.component.ts
+++ b/web/src/app/log/components/log-content.component.ts
@@ -14,7 +14,18 @@
  * limitations under the License.
  */
 
-import { Component, computed, inject, input, output } from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  HostListener,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LogContentHeaderComponent } from 'src/app/log/components/log-content-header.component';
 import { HighlightModule } from 'ngx-highlightjs';
@@ -29,6 +40,8 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
 
 import { ResourceRefAnnotationViewModel } from 'src/app/log/components/resource-reference-list.component';
+import { SearchBarComponent } from 'src/app/shared/components/search-bar/search-bar.component';
+import { SearchScope } from 'src/app/services/view-state.service';
 
 /**
  * View model aggregating the full detailed data required to render the log content and header.
@@ -38,6 +51,21 @@ export interface LogContentViewModel {
   logBody: string;
   parsedLogBody: unknown;
   resourceRefs: ResourceRefAnnotationViewModel[];
+}
+
+interface TextNodeSpan {
+  node: Text;
+  start: number;
+  end: number;
+}
+
+interface TextRange {
+  start: number;
+  end: number;
+}
+
+interface MatchGroup {
+  marks: HTMLElement[];
 }
 
 /**
@@ -59,11 +87,66 @@ export interface LogContentViewModel {
     MatButtonModule,
     MatSnackBarModule,
     ClipboardModule,
+    SearchBarComponent,
   ],
 })
 export class LogContentComponent {
   private readonly clipboard = inject(Clipboard);
   private readonly snackBar = inject(MatSnackBar);
+
+  /**
+   * Signal tracking whether the in-logbody search bar is currently open.
+   */
+  public readonly isSearchOpen = signal<boolean>(false);
+
+  /**
+   * Signal storing the current search query string.
+   */
+  public readonly searchQuery = signal<string>('');
+
+  /**
+   * Signal storing the total number of matched search highlights.
+   */
+  public readonly matchCount = signal<number>(0);
+
+  /**
+   * Signal tracking the 1-based index of the currently active search match.
+   */
+  public readonly currentMatchIndex = signal<number>(0);
+
+  /**
+   * Reference to the code element containing the highlighted log body.
+   */
+  public readonly codeElement =
+    viewChild<ElementRef<HTMLElement>>('codeElement');
+
+  /**
+   * Reference to the search bar component for focus management.
+   */
+  public readonly searchBar = viewChild(SearchBarComponent);
+
+  /** Holds the current active search scope. */
+  public readonly activeSearchScope = input<SearchScope>(SearchScope.Global);
+
+  private matchGroups: MatchGroup[] = [];
+
+  /**
+   * Initializes the component and registers an effect to sync highlights.
+   */
+  constructor() {
+    effect(() => {
+      const query = this.searchQuery();
+      const vm = this.vm();
+      const isOpen = this.isSearchOpen();
+      setTimeout(() => {
+        if (isOpen && vm && query) {
+          this.applyHighlights(query);
+        } else {
+          this.removeHighlights();
+        }
+      });
+    });
+  }
 
   /**
    * The aggregated view model containing the log entry, body, and resolved references.
@@ -84,6 +167,11 @@ export class LogContentComponent {
    * Output emitted when a resource timeline is hovered from the reference list.
    */
   public timelineHighlighted = output<number>();
+
+  /**
+   * Output emitted when the mouse hovers over or focus enters/leaves the log content area.
+   */
+  public scopeActiveChange = output<boolean>();
 
   /**
    * Input tracking the currently selected timeline to visually indicate selection state
@@ -157,5 +245,269 @@ timestamp="${timestampString}"
     this.snackBar.open(success ? 'Copied!' : 'Copy failed', undefined, {
       duration: 1000,
     });
+  }
+
+  /**
+   * Intercepts keyboard events to handle search toggle and shortcuts.
+   * @param event The keyboard event fired on the window.
+   */
+  @HostListener('window:keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    if (this.activeSearchScope() !== SearchScope.Log) {
+      return;
+    }
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'f') {
+      event.preventDefault();
+      this.openSearch();
+    } else if (event.key === 'Escape' && this.isSearchOpen()) {
+      event.preventDefault();
+      this.closeSearch();
+    }
+  }
+
+  /**
+   * Opens the search bar and focuses on the search input field.
+   */
+  openSearch() {
+    this.isSearchOpen.set(true);
+    setTimeout(() => {
+      this.searchBar()?.focus();
+    });
+  }
+
+  /**
+   * Closes the search bar, clearing highlights and resetting state.
+   */
+  closeSearch() {
+    this.isSearchOpen.set(false);
+    this.searchQuery.set('');
+    this.matchCount.set(0);
+    this.currentMatchIndex.set(0);
+    this.removeHighlights();
+  }
+
+  /**
+   * Updates the search query and applies highlights to the log body.
+   * @param query The search query string.
+   */
+  updateSearchQuery(query: string) {
+    this.searchQuery.set(query);
+    this.applyHighlights(query);
+  }
+
+  /**
+   * Navigates to the next search match.
+   */
+  nextMatch() {
+    const count = this.matchCount();
+    if (count === 0) {
+      return;
+    }
+    const next = (this.currentMatchIndex() % count) + 1;
+    this.currentMatchIndex.set(next);
+    this.updateActiveHighlight();
+  }
+
+  /**
+   * Navigates to the previous search match.
+   */
+  prevMatch() {
+    const count = this.matchCount();
+    if (count === 0) {
+      return;
+    }
+    const current = this.currentMatchIndex();
+    const prev = current - 1 > 0 ? current - 1 : count;
+    this.currentMatchIndex.set(prev);
+    this.updateActiveHighlight();
+  }
+
+  /**
+   * Removes all search highlights and restores original text nodes.
+   */
+  private removeHighlights() {
+    const root = this.codeElement()?.nativeElement;
+    if (!root) {
+      return;
+    }
+    const marks = root.querySelectorAll('mark.search-highlight');
+    marks.forEach((mark) => {
+      const parent = mark.parentNode;
+      if (parent) {
+        while (mark.firstChild) {
+          parent.insertBefore(mark.firstChild, mark);
+        }
+        parent.removeChild(mark);
+      }
+    });
+    root.normalize();
+  }
+
+  /**
+   * Applies search highlights to the log body matching the given query across text nodes.
+   * @param query The search query string.
+   */
+  private applyHighlights(query: string) {
+    this.removeHighlights();
+    this.matchGroups = [];
+    if (!query) {
+      this.matchCount.set(0);
+      this.currentMatchIndex.set(0);
+      return;
+    }
+
+    const root = this.codeElement()?.nativeElement;
+    if (!root) {
+      return;
+    }
+
+    const { textNodes, fullText } = this.extractTextNodes(root);
+    const matchRanges = this.findMatchRanges(fullText, query);
+    const marksForMatch = this.applyHighlightsToNodes(textNodes, matchRanges);
+
+    this.matchGroups = marksForMatch.map((marks) => ({ marks }));
+    const count = this.matchGroups.length;
+    this.matchCount.set(count);
+    if (count > 0) {
+      this.currentMatchIndex.set(1);
+      this.updateActiveHighlight();
+    } else {
+      this.currentMatchIndex.set(0);
+    }
+  }
+
+  /**
+   * Extracts text nodes and their global offsets from the root element.
+   * @param root The root element to scan.
+   * @returns An object containing text nodes spans and cumulative full text.
+   */
+  private extractTextNodes(root: HTMLElement): {
+    textNodes: TextNodeSpan[];
+    fullText: string;
+  } {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+    const textNodes: TextNodeSpan[] = [];
+    let fullText = '';
+
+    let node = walker.nextNode();
+    while (node) {
+      const text = node.nodeValue || '';
+      const start = fullText.length;
+      fullText += text;
+      textNodes.push({ node: node as Text, start, end: fullText.length });
+      node = walker.nextNode();
+    }
+
+    return { textNodes, fullText };
+  }
+
+  /**
+   * Finds all matching index ranges within the scanned text for the given query.
+   * @param text The full text string to search within.
+   * @param query The search query string.
+   * @returns An array of start and end match ranges.
+   */
+  private findMatchRanges(text: string, query: string): TextRange[] {
+    const lowerQuery = query.toLowerCase();
+    const queryLen = query.length;
+    const matchRanges: TextRange[] = [];
+    let matchPos = text.toLowerCase().indexOf(lowerQuery);
+
+    while (matchPos !== -1) {
+      matchRanges.push({ start: matchPos, end: matchPos + queryLen });
+      matchPos = text.toLowerCase().indexOf(lowerQuery, matchPos + queryLen);
+    }
+
+    return matchRanges;
+  }
+
+  /**
+   * Applies mark elements to matching text nodes and groups them by match index.
+   * @param textNodes The scanned text node spans.
+   * @param matchRanges The matched search query ranges.
+   * @returns A grouped array of created mark elements per match range.
+   */
+  private applyHighlightsToNodes(
+    textNodes: TextNodeSpan[],
+    matchRanges: TextRange[],
+  ): HTMLElement[][] {
+    const marksForMatch: HTMLElement[][] = matchRanges.map(() => []);
+
+    for (const item of textNodes) {
+      const highlights: {
+        localStart: number;
+        localEnd: number;
+        matchIdx: number;
+      }[] = [];
+
+      matchRanges.forEach((m, matchIdx) => {
+        const oStart = Math.max(item.start, m.start);
+        const oEnd = Math.min(item.end, m.end);
+        if (oStart < oEnd) {
+          highlights.push({
+            localStart: oStart - item.start,
+            localEnd: oEnd - item.start,
+            matchIdx,
+          });
+        }
+      });
+
+      highlights.sort((a, b) => b.localStart - a.localStart);
+
+      for (const h of highlights) {
+        const middleNode = item.node.splitText(h.localStart);
+        middleNode.splitText(h.localEnd - h.localStart);
+
+        const mark = document.createElement('mark');
+        mark.className = 'search-highlight';
+        mark.textContent = middleNode.nodeValue;
+
+        if (middleNode.parentNode) {
+          middleNode.parentNode.replaceChild(mark, middleNode);
+        }
+
+        marksForMatch[h.matchIdx].unshift(mark);
+      }
+    }
+
+    return marksForMatch;
+  }
+
+  /**
+   * Updates the visual active state of the current match and scrolls it into view.
+   */
+  private updateActiveHighlight() {
+    const index = this.currentMatchIndex() - 1;
+    this.matchGroups.forEach((group, idx) => {
+      const isActive = idx === index;
+      group.marks.forEach((mark) => {
+        if (isActive) {
+          mark.classList.add('active');
+        } else {
+          mark.classList.remove('active');
+        }
+      });
+      if (isActive && group.marks.length > 0) {
+        group.marks[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    });
+  }
+
+  /**
+   * Sets the active search scope when mouse enters or focus enters.
+   */
+  @HostListener('mouseenter')
+  @HostListener('focusin')
+  public onScopeEnter(): void {
+    this.scopeActiveChange.emit(true);
+  }
+
+  /**
+   * Clears the active search scope when mouse leaves or focus leaves.
+   */
+  @HostListener('mouseleave')
+  @HostListener('focusout')
+  public onScopeLeave(): void {
+    this.scopeActiveChange.emit(false);
   }
 }

--- a/web/src/app/log/components/log-content.component.ts
+++ b/web/src/app/log/components/log-content.component.ts
@@ -139,6 +139,9 @@ export class LogContentComponent {
       const vm = this.vm();
       const isOpen = this.isSearchOpen();
       setTimeout(() => {
+        // applyHighlights read DOM contents that can be updated by the signals above.
+        // applyHighlights can update a signal and effects shouldn't update signals.
+        // This setTimeout is a workaround to avoid this issue.
         if (isOpen && vm && query) {
           this.applyHighlights(query);
         } else {
@@ -287,12 +290,11 @@ timestamp="${timestampString}"
   }
 
   /**
-   * Updates the search query and applies highlights to the log body.
+   * Updates the search query string.
    * @param query The search query string.
    */
   updateSearchQuery(query: string) {
     this.searchQuery.set(query);
-    this.applyHighlights(query);
   }
 
   /**

--- a/web/src/app/log/log-smart.component.html
+++ b/web/src/app/log/log-smart.component.html
@@ -39,6 +39,8 @@
         [selectedTimeline]="selectedTimeline()"
         (timelineSelected)="onTimelineSelected($event)"
         (timelineHighlighted)="onTimelineHighlighted($event)"
+        (scopeActiveChange)="onScopeActiveChange($event)"
+        [activeSearchScope]="activeSearchScope()"
       >
       </khi-log-content>
     </as-split-area>

--- a/web/src/app/log/log-smart.component.ts
+++ b/web/src/app/log/log-smart.component.ts
@@ -28,7 +28,10 @@ import {
 import { ResourceRefAnnotationViewModel } from 'src/app/log/components/resource-reference-list.component';
 import { LogListComponent } from 'src/app/log/components/log-list.component';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ViewStateService } from 'src/app/services/view-state.service';
+import {
+  SearchScope,
+  ViewStateService,
+} from 'src/app/services/view-state.service';
 import jsyaml from 'js-yaml';
 
 /**
@@ -52,6 +55,9 @@ export class LogSmartComponent {
   private readonly selectionManager = inject(SelectionManagerV2);
   private readonly inspectionDataStore = inject(InspectionDataStoreV2);
   private readonly viewState = inject(ViewStateService);
+
+  /** Holds the active search scope. */
+  public readonly activeSearchScope = this.viewState.activeSearchScope;
 
   /**
    * The timezone shift to apply to the timestamp.
@@ -205,6 +211,17 @@ export class LogSmartComponent {
       ?.timelineStore.getTimeline(timelineId);
     if (timeline) {
       this.selectionManager.onHighlightTimeline(timeline);
+    }
+  }
+
+  /**
+   * Sets the active search scope in the ViewStateService based on whether Log Content is hovered or focused.
+   */
+  protected onScopeActiveChange(active: boolean): void {
+    if (active) {
+      this.viewState.activeSearchScope.set(SearchScope.Log);
+    } else if (this.viewState.activeSearchScope() === SearchScope.Log) {
+      this.viewState.activeSearchScope.set(SearchScope.Global);
     }
   }
 }

--- a/web/src/app/services/view-state.service.ts
+++ b/web/src/app/services/view-state.service.ts
@@ -27,6 +27,15 @@ import {
 import { TimelineFilterConfig } from 'src/app/timeline-toolbar/types/filter-config';
 
 /**
+ * Represents the current active search scope for keyboard shortcut navigation.
+ */
+export enum SearchScope {
+  Global = 'GLOBAL',
+  Log = 'LOG',
+  Diff = 'DIFF',
+}
+
+/**
  * A service to manage statuses used for view in application wide.
  */
 @Injectable({ providedIn: 'root' })
@@ -37,6 +46,11 @@ export class ViewStateService {
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size
    */
   public static DEVICE_PIXEL_RATIO_SCALE = 1;
+
+  /**
+   * The currently active search scope for handling search keyboard shortcuts.
+   */
+  public readonly activeSearchScope = signal<SearchScope>(SearchScope.Global);
 
   /**
    * Whether the timeline toolbar is in advanced (CEL) mode.

--- a/web/src/app/shared/components/search-bar/search-bar.component.html
+++ b/web/src/app/shared/components/search-bar/search-bar.component.html
@@ -1,0 +1,55 @@
+<!--
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div class="search-bar">
+  <input
+    #searchInput
+    type="text"
+    class="search-input"
+    placeholder="Find in body..."
+    [value]="query()"
+    (input)="onInput(searchInput.value)"
+    (keydown.enter)="nextMatch.emit()"
+    (keydown.shift.enter)="prevMatch.emit()"
+  />
+  <span class="match-count">
+    {{ matchLabel() }}
+  </span>
+  <button
+    class="search-button"
+    matIconButton
+    matTooltip="Previous match"
+    (click)="prevMatch.emit()"
+  >
+    <mat-icon>expand_less</mat-icon>
+  </button>
+  <button
+    class="search-button"
+    matIconButton
+    matTooltip="Next match"
+    (click)="nextMatch.emit()"
+  >
+    <mat-icon>expand_more</mat-icon>
+  </button>
+  <button
+    class="search-button"
+    matIconButton
+    matTooltip="Close search"
+    (click)="closeSearch.emit()"
+  >
+    <mat-icon>close</mat-icon>
+  </button>
+</div>

--- a/web/src/app/shared/components/search-bar/search-bar.component.scss
+++ b/web/src/app/shared/components/search-bar/search-bar.component.scss
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+@use '../../../common.scss' as common;
+
+$search-input-border-color: mat.m2-get-color-from-palette(
+  mat.$m2-gray-palette,
+  400
+);
+
+:host {
+  display: contents;
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  .search-input {
+    height: 20px;
+    border: 1px solid $search-input-border-color;
+    border-radius: 4px;
+    padding: 0 4px;
+    font-size: 12px;
+    outline: none;
+  }
+
+  .match-count {
+    font-size: 12px;
+  }
+
+  .search-button {
+    $button-size: 20px;
+    @include mat.icon-button-overrides(
+      (
+        state-layer-size: $button-size,
+        touch-target-size: $button-size,
+        icon-color: mat.m2-get-color-from-palette(mat.$m2-indigo-palette, 500),
+      )
+    );
+
+    mat-icon {
+      @include common.adjust-mat-icon-size(14px);
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+}

--- a/web/src/app/shared/components/search-bar/search-bar.component.spec.ts
+++ b/web/src/app/shared/components/search-bar/search-bar.component.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SearchBarComponent } from 'src/app/shared/components/search-bar/search-bar.component';
+import { By } from '@angular/platform-browser';
+
+describe('SearchBarComponent', () => {
+  let component: SearchBarComponent;
+  let fixture: ComponentFixture<SearchBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchBarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit queryChange on input', () => {
+    let emittedQuery = '';
+    component.queryChange.subscribe((q) => {
+      emittedQuery = q;
+    });
+
+    const inputEl = fixture.debugElement.query(By.css('.search-input'))
+      .nativeElement as HTMLInputElement;
+    inputEl.value = 'test';
+    inputEl.dispatchEvent(new Event('input'));
+
+    expect(emittedQuery).toBe('test');
+  });
+
+  it('should display No matches when query is non-empty and matchCount is 0', () => {
+    fixture.componentRef.setInput('query', 'test');
+    fixture.componentRef.setInput('matchCount', 0);
+    fixture.detectChanges();
+
+    const countSpan = fixture.debugElement.query(By.css('.match-count'))
+      .nativeElement as HTMLElement;
+    expect(countSpan.textContent?.trim()).toBe('No matches');
+  });
+});

--- a/web/src/app/shared/components/search-bar/search-bar.component.ts
+++ b/web/src/app/shared/components/search-bar/search-bar.component.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Component,
+  computed,
+  ElementRef,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
+import { MatButtonModule } from '@angular/material/button';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+
+/**
+ * Component responsible for rendering a search input bar with match counts and navigation controls.
+ */
+@Component({
+  selector: 'khi-search-bar',
+  templateUrl: './search-bar.component.html',
+  styleUrls: ['./search-bar.component.scss'],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatTooltip,
+    MatButtonModule,
+    KHIIconRegistrationModule,
+  ],
+})
+export class SearchBarComponent {
+  /**
+   * The current search query string.
+   */
+  public query = input<string>('');
+
+  /**
+   * The total number of matches found.
+   */
+  public matchCount = input<number>(0);
+
+  /**
+   * The 1-based index of the currently active match.
+   */
+  public currentMatchIndex = input<number>(0);
+
+  /**
+   * Computed string label representing the current match count or no matches state.
+   */
+  public readonly matchLabel = computed(() => {
+    const count = this.matchCount();
+    if (count > 0) {
+      return `${this.currentMatchIndex()} / ${count}`;
+    }
+    if (this.query()) {
+      return 'No matches';
+    }
+    return '0 / 0';
+  });
+
+  /**
+   * Emitted when the search query string is updated.
+   */
+  public queryChange = output<string>();
+
+  /**
+   * Emitted when the next match navigation is triggered.
+   */
+  public nextMatch = output<void>();
+
+  /**
+   * Emitted when the previous match navigation is triggered.
+   */
+  public prevMatch = output<void>();
+
+  /**
+   * Emitted when the search bar close button is clicked.
+   */
+  public closeSearch = output<void>();
+
+  /**
+   * Reference to the search input element for focus management.
+   */
+  public readonly searchInput =
+    viewChild<ElementRef<HTMLInputElement>>('searchInput');
+
+  /**
+   * Emits the updated query string when the input field value changes.
+   * @param query The new search query string.
+   */
+  onInput(query: string) {
+    this.queryChange.emit(query);
+  }
+
+  /**
+   * Focuses on the search input element.
+   */
+  focus() {
+    this.searchInput()?.nativeElement.focus();
+  }
+}

--- a/web/src/app/shared/components/search-bar/search-bar.stories.ts
+++ b/web/src/app/shared/components/search-bar/search-bar.stories.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryObj } from '@storybook/angular';
+import { SearchBarComponent } from 'src/app/shared/components/search-bar/search-bar.component';
+
+export default {
+  title: 'shared/SearchBar',
+  component: SearchBarComponent,
+} as Meta<SearchBarComponent>;
+
+type Story = StoryObj<SearchBarComponent>;
+
+export const Default: Story = {
+  args: {
+    query: '',
+    matchCount: 0,
+    currentMatchIndex: 0,
+  },
+};
+
+export const WithMatches: Story = {
+  args: {
+    query: 'error',
+    matchCount: 5,
+    currentMatchIndex: 2,
+  },
+};
+
+export const NoMatches: Story = {
+  args: {
+    query: 'notfound',
+    matchCount: 0,
+    currentMatchIndex: 0,
+  },
+};

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.component.html
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.component.html
@@ -39,6 +39,7 @@
             (focused)="onTimelineCelFocus()"
           ></khi-timeline-cel-input>
           <khi-timeline-cel-input
+            #logCelInput
             [errorMessage]="logCelError()"
             tooltip="Log CEL"
             icon="notes"

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.component.ts
@@ -20,17 +20,17 @@ import {
   input,
   model,
   output,
-  inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { CelInputComponent } from 'src/app/timeline-toolbar/components/cel-input.component';
 import { ToolbarSettingsComponent } from 'src/app/timeline-toolbar/components/toolbar-settings.component';
+import { SearchScope } from 'src/app/services/view-state.service';
 import {
   CelGuidePopupComponent,
   CelGuideTab,
@@ -58,6 +58,11 @@ export class ToolbarAdvancedComponent {
   protected readonly CelGuideTab = CelGuideTab;
 
   /**
+   * Reference to the Log CEL input component for search focus management.
+   */
+  public readonly logCelInput = viewChild<CelInputComponent>('logCelInput');
+
+  /**
    * Custom positions for the CDK overlay to align the popup top-center with the help button bottom-center.
    */
   protected readonly overlayPositions = [
@@ -68,8 +73,6 @@ export class ToolbarAdvancedComponent {
       overlayY: 'top' as const,
     },
   ];
-
-  private readonly snackbar = inject(MatSnackBar);
 
   /**
    * Signal managing the open/closed state of the help guide popover.
@@ -95,6 +98,11 @@ export class ToolbarAdvancedComponent {
    * Specifies whether a log or timeline is currently not selected.
    */
   readonly logOrTimelineNotSelected = input(true);
+
+  /**
+   * Holds the current active search scope.
+   */
+  readonly activeSearchScope = input<SearchScope>(SearchScope.Global);
 
   /**
    * Validation error message for the timeline CEL filter.
@@ -140,19 +148,6 @@ export class ToolbarAdvancedComponent {
   }
 
   /**
-   * Intercepts standard browser search shortcut to notify users about virtual rendering limitations.
-   */
-  @HostListener('window:keydown', ['$event'])
-  protected interceptBrowserSearch(event: KeyboardEvent): void {
-    if (event.key === 'f' && (event.ctrlKey || event.metaKey)) {
-      this.snackbar.open(
-        'In-browser search may not work on KHI because elements outside the visible area are not rendered. Please use the search text field on the toolbar instead.',
-        'OK',
-      );
-    }
-  }
-
-  /**
    * Switches the CEL guide popup active tab to Timeline CEL when focused if the guide popup is currently open.
    */
   public onTimelineCelFocus(): void {
@@ -167,6 +162,23 @@ export class ToolbarAdvancedComponent {
   public onLogCelFocus(): void {
     if (this.helpPopupOpen()) {
       this.helpActiveTab.set(CelGuideTab.LogCel);
+    }
+  }
+
+  /**
+   * Intercepts Ctrl+F or Cmd+F to focus the Log CEL input when KHI log or diff search is not active.
+   * @param event The keyboard event.
+   */
+  @HostListener('window:keydown', ['$event'])
+  public onKeyDown(event: KeyboardEvent): void {
+    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (this.activeSearchScope() === SearchScope.Global) {
+        event.preventDefault();
+        this.logCelInput()?.focus();
+      }
     }
   }
 }

--- a/web/src/app/timeline-toolbar/components/toolbar-frame.component.html
+++ b/web/src/app/timeline-toolbar/components/toolbar-frame.component.html
@@ -29,6 +29,7 @@ limitations under the License.
     (logCelFilterChange)="logCelFilterChange.emit($event)"
     [timelineCelError]="timelineCelError()"
     [logCelError]="logCelError()"
+    [activeSearchScope]="activeSearchScope()"
     (drawDiagram)="drawDiagram.emit()"
     (switchToStandard)="isAdvancedMode.set(false)"
   ></khi-timeline-toolbar-advanced>
@@ -45,6 +46,7 @@ limitations under the License.
     [timezoneShift]="timezoneShift()"
     (timezoneShiftChange)="timezoneShiftChange.emit($event)"
     [logOrTimelineNotSelected]="logOrTimelineNotSelected()"
+    [activeSearchScope]="activeSearchScope()"
     (drawDiagram)="drawDiagram.emit()"
     (switchToAdvanced)="isAdvancedMode.set(true)"
   ></khi-timeline-toolbar>

--- a/web/src/app/timeline-toolbar/components/toolbar-frame.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-frame.component.ts
@@ -19,6 +19,7 @@ import { CommonModule } from '@angular/common';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { TimelineFilterConfig } from 'src/app/timeline-toolbar/types/filter-config';
 import { TimelineType } from 'src/app/store/domain/style';
+import { SearchScope } from 'src/app/services/view-state.service';
 import { ToolbarComponent } from './toolbar.component';
 import { ToolbarAdvancedComponent } from './toolbar-advanced.component';
 
@@ -40,6 +41,9 @@ import { ToolbarAdvancedComponent } from './toolbar-advanced.component';
 export class ToolbarFrameComponent {
   /** Two-way model binding managing the advanced display mode state. */
   readonly isAdvancedMode = model.required<boolean>();
+
+  /** Holds the current active search scope. */
+  readonly activeSearchScope = input.required<SearchScope>();
 
   // Shared parameters
   /** Flag indicating if the app is currently filtering timelines/logs. */

--- a/web/src/app/timeline-toolbar/components/toolbar.component.html
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.html
@@ -95,6 +95,7 @@ limitations under the License.
             <mat-icon matPrefix class="search-prefix-icon">search</mat-icon>
             <mat-label>Search Logs</mat-label>
             <input
+              #logSearchInput
               matInput
               placeholder="Search in log body..."
               [value]="logSearchQuery()"

--- a/web/src/app/timeline-toolbar/components/toolbar.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.ts
@@ -17,10 +17,11 @@
 import {
   Component,
   HostListener,
+  viewChild,
+  ElementRef,
   input,
   model,
   output,
-  inject,
   signal,
   computed,
 } from '@angular/core';
@@ -30,12 +31,12 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSelectModule } from '@angular/material/select';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
 import { TimelineFilterBuilderComponent } from './timeline-filter-builder.component';
+import { SearchScope } from 'src/app/services/view-state.service';
 import { TimelineFilterConfig } from '../types/filter-config';
 import { TimelineType } from 'src/app/store/domain/style';
 import { RendererConvertUtil } from 'src/app/timeline/components/canvas/convertutil';
@@ -74,7 +75,11 @@ export enum ToolbarPopupStatus {
   ],
 })
 export class ToolbarComponent {
-  private readonly snackbar = inject(MatSnackBar);
+  /**
+   * Reference to the Log Search input element for search focus management.
+   */
+  public readonly logSearchInput =
+    viewChild<ElementRef<HTMLInputElement>>('logSearchInput');
 
   // Inputs (Signals)
   readonly showButtonLabel = input(false);
@@ -89,6 +94,11 @@ export class ToolbarComponent {
   readonly nameFilter = model('');
   readonly selectedSeverity = model<string>('ANY');
   readonly logSearchQuery = model<string>('');
+
+  /**
+   * Holds the current active search scope.
+   */
+  readonly activeSearchScope = input<SearchScope>(SearchScope.Global);
 
   // Timeline Filters (Dumb state)
   readonly timelineFilters = model<TimelineFilterConfig[]>([]);
@@ -287,13 +297,20 @@ export class ToolbarComponent {
     }
   }
 
+  /**
+   * Intercepts Ctrl+F or Cmd+F to focus the Log Search input when KHI log or diff search is not active.
+   * @param event The keyboard event.
+   */
   @HostListener('window:keydown', ['$event'])
-  protected interceptBrowserSearch(event: KeyboardEvent) {
-    if (event.key === 'f' && (event.ctrlKey || event.metaKey)) {
-      this.snackbar.open(
-        'In-browser search may not work on KHI because elements outside the visible area are not rendered. Please use the search text field on the toolbar instead.',
-        'OK',
-      );
+  public onKeyDown(event: KeyboardEvent): void {
+    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (this.activeSearchScope() === SearchScope.Global) {
+        event.preventDefault();
+        this.logSearchInput()?.nativeElement.focus();
+      }
     }
   }
 }

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.html
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.html
@@ -36,6 +36,7 @@ limitations under the License.
   [logCelFilter]="logCelFilter()"
   [timelineCelError]="timelineCelError()"
   [logCelError]="logCelError()"
+  [activeSearchScope]="activeSearchScope()"
   (timezoneShiftChange)="onTimezoneshiftCommit($event)"
   (drawDiagram)="onDrawDiagram()"
   (timelineCelFilterChange)="onTimelineCelFilterChange($event)"

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
@@ -68,6 +68,10 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
   /** Global display mode state signal managed by ViewStateService. */
   protected readonly isAdvancedMode = this.viewStateService.isAdvancedMode;
 
+  /** Signal holding the current active search scope. */
+  protected readonly activeSearchScope =
+    this.viewStateService.activeSearchScope;
+
   /** Signal holding the current timezone shift offset in hours. */
   protected readonly timezoneShift = toSignal(
     this.viewStateService.timezoneShift,


### PR DESCRIPTION
## Overview
This PR introduces fully interactive local content searching inside both the **Log Detail View** (`LogContentComponent`) and **Diff View** (`DiffContentComponent`), supported by robust multi-text-node highlighting. 

## Key Changes

### 1. Robust In-Content Search (Log & Diff Views)
- **Local Search Bar (`<khi-search-bar>`)**: Added interactive search headers to `LogContentComponent` and `DiffContentComponent` with next/prev match navigation, match counts, and escape/close triggers.
- **Cross-Node Substring Highlighting**: Implemented a global character-offset extraction mechanism using `TreeWalker`. This ensures query matches that span across multiple consecutive `Text` nodes or line breaks are accurately detected and wrapped in `<mark>` highlight elements.
- **Automatic Highlighting Restoration**: Safely removes `<mark>` nodes upon clearing or closing search to restore original DOM normalization.

### 2. Search Bar Enhancements (`SearchBarComponent`)
- Added a `No matches` status indicator when a search query is active but yields zero matches.

### 3. Centralized Search Scope & Shortcut Routing (`ViewStateService`)
- **Single Source of Truth**: Introduced `SearchScope` enum (`Global`, `Log`, `Diff`) and `activeSearchScope` signal inside `ViewStateService`.
- **Context-Aware `Ctrl+F` / `Cmd+F` Focus Routing**:
  - When hovering or focusing inside the **Log Content**, opens the Log Content local search bar.
  - When hovering or focusing inside the **Diff Content**, opens the Diff Content local search bar.
  - When in global/outer areas, routes focus directly to the **Standard Log Search input** or the **Advanced Log CEL input**, depending on the active toolbar mode.

## Verification
- Verified local search highlighting and navigation across multi-line logs and unified diffs.
- Verified dynamic shortcut routing behavior across all standard and advanced toolbar modes.
- Passed all linter, formatting (`make format-web`), unit test suites (`make test-web`), and pre-commit checks.
