### PR TITLE
fixed CSM access log timeline style

### DIFF
--- a/pkg/task/inspection/googlecloudlogcsm/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/timeline_type.go
@@ -28,7 +28,7 @@ var (
 		"shuffle",
 		0.6,
 		style.ColorWhite,
-		style.ColorWhite,
+		style.ColorBlack,
 		style.MustForceConvertSRGBHex("#FF8500"),
 		style.ColorWhite,
 		true,


### PR DESCRIPTION
The setting was white text on white background, it's hard to see...