### PR TITLE
update descriptive messages used on KHI

### DIFF
--- a/.agents/rules/description-rule.md
+++ b/.agents/rules/description-rule.md
@@ -1,0 +1,81 @@
+---
+trigger: glob
+globs:
+  - pkg/task/**/*.go
+  - pkg/model/khifile/v6/style/**/*.go
+---
+
+# KHI Description Standards
+
+When developing or modifying task, inspection, or style definitions in the KHI project, you **must** adhere to the following standards for `description` fields and labels.
+
+## 1. RevisionState
+
+When registering a `RevisionState`, both `label` and `description` must be provided according to their display context:
+
+### Label
+
+- **Display Context**: Rendered as a concise legend item in the UI.
+- **Style**: Short phrase expressing the status clearly (e.g., `Processing operation`, `Component is running`).
+
+### Description
+
+- **Display Context**: Rendered as a tooltip providing deeper context.
+- **Style**: Complete sentence or detailed markdown text (starting with a capital letter and ending with a period). If the description spans multiple lines, use Go raw string literals (``` ` ```) to format multiline text clearly.
+- **Format**: `The [resource/component] [is/has] [state description].`
+- **Example**:
+
+  ```go
+  `The condition is set to **True**.
+
+  **Note**: **True** does not always indicate a healthy state (e.g., Ready=True is healthy, but DiskPressure=True is unhealthy).`
+  ```
+
+## 2. TimelineType Descriptions
+
+- **Grammar Style**: Noun phrase (starting with a capital letter and ending **without** a period).
+- **Role and Format**:
+  - **Grouping Timelines**: If the element purely groups child timelines hierarchically.
+    - **Format**: `Grouping timeline for [category/resource types]`
+    - **Example**: `"Grouping timeline for GKE nodepools"`
+  - **Entity Representation Timelines**: If the timeline represents an abstract or standalone entity as a whole.
+    - **Format**: `Timeline representing [a/an entity]`
+    - **Example**: `"Timeline representing a Multi-Cloud cluster"`
+  - **Lifecycle, State Transitions & Field History Timelines**: If the timeline tracks specific state changes, life cycles, or log events of an entity.
+    - **Format**: Directly describe the tracked states or events (e.g., `Lifecycle states and logs of...`, `Phase transitions of...`).
+    - **Examples**:
+
+      ```go
+      "Lifecycle states and logs of the container"
+      "Phase transitions of the pod (from .status.phase)"
+      ```
+
+- **Intent**: Clearly state the role and entity the timeline represents. Avoid using the word `Container` to describe grouping elements, as it can be confused with Kubernetes containers.
+
+## 3. FeatureTask Descriptions
+
+- **Grammar Style**: Imperative verb phrase (starting with a capitalized base verb such as `Gather`, `Parse`, etc., and ending with a period).
+- **UX Requirements**: To help users decide whether to enable the feature, clearly include:
+  1. **Log Source**: What specific log types are required.
+  2. **Troubleshooting Value**: What operations or issues it helps investigate (e.g., autoscaling decisions, network status).
+  3. **Caveats (If any)**: Any specific prerequisites, configuration needs, or performance impact.
+- **Format**: `Gather [log type] logs to visualize [troubleshooting value]. [Caveats if any].`
+- **Example**:
+
+  ```go
+  "Gather Cluster Autoscaler logs to visualize autoscaling decisions and actions on the timelines of the affected resources."
+  ```
+
+- **Intent**: Help users determine whether the feature is relevant to their current debugging task and what log prerequisites apply.
+
+## 4. InspectionType Descriptions
+
+- **Grammar Style**: Imperative verb phrase (starting with `Gather and parse`, etc., and ending with a period).
+- **Format**: `Gather and parse [product] logs ([supported log types]) to visualize [overall operations] on timelines.`
+- **Example**:
+
+  ```go
+  "Gather and parse Google Kubernetes Engine (GKE) cluster logs (Kubernetes audit, event, node, container, GCE audit, Network, and Cluster Autoscaler logs) to visualize cluster operations on timelines."
+  ```
+
+- **Intent**: Describe the full scope of gathered log sources and the primary visualization goal of the inspection.

--- a/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
@@ -24,149 +24,159 @@ import (
 // when this package is imported.
 var (
 	RevisionStateConditionTrue = style.MustRegisterRevisionState(
-		"State is 'True'",
+		"Condition is True",
 		"lightbulb",
-		"State is 'True'",
+		`The condition is set to **True**.
+
+**Note**: **True** does not always indicate a healthy state (e.g., Ready=True is healthy, but DiskPressure=True is unhealthy).`,
 		style.MustForceConvertSRGBHex("#004400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateConditionFalse = style.MustRegisterRevisionState(
-		"State is 'False'",
+		"Condition is False",
 		"light_off",
-		"State is 'False'",
+		`The condition is set to **False**.
+
+**Note**: **False** does not always indicate an unhealthy state (e.g., DiskPressure=False is healthy, but Ready=False is unhealthy).`,
 		style.MustForceConvertSRGBHex("#EE4400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateConditionUnknown = style.MustRegisterRevisionState(
-		"State is 'Unknown'",
+		"Condition is Unknown",
 		"siren_question",
-		"State is 'Unknown'",
+		"The condition is `Unknown`, meaning its state cannot be determined at this moment.",
 		style.MustForceConvertSRGBHex("#663366"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateConditionNotGiven = style.MustRegisterRevisionState(
-		"Condition is not defined at this moment",
+		"Condition is not defined",
 		"select",
-		"Condition is not defined at this moment",
+		"The condition has not yet been set or reported at this point in the timeline.",
 		style.MustForceConvertSRGBHex("#666666"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStateConditionNoAvailableInfo = style.MustRegisterRevisionState(
-		"No enough information to show condition",
+		"Condition info is unavailable",
 		"unknown_document",
-		"No enough information to show condition",
+		`The condition status is undetermined due to insufficient log information in the selected range.
+
+**Tip**: Consider expanding the query time range to capture complete condition reports.`,
 		style.MustForceConvertSRGBHex("#997700"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateEndpointReady = style.MustRegisterRevisionState(
 		"Endpoint is ready",
 		"heart_check",
-		"Endpoint is ready",
+		"The endpoint is active and ready to receive traffic.",
 		style.MustForceConvertSRGBHex("#004400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateEndpointUnready = style.MustRegisterRevisionState(
 		"Endpoint is not ready",
 		"heart_broken",
-		"Endpoint is not ready",
+		"The endpoint is not ready to receive traffic (e.g., the backing pod is unready).",
 		style.MustForceConvertSRGBHex("#EE4400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateEndpointTerminating = style.MustRegisterRevisionState(
 		"Endpoint is being terminated",
 		"auto_delete",
-		"Endpoint is being terminated",
+		"The endpoint is in the process of being deleted or terminated.",
 		style.MustForceConvertSRGBHex("#cea700"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStatePodPhasePending = style.MustRegisterRevisionState(
 		"Pod is pending",
 		"hourglass_empty",
-		"Pod is pending",
+		"The pod is accepted by the Kubernetes cluster, but one or more containers are not yet running.",
 		style.MustForceConvertSRGBHex("#666666"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStatePodPhaseScheduled = style.MustRegisterRevisionState(
 		"Pod is scheduled",
 		"schedule",
-		"Pod is scheduled",
+		"The pod is scheduled to run on a specific node.",
 		style.MustForceConvertSRGBHex("#4444ff"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStatePodPhaseRunning = style.MustRegisterRevisionState(
 		"Pod is running",
 		"motion_play",
-		"Pod is running",
+		"The pod is running on a node, and at least one container is currently active.",
 		style.MustForceConvertSRGBHex("#004400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStatePodPhaseSucceeded = style.MustRegisterRevisionState(
-		"Pod is succeeded",
+		"Pod has succeeded",
 		"check_circle",
-		"Pod is succeeded",
+		"The pod has succeeded (all containers have terminated successfully and will not be restarted).",
 		style.MustForceConvertSRGBHex("#113333"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStatePodPhaseFailed = style.MustRegisterRevisionState(
-		"Pod is failed",
+		"Pod has failed",
 		"error",
-		"Pod is failed",
+		"The pod has failed (all containers have terminated, and at least one container terminated in failure).",
 		style.MustForceConvertSRGBHex("#331111"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStatePodPhaseUnknown = style.MustRegisterRevisionState(
-		"Pod status is not available from current log range",
+		"Pod status is unavailable",
 		"unknown_document",
-		"Pod status is not available from current log range",
+		`The pod status is undetermined due to missing logs in the selected time range.
+
+**Tip**: Consider expanding the query time range to capture complete pod lifecycle events.`,
 		style.MustForceConvertSRGBHex("#997700"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)
 	RevisionStateContainerWaiting = style.MustRegisterRevisionState(
-		"Waiting for starting container",
+		"Container is waiting",
 		"deployed_code_history",
-		"Waiting for starting container",
+		"The container is waiting to start (e.g., image pull or init container execution is in progress).",
 		style.MustForceConvertSRGBHex("#4444ff"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStateContainerRunningNonReady = style.MustRegisterRevisionState(
 		"Container is not ready",
 		"heart_broken",
-		"Container is not ready",
+		"The container is running but has not passed its readiness probe.",
 		style.MustForceConvertSRGBHex("#EE4400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateContainerRunningReady = style.MustRegisterRevisionState(
 		"Container is ready",
 		"heart_check",
-		"Container is ready",
+		"The container is running and has successfully passed its readiness probe.",
 		style.MustForceConvertSRGBHex("#007700"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateContainerTerminatedWithSuccess = style.MustRegisterRevisionState(
-		"Container exited with healthy exit code",
+		"Container exited successfully",
 		"check_circle",
-		"Container exited with healthy exit code",
+		"The container has terminated successfully with an exit code of `0`.",
 		style.MustForceConvertSRGBHex("#113333"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStateContainerTerminatedWithError = style.MustRegisterRevisionState(
-		"Container exited with erroneous exit code",
+		"Container exited with error",
 		"error",
-		"Container exited with erroneous exit code",
+		"The container has terminated in failure with a non-zero exit code.",
 		style.MustForceConvertSRGBHex("#551111"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStateContainerStatusNotAvailable = style.MustRegisterRevisionState(
-		"Container status is not available",
+		"Container status is unavailable",
 		"unknown_document",
-		"Container status is not available",
+		`The container status is unknown or not yet reported in the log data.
+
+**Tip**: Consider expanding the query time range to capture complete container status events.`,
 		style.MustForceConvertSRGBHex("#666666"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)
 	RevisionStateContainerStarted = style.MustRegisterRevisionState(
-		"Container is started but readiness info is not available",
+		"Container is started, readiness unknown",
 		"siren_question",
-		"Container is started but readiness info is not available",
+		`The container has started, but no readiness probe information has been recorded yet.`,
 		style.MustForceConvertSRGBHex("#997700"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)

--- a/pkg/task/inspection/commonlogk8saudit/contract/styles.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/styles.go
@@ -21,18 +21,20 @@ import (
 
 // RevisionStateK8sResourceExisting is the style for a resource that is existing.
 var RevisionStateK8sResourceExisting = style.MustRegisterRevisionState(
-	"Resource is existing",
+	"Resource exists",
 	"deployed_code",
-	"Resource is existing",
+	`The Kubernetes resource exists and is active.
+
+**Note**: This state indicates existence in the API server; it does not guarantee that the resource is healthy or fully reconciled.`,
 	style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
 	pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 )
 
 // RevisionStateK8sResourceDeleting is the style for a resource that is under deletion with graceful termination period or finalizer.
 var RevisionStateK8sResourceDeleting = style.MustRegisterRevisionState(
-	"Resource is under deletion with graceful termination period or finalizer",
+	"Resource is being deleted",
 	"auto_delete",
-	"Resource is under deletion with graceful termination period or finalizer",
+	"The Kubernetes resource is undergoing deletion (e.g., finalizers are running or in a graceful termination phase).",
 	style.Color{R: 0.8, G: 0.33333334, B: 0.0, A: 1.0},
 	pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 )
@@ -41,7 +43,7 @@ var RevisionStateK8sResourceDeleting = style.MustRegisterRevisionState(
 var RevisionStateK8sResourceIsDeleted = style.MustRegisterRevisionState(
 	"Resource is deleted",
 	"delete_forever",
-	"Resource is deleted",
+	"The Kubernetes resource has been deleted.",
 	style.Color{R: 0.8, G: 0.0, B: 0.0, A: 1.0},
 	pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 )

--- a/pkg/task/inspection/commonlogk8saudit/contract/timeline_type.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/timeline_type.go
@@ -24,7 +24,7 @@ import (
 var (
 	TimelineTypeResourceCondition = style.MustRegisterTimelineType(
 		"condition",
-		"Resource conditions from .status.conditions",
+		"Status conditions of the resource (from .status.conditions)",
 		"conditions",
 		0.6,
 		style.ColorWhite,
@@ -37,7 +37,7 @@ var (
 	)
 	TimelineTypeEndpointSlice = style.MustRegisterTimelineType(
 		"endpoint",
-		"Pod serving status from EndpointSlice",
+		"Pod serving status (from EndpointSlice)",
 		"line_end_diamond",
 		0.6,
 		style.ColorWhite,
@@ -50,7 +50,7 @@ var (
 	)
 	TimelineTypeOwnerReference = style.MustRegisterTimelineType(
 		"owns",
-		"Child resource from .metadata.ownerReferences",
+		"Child resources owned by the resource (from .metadata.ownerReferences)",
 		"link",
 		0.6,
 		style.ColorWhite,
@@ -63,7 +63,7 @@ var (
 	)
 	TimelineTypePodPhase = style.MustRegisterTimelineType(
 		"pod",
-		"Pod status on the node from .status.phase",
+		"Phase transitions of the pod (from .status.phase)",
 		"token",
 		0.6,
 		style.ColorWhite,
@@ -77,7 +77,7 @@ var (
 	// TimelineTypeContainer is the timeline type style for Kubernetes containers.
 	TimelineTypeContainer = style.MustRegisterTimelineType(
 		"container",
-		"Container status and logs",
+		"Lifecycle states and logs of the container",
 		"activity_zone",
 		0.6,
 		style.ColorWhite,

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/revision_state.go
@@ -26,91 +26,91 @@ var (
 	RevisionStateComposerTiScheduled = style.MustRegisterRevisionState(
 		"Task instance is scheduled",
 		"schedule",
-		"Task instance is scheduled",
+		"The Airflow task instance has been scheduled and is waiting to be queued.",
 		style.MustForceConvertSRGBHex("#d1b48c"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiQueued = style.MustRegisterRevisionState(
 		"Task instance is queued",
 		"transition_push",
-		"Task instance is queued",
+		"The Airflow task instance has been queued in the executor and is waiting to run.",
 		style.MustForceConvertSRGBHex("#808080"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiRunning = style.MustRegisterRevisionState(
 		"Task instance is running",
 		"directions_run",
-		"Task instance is running",
+		"The Airflow task instance is currently executing.",
 		style.MustForceConvertSRGBHex("#00ff01"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiDeferred = style.MustRegisterRevisionState(
 		"Task instance is deferred",
 		"pause",
-		"Task instance is deferred",
+		"The Airflow task instance is deferred, waiting for a trigger to resume.",
 		style.MustForceConvertSRGBHex("#9470dc"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiSuccess = style.MustRegisterRevisionState(
-		"Task instance completed with success state",
+		"Task instance succeeded",
 		"check",
-		"Task instance completed with success state",
+		"The Airflow task instance has completed successfully.",
 		style.MustForceConvertSRGBHex("#008001"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiFailed = style.MustRegisterRevisionState(
-		"Task instance completed with erroneous state",
+		"Task instance failed",
 		"exclamation",
-		"Task instance completed with erroneous state",
+		"The Airflow task instance has failed during execution.",
 		style.MustForceConvertSRGBHex("#fe0000"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiUpForRetry = style.MustRegisterRevisionState(
-		"Task instance is waiting for next retry",
+		"Task instance is up for retry",
 		"camping",
-		"Task instance is waiting for next retry",
+		"The Airflow task instance has failed and is waiting to be retried.",
 		style.MustForceConvertSRGBHex("#fed700"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiRestarting = style.MustRegisterRevisionState(
 		"Task instance is restarting",
 		"restart_alt",
-		"Task instance is restarting",
+		"The Airflow task instance is being restarted.",
 		style.MustForceConvertSRGBHex("#ee82ef"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiRemoved = style.MustRegisterRevisionState(
 		"Task instance is removed",
 		"waving_hand",
-		"Task instance is removed",
+		"The Airflow task instance has been removed from the DAG run.",
 		style.MustForceConvertSRGBHex("#d3d3d3"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiUpstreamFailed = style.MustRegisterRevisionState(
-		"Upstream task has failed",
+		"Upstream task failed",
 		"falling",
-		"Upstream task has failed",
+		"The Airflow task instance has been skipped because one of its upstream dependencies failed.",
 		style.MustForceConvertSRGBHex("#ffa11b"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiZombie = style.MustRegisterRevisionState(
 		"Task instance is a zombie",
 		"skull",
-		"Task instance is a zombie",
+		"The Airflow task instance is detected as a zombie (the process died without updating the database state).",
 		style.MustForceConvertSRGBHex("#4b0082"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiUpForReschedule = style.MustRegisterRevisionState(
-		"Task instance is waiting to be rescheduled",
+		"Task instance is up for reschedule",
 		"history",
-		"Task instance is waiting to be rescheduled",
+		"The Airflow task instance is in up_for_reschedule state, waiting for the next sensor poll.",
 		style.MustForceConvertSRGBHex("#808080"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateComposerTiSkipped = style.MustRegisterRevisionState(
 		"Task instance is skipped",
 		"step_over",
-		"Task instance is skipped",
+		"The Airflow task instance has been skipped during execution.",
 		style.MustForceConvertSRGBHex("#e60076"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/timeline_type.go
@@ -27,7 +27,7 @@ var (
 	// Background is set to #377e22.
 	TimelineTypeComposerEnvironment = style.MustRegisterTimelineType(
 		"composer_environment",
-		"Composer Environment",
+		"Timeline representing a Cloud Composer environment",
 		"settings",
 		0.6,
 		style.MustForceConvertSRGBHex("#377e22"),
@@ -43,7 +43,7 @@ var (
 	// Progressive lighter green background #5cb239.
 	TimelineTypeDAGs = style.MustRegisterTimelineType(
 		"dags",
-		"DAGs",
+		"Grouping timeline for Airflow DAGs",
 		"folder",
 		0.6,
 		style.MustForceConvertSRGBHex("#5cb239"),
@@ -59,7 +59,7 @@ var (
 	// Progressive lighter green background #89ca6a.
 	TimelineTypeAirflowDAG = style.MustRegisterTimelineType(
 		"airflow_dag",
-		"Airflow DAG",
+		"Timeline representing an Airflow DAG",
 		"account_tree",
 		0.6,
 		style.MustForceConvertSRGBHex("#89ca6a"),
@@ -75,7 +75,7 @@ var (
 	// Progressive lighter green background #bce3a5.
 	TimelineTypeAirflowDAGRun = style.MustRegisterTimelineType(
 		"airflow_dag_run",
-		"Airflow DAG Run",
+		"Timeline representing an Airflow DAG run",
 		"play_circle",
 		0.6,
 		style.MustForceConvertSRGBHex("#bce3a5"),
@@ -91,7 +91,7 @@ var (
 	// As it contains raw log/revisions, its background is set to White.
 	TimelineTypeAirflowTaskInstance = style.MustRegisterTimelineType(
 		"task",
-		"Airflow Task Instance execution state",
+		"Execution states of the Airflow task instance",
 		"mode_fan",
 		0.6,
 		style.ColorWhite,
@@ -107,7 +107,7 @@ var (
 	// Progressive lighter green background #5cb239.
 	TimelineTypeComponents = style.MustRegisterTimelineType(
 		"airflow_components",
-		"Airflow Components",
+		"Grouping timeline for Airflow backend components",
 		"apps",
 		0.6,
 		style.MustForceConvertSRGBHex("#5cb239"),
@@ -123,7 +123,7 @@ var (
 	// Progressive lighter green background #5cb239.
 	TimelineTypeDAGProcessorManager = style.MustRegisterTimelineType(
 		"dag_processor_manager",
-		"DAG Processor Manager",
+		"Timeline representing the Airflow DAG Processor Manager",
 		"summarize",
 		0.6,
 		style.MustForceConvertSRGBHex("#5cb239"),
@@ -139,7 +139,7 @@ var (
 	// Progressive lighter green background #89ca6a.
 	TimelineTypeDAGFile = style.MustRegisterTimelineType(
 		"dag_file",
-		"DAG File",
+		"Timeline representing an Airflow DAG definition file",
 		"description",
 		0.6,
 		style.MustForceConvertSRGBHex("#89ca6a"),
@@ -155,7 +155,7 @@ var (
 	// As it contains revisions, its background is set to White.
 	TimelineTypeDAGProcessorManagerInstance = style.MustRegisterTimelineType(
 		"dag_processor_manager_instance",
-		"DAG Processor Manager Instance",
+		"Logs of the DAG Processor Manager instance",
 		"terminal",
 		0.6,
 		style.ColorWhite,
@@ -168,10 +168,10 @@ var (
 	)
 
 	// Components specific timelines (Actual log/event containers: White background)
-	TimelineTypeAirflowScheduler           = style.MustRegisterTimelineType("airflow_scheduler", "Airflow Scheduler", "schedule", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#4285F4"), style.ColorWhite, true, 100, style.AlphabeticalSortPolicy())
-	TimelineTypeAirflowWorker              = style.MustRegisterTimelineType("airflow_worker", "Airflow Worker", "directions_run", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#0F9D58"), style.ColorWhite, true, 110, style.AlphabeticalSortPolicy())
-	TimelineTypeAirflowDagProcessorManager = style.MustRegisterTimelineType("airflow_dag_processor_manager", "Airflow DAG Processor Manager", "summarize", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#808080"), style.ColorWhite, true, 115, style.AlphabeticalSortPolicy())
-	TimelineTypeAirflowTriggerer           = style.MustRegisterTimelineType("airflow_triggerer", "Airflow Triggerer", "bolt", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#FFBB00"), style.ColorBlack, true, 120, style.AlphabeticalSortPolicy())
-	TimelineTypeAirflowWebserver           = style.MustRegisterTimelineType("airflow_webserver", "Airflow Webserver", "web", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#9470DC"), style.ColorWhite, true, 130, style.AlphabeticalSortPolicy())
-	TimelineTypeAirflowComponent           = style.MustRegisterTimelineType("airflow_component", "Airflow Component", "extension", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#808080"), style.ColorWhite, true, 140, style.AlphabeticalSortPolicy())
+	TimelineTypeAirflowScheduler           = style.MustRegisterTimelineType("airflow_scheduler", "Logs of the Airflow Scheduler", "schedule", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#4285F4"), style.ColorWhite, true, 100, style.AlphabeticalSortPolicy())
+	TimelineTypeAirflowWorker              = style.MustRegisterTimelineType("airflow_worker", "Logs of the Airflow Worker", "directions_run", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#0F9D58"), style.ColorWhite, true, 110, style.AlphabeticalSortPolicy())
+	TimelineTypeAirflowDagProcessorManager = style.MustRegisterTimelineType("airflow_dag_processor_manager", "Logs of the Airflow DAG Processor Manager", "summarize", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#808080"), style.ColorWhite, true, 115, style.AlphabeticalSortPolicy())
+	TimelineTypeAirflowTriggerer           = style.MustRegisterTimelineType("airflow_triggerer", "Logs of the Airflow Triggerer", "bolt", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#FFBB00"), style.ColorBlack, true, 120, style.AlphabeticalSortPolicy())
+	TimelineTypeAirflowWebserver           = style.MustRegisterTimelineType("airflow_webserver", "Logs of the Airflow Webserver", "web", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#9470DC"), style.ColorWhite, true, 130, style.AlphabeticalSortPolicy())
+	TimelineTypeAirflowComponent           = style.MustRegisterTimelineType("airflow_component", "Logs of the generic Airflow component", "extension", 0.6, style.ColorWhite, style.ColorBlack, style.MustForceConvertSRGBHex("#808080"), style.ColorWhite, true, 140, style.AlphabeticalSortPolicy())
 )

--- a/pkg/task/inspection/googlecloudcommon/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/revision_state.go
@@ -26,14 +26,14 @@ var (
 	RevisionStateOperationStarted = style.MustRegisterRevisionState(
 		"Processing operation",
 		"change_circle",
-		"Processing operation",
+		"The GCP API long-running operation is currently in progress.",
 		style.MustForceConvertSRGBHex("#004400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateOperationFinished = style.MustRegisterRevisionState(
 		"Operation is finished",
 		"check_circle",
-		"Operation is finished",
+		"The GCP API long-running operation has completed.",
 		style.MustForceConvertSRGBHex("#333333"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)

--- a/pkg/task/inspection/googlecloudcommon/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/timeline_type.go
@@ -24,7 +24,7 @@ import (
 var (
 	TimelineTypeGKE = style.MustRegisterTimelineType(
 		"gke",
-		"GKE Control Plane and lifecycle logs",
+		"Control plane operations and lifecycle logs of the GKE cluster",
 		"cloud",
 		1.0,
 		style.Color{R: 0.780, G: 0.863, B: 1.000, A: 1.0},
@@ -80,7 +80,7 @@ var (
 	// TimelineTypeGKENodePool is the style for a GKE node pool.
 	TimelineTypeGKENodePool = style.MustRegisterTimelineType(
 		"nodepool",
-		"GKE Nodepool layer",
+		"Grouping timeline for GKE nodepools",
 		"dns",
 		0.8,
 		style.Color{R: 0.941, G: 0.965, B: 1.000, A: 1.0},
@@ -93,7 +93,7 @@ var (
 	)
 	TimelineTypeOperation = style.MustRegisterTimelineType(
 		"operation",
-		"GCP operations associated with this resource",
+		"Google Cloud operations associated with the resource",
 		"engineering",
 		0.6,
 		style.ColorWhite,
@@ -106,7 +106,7 @@ var (
 	)
 	TimelineTypeGCPProject = style.MustRegisterTimelineType(
 		"project",
-		"A Google Cloud Project.",
+		"Timeline representing a Google Cloud project",
 		"cloud",
 		1.0,
 		style.Color{R: 0.102, G: 0.451, B: 0.910, A: 1.0},
@@ -119,7 +119,7 @@ var (
 	)
 	TimelineTypeGCPResourceType = style.MustRegisterTimelineType(
 		"gcp_resource_type",
-		"GCP Resource Type",
+		"Grouping timeline for Google Cloud resource types",
 		"category",
 		0.6,
 		style.ColorWhite,
@@ -132,7 +132,7 @@ var (
 	)
 	TimelineTypeGCPResource = style.MustRegisterTimelineType(
 		"gcp_resource",
-		"GCP Resource",
+		"Timeline representing a Google Cloud resource",
 		"deployed_code",
 		0.6,
 		style.ColorWhite,

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/contract/revision_state.go
@@ -23,7 +23,7 @@ var (
 	RevisionStateProvisioning = style.MustRegisterRevisionState(
 		"Resource is being provisioned",
 		"deployed_code_history",
-		"Resource is being provisioned",
+		"The GKE API resource is currently being provisioned.",
 		style.MustForceConvertSRGBHex("#6666ff"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/contract/revision_state.go
@@ -26,14 +26,14 @@ var (
 	RevisionAutoscalerNoError = style.MustRegisterRevisionState(
 		"Autoscaler has no error",
 		"heart_check",
-		"Autoscaler has no error",
+		"The GKE Cluster Autoscaler is operating normally without any reported errors.",
 		style.MustForceConvertSRGBHex("#004400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionAutoscalerHasErrors = style.MustRegisterRevisionState(
 		"Autoscaler has errors",
 		"heart_broken",
-		"Autoscaler has errors",
+		"The GKE Cluster Autoscaler has encountered errors preventing normal autoscaling operations.",
 		style.MustForceConvertSRGBHex("#EE4400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/contract/timeline_type.go
@@ -24,7 +24,7 @@ import (
 var (
 	TimelineTypeManagedInstanceGroup = style.MustRegisterTimelineType(
 		"mig",
-		"MIG logs for the parent node pool",
+		"Managed Instance Group (MIG) logs for the nodepool",
 		"host",
 		0.6,
 		style.ColorWhite,
@@ -37,7 +37,7 @@ var (
 	)
 	TimelineTypeAutoscaler = style.MustRegisterTimelineType(
 		"autoscaler",
-		"GKE Cluster Autoscaler",
+		"Logs of the GKE Cluster Autoscaler",
 		"smart_toy",
 		0.6,
 		style.ColorWhite,

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/revision_state.go
@@ -24,51 +24,55 @@ import (
 // when this package is imported.
 var (
 	RevisionStateContainerWaiting = style.MustRegisterRevisionState(
-		"Waiting for starting container",
+		"Container is waiting",
 		"deployed_code_history",
-		"Waiting for starting container",
+		"The container is waiting to start (e.g., image pull or init container execution is in progress).",
 		style.MustForceConvertSRGBHex("#4444ff"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStateContainerRunningNonReady = style.MustRegisterRevisionState(
 		"Container is not ready",
 		"heart_broken",
-		"Container is not ready",
+		"The container is running but has not passed its readiness probe.",
 		style.MustForceConvertSRGBHex("#EE4400"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateContainerRunningReady = style.MustRegisterRevisionState(
 		"Container is ready",
 		"heart_check",
-		"Container is ready",
+		"The container is running and has successfully passed its readiness probe.",
 		style.MustForceConvertSRGBHex("#007700"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 	RevisionStateContainerTerminatedWithSuccess = style.MustRegisterRevisionState(
-		"Container exited with healthy exit code",
+		"Container exited successfully",
 		"check_circle",
-		"Container exited with healthy exit code",
+		"The container has terminated successfully with an exit code of `0`.",
 		style.MustForceConvertSRGBHex("#113333"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStateContainerTerminatedWithError = style.MustRegisterRevisionState(
-		"Container exited with erroneous exit code",
+		"Container exited with error",
 		"error",
-		"Container exited with erroneous exit code",
+		"The container has terminated in failure with a non-zero exit code.",
 		style.MustForceConvertSRGBHex("#551111"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 	RevisionStateContainerStatusNotAvailable = style.MustRegisterRevisionState(
-		"Container status is not available",
+		"Container status is unavailable",
 		"unknown_document",
-		"Container status is not available",
+		`The container status is unknown or not yet reported in the log data.
+
+**Tip**: Consider expanding the query time range to capture complete container status events.`,
 		style.MustForceConvertSRGBHex("#666666"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)
 	RevisionStateContainerStarted = style.MustRegisterRevisionState(
-		"Container is started but readiness info is not available",
+		"Container is started, readiness unknown",
 		"siren_question",
-		"Container is started but readiness info is not available",
+		`The container has started, but no readiness probe information has been recorded yet.
+
+**Tip**: Consider expanding the query time range to observe readiness probe events.`,
 		style.MustForceConvertSRGBHex("#997700"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/timeline_type.go
@@ -24,7 +24,7 @@ import (
 var (
 	TimelineTypeControlPlaneComponent = style.MustRegisterTimelineType(
 		"controlplane",
-		"Control plane component of the cluster",
+		"Timeline representing control plane components of the cluster",
 		"crown",
 		0.6,
 		style.ColorWhite,

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/revision_state.go
@@ -24,7 +24,7 @@ var (
 	RevisionStateComponentRunning = style.MustRegisterRevisionState(
 		"Component is running",
 		"check_circle",
-		"Component is running",
+		"The node component (e.g., kubelet, kube-proxy) is running normally.",
 		style.MustForceConvertSRGBHex("#00cc66"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
@@ -33,7 +33,7 @@ var (
 	RevisionStateComponentTerminated = style.MustRegisterRevisionState(
 		"Component is terminated",
 		"cancel",
-		"Component is terminated",
+		"The node component has terminated or stopped.",
 		style.MustForceConvertSRGBHex("#ff3333"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/timeline_type.go
@@ -24,7 +24,7 @@ import (
 var (
 	TimelineTypeNodeComponent = style.MustRegisterTimelineType(
 		"node-component",
-		"Non-containerized component on the node",
+		"Logs of non-containerized system components on the node",
 		"manufacturing",
 		0.6,
 		style.ColorWhite,

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/timeline_type.go
@@ -23,7 +23,7 @@ var (
 	// TimelineTypeMultiCloudCluster is the timeline type style for MultiCloud Cluster resources.
 	TimelineTypeMultiCloudCluster = style.MustRegisterTimelineType(
 		"multicloudCluster",
-		"MultiCloud Cluster",
+		"Timeline representing a Multi-Cloud cluster",
 		"dns",
 		1.0,
 		style.ColorWhite,
@@ -38,7 +38,7 @@ var (
 	// TimelineTypeMultiCloudNodepool is the timeline type style for MultiCloud Nodepool resources.
 	TimelineTypeMultiCloudNodepool = style.MustRegisterTimelineType(
 		"multicloudNodepool",
-		"MultiCloud NodePool",
+		"Timeline representing a Multi-Cloud nodepool",
 		"list",
 		1.0,
 		style.ColorWhite,
@@ -54,7 +54,7 @@ var (
 	RevisionStateProvisioning = style.MustRegisterRevisionState(
 		"Resource is being provisioned",
 		"deployed_code_history",
-		"Resource is being provisioned",
+		"The Multi-Cloud GKE API resource is currently being provisioned.",
 		style.MustForceConvertSRGBHex("#6666ff"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/contract/revision_state.go
@@ -22,54 +22,54 @@ import (
 var (
 	// RevisionStateProvisioning represents the resource provisioning state.
 	RevisionStateProvisioning = style.MustRegisterRevisionState(
-		"Provisioning",
-		"deployed_code_history",
 		"Resource is being provisioned",
+		"deployed_code_history",
+		"The on-prem GKE API resource is currently being provisioned.",
 		style.MustForceConvertSRGBHex("#6666ff"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 
 	// RevisionStateExisting represents the resource existing state.
 	RevisionStateExisting = style.MustRegisterRevisionState(
-		"Existing",
-		"check_circle",
 		"Resource exists",
+		"check_circle",
+		"The on-prem GKE API resource exists and is active.",
 		style.MustForceConvertSRGBHex("#00aa00"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 
 	// RevisionStateDeleting represents the resource deleting state.
 	RevisionStateDeleting = style.MustRegisterRevisionState(
-		"Deleting",
-		"delete_sweep",
 		"Resource is being deleted",
+		"delete_sweep",
+		"The on-prem GKE API resource is in the process of being deleted.",
 		style.MustForceConvertSRGBHex("#ff6666"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 
 	// RevisionStateDeleted represents the resource deleted state.
 	RevisionStateDeleted = style.MustRegisterRevisionState(
-		"Deleted",
-		"cancel",
 		"Resource is deleted",
+		"cancel",
+		"The on-prem GKE API resource has been deleted.",
 		style.MustForceConvertSRGBHex("#aa0000"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
 
 	// RevisionStateOperationStarted represents the operation started state.
 	RevisionStateOperationStarted = style.MustRegisterRevisionState(
-		"OperationStarted",
+		"Processing operation",
 		"play_arrow",
-		"Operation started",
+		"The on-prem GKE API resource is processing a long-running operation.",
 		style.MustForceConvertSRGBHex("#00bb00"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
 
 	// RevisionStateOperationFinished represents the operation finished state.
 	RevisionStateOperationFinished = style.MustRegisterRevisionState(
-		"OperationFinished",
+		"Operation is finished",
 		"stop",
-		"Operation finished",
+		"The on-prem GKE API resource has finished the long-running operation.",
 		style.MustForceConvertSRGBHex("#777777"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/contract/timeline_type.go
@@ -22,7 +22,7 @@ var (
 	// TimelineTypeOnPremCluster is the timeline type style for On-Prem Clusters.
 	TimelineTypeOnPremCluster = style.MustRegisterTimelineType(
 		"onpremCluster",
-		"On-Prem Cluster",
+		"Timeline representing an On-Prem Kubernetes cluster",
 		"dns",
 		0.6,
 		style.ColorWhite,
@@ -37,7 +37,7 @@ var (
 	// TimelineTypeOnPremNodePool is the timeline type style for On-Prem NodePools.
 	TimelineTypeOnPremNodePool = style.MustRegisterTimelineType(
 		"onpremNodePool",
-		"On-Prem NodePool",
+		"Timeline representing an On-Prem nodepool",
 		"workspaces",
 		0.6,
 		style.ColorWhite,

--- a/pkg/task/inspection/inspectioncore/contract/revision_state.go
+++ b/pkg/task/inspection/inspectioncore/contract/revision_state.go
@@ -21,9 +21,11 @@ import (
 
 // RevisionStateInferred is the style for a resource where only incomplete information is available.
 var RevisionStateInferred = style.MustRegisterRevisionState(
-	"Resource may be existing",
+	"Resource may exist",
 	"unknown_document",
-	"Resource may be existing",
+	`The resource is inferred to exist from partial logs, though complete creation logs are not present in the log range.
+
+**Tip**: Consider expanding the query time range to capture complete creation events.`,
 	style.MustForceConvertSRGBHex("#999922"),
 	pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 )

--- a/pkg/task/inspection/inspectioncore/contract/timeline_type.go
+++ b/pkg/task/inspection/inspectioncore/contract/timeline_type.go
@@ -24,7 +24,7 @@ import (
 var (
 	TimelineTypeK8sCluster = style.MustRegisterTimelineType(
 		"k8sCluster",
-		"Kubernetes Cluster layer",
+		"Grouping timeline for Kubernetes clusters",
 		"cloud",
 		0.6,
 		style.MustForceConvertSRGBHex("#111111"),
@@ -37,7 +37,7 @@ var (
 	)
 	TimelineTypeAPIVersion = style.MustRegisterTimelineType(
 		"apiVersion",
-		"Kubernetes API Version layer",
+		"Grouping timeline for Kubernetes API versions",
 		"api",
 		0.6,
 		style.Color{R: 0.165, G: 0.208, B: 0.494, A: 1.0},
@@ -50,7 +50,7 @@ var (
 	)
 	TimelineTypeKind = style.MustRegisterTimelineType(
 		"kind",
-		"Kubernetes API Resource Kind layer",
+		"Grouping timeline for Kubernetes API resource kinds",
 		"workspaces",
 		0.6,
 		style.MustForceConvertSRGBHex("#3949ab"),
@@ -63,7 +63,7 @@ var (
 	)
 	TimelineTypeNamespace = style.MustRegisterTimelineType(
 		"namespace",
-		"Kubernetes Namespace layer",
+		"Grouping timeline for Kubernetes namespaces",
 		"folder",
 		0.6,
 		style.MustForceConvertSRGBHex("#444444"),
@@ -76,7 +76,7 @@ var (
 	)
 	TimelineTypeResource = style.MustRegisterTimelineType(
 		"resource",
-		"General resource lifecycle and logs",
+		"Lifecycle states and logs of the Kubernetes resource",
 		"description",
 		1.0,
 		style.MustForceConvertSRGBHex("#CCCCCC"),
@@ -89,7 +89,7 @@ var (
 	)
 	TimelineTypeSubresource = style.MustRegisterTimelineType(
 		"subresource",
-		"General subresource lifecycle and logs",
+		"Lifecycle states and logs of the Kubernetes subresource",
 		"page_info",
 		0.6,
 		style.ColorWhite,


### PR DESCRIPTION
## Overview
This PR introduces a formal description standard for KHI (`.agents/rules/description-rule.md`) and updates existing `RevisionState` and `TimelineType` definitions across inspection packages to conform to the new guidelines.
## Changes
- **Introduced Description Standards (`.agents/rules/description-rule.md`)**:
  - Documented consistent formatting, grammar, and style rules for `RevisionState`, `TimelineType`, `FeatureTask`, and `InspectionType`.
  - Defined clear structural patterns (e.g., complete sentences ending with a period for `RevisionState` descriptions; noun phrases starting with `"Grouping timeline for..."` or `"Timeline representing a..."` without a period for `TimelineType`).
- **Normalized Existing Definitions (`contract` / `style`)**:
  - Updated labels and descriptions in core and inspection tasks (`commonlogk8saudit`, `googlecloud*`, `inspectioncore`, etc.) to provide clearer tooltip context and legend readability in the UI.