### PR TITLE
feat(inspection): add missing log revision states and refactor GCP cluster/nodepool operation mappers

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
@@ -58,21 +58,21 @@ var (
 	RevisionStateK8sClusterProvisioningLogNotFound = style.MustRegisterRevisionState(
 		"Cluster is being provisioned, but starting log not found",
 		"deployed_code_history",
-		"The Kubernetes cluster or node pool provisioning was started, but the starting log entry was not found in the selected time range.",
+		"The Kubernetes cluster provisioning was started, but the starting log entry was not found in the selected time range.",
 		style.MustForceConvertSRGBHex("#6666ff"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)
 	RevisionStateK8sClusterExistingLogNotFound = style.MustRegisterRevisionState(
 		"Cluster exists, but creation log not found",
 		"deployed_code",
-		"The Kubernetes cluster or node pool exists, but the creation or existence log entry was not found in the selected time range.",
+		"The Kubernetes cluster exists, but the creation or existence log entry was not found in the selected time range.",
 		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)
 	RevisionStateK8sClusterDeletingLogNotFound = style.MustRegisterRevisionState(
 		"Cluster is being deleted, but starting log not found",
 		"auto_delete",
-		"The Kubernetes cluster or node pool deletion was in progress, but the deletion starting log entry was not found in the selected time range.",
+		"The Kubernetes cluster deletion was in progress, but the deletion starting log entry was not found in the selected time range.",
 		style.Color{R: 0.8, G: 0.33333334, B: 0.0, A: 1.0},
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)

--- a/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
@@ -55,6 +55,81 @@ var (
 		style.Color{R: 0.8, G: 0.0, B: 0.0, A: 1.0},
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
 	)
+	RevisionStateK8sClusterProvisioningLogNotFound = style.MustRegisterRevisionState(
+		"Cluster is being provisioned, but starting log not found",
+		"deployed_code_history",
+		"The Kubernetes cluster or node pool provisioning was started, but the starting log entry was not found in the selected time range.",
+		style.MustForceConvertSRGBHex("#6666ff"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
+	RevisionStateK8sClusterExistingLogNotFound = style.MustRegisterRevisionState(
+		"Cluster exists, but creation log not found",
+		"deployed_code",
+		"The Kubernetes cluster or node pool exists, but the creation or existence log entry was not found in the selected time range.",
+		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
+	RevisionStateK8sClusterDeletingLogNotFound = style.MustRegisterRevisionState(
+		"Cluster is being deleted, but starting log not found",
+		"auto_delete",
+		"The Kubernetes cluster or node pool deletion was in progress, but the deletion starting log entry was not found in the selected time range.",
+		style.Color{R: 0.8, G: 0.33333334, B: 0.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
+
+	// =============================================================================
+	// Kubernetes Node Pool States
+	// =============================================================================
+
+	RevisionStateK8sNodepoolProvisioning = style.MustRegisterRevisionState(
+		"Node pool is being provisioned",
+		"deployed_code_history",
+		"The Kubernetes node pool is currently being provisioned.",
+		style.MustForceConvertSRGBHex("#6666ff"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+	RevisionStateK8sNodepoolExisting = style.MustRegisterRevisionState(
+		"Node pool exists",
+		"deployed_code",
+		"The Kubernetes node pool exists and is active.",
+		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+	RevisionStateK8sNodepoolDeleting = style.MustRegisterRevisionState(
+		"Node pool is being deleted",
+		"auto_delete",
+		"The Kubernetes node pool is undergoing deletion.",
+		style.Color{R: 0.8, G: 0.33333334, B: 0.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+	RevisionStateK8sNodepoolDeleted = style.MustRegisterRevisionState(
+		"Node pool is deleted",
+		"delete_forever",
+		"The Kubernetes node pool has been deleted.",
+		style.Color{R: 0.8, G: 0.0, B: 0.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
+	)
+	RevisionStateK8sNodepoolProvisioningLogNotFound = style.MustRegisterRevisionState(
+		"Node pool is being provisioned, but starting log not found",
+		"deployed_code_history",
+		"The Kubernetes node pool provisioning was started, but the starting log entry was not found in the selected time range.",
+		style.MustForceConvertSRGBHex("#6666ff"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
+	RevisionStateK8sNodepoolExistingLogNotFound = style.MustRegisterRevisionState(
+		"Node pool exists, but creation log not found",
+		"deployed_code",
+		"The Kubernetes node pool exists, but the creation or existence log entry was not found in the selected time range.",
+		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
+	RevisionStateK8sNodepoolDeletingLogNotFound = style.MustRegisterRevisionState(
+		"Node pool is being deleted, but starting log not found",
+		"auto_delete",
+		"The Kubernetes node pool deletion was in progress, but the deletion starting log entry was not found in the selected time range.",
+		style.Color{R: 0.8, G: 0.33333334, B: 0.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
 
 	// =============================================================================
 	// Kubernetes Generic Resource States

--- a/pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go
@@ -19,20 +19,178 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 )
 
 // GCPOperationTracker tracks operation start/finish logs within a group and generates revisions.
 type GCPOperationTracker struct {
-	startedOperations map[string]struct{}
-	lastManifest      string
+	startedOperations   map[string]struct{}
+	hasResourceRevision map[uint32]struct{}
+	lastManifest        string
 }
 
 // NewGCPOperationTracker creates a new GCPOperationTracker.
 func NewGCPOperationTracker() *GCPOperationTracker {
 	return &GCPOperationTracker{
-		startedOperations: make(map[string]struct{}),
+		startedOperations:   make(map[string]struct{}),
+		hasResourceRevision: make(map[uint32]struct{}),
 	}
+}
+
+// HasStarted returns true if the operation start log for the given operation ID was observed.
+func (t *GCPOperationTracker) HasStarted(operationID string) bool {
+	_, hasStarted := t.startedOperations[operationID]
+	return hasStarted
+}
+
+// HasResourceRevision returns true if any revision has been added to the given resource timeline path.
+func (t *GCPOperationTracker) HasResourceRevision(path *khifilev6.TimelinePath) bool {
+	_, has := t.hasResourceRevision[path.ID]
+	return has
+}
+
+// MarkResourceRevision records that a revision was added to the given resource timeline path.
+func (t *GCPOperationTracker) MarkResourceRevision(path *khifilev6.TimelinePath) {
+	t.hasResourceRevision[path.ID] = struct{}{}
+}
+
+// ProcessGCPClusterNodepoolOperationLog processes a GCP operation log for a cluster or node pool resource timeline.
+// It generates resource creation/deletion/enrollment/unenrollment revisions, handles missing start logs by prepending
+// appropriate LogNotFound revisions at Unix time 0, and updates operation tracking.
+func ProcessGCPClusterNodepoolOperationLog(
+	ctx context.Context,
+	cs *khifilev6.TimelineChangeSet,
+	tracker *GCPOperationTracker,
+	targetTimeline *khifilev6.TimelinePath,
+	operationTimeline *khifilev6.TimelinePath,
+	audit *GCPAuditLogFieldSet,
+	common *log.CommonFieldSet,
+	shortMethodName string,
+	isCluster bool,
+) {
+	if audit.ImmediateOperation() {
+		cs.AddEvent(targetTimeline)
+		return
+	}
+
+	resourceBodyField := "nodePool"
+	if isCluster {
+		resourceBodyField = "cluster"
+	}
+
+	switch shortMethodName {
+	case "CreateCluster", "CreateNodePool", "EnrollCluster", "EnrollNodePool":
+		var bodyNode structured.Node
+		if audit.Request != nil {
+			if subReader, err := audit.Request.GetReader(resourceBodyField); err == nil {
+				bodyNode = subReader.Node
+			}
+		}
+
+		if audit.Ending() && !tracker.HasStarted(audit.OperationID) {
+			var stateLogNotFound *pb.RevisionState
+			if isCluster {
+				stateLogNotFound = commonlogk8saudit_contract.RevisionStateK8sClusterProvisioningLogNotFound
+			} else {
+				stateLogNotFound = commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioningLogNotFound
+			}
+			cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    stateLogNotFound,
+				Principal:    audit.PrincipalEmail,
+				ChangedTime:  time.Unix(0, 0),
+				ResourceBody: nil,
+			})
+			tracker.MarkResourceRevision(targetTimeline)
+		}
+
+		var state *pb.RevisionState
+		if isCluster {
+			if audit.Ending() {
+				state = commonlogk8saudit_contract.RevisionStateK8sClusterExisting
+			} else {
+				state = commonlogk8saudit_contract.RevisionStateK8sClusterProvisioning
+			}
+		} else {
+			if audit.Ending() {
+				state = commonlogk8saudit_contract.RevisionStateK8sNodepoolExisting
+			} else {
+				state = commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioning
+			}
+		}
+
+		cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
+			VerbType:     commonlogk8saudit_contract.VerbCreate,
+			StateType:    state,
+			Principal:    audit.PrincipalEmail,
+			ChangedTime:  common.Timestamp,
+			ResourceBody: bodyNode,
+		})
+		tracker.MarkResourceRevision(targetTimeline)
+
+	case "DeleteCluster", "DeleteNodePool", "UnenrollCluster", "UnenrollNodePool":
+		if !audit.Ending() && !tracker.HasResourceRevision(targetTimeline) {
+			var stateExistingNotFound *pb.RevisionState
+			if isCluster {
+				stateExistingNotFound = commonlogk8saudit_contract.RevisionStateK8sClusterExistingLogNotFound
+			} else {
+				stateExistingNotFound = commonlogk8saudit_contract.RevisionStateK8sNodepoolExistingLogNotFound
+			}
+			cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    stateExistingNotFound,
+				Principal:    audit.PrincipalEmail,
+				ChangedTime:  time.Unix(0, 0),
+				ResourceBody: nil,
+			})
+			tracker.MarkResourceRevision(targetTimeline)
+		}
+
+		if audit.Ending() && !tracker.HasStarted(audit.OperationID) {
+			var stateDeletingNotFound *pb.RevisionState
+			if isCluster {
+				stateDeletingNotFound = commonlogk8saudit_contract.RevisionStateK8sClusterDeletingLogNotFound
+			} else {
+				stateDeletingNotFound = commonlogk8saudit_contract.RevisionStateK8sNodepoolDeletingLogNotFound
+			}
+			cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbDelete,
+				StateType:    stateDeletingNotFound,
+				Principal:    audit.PrincipalEmail,
+				ChangedTime:  time.Unix(0, 0),
+				ResourceBody: nil,
+			})
+			tracker.MarkResourceRevision(targetTimeline)
+		}
+
+		var state *pb.RevisionState
+		if isCluster {
+			if audit.Ending() {
+				state = commonlogk8saudit_contract.RevisionStateK8sClusterDeleted
+			} else {
+				state = commonlogk8saudit_contract.RevisionStateK8sClusterDeleting
+			}
+		} else {
+			if audit.Ending() {
+				state = commonlogk8saudit_contract.RevisionStateK8sNodepoolDeleted
+			} else {
+				state = commonlogk8saudit_contract.RevisionStateK8sNodepoolDeleting
+			}
+		}
+		cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
+			VerbType:     commonlogk8saudit_contract.VerbDelete,
+			StateType:    state,
+			Principal:    audit.PrincipalEmail,
+			ChangedTime:  common.Timestamp,
+			ResourceBody: nil,
+		})
+		tracker.MarkResourceRevision(targetTimeline)
+	}
+
+	tracker.ProcessOperationLog(ctx, cs, operationTimeline, audit, common.Timestamp)
 }
 
 // TrackAndGetManifest tracks the latest resource manifest from an audit log and returns it if updated.

--- a/pkg/task/inspection/googlecloudcommon/contract/operation_tracker_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/operation_tracker_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 	"github.com/google/go-cmp/cmp"
@@ -160,5 +161,172 @@ func TestGCPOperationTracker_ProcessOperationLog(t *testing.T) {
 				StateType:    RevisionStateOperationStarted,
 				ChangedTime:  testTime,
 			}, cmp.AllowUnexported(structured.StandardScalarNode[string]{}))
+	})
+}
+
+func TestProcessGCPClusterNodepoolOperationLog(t *testing.T) {
+	testTime := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+	builder := khifilev6.NewBuilder()
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	parentPath := MustGCPProjectTimeline(ctx, "test-project")
+	targetTimeline := MustGKEClusterTimeline(ctx, parentPath, "test-cluster")
+	operationTimeline := MustGCPOperationTimeline(ctx, targetTimeline, "CreateCluster", "op-1")
+
+	t.Run("creation start log adds provisioning revision", func(t *testing.T) {
+		tracker := NewGCPOperationTracker()
+		dummyLog := &log.Log{}
+		cs := khifilev6.NewTimelineChangeSet(dummyLog)
+		audit := &GCPAuditLogFieldSet{
+			OperationID:    "op-1",
+			OperationFirst: true,
+		}
+		common := &log.CommonFieldSet{
+			Timestamp: testTime,
+		}
+
+		ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetTimeline, operationTimeline, audit, common, "CreateCluster", true)
+
+		testchangeset.AssertTimeline(t, cs).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbCreate,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterProvisioning,
+				ChangedTime: testTime,
+			})
+	})
+
+	t.Run("creation finish log without start log prepends provisioning log not found at unix 0", func(t *testing.T) {
+		tracker := NewGCPOperationTracker()
+		dummyLog := &log.Log{}
+		cs := khifilev6.NewTimelineChangeSet(dummyLog)
+		audit := &GCPAuditLogFieldSet{
+			OperationID:   "op-1",
+			OperationLast: true,
+		}
+		common := &log.CommonFieldSet{
+			Timestamp: testTime,
+		}
+
+		ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetTimeline, operationTimeline, audit, common, "CreateCluster", true)
+
+		testchangeset.AssertTimeline(t, cs).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbCreate,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterProvisioningLogNotFound,
+				ChangedTime: time.Unix(0, 0),
+			}).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbCreate,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterExisting,
+				ChangedTime: testTime,
+			})
+	})
+
+	t.Run("deletion start log without prior resource revision prepends existing log not found at unix 0", func(t *testing.T) {
+		tracker := NewGCPOperationTracker()
+		dummyLog := &log.Log{}
+		cs := khifilev6.NewTimelineChangeSet(dummyLog)
+		audit := &GCPAuditLogFieldSet{
+			OperationID:    "op-2",
+			OperationFirst: true,
+		}
+		common := &log.CommonFieldSet{
+			Timestamp: testTime,
+		}
+
+		ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetTimeline, operationTimeline, audit, common, "DeleteCluster", true)
+
+		testchangeset.AssertTimeline(t, cs).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbCreate,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterExistingLogNotFound,
+				ChangedTime: time.Unix(0, 0),
+			}).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbDelete,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterDeleting,
+				ChangedTime: testTime,
+			})
+	})
+
+	t.Run("deletion finish log without start log prepends deleting log not found at unix 0", func(t *testing.T) {
+		tracker := NewGCPOperationTracker()
+		dummyLog := &log.Log{}
+		cs := khifilev6.NewTimelineChangeSet(dummyLog)
+		audit := &GCPAuditLogFieldSet{
+			OperationID:   "op-2",
+			OperationLast: true,
+		}
+		common := &log.CommonFieldSet{
+			Timestamp: testTime,
+		}
+
+		ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetTimeline, operationTimeline, audit, common, "DeleteCluster", true)
+
+		testchangeset.AssertTimeline(t, cs).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbDelete,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterDeletingLogNotFound,
+				ChangedTime: time.Unix(0, 0),
+			}).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbDelete,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterDeleted,
+				ChangedTime: testTime,
+			})
+	})
+
+	t.Run("nodepool creation finish log without start log prepends nodepool provisioning log not found at unix 0", func(t *testing.T) {
+		tracker := NewGCPOperationTracker()
+		dummyLog := &log.Log{}
+		cs := khifilev6.NewTimelineChangeSet(dummyLog)
+		audit := &GCPAuditLogFieldSet{
+			OperationID:   "op-1",
+			OperationLast: true,
+		}
+		common := &log.CommonFieldSet{
+			Timestamp: testTime,
+		}
+
+		ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetTimeline, operationTimeline, audit, common, "CreateNodePool", false)
+
+		testchangeset.AssertTimeline(t, cs).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbCreate,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioningLogNotFound,
+				ChangedTime: time.Unix(0, 0),
+			}).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbCreate,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sNodepoolExisting,
+				ChangedTime: testTime,
+			})
+	})
+
+	t.Run("nodepool deletion finish log without start log prepends nodepool deleting log not found at unix 0", func(t *testing.T) {
+		tracker := NewGCPOperationTracker()
+		dummyLog := &log.Log{}
+		cs := khifilev6.NewTimelineChangeSet(dummyLog)
+		audit := &GCPAuditLogFieldSet{
+			OperationID:   "op-2",
+			OperationLast: true,
+		}
+		common := &log.CommonFieldSet{
+			Timestamp: testTime,
+		}
+
+		ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetTimeline, operationTimeline, audit, common, "DeleteNodePool", false)
+
+		testchangeset.AssertTimeline(t, cs).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbDelete,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sNodepoolDeletingLogNotFound,
+				ChangedTime: time.Unix(0, 0),
+			}).
+			HasRevision(targetTimeline, &khifilev6.StagingRevision{
+				VerbType:    commonlogk8saudit_contract.VerbDelete,
+				StateType:   commonlogk8saudit_contract.RevisionStateK8sNodepoolDeleted,
+				ChangedTime: testTime,
+			})
 	})
 }

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks.go
@@ -19,12 +19,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudloggkeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudloggkeapiaudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
@@ -118,55 +116,11 @@ func (g *gkeAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Co
 
 	cs := khifilev6.NewTimelineChangeSet(l)
 
-	if !auditFieldSet.ImmediateOperation() {
-		resourceBodyField := ""
-		if resourceFieldSet.IsCluster() {
-			resourceBodyField = "cluster"
-		} else {
-			resourceBodyField = "nodePool"
-		}
+	methodNameParts := strings.Split(auditFieldSet.MethodName, ".")
+	shortMethodName := methodNameParts[len(methodNameParts)-1]
 
-		methodNameParts := strings.Split(auditFieldSet.MethodName, ".")
-		shortMethodName := methodNameParts[len(methodNameParts)-1]
-
-		switch shortMethodName {
-		case "CreateCluster", "CreateNodePool":
-			var bodyNode structured.Node
-			state := commonlogk8saudit_contract.RevisionStateK8sClusterProvisioning
-			if auditFieldSet.Ending() {
-				state = commonlogk8saudit_contract.RevisionStateK8sClusterExisting
-			}
-			if auditFieldSet.Request != nil {
-				if subReader, err := auditFieldSet.Request.GetReader(resourceBodyField); err == nil {
-					bodyNode = subReader.Node
-				}
-			}
-			cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
-				VerbType:     commonlogk8saudit_contract.VerbCreate,
-				StateType:    state,
-				Principal:    auditFieldSet.PrincipalEmail,
-				ChangedTime:  commonFieldSet.Timestamp,
-				ResourceBody: bodyNode,
-			})
-		case "DeleteCluster", "DeleteNodePool":
-			state := commonlogk8saudit_contract.RevisionStateK8sClusterDeleting
-			if auditFieldSet.Ending() {
-				state = commonlogk8saudit_contract.RevisionStateK8sClusterDeleted
-			}
-			cs.AddRevision(targetTimeline, &khifilev6.StagingRevision{
-				VerbType:     commonlogk8saudit_contract.VerbDelete,
-				StateType:    state,
-				Principal:    auditFieldSet.PrincipalEmail,
-				ChangedTime:  commonFieldSet.Timestamp,
-				ResourceBody: nil,
-			})
-		}
-
-		operationTimeline := googlecloudcommon_contract.MustGCPOperationTimeline(ctx, targetTimeline, shortMethodName, auditFieldSet.OperationID)
-		tracker.ProcessOperationLog(ctx, cs, operationTimeline, auditFieldSet, commonFieldSet.Timestamp)
-	} else {
-		cs.AddEvent(targetTimeline)
-	}
+	operationTimeline := googlecloudcommon_contract.MustGCPOperationTimeline(ctx, targetTimeline, shortMethodName, auditFieldSet.OperationID)
+	googlecloudcommon_contract.ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetTimeline, operationTimeline, auditFieldSet, commonFieldSet, shortMethodName, resourceFieldSet.IsCluster())
 
 	return cs, tracker, nil
 }

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks_test.go
@@ -203,7 +203,7 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				testchangeset.AssertTimeline(t, cs).
 					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
 						VerbType:     commonlogk8saudit_contract.VerbCreate,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sClusterProvisioning,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioning,
 						Principal:    "foobar@qux.test",
 						ChangedTime:  testTime,
 						ResourceBody: bodyNode,
@@ -239,7 +239,13 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				testchangeset.AssertTimeline(t, cs).
 					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
 						VerbType:    commonlogk8saudit_contract.VerbCreate,
-						StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterExisting,
+						StateType:   commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioningLogNotFound,
+						Principal:   "foobar@qux.test",
+						ChangedTime: time.Unix(0, 0),
+					}, compareNodeOption).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						VerbType:    commonlogk8saudit_contract.VerbCreate,
+						StateType:   commonlogk8saudit_contract.RevisionStateK8sNodepoolExisting,
 						Principal:   "foobar@qux.test",
 						ChangedTime: testTime,
 					}, compareNodeOption).
@@ -271,7 +277,13 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				testchangeset.AssertTimeline(t, cs).
 					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
 						VerbType:    commonlogk8saudit_contract.VerbDelete,
-						StateType:   commonlogk8saudit_contract.RevisionStateK8sClusterDeleted,
+						StateType:   commonlogk8saudit_contract.RevisionStateK8sNodepoolDeletingLogNotFound,
+						Principal:   "foobar@qux.test",
+						ChangedTime: time.Unix(0, 0),
+					}, compareNodeOption).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						VerbType:    commonlogk8saudit_contract.VerbDelete,
+						StateType:   commonlogk8saudit_contract.RevisionStateK8sNodepoolDeleted,
 						Principal:   "foobar@qux.test",
 						ChangedTime: testTime,
 					}, compareNodeOption).

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks.go
@@ -19,12 +19,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogmulticloudapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
@@ -116,62 +114,17 @@ func (m *multicloudAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx con
 
 	cs := khifilev6.NewTimelineChangeSet(l)
 
-	if !auditFieldSet.ImmediateOperation() {
-		resourceBodyField := ""
-
-		if resourceFieldSet.IsCluster() {
-			resourceBodyField = "cluster"
-		} else {
-			resourceBodyField = "nodePool"
-		}
-
-		clusterTypeToFragmentInMethodNameMapping := map[googlecloudlogmulticloudapiaudit_contract.MultiCloudClusterType]string{
-			googlecloudlogmulticloudapiaudit_contract.ClusterTypeAWS:   "Aws",
-			googlecloudlogmulticloudapiaudit_contract.ClusterTypeAzure: "Azure",
-		}
-
-		methodNameParts := strings.Split(auditFieldSet.MethodName, ".")
-		shortMethodName := methodNameParts[len(methodNameParts)-1]
-		shortMethodName = strings.ReplaceAll(shortMethodName, clusterTypeToFragmentInMethodNameMapping[resourceFieldSet.ClusterType], "") // Remove type specific part.
-
-		switch shortMethodName {
-		case "CreateCluster", "CreateNodePool":
-			var bodyNode structured.Node
-			state := commonlogk8saudit_contract.RevisionStateK8sClusterProvisioning
-			if auditFieldSet.Ending() {
-				state = commonlogk8saudit_contract.RevisionStateK8sClusterExisting
-			}
-			if auditFieldSet.Request != nil {
-				if r, err := auditFieldSet.Request.GetReader(resourceBodyField); err == nil {
-					bodyNode = r.Node
-				}
-			}
-			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
-				ChangedTime:  commonFieldSet.Timestamp,
-				ResourceBody: bodyNode,
-				Principal:    auditFieldSet.PrincipalEmail,
-				VerbType:     commonlogk8saudit_contract.VerbCreate,
-				StateType:    state,
-			})
-		case "DeleteCluster", "DeleteNodePool":
-			state := commonlogk8saudit_contract.RevisionStateK8sClusterDeleting
-			if auditFieldSet.Ending() {
-				state = commonlogk8saudit_contract.RevisionStateK8sClusterDeleted
-			}
-			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
-				ChangedTime:  commonFieldSet.Timestamp,
-				ResourceBody: nil,
-				Principal:    auditFieldSet.PrincipalEmail,
-				VerbType:     commonlogk8saudit_contract.VerbDelete,
-				StateType:    state,
-			})
-		}
-
-		opPath := googlecloudlogmulticloudapiaudit_contract.MustOperationTimeline(ctx, targetPath, shortMethodName, auditFieldSet.OperationID)
-		tracker.ProcessOperationLog(ctx, cs, opPath, auditFieldSet, commonFieldSet.Timestamp)
-	} else {
-		cs.AddEvent(targetPath)
+	clusterTypeToFragmentInMethodNameMapping := map[googlecloudlogmulticloudapiaudit_contract.MultiCloudClusterType]string{
+		googlecloudlogmulticloudapiaudit_contract.ClusterTypeAWS:   "Aws",
+		googlecloudlogmulticloudapiaudit_contract.ClusterTypeAzure: "Azure",
 	}
+
+	methodNameParts := strings.Split(auditFieldSet.MethodName, ".")
+	shortMethodName := methodNameParts[len(methodNameParts)-1]
+	shortMethodName = strings.ReplaceAll(shortMethodName, clusterTypeToFragmentInMethodNameMapping[resourceFieldSet.ClusterType], "") // Remove type specific part.
+
+	opPath := googlecloudlogmulticloudapiaudit_contract.MustOperationTimeline(ctx, targetPath, shortMethodName, auditFieldSet.OperationID)
+	googlecloudcommon_contract.ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetPath, opPath, auditFieldSet, commonFieldSet, shortMethodName, resourceFieldSet.IsCluster())
 
 	return cs, tracker, nil
 }

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks_test.go
@@ -213,7 +213,7 @@ name: test-cluster`).Node,
 name: test-nodepool`).Node,
 						Principal: "foobar@qux.test",
 						VerbType:  commonlogk8saudit_contract.VerbCreate,
-						StateType: commonlogk8saudit_contract.RevisionStateK8sClusterProvisioning,
+						StateType: commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioning,
 					}, nodeComparer).
 					HasRevision(wantOp2NodepoolPath, &khifilev6.StagingRevision{
 						ChangedTime: testTime,
@@ -246,11 +246,18 @@ name: test-nodepool`).Node,
 			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
 				testchangeset.AssertTimeline(t, cs).
 					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioningLogNotFound,
+					}, nodeComparer).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
 						ResourceBody: nil,
 						Principal:    "foobar@qux.test",
 						VerbType:     commonlogk8saudit_contract.VerbCreate,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sClusterExisting,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolExisting,
 					}, nodeComparer).
 					HasRevision(wantOp2AzureNodepoolPath, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
@@ -281,11 +288,18 @@ name: test-nodepool`).Node,
 			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
 				testchangeset.AssertTimeline(t, cs).
 					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     commonlogk8saudit_contract.VerbDelete,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolDeletingLogNotFound,
+					}, nodeComparer).
+					HasRevision(wantNodepoolPath, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
 						ResourceBody: nil,
 						Principal:    "foobar@qux.test",
 						VerbType:     commonlogk8saudit_contract.VerbDelete,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sClusterDeleted,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolDeleted,
 					}, nodeComparer).
 					HasRevision(wantOp2DeleteNodepoolPath, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/parser_tasks.go
@@ -19,12 +19,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogonpremapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogonpremapiaudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
@@ -114,70 +112,20 @@ func (m *OnPremAPIAuditTimelineMapper) ProcessLogByGroup(ctx context.Context, l 
 		targetPath = googlecloudlogonpremapiaudit_contract.MustOnPremNodePoolTimeline(ctx, clusterPath, resourceFieldSet.NodepoolName)
 	}
 
-	if !auditFieldSet.ImmediateOperation() {
-		resourceBodyField := ""
-		if resourceFieldSet.IsCluster() {
-			resourceBodyField = "cluster"
-		} else {
-			resourceBodyField = "nodePool"
-		}
-
-		clusterTypeToFragmentInMethodNameMapping := map[googlecloudlogonpremapiaudit_contract.OnPremClusterType]string{
-			googlecloudlogonpremapiaudit_contract.ClusterTypeBaremetalAdmin:      "BaremetalAdmin",
-			googlecloudlogonpremapiaudit_contract.ClusterTypeBaremetalStandalone: "BaremetalStandalone",
-			googlecloudlogonpremapiaudit_contract.ClusterTypeBaremetalUser:       "Baremetal",
-			googlecloudlogonpremapiaudit_contract.ClusterTypeVMWareAdmin:         "VmwareAdmin",
-			googlecloudlogonpremapiaudit_contract.ClusterTypeVMWareUser:          "Vmware",
-		}
-
-		methodNameParts := strings.Split(auditFieldSet.MethodName, ".")
-		shortMethodName := methodNameParts[len(methodNameParts)-1]
-		shortMethodName = strings.ReplaceAll(shortMethodName, clusterTypeToFragmentInMethodNameMapping[resourceFieldSet.ClusterType], "")
-
-		switch shortMethodName {
-		case "CreateCluster", "CreateNodePool", "EnrollCluster", "EnrollNodePool":
-			var bodyNode structured.Node
-			state := commonlogk8saudit_contract.RevisionStateK8sClusterProvisioning
-			if auditFieldSet.Ending() {
-				state = commonlogk8saudit_contract.RevisionStateK8sClusterExisting
-			}
-			if auditFieldSet.Request != nil {
-				if reqReader, err := auditFieldSet.Request.GetReader(resourceBodyField); err == nil {
-					bodyNode = reqReader.Node
-				}
-			}
-			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
-				ChangedTime:  commonFieldSet.Timestamp,
-				ResourceBody: bodyNode,
-				Principal:    auditFieldSet.PrincipalEmail,
-				VerbType:     commonlogk8saudit_contract.VerbCreate,
-				StateType:    state,
-			})
-		case "DeleteCluster", "DeleteNodePool", "UnenrollCluster", "UnenrollNodePool":
-			state := commonlogk8saudit_contract.RevisionStateK8sClusterDeleting
-			if auditFieldSet.Ending() {
-				state = commonlogk8saudit_contract.RevisionStateK8sClusterDeleted
-			}
-			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
-				ChangedTime:  commonFieldSet.Timestamp,
-				ResourceBody: nil,
-				Principal:    auditFieldSet.PrincipalEmail,
-				VerbType:     commonlogk8saudit_contract.VerbDelete,
-				StateType:    state,
-			})
-		}
-
-		methodNameSplitted := strings.Split(auditFieldSet.MethodName, ".")
-		originalShortMethodName := "unknown"
-		if len(methodNameSplitted) > 0 {
-			originalShortMethodName = methodNameSplitted[len(methodNameSplitted)-1]
-		}
-		operationPath := googlecloudcommon_contract.MustGCPOperationTimeline(ctx, targetPath, originalShortMethodName, auditFieldSet.OperationID)
-
-		tracker.ProcessOperationLog(ctx, cs, operationPath, auditFieldSet, commonFieldSet.Timestamp)
-	} else {
-		cs.AddEvent(targetPath)
+	clusterTypeToFragmentInMethodNameMapping := map[googlecloudlogonpremapiaudit_contract.OnPremClusterType]string{
+		googlecloudlogonpremapiaudit_contract.ClusterTypeBaremetalAdmin:      "BaremetalAdmin",
+		googlecloudlogonpremapiaudit_contract.ClusterTypeBaremetalStandalone: "BaremetalStandalone",
+		googlecloudlogonpremapiaudit_contract.ClusterTypeBaremetalUser:       "Baremetal",
+		googlecloudlogonpremapiaudit_contract.ClusterTypeVMWareAdmin:         "VmwareAdmin",
+		googlecloudlogonpremapiaudit_contract.ClusterTypeVMWareUser:          "Vmware",
 	}
+
+	methodNameParts := strings.Split(auditFieldSet.MethodName, ".")
+	shortMethodName := methodNameParts[len(methodNameParts)-1]
+	normalizedShortMethodName := strings.ReplaceAll(shortMethodName, clusterTypeToFragmentInMethodNameMapping[resourceFieldSet.ClusterType], "")
+
+	operationPath := googlecloudcommon_contract.MustGCPOperationTimeline(ctx, targetPath, shortMethodName, auditFieldSet.OperationID)
+	googlecloudcommon_contract.ProcessGCPClusterNodepoolOperationLog(ctx, cs, tracker, targetPath, operationPath, auditFieldSet, commonFieldSet, normalizedShortMethodName, resourceFieldSet.IsCluster())
 
 	return cs, tracker, nil
 }

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/parser_tasks_test.go
@@ -320,7 +320,7 @@ func TestOnPremAPIAuditTimelineMapper_ProcessLogByGroup(t *testing.T) {
 						ResourceBody: reqNode,
 						Principal:    "foobar@qux.test",
 						VerbType:     commonlogk8saudit_contract.VerbCreate,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sClusterProvisioning,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioning,
 					}, cmpNode).
 					HasRevision(wantNodePoolOpPath1, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
@@ -351,11 +351,18 @@ func TestOnPremAPIAuditTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
 				testchangeset.AssertTimeline(t, cs).
 					HasRevision(wantNodePoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolProvisioningLogNotFound,
+					}, cmpNode).
+					HasRevision(wantNodePoolPath, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
 						ResourceBody: nil,
 						Principal:    "foobar@qux.test",
 						VerbType:     commonlogk8saudit_contract.VerbCreate,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sClusterExisting,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolExisting,
 					}, cmpNode).
 					HasRevision(wantNodePoolOpPath2, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
@@ -386,11 +393,18 @@ func TestOnPremAPIAuditTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
 				testchangeset.AssertTimeline(t, cs).
 					HasRevision(wantNodePoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     commonlogk8saudit_contract.VerbDelete,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolDeletingLogNotFound,
+					}, cmpNode).
+					HasRevision(wantNodePoolPath, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
 						ResourceBody: nil,
 						Principal:    "foobar@qux.test",
 						VerbType:     commonlogk8saudit_contract.VerbDelete,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sClusterDeleted,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolDeleted,
 					}, cmpNode).
 					HasRevision(wantNodePoolOpPath3, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
@@ -421,11 +435,18 @@ func TestOnPremAPIAuditTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet) {
 				testchangeset.AssertTimeline(t, cs).
 					HasRevision(wantNodePoolPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+						Principal:    "foobar@qux.test",
+						VerbType:     commonlogk8saudit_contract.VerbDelete,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolDeletingLogNotFound,
+					}, cmpNode).
+					HasRevision(wantNodePoolPath, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,
 						ResourceBody: nil,
 						Principal:    "foobar@qux.test",
 						VerbType:     commonlogk8saudit_contract.VerbDelete,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sClusterDeleted,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sNodepoolDeleted,
 					}, cmpNode).
 					HasRevision(wantNodePoolOpPath4, &khifilev6.StagingRevision{
 						ChangedTime:  testTime,


### PR DESCRIPTION
## Summary

This PR introduces support for tracking Kubernetes cluster and node pool lifecycle states when operation starting logs are missing within the selected time window (for example, observing a cluster creation completion without seeing its start log). It also separates Cluster and NodePool revision states into distinct types and unifies the resource lifecycle logging logic across GCP audit log mappers (GKE, Multi-Cloud, and On-Prem).

## Motivation & Background

- **Missing Start Logs**: In long-running clusters or narrow time range inspections, lifecycle operations (such as cluster creation or node pool deletion) may lack a starting log entry. Previously, this resulted in abrupt state transitions. We now prepend a `LogNotFound` state at Unix time 0 to clearly indicate prior activity.
- **State Separation**: Cluster and NodePool timelines previously shared generic cluster states. Defining dedicated NodePool states allows for clearer visual distinction in the timeline UI.
- **Code Consolidation**: The GCP audit log parsers shared near-identical logic for cluster and node pool operations. Consolidating this into a common helper reduces code duplication and enforces consistent lifecycle tracking.

## Key Changes

1. **New RevisionStates**:
   - Added `ProvisioningLogNotFound`, `ExistingLogNotFound`, and `DeletingLogNotFound` states for both Clusters and NodePools.
   - Registered dedicated NodePool lifecycle states (`Provisioning`, `Existing`, `Deleting`, `Deleted`).

2. **Common Helper & Tracker Refactoring**:
   - Updated the operation tracker to use set semantics for tracking resource revisions.
   - Implemented a common processing function using explicit `if-else` blocks to select the appropriate Cluster or NodePool revision state.

3. **Parser Tasks Refactoring**:
   - Refactored GKE, Multi-Cloud, and On-Prem audit mappers to delegate resource lifecycle processing to the common helper.

4. **Unit Tests**:
   - Expanded tests for both cluster and node pool timelines.
   - Updated parser task tests to verify the new NodePool states and Unix epoch 0 prepended revisions.
