### PR TITLE
fix(web): report granular download progress and show initial progressbar

### DIFF
--- a/web/src/app/services/api/backend-api.service.spec.ts
+++ b/web/src/app/services/api/backend-api.service.spec.ts
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
+import { HttpEventType, provideHttpClient } from '@angular/common/http';
 import {
-  HttpClientTestingModule,
+  provideHttpClientTesting,
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { BackendAPIImpl, InspectionClient } from './backend-api.service';
+import {
+  BackendAPIImpl,
+  BackendAPIUtil,
+  InspectionClient,
+} from './backend-api.service';
 import { ViewStateService } from '../view-state.service';
+import { ProgressDialogStatusUpdator } from 'src/app/services/progress/progress-interface';
 import {
   CreateInspectionResponse,
   GetConfigResponse,
@@ -44,8 +50,12 @@ describe('BackendAPIImpl testing', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
-      providers: [BackendAPIImpl, ViewStateService],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        BackendAPIImpl,
+        ViewStateService,
+      ],
     });
 
     api = TestBed.inject(BackendAPIImpl);
@@ -237,6 +247,85 @@ describe('BackendAPIImpl testing', () => {
     req1.flush(testData);
   });
 
+  it('reports granular progress when getInspectionData receives progress events', () => {
+    const fileSize = 100;
+    const testMetadata: InspectionMetadataOfRunResult = {
+      header: {
+        inspectionType: 'test',
+        inspectionName: 'test',
+        inspectionTypeIconPath: 'test',
+        inspectTimeUnixSeconds: 10,
+        startTimeUnixSeconds: 10,
+        endTimeUnixSeconds: 10,
+        suggestedFilename: 'test',
+        fileSize: 100,
+      },
+      query: [],
+      plan: {
+        taskGraph: '',
+      },
+      log: [],
+      error: {
+        errorMessages: [],
+      },
+    };
+    const reporterSpy = jasmine.createSpy('reporter');
+    api.getInspectionData('test', reporterSpy).subscribe();
+
+    const req0 = httpTestingController.expectOne(
+      '/api/v3/inspection/test/metadata',
+    );
+    req0.flush(testMetadata);
+
+    const req1 = httpTestingController.expectOne(
+      '/api/v3/inspection/test/data?start=0&maxSize=100',
+    );
+    req1.event({
+      type: HttpEventType.DownloadProgress,
+      loaded: 30,
+      total: 100,
+    });
+    expect(reporterSpy).toHaveBeenCalledWith(100, 30);
+
+    const testData = new Blob([new ArrayBuffer(fileSize)]);
+    req1.flush(testData);
+    expect(reporterSpy).toHaveBeenCalledWith(100, 100);
+  });
+
+  it('initializes progress dialog immediately when downloadInspectionDataAsFile is called', () => {
+    const progressSpy = jasmine.createSpyObj<ProgressDialogStatusUpdator>(
+      'Progress',
+      ['show', 'updateProgress', 'dismiss'],
+    );
+    BackendAPIUtil.downloadInspectionDataAsFile(
+      api,
+      'test',
+      progressSpy,
+    ).subscribe();
+
+    expect(progressSpy.show).toHaveBeenCalled();
+    expect(progressSpy.updateProgress).toHaveBeenCalledWith({
+      message: 'Downloading inspection data...',
+      percent: 0,
+      mode: 'determinate',
+    });
+
+    const req0 = httpTestingController.expectOne(
+      '/api/v3/inspection/test/metadata',
+    );
+    req0.flush({
+      header: { suggestedFilename: 'test.khi', fileSize: 10 },
+      query: [],
+      plan: { taskGraph: '' },
+      log: [],
+      error: { errorMessages: [] },
+    });
+    const req1 = httpTestingController.expectOne(
+      '/api/v3/inspection/test/data?start=0&maxSize=10',
+    );
+    req1.flush(new Blob([new ArrayBuffer(10)]));
+  });
+
   it('can call runTask', () => {
     const testParameters: InspectionRunRequest = {
       test: 'foo',
@@ -351,7 +440,7 @@ describe('InspectionTaskClient testing', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     });
 
     backendAPISpy = jasmine.createSpyObj<BackendAPI>('BackendAPI', [

--- a/web/src/app/services/api/backend-api.service.ts
+++ b/web/src/app/services/api/backend-api.service.ts
@@ -221,18 +221,26 @@ export class BackendAPIImpl implements BackendAPI {
               })
               .pipe(
                 map((event: HttpEvent<Blob>) => {
+                  let updated = false;
+                  let blob: Blob | null = null;
+
                   if (event.type === HttpEventType.DownloadProgress) {
                     chunkLoaded[index] = event.loaded;
-                    const doneBytes = chunkLoaded.reduce((a, b) => a + b, 0);
-                    reporter(totalSize, doneBytes);
+                    updated = true;
                   } else if (event.type === HttpEventType.Response) {
-                    const blob = event.body!;
-                    chunkLoaded[index] = blob.size;
+                    blob = event.body;
+                    if (blob) {
+                      chunkLoaded[index] = blob.size;
+                      updated = true;
+                    }
+                  }
+
+                  if (updated) {
                     const doneBytes = chunkLoaded.reduce((a, b) => a + b, 0);
                     reporter(totalSize, doneBytes);
-                    return { index, blob };
                   }
-                  return null;
+
+                  return blob ? { index, blob } : null;
                 }),
                 filter(
                   (result): result is { index: number; blob: Blob } =>

--- a/web/src/app/services/api/backend-api.service.ts
+++ b/web/src/app/services/api/backend-api.service.ts
@@ -32,7 +32,7 @@ import {
   GetConfigResponse,
   InspectionPatchRequest,
 } from '../../common/schema/api-types';
-import { HttpClient, HttpEvent } from '@angular/common/http';
+import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http';
 import {
   EMPTY,
   Observable,
@@ -42,6 +42,7 @@ import {
   concat,
   debounceTime,
   exhaustMap,
+  filter,
   map,
   mergeMap,
   of,
@@ -192,14 +193,13 @@ export class BackendAPIImpl implements BackendAPI {
     inspectionID: string,
     reporter: DownloadProgressReporter,
   ) {
-    // accumulator holds donwnloaded bytes for reporter
-    let done = 0;
     return this.getInspectionMetadata(inspectionID).pipe(
       switchMap((metadata) => {
         const totalSize = metadata.header.fileSize ?? 0;
         const chunks = Math.ceil(
           totalSize / this.MAX_INSPECTION_DATA_DOWNLOAD_CHUNK_SIZE,
         );
+        const chunkLoaded: number[] = new Array(chunks).fill(0);
         return range(0, chunks).pipe(
           map((index) => {
             const startInBytes =
@@ -214,13 +214,30 @@ export class BackendAPIImpl implements BackendAPI {
           mergeMap(({ index, params }) => {
             const url = this.baseUrl + `/inspection/${inspectionID}/data`;
             return this.http
-              .get(`${url}?${params}`, { responseType: 'blob' })
+              .get(`${url}?${params}`, {
+                responseType: 'blob',
+                observe: 'events',
+                reportProgress: true,
+              })
               .pipe(
-                map((blob) => {
-                  done += blob.size;
-                  reporter(totalSize, done);
-                  return { index, blob };
+                map((event: HttpEvent<Blob>) => {
+                  if (event.type === HttpEventType.DownloadProgress) {
+                    chunkLoaded[index] = event.loaded;
+                    const doneBytes = chunkLoaded.reduce((a, b) => a + b, 0);
+                    reporter(totalSize, doneBytes);
+                  } else if (event.type === HttpEventType.Response) {
+                    const blob = event.body!;
+                    chunkLoaded[index] = blob.size;
+                    const doneBytes = chunkLoaded.reduce((a, b) => a + b, 0);
+                    reporter(totalSize, doneBytes);
+                    return { index, blob };
+                  }
+                  return null;
                 }),
+                filter(
+                  (result): result is { index: number; blob: Blob } =>
+                    result !== null,
+                ),
               );
           }, this.INSPECTION_DATA_DOWNLOAD_CONCURRENCY),
           reduce(
@@ -384,6 +401,11 @@ export class BackendAPIUtil {
     progress: ProgressDialogStatusUpdator,
   ) {
     progress.show();
+    progress.updateProgress({
+      message: 'Downloading inspection data...',
+      percent: 0,
+      mode: 'determinate',
+    });
     return api
       .getInspectionData(inspectionID, (fileSize, done) => {
         progress.updateProgress({


### PR DESCRIPTION
- Enable reportProgress and observe events in getInspectionData to report progress during chunk downloads.
- Initialize progress dialog state to 0% determinate mode in downloadInspectionDataAsFile.
- Replace deprecated HttpClientTestingModule with provideHttpClient and provideHttpClientTesting in unit tests.
- Add unit tests verifying granular progress reporting and initial dialog state.