### PR TITLE
Simplified and optimized release workflows running on Cloud Build

### DIFF
--- a/.cloudbuild/github-deploy-beta.yaml
+++ b/.cloudbuild/github-deploy-beta.yaml
@@ -12,52 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+substitutions:
+  _VERSION: "${TAG_NAME}"
+  # TODO(#21): Remove asia.gcr.io from the build targets.
+  # The new repository is gcr.io, but we will keep the old one for a while.
+  _DOCKER_TAGS: "-t asia.gcr.io/kubernetes-history-inspector/release:beta -t gcr.io/kubernetes-history-inspector/release:beta -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} -t gcr.io/kubernetes-history-inspector/release:${TAG_NAME}"
+
 steps:
-  - name: "node:22-trixie"
+  - name: "gcr.io/kubernetes-history-inspector/builder:latest"
     args:
       - "-c"
       - |
         cd ./web
         npm ci
-        cd ..
-        npx @bufbuild/buf generate
-        touch scripts/make/build-proto.done
-    id: dependency_web
+    id: install_deps
     waitFor:
       - "-"
     entrypoint: /bin/bash
-  - name: "golang:1.25-trixie"
+  - name: "gcr.io/kubernetes-history-inspector/builder:latest"
     args:
       - "-c"
       - |
-        echo ${TAG_NAME} > VERSION
-        apt-get update && apt-get install jq -y
-        make generate-frontend
-        make generate-backend
-    id: pre_build_web
-    waitFor:
-      - dependency_web
-    entrypoint: /bin/bash
-  - name: "node:22-trixie"
-    args:
-      - "-c"
-      - |
+        echo "${_VERSION}" > VERSION
         make build-web
-    id: build_web
+    id: build_app
     waitFor:
-      - pre_build_web
+      - install_deps
     entrypoint: /bin/bash
   - name: gcr.io/cloud-builders/docker
     args:
       - "-c"
       - |
         docker buildx create --driver docker-container --name container --use
-        # TODO(#21): Remove asia.gcr.io from the build targets.
-        # The new repository is gcr.io, but we will keep the old one for a while.
-        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/release:beta -t gcr.io/kubernetes-history-inspector/release:beta -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} -t gcr.io/kubernetes-history-inspector/release:${TAG_NAME} --push .
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile ${_DOCKER_TAGS} --push .
     id: build_container
     waitFor:
-      - build_web
+      - build_app
     entrypoint: /bin/bash
 options:
   machineType: E2_HIGHCPU_32

--- a/.cloudbuild/github-deploy-latest.yaml
+++ b/.cloudbuild/github-deploy-latest.yaml
@@ -12,52 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+substitutions:
+  _VERSION: "${TAG_NAME}"
+  # TODO(#21): Remove asia.gcr.io from the build targets.
+  # The new repository is gcr.io, but we will keep the old one for a while.
+  _DOCKER_TAGS: "-t asia.gcr.io/kubernetes-history-inspector/release:latest -t gcr.io/kubernetes-history-inspector/release:latest -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} -t gcr.io/kubernetes-history-inspector/release:${TAG_NAME}"
+
 steps:
-  - name: "node:22-trixie"
+  - name: "gcr.io/kubernetes-history-inspector/builder:latest"
     args:
       - "-c"
       - |
         cd ./web
         npm ci
-        cd ..
-        npx @bufbuild/buf generate
-        touch scripts/make/build-proto.done
-    id: dependency_web
+    id: install_deps
     waitFor:
       - "-"
     entrypoint: /bin/bash
-  - name: "golang:1.25-trixie"
+  - name: "gcr.io/kubernetes-history-inspector/builder:latest"
     args:
       - "-c"
       - |
-        echo ${TAG_NAME} > VERSION
-        apt-get update && apt-get install jq -y
-        make generate-frontend
-        make generate-backend
-    id: pre_build_web
-    waitFor:
-      - dependency_web
-    entrypoint: /bin/bash
-  - name: "node:22-trixie"
-    args:
-      - "-c"
-      - |
+        echo "${_VERSION}" > VERSION
         make build-web
-    id: build_web
+    id: build_app
     waitFor:
-      - pre_build_web
+      - install_deps
     entrypoint: /bin/bash
   - name: gcr.io/cloud-builders/docker
     args:
       - "-c"
       - |
         docker buildx create --driver docker-container --name container --use
-        # TODO(#21): Remove asia.gcr.io from the build targets.
-        # The new repository is gcr.io, but we will keep the old one for a while.
-        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t asia.gcr.io/kubernetes-history-inspector/release:latest -t gcr.io/kubernetes-history-inspector/release:latest -t asia.gcr.io/kubernetes-history-inspector/release:${TAG_NAME} -t gcr.io/kubernetes-history-inspector/release:${TAG_NAME} --push .
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile ${_DOCKER_TAGS} --push .
     id: build_container
     waitFor:
-      - build_web
+      - build_app
     entrypoint: /bin/bash
 options:
   machineType: E2_HIGHCPU_32

--- a/.cloudbuild/github-deploy-ondemand.yaml
+++ b/.cloudbuild/github-deploy-ondemand.yaml
@@ -12,50 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+substitutions:
+  _VERSION: "dev-${SHORT_SHA}"
+  # TODO(#21): Remove asia.gcr.io from the build targets.
+  # The new repository is gcr.io, but we will keep the old one for a while.
+  _DOCKER_TAGS: "-t gcr.io/kubernetes-history-inspector/develop:${COMMIT_SHA}"
+
 steps:
-  - name: "node:22-trixie"
+  - name: "gcr.io/kubernetes-history-inspector/builder:latest"
     args:
       - "-c"
       - |
         cd ./web
         npm ci
-        cd ..
-        npx @bufbuild/buf generate
-        touch scripts/make/build-proto.done
-    id: dependency_web
+    id: install_deps
     waitFor:
       - "-"
     entrypoint: /bin/bash
-  - name: "golang:1.25-trixie"
+  - name: "gcr.io/kubernetes-history-inspector/builder:latest"
     args:
       - "-c"
       - |
-        echo "dev-${SHORT_SHA}" > VERSION
-        apt-get update && apt-get install jq -y
-        make generate-frontend
-        make generate-backend
-    id: pre_build_web
-    waitFor:
-      - dependency_web
-    entrypoint: /bin/bash
-  - name: "node:22-trixie"
-    args:
-      - "-c"
-      - |
+        echo "${_VERSION}" > VERSION
         make build-web
-    id: build_web
+    id: build_app
     waitFor:
-      - pre_build_web
+      - install_deps
     entrypoint: /bin/bash
   - name: gcr.io/cloud-builders/docker
     args:
       - "-c"
       - |
         docker buildx create --driver docker-container --name container --use
-        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile -t gcr.io/kubernetes-history-inspector/develop:$SHORT_SHA --push .
+        docker buildx build --platform linux/amd64,linux/arm64 --file=./Dockerfile ${_DOCKER_TAGS} --push .
     id: build_container
     waitFor:
-      - build_web
+      - build_app
     entrypoint: /bin/bash
 options:
   machineType: E2_HIGHCPU_32

--- a/scripts/builder/Dockerfile
+++ b/scripts/builder/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.25-trixie AS golang
+FROM node:22-trixie
+
+COPY --from=golang /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
+ENV PATH="${GOPATH}/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y \
+    jq \
+    make \
+    git \
+    curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/scripts/builder/README.md
+++ b/scripts/builder/README.md
@@ -1,0 +1,22 @@
+# KHI CI Builder Image
+
+This directory contains the Dockerfile for building the unified CI builder image used in `.cloudbuild/` workflows.
+
+## Included Dependencies
+
+- Debian Trixie (base OS)
+- Go 1.25.x (copied from `golang:1.25-trixie`)
+- Node.js 22.x, npm, npx (base from `node:22-trixie`)
+- System utilities: `jq`, `make`, `git`, `curl`
+
+## Building and Pushing
+
+You can build and push this image using the project `Makefile`:
+
+```bash
+# Build the image locally
+make build-builder
+
+# Build and push the image to GCR
+make push-builder
+```

--- a/scripts/builder/README_ja.md
+++ b/scripts/builder/README_ja.md
@@ -1,0 +1,22 @@
+# KHI CI ビルダーイメージ
+
+このディレクトリには、`.cloudbuild/` ワークフローで使用される統合 CI ビルダーイメージ用の Dockerfile が含まれています。
+
+## 含まれる依存関係
+
+- Debian Trixie (ベース OS)
+- Go 1.25.x (`golang:1.25-trixie` からコピー)
+- Node.js 22.x, npm, npx (`node:22-trixie` のベース環境)
+- システムユーティリティ: `jq`, `make`, `git`, `curl`
+
+## ビルドとプッシュ
+
+プロジェクトの `Makefile` を使用してビルドおよびプッシュが行えます。
+
+```bash
+# イメージをローカルでビルドする
+make build-builder
+
+# イメージをビルドして GCR へプッシュする
+make push-builder
+```

--- a/scripts/make/build.mk
+++ b/scripts/make/build.mk
@@ -51,3 +51,13 @@ build-go-binaries: $(GENERATE_BACKEND_DUMMY) $(BACKEND_SRCS) $(FRONTEND_ARTIFACT
 	$(call build_binary,linux,amd64,)
 	$(call build_binary,darwin,arm64,)
 	$(call build_binary,darwin,amd64,)
+
+BUILDER_IMAGE ?= gcr.io/kubernetes-history-inspector/builder:latest
+
+.PHONY: build-builder
+build-builder: ## Build CI builder docker image
+	docker build -t $(BUILDER_IMAGE) ./scripts/builder
+
+.PHONY: push-builder
+push-builder: build-builder ## Push CI builder docker image
+	docker push $(BUILDER_IMAGE)


### PR DESCRIPTION
KHI has been used node or golang builder officially provided from Google Cloud Build.
But KHI uses Make and it can call dependent tasks even if that require other side of the dependency.

To prevent failures due to this missing dependency, we had some tricks on the Cloud Build yaml and it made harder to maintain. Now we have prebuilt image for building KHI.