### PR TITLE
fix style override didn't reflect its status to preview

### DIFF
--- a/pkg/task/inspection/inspectioncore/contract/severity.go
+++ b/pkg/task/inspection/inspectioncore/contract/severity.go
@@ -24,7 +24,7 @@ import (
 // These are registered as package-level variables so they are initialized immediately
 // when this package is imported.
 var (
-	SeverityUnknown = style.MustRegisterSeverity("UNKNOWN", "U", style.ColorBlack, style.ColorWhite, 0)
+	SeverityUnknown = style.MustRegisterSeverity("UNKNOWN", "", style.ColorBlack, style.ColorWhite, 0)
 	SeverityInfo    = style.MustRegisterSeverity("INFO", "I", style.MustForceConvertSRGBHex("#0000FF"), style.ColorWhite, 1)
 	SeverityWarning = style.MustRegisterSeverity("WARNING", "W", style.MustForceConvertSRGBHex("#FFAA44"), style.ColorWhite, 2)
 	SeverityError   = style.MustRegisterSeverity("ERROR", "E", style.MustForceConvertSRGBHex("#FF3935"), style.ColorWhite, 3)

--- a/web/src/app/log/components/log-view-log-line.component.html
+++ b/web/src/app/log/components/log-view-log-line.component.html
@@ -35,7 +35,7 @@
       [ngStyle]="severityStyle()"
       [matTooltip]="'severity:' + logEntry.severity.label"
     >
-      {{ (logEntry.severity.label | uppercase)[0] }}
+      {{ logEntry.severity.shortLabel }}
     </div>
   </div>
   <div class="ts">{{ logEntry.legacyTimestampMs | tsf | async }}</div>

--- a/web/src/app/timeline/components/calculator/vertical-scroll-calculator.spec.ts
+++ b/web/src/app/timeline/components/calculator/vertical-scroll-calculator.spec.ts
@@ -16,6 +16,8 @@
 
 import { VerticalScrollCalculator } from './vertical-scroll-calculator';
 import { Timeline } from 'src/app/store/domain/timeline';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
+import { TimelineType } from 'src/app/store/domain/style';
 
 describe('VerticalScrollCalculator', () => {
   interface TimelineSpecConfig {
@@ -23,6 +25,28 @@ describe('VerticalScrollCalculator', () => {
     readonly parentIndex?: number;
     readonly childrenCount?: number;
   }
+
+  const mockStyleStore: StyleStoreLike = {
+    severities: [],
+    logTypes: [],
+    verbs: [],
+    revisionStates: [],
+    timelineTypes: [],
+    getSeverity: () => {
+      throw new Error('not implemented');
+    },
+    getLogType: () => {
+      throw new Error('not implemented');
+    },
+    getVerb: () => {
+      throw new Error('not implemented');
+    },
+    getRevisionState: () => {
+      throw new Error('not implemented');
+    },
+    getTimelineType: () => undefined as unknown as TimelineType,
+    getIconAtlas: () => undefined,
+  };
 
   const createMockTimelines = (
     configs: readonly TimelineSpecConfig[],
@@ -58,19 +82,43 @@ describe('VerticalScrollCalculator', () => {
         { height: 4.0 }, // 100
         { height: 2.0 }, // 50
       ]);
-      const calculator = new VerticalScrollCalculator(timelines, 0);
+      const calculator = new VerticalScrollCalculator(
+        timelines,
+        0,
+        mockStyleStore,
+      );
       expect(calculator.totalHeight).toBe(250);
     });
 
     it('should handle empty timelines', () => {
-      const calculator = new VerticalScrollCalculator([], 0);
+      const calculator = new VerticalScrollCalculator([], 0, mockStyleStore);
       expect(calculator.totalHeight).toBe(0);
+    });
+
+    it('should respect overridden timeline heights from styleStore', () => {
+      const timelines = createMockTimelines([{ height: 4.0 }]);
+      (timelines[0].type as { id: number }).id = 101;
+      const customStyleStore: StyleStoreLike = {
+        ...mockStyleStore,
+        getTimelineType: (id: number) => {
+          if (id === 101) {
+            return { height: 2.0 } as unknown as TimelineType;
+          }
+          return undefined as unknown as TimelineType;
+        },
+      };
+      const calculator = new VerticalScrollCalculator(
+        timelines,
+        0,
+        customStyleStore,
+      );
+      expect(calculator.totalHeight).toBe(50);
     });
   });
 
   describe('topDrawAreaOffset', () => {
     it('should return 0 when timelines are empty', () => {
-      const calculator = new VerticalScrollCalculator([], 0);
+      const calculator = new VerticalScrollCalculator([], 0, mockStyleStore);
       expect(calculator.topDrawAreaOffset(100)).toBe(0);
     });
 
@@ -79,7 +127,11 @@ describe('VerticalScrollCalculator', () => {
         { height: 4.0 }, // 100
         { height: 4.0 }, // 100
       ]);
-      const calculator = new VerticalScrollCalculator(timelines, 0);
+      const calculator = new VerticalScrollCalculator(
+        timelines,
+        0,
+        mockStyleStore,
+      );
       expect(calculator.topDrawAreaOffset(250)).toBe(100);
     });
 
@@ -89,7 +141,11 @@ describe('VerticalScrollCalculator', () => {
         { height: 4.0 }, // 100
         { height: 2.0 }, // 50
       ]);
-      const calculator = new VerticalScrollCalculator(timelines, 0);
+      const calculator = new VerticalScrollCalculator(
+        timelines,
+        0,
+        mockStyleStore,
+      );
 
       // scrollY at 0
       expect(calculator.topDrawAreaOffset(0)).toBe(0);
@@ -110,7 +166,7 @@ describe('VerticalScrollCalculator', () => {
 
   describe('timelinesInDrawArea', () => {
     it('should return empty array when timelines are empty', () => {
-      const calculator = new VerticalScrollCalculator([], 0);
+      const calculator = new VerticalScrollCalculator([], 0, mockStyleStore);
       expect(calculator.timelinesInDrawArea(0, 100)).toEqual([]);
     });
 
@@ -120,7 +176,11 @@ describe('VerticalScrollCalculator', () => {
         { height: 4.0 }, // 100
         { height: 2.0 }, // 50
       ]);
-      const calculator = new VerticalScrollCalculator(timelines, 0);
+      const calculator = new VerticalScrollCalculator(
+        timelines,
+        0,
+        mockStyleStore,
+      );
 
       // Case 1: Only first timeline visible (0-50)
       let result = calculator.timelinesInDrawArea(0, 50);
@@ -151,7 +211,11 @@ describe('VerticalScrollCalculator', () => {
         { height: 4.0 }, // 100
         { height: 4.0 }, // 100
       ]);
-      const calculator = new VerticalScrollCalculator(timelines, margin);
+      const calculator = new VerticalScrollCalculator(
+        timelines,
+        margin,
+        mockStyleStore,
+      );
 
       // Only Timeline 2 (200-250) is strictly visible
       // scrollY=210, visibleHeight=10
@@ -164,14 +228,18 @@ describe('VerticalScrollCalculator', () => {
 
     it('should calculate totalRenderHeight with margin', () => {
       const timelines = createMockTimelines([{ height: 4.0 }]); // max 100
-      const calculator = new VerticalScrollCalculator(timelines, margin);
+      const calculator = new VerticalScrollCalculator(
+        timelines,
+        margin,
+        mockStyleStore,
+      );
       expect(calculator.totalRenderHeight(500)).toBe(900);
     });
   });
 
   describe('stickyTimelines', () => {
     it('should return empty array when timelines are empty', () => {
-      const calculator = new VerticalScrollCalculator([], 0);
+      const calculator = new VerticalScrollCalculator([], 0, mockStyleStore);
       expect(calculator.stickyTimelines(100)).toEqual([]);
     });
 
@@ -193,7 +261,7 @@ describe('VerticalScrollCalculator', () => {
           { height: 4.0, parentIndex: 8 }, // index 9 (Pod4)
           { height: 2.0, parentIndex: 9 }, // index 10 (Subresource2)
         ]);
-        calculator = new VerticalScrollCalculator(timelines, 0);
+        calculator = new VerticalScrollCalculator(timelines, 0, mockStyleStore);
       });
 
       it('should return initial sticky header at scroll 0', () => {

--- a/web/src/app/timeline/components/calculator/vertical-scroll-calculator.ts
+++ b/web/src/app/timeline/components/calculator/vertical-scroll-calculator.ts
@@ -19,6 +19,7 @@ import {
   bisectRight,
   defaultNumberComparator,
 } from 'src/app/common/misc-util';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
 import { Timeline } from 'src/app/store/domain/timeline';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { BASE_ROW_HEIGHT } from '../style-model-v2';
@@ -61,17 +62,20 @@ export class VerticalScrollCalculator {
   /**
    * @param timelines List of resource timelines to be displayed.
    * @param marginTimelineCount Number of timelines to render outside the visible area as a buffer. Defaults to 10.
+   * @param styleStore Style store to resolve overridden timeline heights.
    */
   constructor(
     private readonly timelines: readonly ReadonlyDomainElement<Timeline>[],
     private readonly marginTimelineCount = 10,
+    private readonly styleStore?: StyleStoreLike,
   ) {
     this.accumulatedHeights = new Array<number>(this.timelines.length);
     let height = 0;
     for (let i = 0; i < this.timelines.length; i++) {
       this.accumulatedHeights[i] = height;
       const timeline = this.timelines[i];
-      const timelineHeight = timeline.type.height * BASE_ROW_HEIGHT;
+      const timelineType = this.resolveTimelineType(timeline);
+      const timelineHeight = timelineType.height * BASE_ROW_HEIGHT;
       height += timelineHeight;
       this.maxTimelineHeight = Math.max(this.maxTimelineHeight, timelineHeight);
     }
@@ -170,7 +174,8 @@ export class VerticalScrollCalculator {
       // The timeline is visible even if the sticky timeline is drawn from its parent
       if (
         stickyHeight + scrollY <
-        this.accumulatedHeights[i] + timeline.type.height * BASE_ROW_HEIGHT
+        this.accumulatedHeights[i] +
+          this.resolveTimelineType(timeline).height * BASE_ROW_HEIGHT
       ) {
         break;
       }
@@ -218,8 +223,10 @@ export class VerticalScrollCalculator {
     if (timelineIndex === -1) {
       return 0;
     }
-    const timelineHeight =
-      this.timelines[timelineIndex].type.height * BASE_ROW_HEIGHT;
+    const timelineType = this.resolveTimelineType(
+      this.timelines[timelineIndex],
+    );
+    const timelineHeight = timelineType.height * BASE_ROW_HEIGHT;
     return this.accumulatedHeights[timelineIndex] + timelineHeight;
   }
 
@@ -249,8 +256,21 @@ export class VerticalScrollCalculator {
       t !== null;
       t = t.parent
     ) {
-      result += t.type.height * BASE_ROW_HEIGHT;
+      result += this.resolveTimelineType(t).height * BASE_ROW_HEIGHT;
     }
     return result;
+  }
+
+  private resolveTimelineType(timeline: ReadonlyDomainElement<Timeline>) {
+    if (this.styleStore) {
+      try {
+        return (
+          this.styleStore.getTimelineType(timeline.type.id) ?? timeline.type
+        );
+      } catch {
+        return timeline.type;
+      }
+    }
+    return timeline.type;
   }
 }

--- a/web/src/app/timeline/components/calculator/vertical-scroll-calculator.ts
+++ b/web/src/app/timeline/components/calculator/vertical-scroll-calculator.ts
@@ -67,7 +67,7 @@ export class VerticalScrollCalculator {
   constructor(
     private readonly timelines: readonly ReadonlyDomainElement<Timeline>[],
     private readonly marginTimelineCount = 10,
-    private readonly styleStore?: StyleStoreLike,
+    private readonly styleStore: StyleStoreLike,
   ) {
     this.accumulatedHeights = new Array<number>(this.timelines.length);
     let height = 0;
@@ -261,16 +261,11 @@ export class VerticalScrollCalculator {
     return result;
   }
 
+  /**
+   * Resolves the latest timeline type.
+   * Timeline type styles may be updated from the override dialog. This returns the latest one.
+   */
   private resolveTimelineType(timeline: ReadonlyDomainElement<Timeline>) {
-    if (this.styleStore) {
-      try {
-        return (
-          this.styleStore.getTimelineType(timeline.type.id) ?? timeline.type
-        );
-      } catch {
-        return timeline.type;
-      }
-    }
-    return timeline.type;
+    return this.styleStore?.getTimelineType(timeline.type.id) ?? timeline.type;
   }
 }

--- a/web/src/app/timeline/components/canvas/timeline-background-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-background-renderer.ts
@@ -143,12 +143,15 @@ export class TimelineBackgroundRenderer {
   ) {
     let currentY = 0;
     for (const timeline of viewModel.timelinesInDrawArea) {
-      const rowHeight = timeline.type.height * BASE_ROW_HEIGHT;
+      const timelineType =
+        viewModel.styleStore?.getTimelineType(timeline.type.id) ??
+        timeline.type;
+      const rowHeight = timelineType.height * BASE_ROW_HEIGHT;
       this.ctx.lineWidth = Math.min(
         HORIZONTAL_BORDER_THICKNESS_RANGE[1],
         Math.max(
           HORIZONTAL_BORDER_THICKNESS_RANGE[0],
-          BASE_HORIZONTAL_BORDER_THICKNESS * timeline.type.height,
+          BASE_HORIZONTAL_BORDER_THICKNESS * timelineType.height,
         ),
       );
       this.ctx.strokeStyle = RendererConvertUtil.hdrColorToCSSColor(
@@ -194,11 +197,17 @@ export class TimelineBackgroundRenderer {
     }
     let currentY = 0;
     for (const timeline of viewModel.timelinesInDrawArea) {
-      currentY += timeline.type.height * BASE_ROW_HEIGHT;
+      const timelineType =
+        viewModel.styleStore?.getTimelineType(timeline.type.id) ??
+        timeline.type;
+      currentY += timelineType.height * BASE_ROW_HEIGHT;
     }
     for (let i = viewModel.timelinesInDrawArea.length - 1; i >= 0; i--) {
       const timeline = viewModel.timelinesInDrawArea[i];
-      const rowHeight = timeline.type.height * BASE_ROW_HEIGHT;
+      const timelineType =
+        viewModel.styleStore?.getTimelineType(timeline.type.id) ??
+        timeline.type;
+      const rowHeight = timelineType.height * BASE_ROW_HEIGHT;
       currentY -= rowHeight;
 
       const isNextTimelineChild =
@@ -218,7 +227,7 @@ export class TimelineBackgroundRenderer {
       this.ctx.fillRect(0, currentY, this.width, rowHeight);
       this.ctx.shadowColor = 'transparent';
 
-      const bg = timeline.type.backgroundColor;
+      const bg = timelineType.backgroundColor;
       this.ctx.fillStyle = RendererConvertUtil.hdrColorToCSSColor([
         bg.r,
         bg.g,

--- a/web/src/app/timeline/components/canvas/timeline-events-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-events-renderer.ts
@@ -478,4 +478,11 @@ export class TimelineEventsSharedResources {
     this.chartStyle = chartStyle;
     this.styleUpdated = true;
   }
+
+  /**
+   * Invalidates cached styles, forcing UBOs to rebuild on next frame.
+   */
+  public invalidateStyles() {
+    this.styleUpdated = true;
+  }
 }

--- a/web/src/app/timeline/components/canvas/timeline-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-renderer.ts
@@ -272,6 +272,7 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
    */
   public invalidateStyles() {
     this.revisionSharedResource.invalidateStyles();
+    this.eventSharedResource.invalidateStyles();
   }
 
   /**
@@ -315,7 +316,10 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
       let hit = false;
       for (let i = 0; i < this.chartViewModel.timelinesInDrawArea.length; i++) {
         const tl = this.chartViewModel.timelinesInDrawArea[i];
-        const height = tl.type.height * BASE_ROW_HEIGHT;
+        const tlType =
+          this.chartViewModel.styleStore?.getTimelineType(tl.type.id) ??
+          tl.type;
+        const height = tlType.height * BASE_ROW_HEIGHT;
         if (request.y < offsetY + height) {
           const result = this.hittestSharedResource.hittest(
             gl,
@@ -357,7 +361,9 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
       height: 0,
     };
     for (const t of this.chartViewModel.timelinesInDrawArea) {
-      drawRect.height = t.type.height * BASE_ROW_HEIGHT;
+      const tType =
+        this.chartViewModel.styleStore?.getTimelineType(t.type.id) ?? t.type;
+      drawRect.height = tType.height * BASE_ROW_HEIGHT;
       drawRect.offsetY -= drawRect.height;
       onRender(t, drawRect);
     }

--- a/web/src/app/timeline/components/timeline-frame.component.spec.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.spec.ts
@@ -131,9 +131,7 @@ const mockStyleStore: StyleStoreLike = {
   getRevisionState: () => {
     throw new Error();
   },
-  getTimelineType: () => {
-    throw new Error();
-  },
+  getTimelineType: () => undefined as unknown as TimelineType,
   getIconAtlas: () => undefined,
 };
 

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -557,9 +557,11 @@ export class TimelineFrameComponent implements AfterViewInit {
    * Calculator for vertical scrolling and layout of rows.
    */
   protected readonly verticalScrollCalculator = computed(() => {
+    this.styleStore()?.stylesUpdated?.();
     return new VerticalScrollCalculator(
       this.timelines(),
       this.verticalOverdrawTimelineCount(),
+      this.styleStore(),
     );
   });
 
@@ -646,9 +648,18 @@ export class TimelineFrameComponent implements AfterViewInit {
    */
   protected readonly stickyHeaderHeight = computed(() => {
     const stickyTimelines = this.stickyTimelines();
+    const styleStore = this.styleStore();
     let height = 0;
     for (const t of stickyTimelines) {
-      height += t.type.height * BASE_ROW_HEIGHT;
+      let tType = t.type;
+      if (styleStore) {
+        try {
+          tType = styleStore.getTimelineType(t.type.id) ?? t.type;
+        } catch {
+          tType = t.type;
+        }
+      }
+      height += tType.height * BASE_ROW_HEIGHT;
     }
     return height;
   });

--- a/web/src/app/timeline/components/timeline-index.component.ts
+++ b/web/src/app/timeline/components/timeline-index.component.ts
@@ -128,11 +128,14 @@ export class TimelineIndexComponent {
     timelines: ReadonlyDomainElement<Timeline[]>,
   ): TimelineIndexViewModel[] {
     const highlights = this.highlights();
+    const styleStore = this.styleStore();
     return timelines.map((timeline, i, arr) => {
+      const timelineType =
+        styleStore?.getTimelineType(timeline.type.id) ?? timeline.type;
       const nextTimeline = arr[i + 1];
       const isNextChildren =
         nextTimeline && nextTimeline.layer > timeline.layer;
-      const containerClasses = [timeline.type.label];
+      const containerClasses = [timelineType.label];
       if (isNextChildren) {
         containerClasses.push('is-next-children');
       }
@@ -148,10 +151,10 @@ export class TimelineIndexComponent {
           containerClasses.push('children-of-selected');
           break;
       }
-      const bg = timeline.type.backgroundColor;
-      const fg = timeline.type.foregroundColor;
-      const chipBg = timeline.type.typeChipBackgroundColor;
-      const height = timeline.type.height * BASE_ROW_HEIGHT;
+      const bg = timelineType.backgroundColor;
+      const fg = timelineType.foregroundColor;
+      const chipBg = timelineType.typeChipBackgroundColor;
+      const height = timelineType.height * BASE_ROW_HEIGHT;
       const style: Record<string, string> = {
         '--timeline-bg-color': RendererConvertUtil.hdrColorToCSSColor([
           bg.r,
@@ -172,15 +175,16 @@ export class TimelineIndexComponent {
           chipBg.a,
         ]),
         '--timeline-chip-fg-color': RendererConvertUtil.hdrColorToCSSColor([
-          timeline.type.typeChipForegroundColor.r,
-          timeline.type.typeChipForegroundColor.g,
-          timeline.type.typeChipForegroundColor.b,
-          timeline.type.typeChipForegroundColor.a,
+          timelineType.typeChipForegroundColor.r,
+          timelineType.typeChipForegroundColor.g,
+          timelineType.typeChipForegroundColor.b,
+          timelineType.typeChipForegroundColor.a,
         ]),
         '--timeline-height': `${height}px`,
         '--timeline-layer': `${timeline.layer}`,
       };
       const isLastChild = !nextTimeline || nextTimeline.layer < timeline.layer;
+
       const levels: TreeGuideViewModel[] = [];
       for (let d = 0; d < timeline.layer; d++) {
         const isParent = d === timeline.layer - 1;


### PR DESCRIPTION
The style override dialog didn't update the style for timeline views.  
This PR fixes this bug and reflect the style changes to visible timelines reactively.