### PR TITLE
fix composer parsers to use GCPMainMessageFieldSet because log.MainMessageFieldSet is no longer used by default

### DIFF
--- a/pkg/model/log/common_field_set.go
+++ b/pkg/model/log/common_field_set.go
@@ -30,18 +30,3 @@ func (c *CommonFieldSet) Kind() string {
 }
 
 var _ FieldSet = (*CommonFieldSet)(nil)
-
-// MainMessageFieldSet is an abstract FieldSet struct type to get the main message of its log.
-// This would be read from `textPayload`, `protoPayload` or `jsonPayload` when it is read from Cloud Logging.
-//
-// Deprecated: Define custom FieldSet and FieldSetReader instead.
-type MainMessageFieldSet struct {
-	MainMessage string
-}
-
-// Kind implements FieldSet.
-func (d *MainMessageFieldSet) Kind() string {
-	return "main_message"
-}
-
-var _ FieldSet = (*MainMessageFieldSet)(nil)

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
@@ -104,7 +105,7 @@ func (i *dagProcessorManagerLogIngester) ProcessLogByGroup(ctx context.Context, 
 	cs.SetSeverity(inspectioncore_contract.SeverityUnknown)
 	cs.SetSummary("")
 
-	mainMessage, err := log.GetFieldSet(l, &log.MainMessageFieldSet{})
+	mainMessage, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPMainMessageFieldSet{})
 	if err != nil {
 		return cs, prevGroupData, nil
 	}
@@ -183,7 +184,7 @@ func (m *dagProcessorManagerTimelineMapper) ProcessLogByGroup(ctx context.Contex
 	envPath := googlecloudclustercomposer_contract.MustComposerEnvironmentTimeline(ctx, clusterIdentity.ProjectID, environmentName)
 
 	commonField, _ := log.GetFieldSet(l, &log.CommonFieldSet{})
-	mainMessage, err := log.GetFieldSet(l, &log.MainMessageFieldSet{})
+	mainMessage, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPMainMessageFieldSet{})
 	if err != nil {
 		return nil, prevGroupData, nil
 	}

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper_test.go
@@ -29,6 +29,7 @@ import (
 	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
@@ -44,19 +45,19 @@ func TestDagProcessorMapperTask_ProcessLogByGroup(t *testing.T) {
 	logsCase1 := []*log.Log{
 		log.NewLogWithFieldSetsForTest(
 			&log.CommonFieldSet{Timestamp: timestamp2},
-			&log.MainMessageFieldSet{MainMessage: "DAG_PROCESSOR_MANAGER_LOG: =========== DAG File Processing Stats ============"},
+			&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "DAG_PROCESSOR_MANAGER_LOG: =========== DAG File Processing Stats ============"},
 		),
 		log.NewLogWithFieldSetsForTest(
 			&log.CommonFieldSet{Timestamp: timestamp3},
-			&log.MainMessageFieldSet{MainMessage: "DAG_PROCESSOR_MANAGER_LOG: File Path                                           PID    Runtime      # DAGs    # Errors  Last Runtime    Last Run"},
+			&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "DAG_PROCESSOR_MANAGER_LOG: File Path                                           PID    Runtime      # DAGs    # Errors  Last Runtime    Last Run"},
 		),
 		log.NewLogWithFieldSetsForTest(
 			&log.CommonFieldSet{Timestamp: timestamp4},
-			&log.MainMessageFieldSet{MainMessage: "DAG_PROCESSOR_MANAGER_LOG: --------------------------------------------------  -----  ---------  --------  ----------  --------------  -------------------"},
+			&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "DAG_PROCESSOR_MANAGER_LOG: --------------------------------------------------  -----  ---------  --------  ----------  --------------  -------------------"},
 		),
 		log.NewLogWithFieldSetsForTest(
 			&log.CommonFieldSet{Timestamp: timestamp5},
-			&log.MainMessageFieldSet{MainMessage: "DAG_PROCESSOR_MANAGER_LOG: /home/airflow/gcs/dags/airflow_monitoring.py                                 1           0  0.36s           2026-03-08T04:49:37"},
+			&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "DAG_PROCESSOR_MANAGER_LOG: /home/airflow/gcs/dags/airflow_monitoring.py                                 1           0  0.36s           2026-03-08T04:49:37"},
 		),
 	}
 
@@ -192,7 +193,7 @@ func TestDagProcessorLogIngester_ProcessLog(t *testing.T) {
 			for _, msg := range tc.messages {
 				inputLog := log.NewLogWithFieldSetsForTest(
 					&log.CommonFieldSet{Timestamp: timestamp},
-					&log.MainMessageFieldSet{MainMessage: msg},
+					&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: msg},
 				)
 				cs, nextState, err := ingester.ProcessLogByGroup(context.Background(), inputLog, state)
 				if err != nil {

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/other.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/other.go
@@ -23,6 +23,7 @@ import (
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
@@ -73,7 +74,7 @@ func (i *otherLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifile
 		cs.SetSeverity(inspectioncore_contract.SeverityUnknown)
 	}
 
-	if messageFS, err := log.GetFieldSet(l, &log.MainMessageFieldSet{}); err == nil {
+	if messageFS, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPMainMessageFieldSet{}); err == nil {
 		cs.SetSummary(messageFS.MainMessage)
 	}
 

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler.go
@@ -24,6 +24,7 @@ import (
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
@@ -68,7 +69,7 @@ func (i *schedulerLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khi
 		cs.SetSeverity(inspectioncore_contract.SeverityUnknown)
 	}
 
-	if messageFS, err := log.GetFieldSet(l, &log.MainMessageFieldSet{}); err == nil {
+	if messageFS, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPMainMessageFieldSet{}); err == nil {
 		cs.SetSummary(messageFS.MainMessage)
 	}
 

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
@@ -45,7 +46,7 @@ func TestAirflowSchedulerMapperTask_ProcessLogByGroup(t *testing.T) {
 			name: "Scheduler basic identification and TaskInstance extraction",
 			input: log.NewLogWithFieldSetsForTest(
 				&log.CommonFieldSet{Timestamp: timestamp},
-				&log.MainMessageFieldSet{MainMessage: "Processing /app/models.py"},
+				&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "Processing /app/models.py"},
 				&googlecloudclustercomposer_contract.ComposerFieldSet{
 					SchedulerID: "airflow-scheduler-7b5f",
 				},
@@ -84,7 +85,7 @@ func TestAirflowSchedulerMapperTask_ProcessLogByGroup(t *testing.T) {
 			name: "Zombie task adds event to worker",
 			input: log.NewLogWithFieldSetsForTest(
 				&log.CommonFieldSet{Timestamp: timestamp},
-				&log.MainMessageFieldSet{MainMessage: "Detected zombie task"},
+				&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "Detected zombie task"},
 				&googlecloudclustercomposer_contract.ComposerFieldSet{
 					SchedulerID: "airflow-scheduler-7b5f",
 				},
@@ -125,7 +126,7 @@ func TestAirflowSchedulerMapperTask_ProcessLogByGroup(t *testing.T) {
 			name: "Scheduler log without TaskInstance",
 			input: log.NewLogWithFieldSetsForTest(
 				&log.CommonFieldSet{Timestamp: timestamp},
-				&log.MainMessageFieldSet{MainMessage: "Heartbeat"},
+				&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "Heartbeat"},
 				&googlecloudclustercomposer_contract.ComposerFieldSet{
 					SchedulerID: "airflow-scheduler-7b5f",
 				},

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/worker.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/worker.go
@@ -24,6 +24,7 @@ import (
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
@@ -68,7 +69,7 @@ func (i *workerLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifil
 		cs.SetSeverity(inspectioncore_contract.SeverityUnknown)
 	}
 
-	if messageFS, err := log.GetFieldSet(l, &log.MainMessageFieldSet{}); err == nil {
+	if messageFS, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPMainMessageFieldSet{}); err == nil {
 		cs.SetSummary(messageFS.MainMessage)
 	}
 

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/worker_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/worker_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
@@ -45,7 +46,7 @@ func TestAirflowWorkerMapperTask_ProcessLogByGroup(t *testing.T) {
 			name: "Worker basic identification and TaskInstance extraction",
 			input: log.NewLogWithFieldSetsForTest(
 				&log.CommonFieldSet{Timestamp: timestamp},
-				&log.MainMessageFieldSet{MainMessage: "Executing task"},
+				&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "Executing task"},
 				&googlecloudclustercomposer_contract.ComposerFieldSet{
 					WorkerID: "airflow-worker-abc",
 				},
@@ -83,7 +84,7 @@ func TestAirflowWorkerMapperTask_ProcessLogByGroup(t *testing.T) {
 			name: "Worker log without TaskInstance",
 			input: log.NewLogWithFieldSetsForTest(
 				&log.CommonFieldSet{Timestamp: timestamp},
-				&log.MainMessageFieldSet{MainMessage: "Worker Heartbeat"},
+				&googlecloudcommon_contract.GCPMainMessageFieldSet{MainMessage: "Worker Heartbeat"},
 				&googlecloudclustercomposer_contract.ComposerFieldSet{
 					WorkerID: "airflow-worker-abc",
 				},


### PR DESCRIPTION
Airflow parsers unintentionally still uses log.MainMessageFieldSet. It should be removed and GCPMainMessageFieldSet should be used.