### PR TITLE
docs: fix typo in development guide (automativally → automatically)

### DIFF
--- a/docs/en/development-contribution/development-guide.md
+++ b/docs/en/development-contribution/development-guide.md
@@ -82,7 +82,7 @@ Storybook automatically builds and serves the new build when you change the fron
 
 ### Generated codes from backend codes
 
-Several frontend codes are automativally generated from backend codes.
+Several frontend codes are automatically generated from backend codes.
 
 * `/web/src/app/generated.scss`
 * `/web/src/app/generated.ts`


### PR DESCRIPTION
Small typo fix in `docs/en/development-contribution/development-guide.md`: "automativally" → "automatically".