### PR TITLE
bug: fix CSM's access log query was wrong for GDC clusters

### DIFF
--- a/pkg/task/inspection/googlecloudclustergdcbaremetal/impl/gdcvforbaremetalclusternameprefix_task.go
+++ b/pkg/task/inspection/googlecloudclustergdcbaremetal/impl/gdcvforbaremetalclusternameprefix_task.go
@@ -20,10 +20,17 @@ import (
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	googlecloudclustergdcbaremetal_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergdcbaremetal/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 )
 
-// GDCVForBaremetalClusterNamePrefixTask is a task that returns an empty string as the cluster name prefix for GDCV for Baremetal.
-// This task is necessary to satisfy the dependency of the log source profile, but GDCV for Baremetal does not require a prefix.
-var GDCVForBaremetalClusterNamePrefixTask = coretask.NewTask(googlecloudclustergdcbaremetal_contract.ClusterNamePrefixTaskIDForGDCVForBaremetal, []taskid.UntypedTaskReference{}, func(_ context.Context) (string, error) {
-	return "", nil
+// GDCVForBaremetalClusterNamePrefixTask is a task that returns a prefix policy as the cluster name prefix for GDCV for Baremetal.
+// This task applies "baremetalClusters/" prefix only for platform audit and CSM logs.
+var GDCVForBaremetalClusterNamePrefixTask = coretask.NewTask(googlecloudclustergdcbaremetal_contract.ClusterNamePrefixTaskIDForGDCVForBaremetal, []taskid.UntypedTaskReference{}, func(_ context.Context) (googlecloudk8scommon_contract.ClusterPrefixPolicy, error) {
+	return googlecloudk8scommon_contract.ClusterPrefixPolicy{
+		Prefix: "baremetalClusters/",
+		RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+			googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+			googlecloudk8scommon_contract.ClusterNameUsageCSM,
+		},
+	}, nil
 })

--- a/pkg/task/inspection/googlecloudclustergdcvmware/impl/gdcvforvmwareclusternameprefix_task.go
+++ b/pkg/task/inspection/googlecloudclustergdcvmware/impl/gdcvforvmwareclusternameprefix_task.go
@@ -20,10 +20,17 @@ import (
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	googlecloudclustergdcvmware_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergdcvmware/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 )
 
-// GDCVForVMWareClusterNamePrefixTask is a task that returns an empty string as the cluster name prefix for GDCV for VMWare.
-// This task is necessary to satisfy the dependency of the log source profile, but GDCV for VMWare does not require a prefix.
-var GDCVForVMWareClusterNamePrefixTask = coretask.NewTask(googlecloudclustergdcvmware_contract.ClusterNamePrefixTaskIDForGDCVForVMWare, []taskid.UntypedTaskReference{}, func(_ context.Context) (string, error) {
-	return "", nil
+// GDCVForVMWareClusterNamePrefixTask is a task that returns a prefix policy as the cluster name prefix for GDCV for VMWare.
+// This task applies "vmwareClusters/" prefix only for platform audit and CSM logs.
+var GDCVForVMWareClusterNamePrefixTask = coretask.NewTask(googlecloudclustergdcvmware_contract.ClusterNamePrefixTaskIDForGDCVForVMWare, []taskid.UntypedTaskReference{}, func(_ context.Context) (googlecloudk8scommon_contract.ClusterPrefixPolicy, error) {
+	return googlecloudk8scommon_contract.ClusterPrefixPolicy{
+		Prefix: "vmwareClusters/",
+		RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+			googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+			googlecloudk8scommon_contract.ClusterNameUsageCSM,
+		},
+	}, nil
 })

--- a/pkg/task/inspection/googlecloudclustergke/impl/gkeclusternameprefix_task.go
+++ b/pkg/task/inspection/googlecloudclustergke/impl/gkeclusternameprefix_task.go
@@ -20,10 +20,14 @@ import (
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	googlecloudclustergke_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergke/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 )
 
-// GKEClusterNamePrefixTask is a task that returns an empty string as the cluster name prefix for GKE.
+// GKEClusterNamePrefixTask is a task that returns an empty prefix policy as the cluster name prefix for GKE.
 // This task is necessary to satisfy the dependency of the log source profile, but GKE does not require a prefix.
-var GKEClusterNamePrefixTask = coretask.NewTask(googlecloudclustergke_contract.ClusterNamePrefixTaskIDForGKE, []taskid.UntypedTaskReference{}, func(ctx context.Context) (string, error) {
-	return "", nil
+var GKEClusterNamePrefixTask = coretask.NewTask(googlecloudclustergke_contract.ClusterNamePrefixTaskIDForGKE, []taskid.UntypedTaskReference{}, func(ctx context.Context) (googlecloudk8scommon_contract.ClusterPrefixPolicy, error) {
+	return googlecloudk8scommon_contract.ClusterPrefixPolicy{
+		Prefix:         "",
+		RequiredUsages: nil,
+	}, nil
 })

--- a/pkg/task/inspection/googlecloudclustergkeonaws/impl/prefix.go
+++ b/pkg/task/inspection/googlecloudclustergkeonaws/impl/prefix.go
@@ -20,9 +20,18 @@ import (
 	common_task "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	googlecloudclustergkeonaws_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergkeonaws/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 )
 
-// AnthosOnAWSClusterNamePrefixTask is a task that provides the cluster name prefix for GKE on AWS.
-var AnthosOnAWSClusterNamePrefixTask = common_task.NewTask(googlecloudclustergkeonaws_contract.ClusterNamePrefixTaskID, []taskid.UntypedTaskReference{}, func(_ context.Context) (string, error) {
-	return "awsClusters/", nil
+// AnthosOnAWSClusterNamePrefixTask is a task that provides the cluster name prefix policy for GKE on AWS.
+// This task applies "awsClusters/" prefix across all usage layers.
+var AnthosOnAWSClusterNamePrefixTask = common_task.NewTask(googlecloudclustergkeonaws_contract.ClusterNamePrefixTaskID, []taskid.UntypedTaskReference{}, func(_ context.Context) (googlecloudk8scommon_contract.ClusterPrefixPolicy, error) {
+	return googlecloudk8scommon_contract.ClusterPrefixPolicy{
+		Prefix: "awsClusters/",
+		RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+			googlecloudk8scommon_contract.ClusterNameUsageK8sCluster,
+			googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+			googlecloudk8scommon_contract.ClusterNameUsageCSM,
+		},
+	}, nil
 })

--- a/pkg/task/inspection/googlecloudclustergkeonazure/impl/prefix.go
+++ b/pkg/task/inspection/googlecloudclustergkeonazure/impl/prefix.go
@@ -20,9 +20,18 @@ import (
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	googlecloudclustergkeonazure_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergkeonazure/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 )
 
-// AnthosOnAzureClusterNamePrefixTask is a task that provides the cluster name prefix for GKE on Azure.
-var AnthosOnAzureClusterNamePrefixTask = coretask.NewTask(googlecloudclustergkeonazure_contract.ClusterNamePrefixTaskID, []taskid.UntypedTaskReference{}, func(_ context.Context) (string, error) {
-	return "azureClusters/", nil
+// AnthosOnAzureClusterNamePrefixTask is a task that provides the cluster name prefix policy for GKE on Azure.
+// This task applies "azureClusters/" prefix across all usage layers.
+var AnthosOnAzureClusterNamePrefixTask = coretask.NewTask(googlecloudclustergkeonazure_contract.ClusterNamePrefixTaskID, []taskid.UntypedTaskReference{}, func(_ context.Context) (googlecloudk8scommon_contract.ClusterPrefixPolicy, error) {
+	return googlecloudk8scommon_contract.ClusterPrefixPolicy{
+		Prefix: "azureClusters/",
+		RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+			googlecloudk8scommon_contract.ClusterNameUsageK8sCluster,
+			googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+			googlecloudk8scommon_contract.ClusterNameUsageCSM,
+		},
+	}, nil
 })

--- a/pkg/task/inspection/googlecloudk8scommon/contract/cluster.go
+++ b/pkg/task/inspection/googlecloudk8scommon/contract/cluster.go
@@ -16,23 +16,64 @@ package googlecloudk8scommon_contract
 
 import "fmt"
 
+// ClusterNameUsage represents a usage context layer of a cluster name.
+type ClusterNameUsage string
+
+const (
+	// ClusterNameUsageK8sCluster is the usage context for Kubernetes internal common logs.
+	ClusterNameUsageK8sCluster ClusterNameUsage = "k8s_cluster"
+	// ClusterNameUsageK8sPlatformAudit is the usage context for Kubernetes platform management audit logs.
+	ClusterNameUsageK8sPlatformAudit ClusterNameUsage = "k8s_platform_audit"
+	// ClusterNameUsageCSM is the usage context for Cloud Service Mesh logs.
+	ClusterNameUsageCSM ClusterNameUsage = "csm"
+)
+
+// ClusterPrefixPolicy defines a policy to apply a prefix to a cluster name based on the usage context.
+type ClusterPrefixPolicy struct {
+	// Prefix is the single cluster prefix string.
+	Prefix string
+	// RequiredUsages represents the list of usages that require the prefix.
+	RequiredUsages []ClusterNameUsage
+}
+
+// PrefixFor returns the prefix for the given usage context if the usage is listed in RequiredUsages.
+func (c *ClusterPrefixPolicy) PrefixFor(usage ClusterNameUsage) string {
+	for _, u := range c.RequiredUsages {
+		if u == usage {
+			return c.Prefix
+		}
+	}
+	return ""
+}
+
+// Apply applies the prefix to the given cluster name if the usage is listed in RequiredUsages.
+func (c *ClusterPrefixPolicy) Apply(usage ClusterNameUsage, clusterName string) string {
+	return fmt.Sprintf("%s%s", c.PrefixFor(usage), clusterName)
+}
+
 // GoogleCloudClusterIdentity is the tuple identify a cluster in Google Cloud.
 type GoogleCloudClusterIdentity struct {
 	// ProjectID is the project ID of the cluster.
 	ProjectID string
-	// ClusterTypePrefix is an empty string for GKE & GDC, "awsClusters/" for GKE on AWS and "azureClusters/" for GKE on Azure.
-	ClusterTypePrefix string
+	// PrefixPolicy is the prefix policy applied to the cluster name.
+	PrefixPolicy ClusterPrefixPolicy
 	// ClusterName is the name of the cluster.
 	ClusterName string
 	// Location is the location of the cluster.
 	Location string
 }
 
-func (g *GoogleCloudClusterIdentity) NameWithClusterTypePrefix() string {
-	return fmt.Sprintf("%s%s", g.ClusterTypePrefix, g.ClusterName)
+// NameFor returns the cluster name representation for the given usage context.
+func (g *GoogleCloudClusterIdentity) NameFor(usage ClusterNameUsage) string {
+	return g.PrefixPolicy.Apply(usage, g.ClusterName)
+}
+
+// PrefixFor returns the cluster prefix for the given usage context.
+func (g *GoogleCloudClusterIdentity) PrefixFor(usage ClusterNameUsage) string {
+	return g.PrefixPolicy.PrefixFor(usage)
 }
 
 // UniqueDigest returns an unique string for the cluster identity. This can be used as the cache key depending on a cluster.
 func (g *GoogleCloudClusterIdentity) UniqueDigest() string {
-	return fmt.Sprintf("%s|%s|%s|%s", g.ProjectID, g.ClusterTypePrefix, g.ClusterName, g.Location)
+	return fmt.Sprintf("%s|%s|%s|%s", g.ProjectID, g.PrefixPolicy.Prefix, g.ClusterName, g.Location)
 }

--- a/pkg/task/inspection/googlecloudk8scommon/contract/cluster.go
+++ b/pkg/task/inspection/googlecloudk8scommon/contract/cluster.go
@@ -37,7 +37,7 @@ type ClusterPrefixPolicy struct {
 }
 
 // PrefixFor returns the prefix for the given usage context if the usage is listed in RequiredUsages.
-func (c *ClusterPrefixPolicy) PrefixFor(usage ClusterNameUsage) string {
+func (c ClusterPrefixPolicy) PrefixFor(usage ClusterNameUsage) string {
 	for _, u := range c.RequiredUsages {
 		if u == usage {
 			return c.Prefix
@@ -47,7 +47,7 @@ func (c *ClusterPrefixPolicy) PrefixFor(usage ClusterNameUsage) string {
 }
 
 // Apply applies the prefix to the given cluster name if the usage is listed in RequiredUsages.
-func (c *ClusterPrefixPolicy) Apply(usage ClusterNameUsage, clusterName string) string {
+func (c ClusterPrefixPolicy) Apply(usage ClusterNameUsage, clusterName string) string {
 	return fmt.Sprintf("%s%s", c.PrefixFor(usage), clusterName)
 }
 

--- a/pkg/task/inspection/googlecloudk8scommon/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudk8scommon/contract/taskid.go
@@ -49,10 +49,10 @@ var AutocompletePodNamesTaskID = taskid.NewDefaultImplementationID[*inspectionco
 var HeaderSuggestedFileNameTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudCommonK8STaskIDPrefix + "header-suggested-file-name")
 
 // ClusterNamePrefixTaskRef is the task reference ID for generating the cluster name prefix used in query.
-// For GKE, it's just a task to return "" always.
-// For Anthos on AWS, it should return "awsClusters/" because the `resource.labels.cluster_name` field would be `awsClusters/<cluster-name>`
-// For Anthos on Azure, it will be "azureClusters/"
-var ClusterNamePrefixTaskRef = taskid.NewTaskReference[string](GoogleCloudCommonK8STaskIDPrefix + "cluster-name-prefix")
+// For GKE, it's just a task to return empty prefix policy always.
+// For Anthos on AWS, it should return "awsClusters/".
+// For Anthos on Azure, it will be "azureClusters/".
+var ClusterNamePrefixTaskRef = taskid.NewTaskReference[ClusterPrefixPolicy](GoogleCloudCommonK8STaskIDPrefix + "cluster-name-prefix")
 
 // InputClusterNameTaskID is the task ID for the cluster name.
 var InputClusterNameTaskID = taskid.NewDefaultImplementationID[string](GoogleCloudCommonK8STaskIDPrefix + "input-cluster-name")

--- a/pkg/task/inspection/googlecloudk8scommon/impl/autocomplete.go
+++ b/pkg/task/inspection/googlecloudk8scommon/impl/autocomplete.go
@@ -58,7 +58,7 @@ var AutocompleteClusterIdentityTask = inspectiontaskbase.NewCachedTask(googleclo
 	cf := coretask.GetTaskResult(ctx, googlecloudcommon_contract.APIClientFactoryTaskID.Ref())
 	optionInjector := coretask.GetTaskResult(ctx, googlecloudcommon_contract.APIClientCallOptionsInjectorTaskID.Ref())
 
-	currentDigest := fmt.Sprintf("%s-%s-%d-%d", clusterNamePrefix, projectID, startTime.Unix(), endTime.Unix())
+	currentDigest := fmt.Sprintf("%s-%s-%d-%d", clusterNamePrefix.PrefixFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), projectID, startTime.Unix(), endTime.Unix())
 	if currentDigest == prevValue.DependencyDigest {
 		return prevValue, nil
 	}
@@ -91,7 +91,7 @@ var AutocompleteClusterIdentityTask = inspectiontaskbase.NewCachedTask(googleclo
 	if err != nil {
 		errorString = err.Error()
 	}
-	metricsLabels = filterAndTrimPrefixFromClusterNames(metricsLabels, clusterNamePrefix)
+	metricsLabels = filterAndTrimPrefixFromClusterNames(metricsLabels, clusterNamePrefix.PrefixFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster))
 	if hintString == "" && errorString == "" && len(metricsLabels) == 0 {
 		hintString = fmt.Sprintf("No cluster names found between %s and %s. It is highly likely that the time range is incorrect. Please verify the time range, or proceed by manually entering the cluster name.", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
 	}
@@ -99,10 +99,10 @@ var AutocompleteClusterIdentityTask = inspectiontaskbase.NewCachedTask(googleclo
 	identities := make([]googlecloudk8scommon_contract.GoogleCloudClusterIdentity, len(metricsLabels))
 	for i, labels := range metricsLabels {
 		identities[i] = googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:         projectID,
-			ClusterTypePrefix: clusterNamePrefix,
-			ClusterName:       labels["cluster_name"],
-			Location:          labels["location"],
+			ProjectID:    projectID,
+			PrefixPolicy: clusterNamePrefix,
+			ClusterName:  labels["cluster_name"],
+			Location:     labels["location"],
 		}
 	}
 

--- a/pkg/task/inspection/googlecloudk8scommon/impl/clusteridentity.go
+++ b/pkg/task/inspection/googlecloudk8scommon/impl/clusteridentity.go
@@ -34,11 +34,12 @@ var ClusterIdentityTask = inspectiontaskbase.NewInspectionTask(googlecloudk8scom
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
 	clusterName := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref())
 	location := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputLocationsTaskID.Ref())
-	clusterTypePrefix := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterNamePrefixTaskRef)
+	prefixPolicy := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterNamePrefixTaskRef)
 	return googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-		ProjectID:         projectID,
-		ClusterTypePrefix: clusterTypePrefix,
-		ClusterName:       clusterName,
-		Location:          location,
+		ProjectID:    projectID,
+		PrefixPolicy: prefixPolicy,
+		ClusterName:  clusterName,
+		Location:     location,
 	}, nil
+
 })

--- a/pkg/task/inspection/googlecloudk8scommon/impl/inputclustername_task.go
+++ b/pkg/task/inspection/googlecloudk8scommon/impl/inputclustername_task.go
@@ -63,10 +63,11 @@ var InputClusterNameTask = formtask.NewTextFormTaskBuilder(googlecloudk8scommon_
 			return clusters.Hint, inspectionmetadata.Info, nil
 		}
 		for _, suggestedCluster := range clusters.Values {
-			if suggestedCluster.NameWithClusterTypePrefix() == convertedValue.(string) {
+			if suggestedCluster.ClusterName == convertedValue.(string) {
 				return "", inspectionmetadata.Info, nil
 			}
 		}
+
 		availableClusterNameStr := ""
 		for _, cluster := range dedupeClusterName(clusters.Values) {
 			availableClusterNameStr += fmt.Sprintf("* %s\n", cluster)

--- a/pkg/task/inspection/googlecloudk8scommon/impl/inputclustername_task_test.go
+++ b/pkg/task/inspection/googlecloudk8scommon/impl/inputclustername_task_test.go
@@ -23,6 +23,8 @@ import (
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudclustergke_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergke/impl"
+	googlecloudclustergkeonaws_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergkeonaws/impl"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/google/go-cmp/cmp"
@@ -30,7 +32,7 @@ import (
 
 func TestClusterNameInput(t *testing.T) {
 	wantDescription := "The cluster name to gather logs."
-	testClusterNamePrefix := tasktest.StubTaskFromReferenceID(googlecloudk8scommon_contract.ClusterNamePrefixTaskRef, "", nil)
+
 	mockClusterNamesTask1 := tasktest.StubTaskFromReferenceID(googlecloudk8scommon_contract.AutocompleteClusterIdentityTaskID.Ref(), &inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]{
 		Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
 			{
@@ -42,12 +44,40 @@ func TestClusterNameInput(t *testing.T) {
 		},
 		Error: "",
 	}, nil)
+
+	mockAWSClusterNamesTask := tasktest.StubTaskFromReferenceID(googlecloudk8scommon_contract.AutocompleteClusterIdentityTaskID.Ref(), &inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]{
+		Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+			{
+				ClusterName: "foo-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "awsClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sCluster,
+						googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+						googlecloudk8scommon_contract.ClusterNameUsageCSM,
+					},
+				},
+			},
+			{
+				ClusterName: "bar-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "awsClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sCluster,
+						googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+						googlecloudk8scommon_contract.ClusterNameUsageCSM,
+					},
+				},
+			},
+		},
+		Error: "",
+	}, nil)
 	form_task_test.TestTextForms(t, "cluster name", InputClusterNameTask, []*form_task_test.TextFormTestCase{
 		{
-			Name:          "with valid cluster name",
+			Name:          "with valid cluster name under GKE prefix task",
 			Input:         "foo-cluster",
 			ExpectedValue: "foo-cluster",
-			Dependencies:  []coretask.UntypedTask{mockClusterNamesTask1, testClusterNamePrefix},
+			Dependencies:  []coretask.UntypedTask{mockClusterNamesTask1, googlecloudclustergke_impl.GKEClusterNamePrefixTask},
 			ExpectedFormField: inspectionmetadata.TextParameterFormField{
 				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
 					ID:          googlecloudk8scommon_contract.GoogleCloudCommonK8STaskIDPrefix + "input-cluster-name",
@@ -62,10 +92,29 @@ func TestClusterNameInput(t *testing.T) {
 			},
 		},
 		{
+			Name:          "with valid cluster name under AWS prefix task",
+			Input:         "foo-cluster",
+			ExpectedValue: "foo-cluster",
+			Dependencies:  []coretask.UntypedTask{mockAWSClusterNamesTask, googlecloudclustergkeonaws_impl.AnthosOnAWSClusterNamePrefixTask},
+			ExpectedFormField: inspectionmetadata.TextParameterFormField{
+				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
+					ID:          googlecloudk8scommon_contract.GoogleCloudCommonK8STaskIDPrefix + "input-cluster-name",
+					Type:        "Text",
+					Label:       "Cluster name",
+					HintType:    inspectionmetadata.None,
+					Description: wantDescription,
+				},
+				Suggestions:      []string{"foo-cluster", "bar-cluster"},
+				Default:          "foo-cluster",
+				ValidationTiming: inspectionmetadata.Change,
+			},
+		},
+
+		{
 			Name:          "spaces around cluster name must be trimmed",
 			Input:         "  foo-cluster   ",
 			ExpectedValue: "foo-cluster",
-			Dependencies:  []coretask.UntypedTask{mockClusterNamesTask1, testClusterNamePrefix},
+			Dependencies:  []coretask.UntypedTask{mockClusterNamesTask1, googlecloudclustergke_impl.GKEClusterNamePrefixTask},
 			ExpectedFormField: inspectionmetadata.TextParameterFormField{
 				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
 					ID:          googlecloudk8scommon_contract.GoogleCloudCommonK8STaskIDPrefix + "input-cluster-name",
@@ -83,7 +132,7 @@ func TestClusterNameInput(t *testing.T) {
 			Name:          "invalid cluster name",
 			Input:         "An invalid cluster name",
 			ExpectedValue: "foo-cluster",
-			Dependencies:  []coretask.UntypedTask{mockClusterNamesTask1, testClusterNamePrefix},
+			Dependencies:  []coretask.UntypedTask{mockClusterNamesTask1, googlecloudclustergke_impl.GKEClusterNamePrefixTask},
 			ExpectedFormField: inspectionmetadata.TextParameterFormField{
 				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
 					ID:          googlecloudk8scommon_contract.GoogleCloudCommonK8STaskIDPrefix + "input-cluster-name",
@@ -102,7 +151,7 @@ func TestClusterNameInput(t *testing.T) {
 			Name:          "non existing cluster should show a hint",
 			Input:         "nonexisting-cluster",
 			ExpectedValue: "nonexisting-cluster",
-			Dependencies:  []coretask.UntypedTask{mockClusterNamesTask1, testClusterNamePrefix},
+			Dependencies:  []coretask.UntypedTask{mockClusterNamesTask1, googlecloudclustergke_impl.GKEClusterNamePrefixTask},
 			ExpectedFormField: inspectionmetadata.TextParameterFormField{
 				ParameterFormFieldBase: inspectionmetadata.ParameterFormFieldBase{
 					ID:          googlecloudk8scommon_contract.GoogleCloudCommonK8STaskIDPrefix + "input-cluster-name",

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
@@ -38,7 +38,7 @@ func csmAccessLogsFilter(cluster googlecloudk8scommon_contract.GoogleCloudCluste
 %s
 resource.labels.project_id="%s"
 resource.labels.location="%s"
-resource.labels.cluster_name="%s"`, responseFlagsFilterStr, namespaceFilterStr, cluster.ProjectID, cluster.Location, cluster.NameWithClusterTypePrefix())
+resource.labels.cluster_name="%s"`, responseFlagsFilterStr, namespaceFilterStr, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageCSM))
 }
 
 func responseFlagsFilter(responseFlagsFilter *gcpqueryutil.SetFilterParseResult) string {

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task_test.go
@@ -15,10 +15,23 @@
 package googlecloudlogcsm_impl
 
 import (
+	"context"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudclustergdcbaremetal_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergdcbaremetal/impl"
+	googlecloudclustergke_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergke/impl"
+	googlecloudclustergkeonaws_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergkeonaws/impl"
+	googlecloudclustergkeonazure_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergkeonazure/impl"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudk8scommon_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/impl"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCsmAccessLogsFilter(t *testing.T) {
@@ -154,8 +167,84 @@ resource.labels.cluster_name="test-cluster"`,
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			got := csmAccessLogsFilter(tc.cluster, tc.responseFlagsFilter, tc.namespaceFilter)
-			if got != tc.want {
-				t.Errorf("csmAccessLogsFilter() got = %v, want %v", got, tc.want)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("csmAccessLogsFilter() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCSMQueryTaskPrefixResolution(t *testing.T) {
+	testCases := []struct {
+		name       string
+		prefixTask coretask.Task[googlecloudk8scommon_contract.ClusterPrefixPolicy]
+		want       string
+	}{
+		{
+			name:       "GKE side task generates no prefix",
+			prefixTask: googlecloudclustergke_impl.GKEClusterNamePrefixTask,
+			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
+labels.response_flag:("UH")
+resource.labels.namespace_name:("default")
+resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"`,
+		},
+		{
+			name:       "baremetal side task adds prefix",
+			prefixTask: googlecloudclustergdcbaremetal_impl.GDCVForBaremetalClusterNamePrefixTask,
+			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
+labels.response_flag:("UH")
+resource.labels.namespace_name:("default")
+resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="baremetalClusters/test-cluster"`,
+		},
+		{
+			name:       "aws side task adds prefix",
+			prefixTask: googlecloudclustergkeonaws_impl.AnthosOnAWSClusterNamePrefixTask,
+			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
+labels.response_flag:("UH")
+resource.labels.namespace_name:("default")
+resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="awsClusters/test-cluster"`,
+		},
+		{
+			name:       "azure side task adds prefix",
+			prefixTask: googlecloudclustergkeonazure_impl.AnthosOnAzureClusterNamePrefixTask,
+			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
+labels.response_flag:("UH")
+resource.labels.namespace_name:("default")
+resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="azureClusters/test-cluster"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = khictx.WithValue(ctx, inspectioncore_contract.InspectionTaskMode, inspectioncore_contract.TaskModeRun)
+			prefixPolicy, err := tasktest.RunTask(ctx, tc.prefixTask)
+			if err != nil {
+				t.Fatalf("unexpected error running prefix task: %v", err)
+			}
+
+			idRes, err := tasktest.RunTask(ctx, googlecloudk8scommon_impl.ClusterIdentityTask,
+				tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputProjectIdTaskID.Ref(), "test-project"),
+				tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(), "test-cluster"),
+				tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLocationsTaskID.Ref(), "test-location"),
+				tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.ClusterNamePrefixTaskRef, prefixPolicy),
+			)
+			if err != nil {
+				t.Fatalf("unexpected error running cluster identity task: %v", err)
+			}
+
+			got := csmAccessLogsFilter(idRes, &gcpqueryutil.SetFilterParseResult{Additives: []string{"UH"}}, &gcpqueryutil.SetFilterParseResult{Additives: []string{"default"}})
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("csmAccessLogsFilter() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/impl/query.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/impl/query.go
@@ -38,7 +38,7 @@ resource.labels.project_id="%s"
 resource.labels.location="%s"
 resource.labels.cluster_name="%s"
 %s
-logName="projects/%s/logs/container.googleapis.com%%2Fcluster-autoscaler-visibility"`, cluster.ProjectID, cluster.Location, cluster.NameWithClusterTypePrefix(), excludeStatusQueryFragment, cluster.ProjectID)
+logName="projects/%s/logs/container.googleapis.com%%2Fcluster-autoscaler-visibility"`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), excludeStatusQueryFragment, cluster.ProjectID)
 }
 
 type autoscalerListLogEntriesTaskSetting struct{}

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/query.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/query.go
@@ -103,7 +103,7 @@ resource.labels.cluster_name="%s"
 protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
 %s
 %s
-`, cluster.ProjectID, cluster.Location, cluster.NameWithClusterTypePrefix(), generateAuditKindFilter(auditKindFilter), generateK8sAuditNamespaceFilter(namespaceFilter))
+`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateAuditKindFilter(auditKindFilter), generateK8sAuditNamespaceFilter(namespaceFilter))
 }
 
 // generateAuditKindFilter creates a log filter snippet for Kubernetes resource kinds

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task.go
@@ -37,7 +37,7 @@ resource.labels.project_id="%s"
 resource.labels.location="%s"
 resource.labels.cluster_name="%s"
 %s
-%s`, cluster.ProjectID, cluster.Location, cluster.NameWithClusterTypePrefix(), generateNamespacesFilter(namespacesFilter), generatePodNamesFilter(podNamesFilter))
+%s`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateNamespacesFilter(namespacesFilter), generatePodNamesFilter(podNamesFilter))
 }
 
 func generateNamespacesFilter(namespacesFilter *gcpqueryutil.SetFilterParseResult) string {

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task.go
@@ -36,7 +36,7 @@ resource.labels.project_id="%s"
 resource.labels.location="%s"
 resource.labels.cluster_name="%s"
 -sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
-%s`, cluster.ProjectID, cluster.Location, cluster.NameWithClusterTypePrefix(), generateK8sControlPlaneComponentFilter(controlplaneComponentFilter))
+%s`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateK8sControlPlaneComponentFilter(controlplaneComponentFilter))
 }
 
 func generateK8sControlPlaneComponentFilter(filter *gcpqueryutil.SetFilterParseResult) string {

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/query_task.go
@@ -37,7 +37,7 @@ func GenerateK8sEventQuery(cluster googlecloudk8scommon_contract.GoogleCloudClus
 resource.labels.project_id="%s"
 resource.labels.location="%s"
 resource.labels.cluster_name="%s"
-%s`, cluster.ProjectID, cluster.Location, cluster.NameWithClusterTypePrefix(), generateK8sEventNamespaceFilter(namespaceFilter))
+%s`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateK8sEventNamespaceFilter(namespaceFilter))
 }
 
 func generateK8sEventNamespaceFilter(filter *gcpqueryutil.SetFilterParseResult) string {

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/query_task.go
@@ -38,7 +38,7 @@ resource.labels.location="%s"
 resource.labels.cluster_name="%s"
 -log_id("events") -- ignore node related events because it's captured in k8s event log parsers
 %s
-`, cluster.ProjectID, cluster.Location, cluster.NameWithClusterTypePrefix(), generateNodeNameSubstringLogFilter(nodeNameSubstrings))
+`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateNodeNameSubstringLogFilter(nodeNameSubstrings))
 }
 
 func generateNodeNameSubstringLogFilter(nodeNameSubstrings []string) string {

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/query_task.go
@@ -37,7 +37,7 @@ resource.labels.service="gkemulticloud.googleapis.com"
 resource.labels.method:("Update" OR "Create" OR "Delete")
 protoPayload.resourceName:"projects/%s/locations/%s/"
 protoPayload.resourceName:"%s"
-`, clusterIdentity.ProjectID, clusterIdentity.Location, clusterIdentity.NameWithClusterTypePrefix())
+`, clusterIdentity.ProjectID, clusterIdentity.Location, clusterIdentity.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit))
 }
 
 type multicloudAPIListLogEntriesTaskSetting struct {
@@ -62,10 +62,15 @@ func (g *multicloudAPIListLogEntriesTaskSetting) Description() *googlecloudcommo
 		DefaultLogType: enum.LogTypeMulticloudAPI,
 		QueryName:      "Multicloud API Logs",
 		ExampleQuery: generateQuery(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:         "example-project-id",
-			Location:          "example-location",
-			ClusterName:       "example-cluster-name",
-			ClusterTypePrefix: "awsClusters/",
+			ProjectID:   "example-project-id",
+			Location:    "example-location",
+			ClusterName: "example-cluster-name",
+			PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+				Prefix: "awsClusters/",
+				RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+					googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+				},
+			},
 		}),
 	}
 }

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/query_task_test.go
@@ -31,10 +31,15 @@ func TestGenerateMultiCloudAPIQuery(t *testing.T) {
 		{
 			name: "standard input",
 			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:         "test-project",
-				ClusterName:       "test-cluster",
-				ClusterTypePrefix: "awsClusters/",
-				Location:          "asia-northeast1",
+				ProjectID:   "test-project",
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "awsClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+					},
+				},
+				Location: "asia-northeast1",
 			},
 			want: `
 log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access")
@@ -65,10 +70,15 @@ func TestGenerateMultiCloudAPIQueryIsValid(t *testing.T) {
 		{
 			name: "Valid Query",
 			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:         "test-project",
-				ClusterName:       "test-cluster",
-				ClusterTypePrefix: "awsClusters/",
-				Location:          "asia-northeast1",
+				ProjectID:   "test-project",
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "awsClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+					},
+				},
+				Location: "asia-northeast1",
 			},
 		},
 	}

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task.go
@@ -36,7 +36,7 @@ resource.labels.service="gkeonprem.googleapis.com"
 resource.labels.method:("Update" OR "Create" OR "Delete" OR "Enroll" OR "Unenroll")
 protoPayload.resourceName:"projects/%s/locations/%s/"
 protoPayload.resourceName:"%s"
-`, clusterIdentiy.ProjectID, clusterIdentiy.Location, clusterIdentiy.NameWithClusterTypePrefix())
+`, clusterIdentiy.ProjectID, clusterIdentiy.Location, clusterIdentiy.ClusterName)
 }
 
 type onpremAPIListLogEntriesTaskSetting struct {

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task_test.go
@@ -47,7 +47,7 @@ resource.type="audited_resource"
 resource.labels.service="gkeonprem.googleapis.com"
 resource.labels.method:("Update" OR "Create" OR "Delete" OR "Enroll" OR "Unenroll")
 protoPayload.resourceName:"projects/test-project/locations/asia-northeast1/"
-protoPayload.resourceName:"baremetalClusters/test-cluster"
+protoPayload.resourceName:"test-cluster"
 `,
 		},
 	}

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task_test.go
@@ -31,10 +31,15 @@ func TestGenerateOnPremAPIQuery(t *testing.T) {
 		{
 			name: "BaremetalCluster",
 			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:         "test-project",
-				ClusterName:       "test-cluster",
-				ClusterTypePrefix: "baremetalClusters/",
-				Location:          "asia-northeast1",
+				ProjectID:   "test-project",
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "baremetalClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+					},
+				},
+				Location: "asia-northeast1",
 			},
 			want: `
 log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access")
@@ -65,10 +70,15 @@ func TestGenerateOnPremAPIQueryIsValid(t *testing.T) {
 		{
 			name: "Valid Query",
 			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:         "test-project",
-				ClusterName:       "test-cluster",
-				ClusterTypePrefix: "baremetalClusters/",
-				Location:          "asia-northeast1",
+				ProjectID:   "test-project",
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "baremetalClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+					},
+				},
+				Location: "asia-northeast1",
 			},
 		},
 	}


### PR DESCRIPTION
`cluster_name` field used in `resource.labels` can contain its prefix depending on log types.
`resource_type=("k8s_event" OR "k8s_pod" OR "k8s_container" OR "k8s_control_plane_component")` omits cluster prefix in GDC baremetal and vmware clusters, however, GKE multicloud clusters contains `awsClusters/` or `azureClusters/` in its property.

Thus KHI has hold ClusterNamePrefix apart from its ClusterName. But now we found the other type of combinations.
In CSM access logs, GDC cluster logs contains `baremetalClusters/` or `vmwareClusters/` in its prefix and GKE multicloud also contain its prefix in the cluster name.
To support this various combination of using prefix or not using prefix, I extended the ClusterIdentity type to return a valid cluster name for each cluster types appopriately.
