### PR TITLE
Added timeline exclusion filter

### DIFF
--- a/web/src/app/services/inspection-data-store-v2.service.ts
+++ b/web/src/app/services/inspection-data-store-v2.service.ts
@@ -19,6 +19,7 @@ import { InspectionDataV2 } from 'src/app/store/domain/inspection-data';
 import { TimelineView } from 'src/app/store/domain/timeline-view';
 import {
   CelTimelineFilter,
+  CelTimelineExclusionFilter,
   CelLogFilter,
 } from 'src/app/store/domain/filter/cel-filter';
 import {
@@ -37,6 +38,9 @@ export class InspectionDataStoreV2 {
   private readonly _inspectionData = signal<InspectionDataV2 | null>(null);
   private readonly _timelineView = signal<TimelineView | null>(null);
   private readonly celTimelineFilter = inject(CelTimelineFilter);
+  private readonly celTimelineExclusionFilter = inject(
+    CelTimelineExclusionFilter,
+  );
   private readonly celLogFilter = inject(CelLogFilter);
   private readonly excludeNoLogsFilter = inject(ExcludeNoLogsFilter);
   private readonly searchWorkerManager = inject(SearchWorkerManager);
@@ -78,6 +82,7 @@ export class InspectionDataStoreV2 {
     const view = new TimelineView(data.timelineStore);
     view.addFilter(this.celTimelineFilter);
     view.addFilter(new IncludeDescendantsFilter());
+    view.addFilter(this.celTimelineExclusionFilter);
     view.addFilter(this.celLogFilter);
     view.addFilter(new IncludeAncestorsFilter());
     view.addFilter(this.excludeNoLogsFilter);

--- a/web/src/app/store/domain/filter/cel-filter.spec.ts
+++ b/web/src/app/store/domain/filter/cel-filter.spec.ts
@@ -17,6 +17,7 @@
 import { TestBed } from '@angular/core/testing';
 import {
   CelTimelineFilter,
+  CelTimelineExclusionFilter,
   CelLogFilter,
 } from 'src/app/store/domain/filter/cel-filter';
 import { LogTimelineFilterContext } from 'src/app/store/domain/filter/types';
@@ -216,5 +217,71 @@ describe('CelLogFilter', () => {
 
     const result = await filter.process(context, timelineStoreSpy);
     expect(result).toBe(context);
+  });
+});
+
+describe('CelTimelineExclusionFilter', () => {
+  let filter: CelTimelineExclusionFilter;
+  let searchWorkerManagerSpy: jasmine.SpyObj<SearchWorkerManager>;
+
+  beforeEach(() => {
+    searchWorkerManagerSpy = jasmine.createSpyObj<SearchWorkerManager>(
+      'SearchWorkerManager',
+      ['searchTimelines', 'searchLogs'],
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        CelTimelineExclusionFilter,
+        { provide: SearchWorkerManager, useValue: searchWorkerManagerSpy },
+      ],
+    });
+
+    filter = TestBed.inject(CelTimelineExclusionFilter);
+  });
+
+  it('should exclude timeline and its descendants when ancestor fails exclusion filter', async () => {
+    const rootTimeline = {
+      id: 10,
+      name: 'Root',
+      parent: null,
+      events: [],
+      revisions: [],
+    };
+    const childTimeline = {
+      id: 11,
+      name: 'Child',
+      parent: rootTimeline,
+      events: [],
+      revisions: [],
+    };
+
+    const timelines = [rootTimeline, childTimeline];
+
+    const timelineStoreSpy = jasmine.createSpyObj<TimelineStore>(
+      'TimelineStore',
+      ['getTimeline'],
+    );
+    timelineStoreSpy.getTimeline.and.callFake((id: number) => {
+      const found = timelines.find((t) => t.id === id);
+      if (!found) {
+        throw new Error(`Timeline ${id} not found`);
+      }
+      return found as unknown as ReadonlyDomainElement<Timeline>;
+    });
+
+    searchWorkerManagerSpy.searchTimelines.and.returnValue(
+      Promise.resolve(new Set([10])),
+    );
+
+    filter.updateFilter('match("kube-system")');
+
+    const context: LogTimelineFilterContext = {
+      timelineIds: new Set([10, 11]),
+      logIds: new Set(),
+    };
+
+    const result = await filter.process(context, timelineStoreSpy);
+    expect(result.timelineIds.size).toBe(0);
   });
 });

--- a/web/src/app/store/domain/filter/cel-filter.ts
+++ b/web/src/app/store/domain/filter/cel-filter.ts
@@ -21,7 +21,9 @@ import {
   LogTimelineFilter,
   LogTimelineFilterContext,
 } from 'src/app/store/domain/filter/types';
+import { Timeline } from 'src/app/store/domain/timeline';
 import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { CelFilterUpdateResult } from 'src/app/store/domain/filter/cel-types';
 import {
   CELTimelineFilterEnvironment,
@@ -104,6 +106,105 @@ export class CelTimelineFilter implements LogTimelineFilter {
     const filteredIds = new Set<number>();
     for (const id of context.timelineIds) {
       if (passedTimelineIds.has(id)) {
+        filteredIds.add(id);
+      }
+    }
+
+    return {
+      timelineIds: filteredIds,
+      logIds: context.logIds,
+    };
+  }
+}
+
+/**
+ * Filters timelines based on the configured CEL exclusion expression, removing matched timelines and their descendants.
+ */
+@Injectable({ providedIn: 'root' })
+export class CelTimelineExclusionFilter implements LogTimelineFilter {
+  readonly displayName = 'Timeline CEL exclusion filter';
+  readonly priority = 25;
+  private readonly searchWorkerManager = inject(SearchWorkerManager);
+  private readonly celEnv = new CELTimelineFilterEnvironment();
+  private readonly _celExpr = signal<string>('');
+  private readonly _onChanged = new Subject<void>();
+
+  /**
+   * Emits whenever the filter's internal configurations or state changes.
+   */
+  public readonly onChanged = this._onChanged.asObservable();
+
+  /**
+   * The currently active CEL timeline exclusion filter expression as a read-only signal.
+   */
+  public readonly celExpr = this._celExpr.asReadonly();
+
+  /**
+   * Validates the given CEL timeline expression against the registered environment schemas.
+   */
+  public validate(celExpr: string): CelFilterUpdateResult {
+    const tempEnv = new CELTimelineFilterEnvironment();
+    return tempEnv.compile(celExpr);
+  }
+
+  /**
+   * Updates the evaluator with a new CEL expression, validating its syntax beforehand.
+   */
+  public updateFilter(celExpr: string): CelFilterUpdateResult {
+    const compileRes = this.celEnv.compile(celExpr);
+    if (!compileRes.success) {
+      this._celExpr.set('');
+      return compileRes;
+    }
+    this._celExpr.set(celExpr);
+    this._onChanged.next();
+    return { success: true };
+  }
+
+  /**
+   * Evaluates each timeline in the context against the CEL exclusion expression and removes matching timeline IDs and their descendants.
+   */
+  public async process(
+    context: LogTimelineFilterContext,
+    timelineStore: TimelineStore,
+    signal?: AbortSignal,
+    onProgress?: (current: number, total: number) => void,
+  ): Promise<LogTimelineFilterContext> {
+    if (this.celExpr() === '') {
+      return context;
+    }
+    if (signal?.aborted) {
+      throw new CancellationError();
+    }
+
+    onProgress?.(0, context.timelineIds.size);
+
+    const excludedTimelineIds = await this.searchWorkerManager.searchTimelines(
+      this.celExpr(),
+      onProgress,
+    );
+
+    if (signal?.aborted) {
+      throw new CancellationError();
+    }
+
+    const filteredIds = new Set<number>();
+    const isTimelineAndAncestorsValid = (
+      t: ReadonlyDomainElement<Timeline>,
+    ): boolean => {
+      let current: ReadonlyDomainElement<Timeline> | null | undefined = t;
+      while (current) {
+        if (excludedTimelineIds.has(current.id)) {
+          return false;
+        }
+        current = current.parent;
+      }
+      return true;
+    };
+
+    for (const id of context.timelineIds) {
+      const t = timelineStore.getTimeline(id);
+      if (t && isTimelineAndAncestorsValid(t)) {
         filteredIds.add(id);
       }
     }

--- a/web/src/app/store/domain/timeline-view.ts
+++ b/web/src/app/store/domain/timeline-view.ts
@@ -52,6 +52,13 @@ export class TimelineView {
   });
   private readonly _isFiltering = signal<boolean>(false);
   private readonly _progress = signal<FilteringProgressInfo | null>(null);
+  private readonly _stepContexts = signal<
+    {
+      filterName: string;
+      priority: number;
+      contextAfter: LogTimelineFilterContext;
+    }[]
+  >([]);
   private activeAbortController?: AbortController;
 
   /**
@@ -150,6 +157,12 @@ export class TimelineView {
     };
 
     try {
+      const stepContexts: {
+        filterName: string;
+        priority: number;
+        contextAfter: LogTimelineFilterContext;
+      }[] = [];
+
       for (const filter of sortedFilters) {
         ctx = await filter.process(
           ctx,
@@ -165,9 +178,21 @@ export class TimelineView {
             }
           },
         );
+
+        if (!abortController.signal.aborted) {
+          stepContexts.push({
+            filterName: filter.displayName,
+            priority: filter.priority,
+            contextAfter: {
+              timelineIds: new Set(ctx.timelineIds),
+              logIds: new Set(ctx.logIds),
+            },
+          });
+        }
       }
 
       if (!abortController.signal.aborted) {
+        this._stepContexts.set(stepContexts);
         this._context.set(ctx);
       }
     } catch (err) {

--- a/web/src/app/store/domain/timeline-view.ts
+++ b/web/src/app/store/domain/timeline-view.ts
@@ -52,13 +52,6 @@ export class TimelineView {
   });
   private readonly _isFiltering = signal<boolean>(false);
   private readonly _progress = signal<FilteringProgressInfo | null>(null);
-  private readonly _stepContexts = signal<
-    {
-      filterName: string;
-      priority: number;
-      contextAfter: LogTimelineFilterContext;
-    }[]
-  >([]);
   private activeAbortController?: AbortController;
 
   /**
@@ -157,12 +150,6 @@ export class TimelineView {
     };
 
     try {
-      const stepContexts: {
-        filterName: string;
-        priority: number;
-        contextAfter: LogTimelineFilterContext;
-      }[] = [];
-
       for (const filter of sortedFilters) {
         ctx = await filter.process(
           ctx,
@@ -178,21 +165,9 @@ export class TimelineView {
             }
           },
         );
-
-        if (!abortController.signal.aborted) {
-          stepContexts.push({
-            filterName: filter.displayName,
-            priority: filter.priority,
-            contextAfter: {
-              timelineIds: new Set(ctx.timelineIds),
-              logIds: new Set(ctx.logIds),
-            },
-          });
-        }
       }
 
       if (!abortController.signal.aborted) {
-        this._stepContexts.set(stepContexts);
         this._context.set(ctx);
       }
     } catch (err) {

--- a/web/src/app/timeline-toolbar/components/cel-guide-overview.component.html
+++ b/web/src/app/timeline-toolbar/components/cel-guide-overview.component.html
@@ -27,10 +27,12 @@
   <div class="concepts-section concept-section">
     <div class="concept-grid">
       <div class="concept-card">
-        <h4>1. Timeline Filter</h4>
+        <h4>1. Timeline Filter (Include / Exclude)</h4>
         <p>
           Filters which resource timelines to display (e.g., by namespace, kind,
-          or name).
+          or name). Supports both Include filters (showing matching timelines
+          and their descendants) and Exclusion filters (hiding matching
+          timelines and their descendants).
         </p>
       </div>
       <div class="concept-card">

--- a/web/src/app/timeline-toolbar/components/cel-guide-timeline-cel.component.html
+++ b/web/src/app/timeline-toolbar/components/cel-guide-timeline-cel.component.html
@@ -16,9 +16,20 @@
 
 <div class="guide-content">
   <p>
-    Timeline CEL expressions filter which resource timelines are shown. The
-    expression must evaluate to a boolean.
+    Timeline CEL expressions filter which resource timelines are shown or
+    excluded. The expression must evaluate to a boolean.
   </p>
+
+  <div class="section-block">
+    <h3>Timeline Exclusion Filter</h3>
+    <p>
+      When an expression is used in the
+      <strong>Timeline Exclusion filter</strong>, any timeline that evaluates to
+      <code>true</code>
+      <strong>and all of its descendant timelines</strong> (e.g., Pods belonging
+      to an excluded Node or Workload) will be hidden from the view.
+    </p>
+  </div>
 
   <div class="section-block">
     <h3>Examples</h3>
@@ -59,6 +70,13 @@
           using regex</span
         >
         <code>revision_body('status.podIP', '^10\\..*')</code>
+      </div>
+      <div class="example-card">
+        <span class="example-label"
+          >Exclude kube-system namespace and all resources inside it (for
+          Exclusion filter)</span
+        >
+        <code>match('namespace', '^kube-system$')</code>
       </div>
     </div>
   </div>

--- a/web/src/app/timeline-toolbar/components/cel-guide-timeline-cel.component.scss
+++ b/web/src/app/timeline-toolbar/components/cel-guide-timeline-cel.component.scss
@@ -97,6 +97,7 @@ $code-text-color: mat.m2-get-color-from-palette($blue-palette, 800);
       'ex4' auto
       'ex5' auto
       'ex6' auto
+      'ex7' auto
       / auto;
     gap: 8px;
   }

--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.html
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.html
@@ -31,6 +31,27 @@ limitations under the License.
     }
   </div>
 
+  <div class="action-selector-wrapper">
+    <mat-button-toggle-group
+      [value]="filterAction()"
+      (change)="filterAction.set($event.value)"
+      class="action-toggle-group"
+    >
+      <mat-button-toggle value="include" class="action-toggle include-toggle">
+        <div class="toggle-button-content">
+          <mat-icon class="toggle-icon">filter_alt</mat-icon>
+          <span>Include</span>
+        </div>
+      </mat-button-toggle>
+      <mat-button-toggle value="exclude" class="action-toggle exclude-toggle">
+        <div class="toggle-button-content">
+          <mat-icon class="toggle-icon">filter_alt_off</mat-icon>
+          <span>Exclude</span>
+        </div>
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
   <div class="type-field-wrapper">
     <mat-form-field appearance="outline" class="form-field">
       <mat-label>Timeline Type</mat-label>
@@ -97,7 +118,9 @@ limitations under the License.
       <mat-form-field appearance="outline" class="form-field">
         <mat-label>Filter Pattern (Regex)</mat-label>
         <input
+          #regexInput
           matInput
+          autofocus
           placeholder="e.g. pod-a.*"
           [value]="regexValue()"
           (input)="regexValue.set($any($event.target).value)"

--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.scss
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.scss
@@ -17,11 +17,26 @@
 @use '@angular/material' as mat;
 
 $gray-palette: mat.$m2-gray-palette;
+$blue-palette: mat.$m2-blue-palette;
+$red-palette: mat.$m2-red-palette;
 
 $popover-bg-color: mat.m2-get-color-from-palette($gray-palette, 50);
 $popover-border-color: mat.m2-get-color-from-palette($gray-palette, 200);
 $popover-shadow-color: rgba(0, 0, 0, 0.12);
 $text-primary-color: mat.m2-get-color-from-palette($gray-palette, 800);
+
+// Action toggle button tokens
+$include-fg-color: mat.m2-get-color-from-palette($blue-palette, 700);
+$include-bg-color: mat.m2-get-color-from-palette($blue-palette, 50);
+$include-border-color: mat.m2-get-color-from-palette($blue-palette, 300);
+$include-checked-bg-color: mat.m2-get-color-from-palette($blue-palette, 600);
+$include-checked-fg-color: mat.m2-get-color-from-palette($gray-palette, 50);
+
+$exclude-fg-color: mat.m2-get-color-from-palette($red-palette, 700);
+$exclude-bg-color: mat.m2-get-color-from-palette($red-palette, 50);
+$exclude-border-color: mat.m2-get-color-from-palette($red-palette, 400);
+$exclude-checked-bg-color: mat.m2-get-color-from-palette($red-palette, 600);
+$exclude-checked-fg-color: mat.m2-get-color-from-palette($gray-palette, 50);
 
 .filter-builder-card {
   background-color: $popover-bg-color;
@@ -32,6 +47,7 @@ $text-primary-color: mat.m2-get-color-from-palette($gray-palette, 800);
   display: grid;
   grid-template:
     'title' auto
+    'action-toggle' auto
     'type-field' auto
     'mode-toggle' auto
     'input-field' auto
@@ -70,6 +86,74 @@ $text-primary-color: mat.m2-get-color-from-palette($gray-palette, 800);
 
 .type-field-wrapper {
   grid-area: type-field;
+}
+
+.action-selector-wrapper {
+  grid-area: action-toggle;
+  display: grid;
+  grid-template:
+    'toggle' auto
+    / 100%;
+  justify-items: center;
+  width: 100%;
+}
+
+.action-toggle-group {
+  grid-area: toggle;
+  width: 100%;
+  display: grid;
+  grid-template:
+    'include-toggle exclude-toggle' auto
+    / 1fr 1fr;
+
+  .action-toggle {
+    text-align: center;
+    border: 1px solid transparent;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease,
+      border-color 0.2s ease;
+
+    &.include-toggle {
+      background-color: $include-bg-color;
+      color: $include-fg-color;
+      border-color: $include-border-color;
+
+      .toggle-icon {
+        color: $include-fg-color;
+      }
+
+      &.mat-button-toggle-checked {
+        background-color: $include-checked-bg-color;
+        color: $include-checked-fg-color;
+        border-color: $include-checked-bg-color;
+
+        .toggle-icon {
+          color: $include-checked-fg-color;
+        }
+      }
+    }
+
+    &.exclude-toggle {
+      background-color: $exclude-bg-color;
+      color: $exclude-fg-color;
+      border-color: $exclude-border-color;
+
+      .toggle-icon {
+        color: $exclude-fg-color;
+      }
+
+      &.mat-button-toggle-checked {
+        background-color: $exclude-checked-bg-color;
+        color: $exclude-checked-fg-color;
+        border-color: $exclude-checked-bg-color;
+
+        .toggle-icon {
+          color: $exclude-checked-fg-color;
+        }
+      }
+    }
+  }
 }
 
 .mode-selector-wrapper {

--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.spec.ts
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.spec.ts
@@ -69,6 +69,7 @@ describe('TimelineFilterBuilderComponent', () => {
   it('should have correct defaults', () => {
     expect(component.selectedTimelineType()).toBe('*');
     expect(component.filterMode()).toBe('regex');
+    expect(component.filterAction()).toBe('include');
     expect(component.regexValue()).toBe('');
     expect(component.selectedCandidates()).toEqual([]);
     expect(component['typeInputQuery']()).toBe('');
@@ -134,6 +135,7 @@ describe('TimelineFilterBuilderComponent', () => {
       timelineType: string;
       mode: 'regex' | 'selection';
       value: string;
+      action: 'include' | 'exclude';
     } | null = null;
     component.confirm.subscribe((data) => (confirmData = data));
 
@@ -153,6 +155,7 @@ describe('TimelineFilterBuilderComponent', () => {
       timelineType: 'K8sResource',
       mode: 'regex',
       value: 'my-regex-pattern',
+      action: 'include',
     });
   });
 
@@ -161,6 +164,7 @@ describe('TimelineFilterBuilderComponent', () => {
       timelineType: string;
       mode: 'regex' | 'selection';
       value: string;
+      action: 'include' | 'exclude';
     } | null = null;
     component.confirm.subscribe((data) => (confirmData = data));
 
@@ -179,6 +183,7 @@ describe('TimelineFilterBuilderComponent', () => {
       timelineType: 'K8sResource',
       mode: 'selection',
       value: 'pod',
+      action: 'include',
     });
   });
 
@@ -187,12 +192,14 @@ describe('TimelineFilterBuilderComponent', () => {
       timelineType: string;
       mode: 'regex' | 'selection';
       value: string;
+      action: 'include' | 'exclude';
     } | null = null;
     component.confirm.subscribe((data) => (confirmData = data));
 
     fixture.componentRef.setInput('selectedTimelineType', 'K8sResource');
     fixture.componentRef.setInput('filterMode', 'selection');
     fixture.componentRef.setInput('selectedCandidates', ['pod-x', 'pod-y']);
+    fixture.componentRef.setInput('filterAction', 'exclude');
     fixture.detectChanges();
 
     const addButton = fixture.debugElement
@@ -205,6 +212,7 @@ describe('TimelineFilterBuilderComponent', () => {
       timelineType: 'K8sResource',
       mode: 'selection',
       value: 'pod-x|pod-y',
+      action: 'exclude',
     });
   });
 

--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.ts
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.component.ts
@@ -16,12 +16,14 @@
 
 import {
   Component,
+  ElementRef,
   computed,
   effect,
   input,
   model,
   output,
   signal,
+  viewChild,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
@@ -77,11 +79,17 @@ export class TimelineFilterBuilderComponent {
   /** The selected filter mode: regex or selection (model). */
   readonly filterMode = model<'regex' | 'selection'>('selection');
 
+  /** The selected filter action: include or exclude (model). */
+  readonly filterAction = model<'include' | 'exclude'>('include');
+
   /** The current raw regex filter string input (model). */
   readonly regexValue = model<string>('');
 
   /** The selected candidate values in selection mode (model). */
   readonly selectedCandidates = model<string[]>([]);
+
+  /** Holds reference to the regex input box element. */
+  readonly regexInput = viewChild<ElementRef<HTMLInputElement>>('regexInput');
 
   /** Holds the current text input query for autocomplete filtering. */
   protected readonly typeInputQuery = signal<string>('');
@@ -127,6 +135,7 @@ export class TimelineFilterBuilderComponent {
     timelineType: string;
     mode: 'regex' | 'selection';
     value: string;
+    action: 'include' | 'exclude';
   }>();
 
   constructor() {
@@ -140,6 +149,16 @@ export class TimelineFilterBuilderComponent {
       if (currentType !== this.lastSyncedType) {
         this.lastSyncedType = currentType;
         this.typeInputQuery.set(currentType === '*' ? '' : currentType);
+      }
+    });
+
+    // Auto-focus the regex input field whenever regex mode is active.
+    effect(() => {
+      if (this.filterMode() === 'regex') {
+        const inputEl = this.regexInput()?.nativeElement;
+        if (inputEl) {
+          setTimeout(() => inputEl.focus(), 0);
+        }
       }
     });
   }
@@ -242,6 +261,7 @@ export class TimelineFilterBuilderComponent {
       timelineType: this.selectedTimelineType(),
       mode: this.filterMode(),
       value,
+      action: this.filterAction(),
     });
   }
 }

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.component.html
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.component.html
@@ -30,20 +30,30 @@
       </div>
       <div class="center-control">
         <div class="cel-inputs-grid">
-          <khi-timeline-cel-input
-            [errorMessage]="timelineCelError()"
-            tooltip="Timeline CEL"
-            icon="view_timeline"
-            placeholder='e.g. match("kind", "pod") && !match("namespace", "kube-system")'
-            [(value)]="timelineCelFilter"
-            (focused)="onTimelineCelFocus()"
-          ></khi-timeline-cel-input>
+          <div class="timeline-cel-inputs-row">
+            <khi-timeline-cel-input
+              [errorMessage]="timelineIncludeCelError()"
+              tooltip="Timeline Include CEL"
+              icon="filter_alt"
+              placeholder='e.g. match("kind", "pod")'
+              [(value)]="timelineIncludeCelFilter"
+              (focused)="onTimelineCelFocus()"
+            ></khi-timeline-cel-input>
+            <khi-timeline-cel-input
+              [errorMessage]="timelineExcludeCelError()"
+              tooltip="Timeline Exclude CEL"
+              icon="filter_alt_off"
+              placeholder='e.g. match("namespace", "kube-system")'
+              [(value)]="timelineExcludeCelFilter"
+              (focused)="onTimelineCelFocus()"
+            ></khi-timeline-cel-input>
+          </div>
           <khi-timeline-cel-input
             #logCelInput
             [errorMessage]="logCelError()"
             tooltip="Log CEL"
             icon="notes"
-            placeholder='e.g. body("jsonPayload.message","error") && severity == "ERROR"'
+            placeholder='e.g. body("jsonPayload.message","error") && severity == ERROR'
             [(value)]="logCelFilter"
             (focused)="onLogCelFocus()"
           ></khi-timeline-cel-input>
@@ -101,6 +111,7 @@
             "
           ></khi-timeline-toolbar-settings>
         </ng-template>
+
         <div class="timezone-control">
           <p>UTC+</p>
           <input

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.component.scss
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.component.scss
@@ -53,6 +53,15 @@ $timezone-color: mat.m2-get-color-from-palette($primary-palette, 500);
   padding: 4px 16px;
 }
 
+.timeline-cel-inputs-row {
+  display: grid;
+  grid-template:
+    'inc exc' 1fr
+    / 1fr 1fr;
+  gap: 8px;
+  width: 100%;
+}
+
 .left-control {
   grid-area: left;
   justify-content: center;

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.component.spec.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.component.spec.ts
@@ -35,7 +35,8 @@ describe('ToolbarAdvancedComponent', () => {
 
     fixture = TestBed.createComponent(ToolbarAdvancedComponent);
     component = fixture.componentInstance;
-    fixture.componentRef.setInput('timelineCelError', '');
+    fixture.componentRef.setInput('timelineIncludeCelError', '');
+    fixture.componentRef.setInput('timelineExcludeCelError', '');
     fixture.componentRef.setInput('logCelError', '');
     fixture.detectChanges();
   });
@@ -50,13 +51,16 @@ describe('ToolbarAdvancedComponent', () => {
   });
 
   it('should bind timeline CEL filter value correctly', () => {
-    component.timelineCelFilter.set('timeline.name == "test"');
+    component.timelineIncludeCelFilter.set('timeline.name == "test"');
+    component.timelineExcludeCelFilter.set(
+      'timeline.namespace == "kube-system"',
+    );
     fixture.detectChanges();
 
     const celInputs = fixture.debugElement.queryAll(
       By.css('khi-timeline-cel-input'),
     );
-    expect(celInputs.length).toBe(2);
+    expect(celInputs.length).toBe(3);
   });
 
   it('should emit switchToStandard when standard button is clicked', () => {

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.component.ts
@@ -105,9 +105,14 @@ export class ToolbarAdvancedComponent {
   readonly activeSearchScope = input<SearchScope>(SearchScope.Global);
 
   /**
-   * Validation error message for the timeline CEL filter.
+   * Validation error message for the timeline include CEL filter.
    */
-  readonly timelineCelError = input('');
+  readonly timelineIncludeCelError = input('');
+
+  /**
+   * Validation error message for the timeline exclude CEL filter.
+   */
+  readonly timelineExcludeCelError = input('');
 
   /**
    * Validation error message for the log CEL filter.
@@ -120,9 +125,14 @@ export class ToolbarAdvancedComponent {
   readonly hideTimelinesWithoutMatchingLogs = model(false);
 
   /**
-   * Holds the two-way bound timeline CEL filter string.
+   * Holds the two-way bound timeline include CEL filter string.
    */
-  readonly timelineCelFilter = model('');
+  readonly timelineIncludeCelFilter = model('');
+
+  /**
+   * Holds the two-way bound timeline exclude CEL filter string.
+   */
+  readonly timelineExcludeCelFilter = model('');
 
   /**
    * Holds the two-way bound log CEL filter string.

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.stories.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.stories.ts
@@ -35,11 +35,13 @@ type Story = StoryObj<ToolbarAdvancedComponent>;
 
 export const Default: Story = {
   args: {
-    timelineCelError: '',
-    logCelError: '',
     timezoneShift: 0,
     logOrTimelineNotSelected: false,
-    timelineCelFilter: 'timeline.name == "foo"',
+    timelineIncludeCelFilter: 'timeline.name == "foo"',
+    timelineIncludeCelError: '',
+    timelineExcludeCelFilter: 'timeline.name == "bar"',
+    timelineExcludeCelError: '',
     logCelFilter: 'log.severity == ERROR',
+    logCelError: '',
   },
 };

--- a/web/src/app/timeline-toolbar/components/toolbar-frame.component.html
+++ b/web/src/app/timeline-toolbar/components/toolbar-frame.component.html
@@ -23,11 +23,18 @@ limitations under the License.
     (hideTimelinesWithoutMatchingLogsChange)="
       hideTimelinesWithoutMatchingLogsChange.emit($event)
     "
-    [timelineCelFilter]="timelineCelFilter()"
-    (timelineCelFilterChange)="timelineCelFilterChange.emit($event)"
+    [timelineIncludeCelFilter]="timelineIncludeCelFilter()"
+    (timelineIncludeCelFilterChange)="
+      timelineIncludeCelFilterChange.emit($event)
+    "
+    [timelineExcludeCelFilter]="timelineExcludeCelFilter()"
+    (timelineExcludeCelFilterChange)="
+      timelineExcludeCelFilterChange.emit($event)
+    "
     [logCelFilter]="logCelFilter()"
     (logCelFilterChange)="logCelFilterChange.emit($event)"
-    [timelineCelError]="timelineCelError()"
+    [timelineIncludeCelError]="timelineIncludeCelError()"
+    [timelineExcludeCelError]="timelineExcludeCelError()"
     [logCelError]="logCelError()"
     [activeSearchScope]="activeSearchScope()"
     (switchToStandard)="isAdvancedMode.set(false)"

--- a/web/src/app/timeline-toolbar/components/toolbar-frame.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-frame.component.ts
@@ -84,14 +84,20 @@ export class ToolbarFrameComponent {
   readonly showButtonLabel = input.required<boolean>();
 
   // Advanced Toolbar properties
-  /** Holds the advanced timeline CEL filter text. */
-  readonly timelineCelFilter = input.required<string>();
+  /** Holds the advanced timeline include CEL filter text. */
+  readonly timelineIncludeCelFilter = input.required<string>();
+
+  /** Holds the advanced timeline exclude CEL filter text. */
+  readonly timelineExcludeCelFilter = input.required<string>();
 
   /** Holds the advanced log CEL filter text. */
   readonly logCelFilter = input.required<string>();
 
-  /** Displays validation error for timeline CEL field. */
-  readonly timelineCelError = input.required<string>();
+  /** Displays validation error for timeline include CEL field. */
+  readonly timelineIncludeCelError = input.required<string>();
+
+  /** Displays validation error for timeline exclude CEL field. */
+  readonly timelineExcludeCelError = input.required<string>();
 
   /** Displays validation error for log CEL field. */
   readonly logCelError = input.required<string>();
@@ -106,8 +112,11 @@ export class ToolbarFrameComponent {
   /** Commits hide timelines without matching logs toggle changes. */
   readonly hideTimelinesWithoutMatchingLogsChange = output<boolean>();
 
-  /** Pushes changes to the timeline CEL string. */
-  readonly timelineCelFilterChange = output<string>();
+  /** Pushes changes to the timeline include CEL string. */
+  readonly timelineIncludeCelFilterChange = output<string>();
+
+  /** Pushes changes to the timeline exclude CEL string. */
+  readonly timelineExcludeCelFilterChange = output<string>();
 
   /** Pushes changes to the log CEL string. */
   readonly logCelFilterChange = output<string>();

--- a/web/src/app/timeline-toolbar/components/toolbar.component.html
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.html
@@ -34,6 +34,7 @@ limitations under the License.
             <button
               mat-stroked-button
               class="filter-badge"
+              [class.action-exclude]="filter.action === 'exclude'"
               [matTooltip]="getFilterTooltip(filter)"
               (click)="openEditFilterPopup(filter)"
               [style.--badge-bg]="getTypeRowBgColor(filter.timelineType)"
@@ -48,6 +49,9 @@ limitations under the License.
                 }}
               </mat-icon>
               <span class="filter-label">
+                @if (filter.action === "exclude") {
+                  <span class="action-tag exclude">Exclude</span>
+                }
                 <span class="filter-type">{{ filter.timelineType }}</span
                 ><span class="filter-colon">: </span
                 ><span class="filter-value">{{
@@ -149,6 +153,7 @@ limitations under the License.
     [showDeleteButton]="editingFilter() !== null"
     [(selectedTimelineType)]="selectedTimelineTypeForBuilder"
     [(filterMode)]="builderFilterMode"
+    [(filterAction)]="builderFilterAction"
     [(regexValue)]="builderRegexValue"
     [(selectedCandidates)]="builderSelectedCandidates"
     (closeButtonClicked)="toggleFilterBuilder()"

--- a/web/src/app/timeline-toolbar/components/toolbar.component.scss
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.scss
@@ -18,11 +18,18 @@
 
 $gray-palette: mat.$m2-gray-palette;
 $indigo-palette: mat.$m2-indigo-palette;
+$red-palette: mat.$m2-red-palette;
 
 // Design system tokens for filter badges and buttons
 $badge-border-color: mat.m2-get-color-from-palette($gray-palette, 300);
 $badge-bg-color: mat.m2-get-color-from-palette($gray-palette, 50);
 $badge-hover-bg-color: mat.m2-get-color-from-palette($gray-palette, 100);
+
+$exclude-badge-bg: mat.m2-get-color-from-palette($red-palette, 50);
+$exclude-badge-border: mat.m2-get-color-from-palette($red-palette, 400);
+$exclude-badge-fg: mat.m2-get-color-from-palette($red-palette, 700);
+$exclude-tag-bg: mat.m2-get-color-from-palette($red-palette, 100);
+$exclude-tag-fg: mat.m2-get-color-from-palette($red-palette, 800);
 
 $icon-color: mat.m2-get-color-from-palette($indigo-palette, 500);
 $type-color: mat.m2-get-color-from-palette($indigo-palette, 700);
@@ -171,6 +178,30 @@ $delete-icon-hover-color: mat.m2-get-color-from-palette($gray-palette, 800);
   &:hover {
     background-color: var(--badge-bg, #{$badge-hover-bg-color}) !important;
     opacity: 0.9;
+  }
+
+  &.action-exclude {
+    border-style: dashed !important;
+    border-color: var(--badge-border, #{$exclude-badge-border}) !important;
+
+    &:hover {
+      background-color: var(--badge-bg, #{$exclude-badge-bg}) !important;
+    }
+  }
+}
+
+.action-tag {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 4px;
+  letter-spacing: 0.5px;
+  margin-right: 2px;
+
+  &.exclude {
+    background-color: $exclude-tag-bg;
+    color: $exclude-tag-fg;
   }
 }
 

--- a/web/src/app/timeline-toolbar/components/toolbar.component.spec.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.spec.ts
@@ -68,8 +68,20 @@ describe('ToolbarComponent', () => {
 
   it('should render the filter badges for provided filters', () => {
     fixture.componentRef.setInput('timelineFilters', [
-      { id: '1', timelineType: 'K8sResource', mode: 'regex', value: 'Pod' },
-      { id: '2', timelineType: '*', mode: 'regex', value: 'test-pattern' },
+      {
+        id: '1',
+        timelineType: 'K8sResource',
+        mode: 'regex',
+        value: 'Pod',
+        action: 'include',
+      },
+      {
+        id: '2',
+        timelineType: '*',
+        mode: 'regex',
+        value: 'test-pattern',
+        action: 'include',
+      },
     ]);
     fixture.detectChanges();
 
@@ -92,7 +104,13 @@ describe('ToolbarComponent', () => {
 
   it('should delete the filter when delete icon in a badge is clicked', () => {
     fixture.componentRef.setInput('timelineFilters', [
-      { id: '1', timelineType: 'K8sResource', mode: 'selection', value: 'Pod' },
+      {
+        id: '1',
+        timelineType: 'K8sResource',
+        mode: 'selection',
+        value: 'Pod',
+        action: 'include',
+      },
     ]);
     fixture.detectChanges();
 

--- a/web/src/app/timeline-toolbar/components/toolbar.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.ts
@@ -196,11 +196,12 @@ export class ToolbarComponent {
    * For selection mode, replaces '|' with ', ' for cleaner list presentation.
    */
   protected getFilterTooltip(filter: TimelineFilterConfig): string {
+    const actionPrefix = filter.action === 'exclude' ? '(Exclude) ' : '';
     if (filter.mode === 'regex') {
-      return `${filter.timelineType}: ${filter.value}`;
+      return `${actionPrefix}${filter.timelineType}: ${filter.value}`;
     }
     const formattedValue = filter.value.split('|').join(', ');
-    return `${filter.timelineType}: ${formattedValue}`;
+    return `${actionPrefix}${filter.timelineType}: ${formattedValue}`;
   }
 
   protected readonly ToolbarPopupStatus = ToolbarPopupStatus;
@@ -212,6 +213,9 @@ export class ToolbarComponent {
   protected readonly editingFilter = signal<TimelineFilterConfig | null>(null);
   protected readonly builderFilterMode = signal<'regex' | 'selection'>(
     'selection',
+  );
+  protected readonly builderFilterAction = signal<'include' | 'exclude'>(
+    'include',
   );
   protected readonly builderRegexValue = signal<string>('');
   protected readonly builderSelectedCandidates = signal<string[]>([]);
@@ -247,6 +251,7 @@ export class ToolbarComponent {
     timelineType: string;
     mode: 'regex' | 'selection';
     value: string;
+    action: 'include' | 'exclude';
   }): void {
     const currentFilters = this.timelineFilters();
     const editFilter = this.editingFilter();
@@ -260,6 +265,7 @@ export class ToolbarComponent {
             timelineType: event.timelineType,
             mode: event.mode,
             value: event.value,
+            action: event.action,
           };
         }
         return f;
@@ -272,6 +278,7 @@ export class ToolbarComponent {
         timelineType: event.timelineType,
         mode: event.mode,
         value: event.value,
+        action: event.action,
       };
       this.timelineFilters.set([...currentFilters, newFilter]);
     }
@@ -281,6 +288,7 @@ export class ToolbarComponent {
     this.editingFilter.set(null);
     this.selectedTimelineTypeForBuilder.set('*');
     this.builderFilterMode.set('selection');
+    this.builderFilterAction.set('include');
     this.builderRegexValue.set('');
     this.builderSelectedCandidates.set([]);
   }
@@ -292,6 +300,7 @@ export class ToolbarComponent {
     this.editingFilter.set(filter);
     this.selectedTimelineTypeForBuilder.set(filter.timelineType);
     this.builderFilterMode.set(filter.mode);
+    this.builderFilterAction.set(filter.action ?? 'include');
     if (filter.mode === 'regex') {
       this.builderRegexValue.set(filter.value);
       this.builderSelectedCandidates.set([]);
@@ -315,6 +324,7 @@ export class ToolbarComponent {
       this.editingFilter.set(null);
       this.selectedTimelineTypeForBuilder.set('*');
       this.builderFilterMode.set('selection');
+      this.builderFilterAction.set('include');
       this.builderRegexValue.set('');
       this.builderSelectedCandidates.set([]);
     }

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.html
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.html
@@ -32,12 +32,15 @@ limitations under the License.
   (hideTimelinesWithoutMatchingLogsChange)="
     onToggleHideTimelinesWithoutMatchingLogs($event)
   "
-  [timelineCelFilter]="timelineCelFilter()"
+  [timelineIncludeCelFilter]="timelineIncludeCelFilter()"
+  [timelineExcludeCelFilter]="timelineExcludeCelFilter()"
+  [timelineIncludeCelError]="timelineIncludeCelError()"
+  [timelineExcludeCelError]="timelineExcludeCelError()"
   [logCelFilter]="logCelFilter()"
-  [timelineCelError]="timelineCelError()"
   [logCelError]="logCelError()"
   [activeSearchScope]="activeSearchScope()"
   (timezoneShiftChange)="onTimezoneshiftCommit($event)"
-  (timelineCelFilterChange)="onTimelineCelFilterChange($event)"
+  (timelineIncludeCelFilterChange)="onTimelineIncludeCelFilterChange($event)"
+  (timelineExcludeCelFilterChange)="onTimelineExcludeCelFilterChange($event)"
   (logCelFilterChange)="onLogCelFilterChange($event)"
 ></khi-toolbar-frame>

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.spec.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.spec.ts
@@ -17,6 +17,7 @@
 import {
   compileLogFiltersToCel,
   compileFiltersToCel,
+  compileExclusionFiltersToCel,
 } from './timeline-toolbar-smart.component';
 import { TimelineFilterConfig } from 'src/app/timeline-toolbar/types/filter-config';
 
@@ -64,6 +65,7 @@ describe('TimelineToolbarSmart compilation helpers', () => {
           timelineType: '*',
           mode: 'regex',
           value: 'pod-.*',
+          action: 'include',
         },
       ];
       expect(compileFiltersToCel(filters)).toBe('match("pod-.*")');
@@ -76,6 +78,7 @@ describe('TimelineToolbarSmart compilation helpers', () => {
           timelineType: 'K8sResource',
           mode: 'regex',
           value: 'pod-.*',
+          action: 'include',
         },
       ];
       expect(compileFiltersToCel(filters)).toBe(
@@ -90,6 +93,7 @@ describe('TimelineToolbarSmart compilation helpers', () => {
           timelineType: 'K8sResource',
           mode: 'regex',
           value: 'test"val\\ue',
+          action: 'include',
         },
       ];
       expect(compileFiltersToCel(filters)).toBe(
@@ -104,6 +108,7 @@ describe('TimelineToolbarSmart compilation helpers', () => {
           timelineType: 'K8sResource',
           mode: 'selection',
           value: 'pod-a|pod.b|pod+c',
+          action: 'include',
         },
       ];
       expect(compileFiltersToCel(filters)).toBe(
@@ -118,6 +123,7 @@ describe('TimelineToolbarSmart compilation helpers', () => {
           timelineType: 'K8sResource',
           mode: 'selection',
           value: 'val"ue\\1|val"ue\\2',
+          action: 'include',
         },
       ];
       expect(compileFiltersToCel(filters)).toBe(
@@ -125,23 +131,25 @@ describe('TimelineToolbarSmart compilation helpers', () => {
       );
     });
 
-    it('should join multiple filters with &&', () => {
+    it('should ignore exclude filters in compileFiltersToCel', () => {
       const filters: TimelineFilterConfig[] = [
         {
           id: '1',
           timelineType: 'K8sResource',
           mode: 'regex',
           value: 'pod-.*',
+          action: 'include',
         },
         {
           id: '2',
           timelineType: '*',
           mode: 'selection',
           value: 'ns-1|ns-2',
+          action: 'exclude',
         },
       ];
       expect(compileFiltersToCel(filters)).toBe(
-        'match("K8sResource", "pod-.*") && match("^(?:ns-1|ns-2)$")',
+        'match("K8sResource", "pod-.*")',
       );
     });
 
@@ -152,6 +160,7 @@ describe('TimelineToolbarSmart compilation helpers', () => {
           timelineType: '*',
           mode: 'regex',
           value: 'pod-.*',
+          action: 'include',
         },
       ];
       expect(compileFiltersToCel(filters, 'ERROR')).toBe(
@@ -161,6 +170,43 @@ describe('TimelineToolbarSmart compilation helpers', () => {
 
     it('should return minSeverity only when filters is empty and severity is not ANY', () => {
       expect(compileFiltersToCel([], 'ERROR')).toBe('minSeverity(ERROR)');
+    });
+  });
+
+  describe('compileExclusionFiltersToCel', () => {
+    it('should return empty string when no exclude filters exist', () => {
+      const filters: TimelineFilterConfig[] = [
+        {
+          id: '1',
+          timelineType: '*',
+          mode: 'regex',
+          value: 'pod-.*',
+          action: 'include',
+        },
+      ];
+      expect(compileExclusionFiltersToCel(filters)).toBe('');
+    });
+
+    it('should compile exclude filters to match', () => {
+      const filters: TimelineFilterConfig[] = [
+        {
+          id: '1',
+          timelineType: 'K8sResource',
+          mode: 'regex',
+          value: 'pod-.*',
+          action: 'exclude',
+        },
+        {
+          id: '2',
+          timelineType: '*',
+          mode: 'selection',
+          value: 'ns-1',
+          action: 'exclude',
+        },
+      ];
+      expect(compileExclusionFiltersToCel(filters)).toBe(
+        'match("K8sResource", "pod-.*") || match("^(?:ns-1)$")',
+      );
     });
   });
 });

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
@@ -38,6 +38,7 @@ import { SelectionManagerV2 } from 'src/app/services/selection-manager-v2.servic
 import { InspectionDataStoreV2 } from 'src/app/services/inspection-data-store-v2.service';
 import {
   CelTimelineFilter,
+  CelTimelineExclusionFilter,
   CelLogFilter,
 } from 'src/app/store/domain/filter/cel-filter';
 import { ExcludeNoLogsFilter } from 'src/app/store/domain/filter/other-filter';
@@ -57,6 +58,9 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
   private readonly viewStateService = inject(ViewStateService);
   private readonly inspectionDataStore = inject(InspectionDataStoreV2);
   private readonly celTimelineFilter = inject(CelTimelineFilter);
+  private readonly celTimelineExclusionFilter = inject(
+    CelTimelineExclusionFilter,
+  );
   private readonly celLogFilter = inject(CelLogFilter);
   private readonly excludeNoLogsFilter = inject(ExcludeNoLogsFilter);
   private readonly selectionManager = inject(SelectionManagerV2);
@@ -206,25 +210,51 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
   );
 
   // Advanced Mode properties
-  private readonly timelineCelFilter$ = new BehaviorSubject<string>('');
+  private readonly timelineIncludeCelFilter$ = new BehaviorSubject<string>('');
+  private readonly timelineExcludeCelFilter$ = new BehaviorSubject<string>('');
   private readonly logCelFilter$ = new BehaviorSubject<string>('');
 
-  /** Active advanced timeline CEL expression signal. */
-  protected readonly timelineCelFilter = toSignal(this.timelineCelFilter$, {
-    initialValue: '',
-  });
+  /** Active advanced timeline include CEL expression signal. */
+  protected readonly timelineIncludeCelFilter = toSignal(
+    this.timelineIncludeCelFilter$,
+    {
+      initialValue: '',
+    },
+  );
+
+  /** Active advanced timeline exclude CEL expression signal. */
+  protected readonly timelineExcludeCelFilter = toSignal(
+    this.timelineExcludeCelFilter$,
+    {
+      initialValue: '',
+    },
+  );
 
   /** Active advanced log CEL expression signal. */
   protected readonly logCelFilter = toSignal(this.logCelFilter$, {
     initialValue: '',
   });
 
-  /** Validation result error output for timeline CEL queries. */
-  protected readonly timelineCelError = toSignal(
-    this.timelineCelFilter$.pipe(
+  /** Validation result error output for timeline include CEL queries. */
+  protected readonly timelineIncludeCelError = toSignal(
+    this.timelineIncludeCelFilter$.pipe(
       map((val) => {
         if (!val || val.trim() === '') return '';
         const checkRes = this.celTimelineFilter.validate(val);
+        return checkRes.success
+          ? ''
+          : (checkRes.error?.message ?? 'Invalid CEL expression.');
+      }),
+    ),
+    { initialValue: '' },
+  );
+
+  /** Validation result error output for timeline exclude CEL queries. */
+  protected readonly timelineExcludeCelError = toSignal(
+    this.timelineExcludeCelFilter$.pipe(
+      map((val) => {
+        if (!val || val.trim() === '') return '';
+        const checkRes = this.celTimelineExclusionFilter.validate(val);
         return checkRes.success
           ? ''
           : (checkRes.error?.message ?? 'Invalid CEL expression.');
@@ -255,21 +285,29 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
 
   constructor() {
     const viewState = this.viewStateService;
-    const currentTimelineCel = this.celTimelineFilter.celExpr();
+    const currentTimelineIncludeCel = this.celTimelineFilter.celExpr();
+    const currentTimelineExcludeCel = this.celTimelineExclusionFilter.celExpr();
     const currentLogCel = this.celLogFilter.celExpr();
 
-    const hypotheticalTimelineCel = compileFiltersToCel(
+    const hypotheticalTimelineIncludeCel = compileFiltersToCel(
       viewState.standardTimelineFilters(),
       viewState.standardSelectedSeverity(),
+    );
+    const hypotheticalTimelineExcludeCel = compileExclusionFiltersToCel(
+      viewState.standardTimelineFilters(),
     );
     const hypotheticalLogCel = compileLogFiltersToCel(
       viewState.standardSelectedSeverity(),
       viewState.standardLogSearchQuery(),
     );
 
-    if (currentTimelineCel !== hypotheticalTimelineCel) {
+    if (
+      currentTimelineIncludeCel !== hypotheticalTimelineIncludeCel ||
+      currentTimelineExcludeCel !== hypotheticalTimelineExcludeCel
+    ) {
       viewState.standardTimelineFilters.set([]);
       this.celTimelineFilter.updateFilter('');
+      this.celTimelineExclusionFilter.updateFilter('');
     }
 
     if (currentLogCel !== hypotheticalLogCel) {
@@ -283,8 +321,10 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
       if (!this.isAdvancedMode()) {
         const filters = this.timelineFilters();
         const severity = this.selectedSeverity();
-        const celExpr = compileFiltersToCel(filters, severity);
-        this.celTimelineFilter.updateFilter(celExpr);
+        const includeCelExpr = compileFiltersToCel(filters, severity);
+        const excludeCelExpr = compileExclusionFiltersToCel(filters);
+        this.celTimelineFilter.updateFilter(includeCelExpr);
+        this.celTimelineExclusionFilter.updateFilter(excludeCelExpr);
       }
     });
 
@@ -300,11 +340,23 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
     // Sync advanced mode CEL triggers
     effect(() => {
       if (this.isAdvancedMode()) {
-        const currentTimelineExpr = this.celTimelineFilter.celExpr();
-        if (this.timelineCelFilter$.value !== currentTimelineExpr) {
-          const hasError = untracked(() => this.timelineCelError() !== '');
-          if (currentTimelineExpr !== '' || !hasError) {
-            this.timelineCelFilter$.next(currentTimelineExpr);
+        const currentIncludeExpr = this.celTimelineFilter.celExpr();
+        if (this.timelineIncludeCelFilter$.value !== currentIncludeExpr) {
+          const hasError = untracked(
+            () => this.timelineIncludeCelError() !== '',
+          );
+          if (currentIncludeExpr !== '' || !hasError) {
+            this.timelineIncludeCelFilter$.next(currentIncludeExpr);
+          }
+        }
+
+        const currentExcludeExpr = this.celTimelineExclusionFilter.celExpr();
+        if (this.timelineExcludeCelFilter$.value !== currentExcludeExpr) {
+          const hasError = untracked(
+            () => this.timelineExcludeCelError() !== '',
+          );
+          if (currentExcludeExpr !== '' || !hasError) {
+            this.timelineExcludeCelFilter$.next(currentExcludeExpr);
           }
         }
       }
@@ -323,15 +375,27 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
     });
 
     // Advanced mode RxJS streams debouncers
-    this.timelineCelFilter$
+    this.timelineIncludeCelFilter$
       .pipe(
         debounceTime(200),
         distinctUntilChanged(),
         takeUntil(this.destroyed),
       )
-      .subscribe((filter) => {
+      .subscribe((filter: string) => {
         if (this.isAdvancedMode()) {
           this.celTimelineFilter.updateFilter(filter);
+        }
+      });
+
+    this.timelineExcludeCelFilter$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        takeUntil(this.destroyed),
+      )
+      .subscribe((filter: string) => {
+        if (this.isAdvancedMode()) {
+          this.celTimelineExclusionFilter.updateFilter(filter);
         }
       });
 
@@ -341,7 +405,7 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
         distinctUntilChanged(),
         takeUntil(this.destroyed),
       )
-      .subscribe((filter) => {
+      .subscribe((filter: string) => {
         if (this.isAdvancedMode()) {
           this.celLogFilter.updateFilter(filter);
         }
@@ -371,10 +435,17 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
   }
 
   /**
-   * Commits a modified timeline CEL filter expression text queries.
+   * Commits a modified timeline include CEL filter expression text queries.
    */
-  protected onTimelineCelFilterChange(filter: string): void {
-    this.timelineCelFilter$.next(filter);
+  protected onTimelineIncludeCelFilterChange(filter: string): void {
+    this.timelineIncludeCelFilter$.next(filter);
+  }
+
+  /**
+   * Commits a modified timeline exclude CEL filter expression text queries.
+   */
+  protected onTimelineExcludeCelFilterChange(filter: string): void {
+    this.timelineExcludeCelFilter$.next(filter);
   }
 
   /**
@@ -411,7 +482,7 @@ export function compileLogFiltersToCel(
 }
 
 /**
- * Compiles a list of standard timeline filters and a severity level into a CEL expression.
+ * Compiles a list of standard timeline filters and a severity level into a CEL expression for inclusion.
  */
 export function compileFiltersToCel(
   filters: TimelineFilterConfig[],
@@ -421,8 +492,9 @@ export function compileFiltersToCel(
   if (severity && severity !== 'ANY') {
     parts.push(`minSeverity(${severity})`);
   }
-  if (filters.length > 0) {
-    const filtersCel = filters
+  const includeFilters = filters.filter((f) => f.action !== 'exclude');
+  if (includeFilters.length > 0) {
+    const filtersCel = includeFilters
       .map((f) => {
         let celValue = f.value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         if (f.mode === 'selection') {
@@ -444,4 +516,35 @@ export function compileFiltersToCel(
     parts.push(filtersCel);
   }
   return parts.join(' && ');
+}
+
+/**
+ * Compiles a list of standard timeline exclusion filters into a CEL expression for exclusion.
+ */
+export function compileExclusionFiltersToCel(
+  filters: TimelineFilterConfig[],
+): string {
+  const excludeFilters = filters.filter((f) => f.action === 'exclude');
+  if (excludeFilters.length === 0) {
+    return '';
+  }
+  return excludeFilters
+    .map((f) => {
+      let celValue = f.value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      if (f.mode === 'selection') {
+        const escapedParts = f.value.split('|').map((val) =>
+          val
+            .replace(/\\/g, '\\\\')
+            .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            .replace(/"/g, '\\"'),
+        );
+        celValue = `^(?:${escapedParts.join('|')})$`;
+      }
+      if (f.timelineType === '*') {
+        return `match("${celValue}")`;
+      } else {
+        return `match("${f.timelineType}", "${celValue}")`;
+      }
+    })
+    .join(' || ');
 }

--- a/web/src/app/timeline-toolbar/types/filter-config.ts
+++ b/web/src/app/timeline-toolbar/types/filter-config.ts
@@ -19,4 +19,5 @@ export interface TimelineFilterConfig {
   timelineType: string;
   mode: 'regex' | 'selection';
   value: string;
+  action: 'include' | 'exclude';
 }

--- a/web/src/app/timeline/components/timeline-frame.component.html
+++ b/web/src/app/timeline/components/timeline-frame.component.html
@@ -89,6 +89,8 @@
           (clickOnTimeline)="
             handleTimelineEventForIndex($event, clickOnTimeline)
           "
+          (excludeTimeline)="excludeTimeline.emit($event)"
+          (excludeTimelineType)="excludeTimelineType.emit($event)"
           [highlights]="timelineHighlights()"
         ></khi-timeline-index>
       </div>
@@ -170,6 +172,8 @@
             (clickOnTimeline)="
               handleTimelineEventForIndex($event, clickOnTimeline)
             "
+            (excludeTimeline)="excludeTimeline.emit($event)"
+            (excludeTimelineType)="excludeTimelineType.emit($event)"
             [highlights]="timelineHighlights()"
           ></khi-timeline-index>
         </div>

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -454,6 +454,18 @@ export class TimelineFrameComponent implements AfterViewInit {
    * Emitted when the user clicks on a timeline (row).
    */
   readonly clickOnTimeline = output<Timeline>();
+  /**
+   * Emitted when toggling timeline registration in the CEL debugger.
+   */
+  readonly toggleDebugTimeline = output<Timeline>();
+  /**
+   * Emitted when requesting to exclude a specific timeline.
+   */
+  readonly excludeTimeline = output<Timeline>();
+  /**
+   * Emitted when requesting to exclude all timelines of a specific type.
+   */
+  readonly excludeTimelineType = output<string>();
 
   /**
    * Emitted when the user hovers over an item (event or revision) in the chart.

--- a/web/src/app/timeline/components/timeline-index.component.html
+++ b/web/src/app/timeline/components/timeline-index.component.html
@@ -40,7 +40,9 @@
         }}</mat-icon>
       }
       <div class="index">
-        <p class="main-name" [matTooltip]="t.name">{{ t.name }}</p>
+        <p class="main-name" [matTooltip]="t.name">
+          {{ t.name }}
+        </p>
         @if (t.subLabel !== "") {
           <p class="sub-label">{{ t.subLabel }}</p>
         }
@@ -48,6 +50,28 @@
           <span class="layer-name">{{ t.layerName }}</span>
         }
       </div>
+      <button
+        type="button"
+        class="menu-trigger-btn"
+        [matMenuTriggerFor]="itemMenu"
+        (click)="$event.stopPropagation()"
+        matTooltip="Menu"
+      >
+        <mat-icon class="menu-icon">more_vert</mat-icon>
+      </button>
+      <mat-menu #itemMenu="matMenu">
+        <button mat-menu-item (click)="excludeTimeline.emit(t.timeline)">
+          <mat-icon>filter_alt_off</mat-icon>
+          <span>Exclude this timeline</span>
+        </button>
+        <button
+          mat-menu-item
+          (click)="excludeTimelineType.emit(t.timeline.type.label)"
+        >
+          <mat-icon>block</mat-icon>
+          <span>Exclude all timelines of this type</span>
+        </button>
+      </mat-menu>
     </div>
   }
 </div>

--- a/web/src/app/timeline/components/timeline-index.component.scss
+++ b/web/src/app/timeline/components/timeline-index.component.scss
@@ -54,9 +54,9 @@ $tint-border-color: mat.m2-get-color-from-palette(mat.$m2-green-palette, 600);
   border-left: 5px dashed transparent;
 
   grid-template:
-    'icon label' 1fr
-    / var(--icon-size) 1fr;
-  gap: 0 6px;
+    'icon label menu' 1fr
+    / var(--icon-size) 1fr auto;
+  gap: 0 4px;
 
   .tree-guide {
     position: absolute;
@@ -129,6 +129,8 @@ $tint-border-color: mat.m2-get-color-from-palette(mat.$m2-green-palette, 600);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      display: flex;
+      align-items: center;
     }
 
     .sub-label {
@@ -160,6 +162,31 @@ $tint-border-color: mat.m2-get-color-from-palette(mat.$m2-green-palette, 600);
       letter-spacing: 0.5px;
       user-select: none;
       text-align: center;
+    }
+  }
+
+  .menu-trigger-btn {
+    grid-area: menu;
+    border: 0;
+    background-color: transparent;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--timeline-fg-color);
+    opacity: 0.4;
+    outline: none;
+    width: var(--icon-size);
+    height: var(--icon-size);
+
+    &:hover {
+      opacity: 1;
+    }
+
+    .menu-icon {
+      @include common.adjust-mat-icon-size(var(--icon-size));
     }
   }
 

--- a/web/src/app/timeline/components/timeline-index.component.ts
+++ b/web/src/app/timeline/components/timeline-index.component.ts
@@ -18,6 +18,7 @@ import { Component, computed, input, output } from '@angular/core';
 import { Timeline } from 'src/app/store/domain/timeline';
 import { CommonModule } from '@angular/common';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
 import { RendererConvertUtil } from 'src/app/timeline/components/canvas/convertutil';
 import { MatIconModule } from '@angular/material/icon';
 import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
@@ -75,6 +76,7 @@ interface TimelineIndexViewModel {
   imports: [
     CommonModule,
     MatTooltipModule,
+    MatMenuModule,
     MatIconModule,
     KHIIconRegistrationModule,
   ],
@@ -100,6 +102,12 @@ export class TimelineIndexComponent {
 
   /** Emits the timeline when the user clicks on a row. */
   clickOnTimeline = output<Timeline>();
+
+  /** Emits the timeline when requesting to exclude it. */
+  excludeTimeline = output<Timeline>();
+
+  /** Emits the timeline type label when requesting to exclude all timelines of that type. */
+  excludeTimelineType = output<string>();
 
   /**
    * Handles mouse over events on a timeline row.

--- a/web/src/app/timeline/timeline-smart.component.html
+++ b/web/src/app/timeline/timeline-smart.component.html
@@ -35,6 +35,8 @@
   [timelineChartItemHighlights]="timelineChartItemHighlights()"
   (hoverOnTimeline)="hoverOnTimeline($event)"
   (clickOnTimeline)="clickOnTimeline($event)"
+  (excludeTimeline)="excludeTimeline($event)"
+  (excludeTimelineType)="excludeTimelineType($event)"
   (hoverOnTimelineItem)="hoverOnTimelineItem($event)"
   (clickOnTimelineItem)="clickOnTimelineItem($event)"
   [cursorTimeMS]="cursorTimeMs()"

--- a/web/src/app/timeline/timeline-smart.component.ts
+++ b/web/src/app/timeline/timeline-smart.component.ts
@@ -23,6 +23,7 @@ import {
 import { ViewStateService } from 'src/app/services/view-state.service';
 import { InspectionDataStoreV2 } from 'src/app/services/inspection-data-store-v2.service';
 import { SelectionManagerV2 } from 'src/app/services/selection-manager-v2.service';
+
 import {
   TimelineChartItemHighlight,
   TimelineChartItemHighlightType,
@@ -43,6 +44,8 @@ import {
 import { TimelineChartMouseEvent } from 'src/app/timeline/components/timeline-chart.component';
 import { bisectLeft } from 'src/app/common/misc-util';
 import { BigIntTimeUtil } from 'src/app/utils/bigint-time-util';
+import { TimelineFilterConfig } from 'src/app/timeline-toolbar/types/filter-config';
+import { CelTimelineExclusionFilter } from 'src/app/store/domain/filter/cel-filter';
 
 /**
  * Smart component for the timeline view.
@@ -71,6 +74,10 @@ export class TimelineSmartComponent {
   private readonly selectionManager = inject(SelectionManagerV2);
 
   private readonly styleOverrideService = inject(StyleOverrideService);
+
+  private readonly celTimelineExclusionFilter = inject(
+    CelTimelineExclusionFilter,
+  );
 
   private readonly inspectionData = computed(() => {
     return this.inspectionDataStore.inspectionData();
@@ -532,6 +539,90 @@ export class TimelineSmartComponent {
    */
   protected clickOnTimeline(event: ReadonlyDomainElement<Timeline>): void {
     this.selectionManager.onSelectTimeline(event);
+  }
+
+  /**
+   * Handles excluding a single timeline by adding or updating an exclusion filter.
+   * @param timeline - The timeline to exclude.
+   */
+  protected excludeTimeline(timeline: Timeline): void {
+    if (this.viewStateService.isAdvancedMode()) {
+      const currentExpr = this.celTimelineExclusionFilter.celExpr();
+      const escapedName = timeline.name
+        .replace(/\\/g, '\\\\')
+        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        .replace(/"/g, '\\"');
+      const predicate = `match("${timeline.type.label}", "^(?:${escapedName})$")`;
+      const updatedExpr = currentExpr
+        ? `${currentExpr} || ${predicate}`
+        : predicate;
+      this.celTimelineExclusionFilter.updateFilter(updatedExpr);
+      return;
+    }
+
+    const currentFilters = this.viewStateService.standardTimelineFilters();
+    const typeLabel = timeline.type.label;
+    const existingIndex = currentFilters.findIndex(
+      (f) =>
+        f.timelineType === typeLabel &&
+        f.action === 'exclude' &&
+        f.mode === 'selection',
+    );
+
+    if (existingIndex !== -1) {
+      const existingFilter = currentFilters[existingIndex];
+      const parts = existingFilter.value.split('|');
+      if (!parts.includes(timeline.name)) {
+        parts.push(timeline.name);
+        const updatedFilters = [...currentFilters];
+        updatedFilters[existingIndex] = {
+          ...existingFilter,
+          value: parts.join('|'),
+        };
+        this.viewStateService.standardTimelineFilters.set(updatedFilters);
+      }
+    } else {
+      const newFilter: TimelineFilterConfig = {
+        id: crypto.randomUUID(),
+        timelineType: typeLabel,
+        mode: 'selection',
+        value: timeline.name,
+        action: 'exclude',
+      };
+      this.viewStateService.standardTimelineFilters.set([
+        ...currentFilters,
+        newFilter,
+      ]);
+    }
+  }
+
+  /**
+   * Handles excluding all timelines of a specific type.
+   * @param typeLabel - The label of the timeline type to exclude.
+   */
+  protected excludeTimelineType(typeLabel: string): void {
+    if (this.viewStateService.isAdvancedMode()) {
+      const currentExpr = this.celTimelineExclusionFilter.celExpr();
+      const predicate = `match("${typeLabel}", ".*")`;
+      const updatedExpr = currentExpr
+        ? `${currentExpr} || ${predicate}`
+        : predicate;
+      this.celTimelineExclusionFilter.updateFilter(updatedExpr);
+      return;
+    }
+
+    const currentFilters = this.viewStateService.standardTimelineFilters();
+    const newFilter: TimelineFilterConfig = {
+      id: crypto.randomUUID(),
+      timelineType: typeLabel,
+      mode: 'regex',
+      value: '.*',
+      action: 'exclude',
+    };
+    this.viewStateService.standardTimelineFilters.set([
+      ...currentFilters,
+      newFilter,
+    ]);
   }
 
   /**

--- a/web/src/app/timeline/timeline-smart.component.ts
+++ b/web/src/app/timeline/timeline-smart.component.ts
@@ -571,7 +571,7 @@ export class TimelineSmartComponent {
 
     if (existingIndex !== -1) {
       const existingFilter = currentFilters[existingIndex];
-      const parts = existingFilter.value.split('|');
+      const parts = existingFilter.value ? existingFilter.value.split('|') : [];
       if (!parts.includes(timeline.name)) {
         parts.push(timeline.name);
         const updatedFilters = [...currentFilters];


### PR DESCRIPTION
KHI timeline filter has selected descendants of filtered timelines for the better usability. But this behavior was hard to be used with exclusive filter. I added exclusion filter as well and its excluded descendants are also removed from the result.

**timeline CEL filters**
<img width="3826" height="248" alt="image" src="https://github.com/user-attachments/assets/577a971c-6477-43cc-ac31-3431dfac6dbb" />

**new filter builder**
<img width="1200" height="854" alt="image" src="https://github.com/user-attachments/assets/598c3b59-f532-4829-be93-3a71b2176527" />

**Exclusion menus**
<img width="3840" height="1926" alt="image" src="https://github.com/user-attachments/assets/d7826379-b694-4d7e-8316-84e575f3b92d" />
