### PR TITLE
added RevisionStateK8sResourceExistingLogNotFound

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
@@ -69,6 +69,13 @@ var (
 		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
+	RevisionStateK8sResourceExistingLogNotFound = style.MustRegisterRevisionState(
+		"Resource exists, but creation log not found",
+		"deployed_code",
+		"The Kubernetes resource exists, but the creation or existence log entry was not found in the selected time range.",
+		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
 	RevisionStateK8sResourceDeleting = style.MustRegisterRevisionState(
 		"Resource is being deleted",
 		"auto_delete",

--- a/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task.go
@@ -94,8 +94,9 @@ func (r *lifeTimeTrackerTaskSetting) DetectLifetimeLogEvent(ctx context.Context,
 		deletionCompleted := false
 		uid, _ := GetUID(l.ResourceBodyReader)
 		if uid != prevGroupData.PrevUID {
+			isInitialUIDDiscovery := prevGroupData.PrevUID == ""
 			prevGroupData.PrevUID = uid
-			if !isDeletiveVerb(k8sFieldSet.Verb) {
+			if !isDeletiveVerb(k8sFieldSet.Verb) && !isInitialUIDDiscovery {
 				l.ResourceCreated = true
 			}
 			prevGroupData.DeletionStarted = false

--- a/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task_test.go
@@ -425,6 +425,39 @@ metadata:
 				},
 			},
 		},
+		{
+			name:       "patch without UID followed by patch without UID and update with UID",
+			apiVersion: "core/v1",
+			pluralKind: "pods",
+			kindsToWaitExactDeletionToDetermineDeletion: map[string]struct{}{},
+			steps: []step{
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					resourceBodyYAML: `metadata:
+  name: "test"`,
+					wantResourceCreated: true,
+					wantDeletionStarted: false,
+					wantResourceDeleted: false,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					resourceBodyYAML: `metadata:
+  name: "test"`,
+					wantResourceCreated: false,
+					wantDeletionStarted: false,
+					wantResourceDeleted: false,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbUpdate,
+					resourceBodyYAML: `metadata:
+  name: "test"
+  uid: "uid-1"`,
+					wantResourceCreated: false,
+					wantDeletionStarted: false,
+					wantResourceDeleted: false,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2.go
@@ -36,12 +36,16 @@ type resourceRevisionLogToTimelineMapperStateV2 struct {
 	DeletionStarted bool
 	// PrevUID is the previous UID of the resource.
 	PrevUID string
+	// creationTimePerUID maps resource UID to its creationTimestamp collected during PreProcessLog pass.
+	creationTimePerUID map[string]time.Time
+	// fallbackCreationTime is the first creationTimestamp found in the log group during PreProcessLog pass.
+	fallbackCreationTime time.Time
+	// hasFallbackCreationTime is true if fallbackCreationTime was recorded.
+	hasFallbackCreationTime bool
 }
 
 // ResourceRevisionLogToTimelineMapperTaskSettingV2 is the setting for the V2 resource revision timeline mapper task.
 type ResourceRevisionLogToTimelineMapperTaskSettingV2 struct {
-	commonlogk8saudit_contract.ManifestSinglePassMapperBaseV2[*resourceRevisionLogToTimelineMapperStateV2]
-
 	// minimumDeltaTimeToCreateInferredCreationRevision is a threshold of a duration that controls if KHI should create an inferred creation revision from creationTimestamp.
 	minimumDeltaTimeToCreateInferredCreationRevision time.Duration
 	// kindsToWaitExactDeletionToDeterminDeletion is the map of kinds to wait exact deletion to determine deletion.
@@ -51,6 +55,44 @@ type ResourceRevisionLogToTimelineMapperTaskSettingV2 struct {
 // Dependencies implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
 func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{}
+}
+
+// PassCount implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
+func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) PassCount() int {
+	return 1
+}
+
+// PreProcessLog implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
+func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) PreProcessLog(ctx context.Context, passIndex int, event commonlogk8saudit_contract.MultiGroupLogEvent, prevGroupData *resourceRevisionLogToTimelineMapperStateV2) (*resourceRevisionLogToTimelineMapperStateV2, error) {
+	if prevGroupData == nil {
+		prevGroupData = &resourceRevisionLogToTimelineMapperStateV2{
+			creationTimePerUID: make(map[string]time.Time),
+		}
+	}
+	if prevGroupData.creationTimePerUID == nil {
+		prevGroupData.creationTimePerUID = make(map[string]time.Time)
+	}
+	if event.GroupRole != "target" {
+		return prevGroupData, nil
+	}
+
+	bodyReader, hasBody := event.GetLastBodyReader(event.GroupRole)
+	if hasBody && bodyReader != nil {
+		creationTime, found := GetCreationTimestamp(bodyReader)
+		if found {
+			if !prevGroupData.hasFallbackCreationTime {
+				prevGroupData.fallbackCreationTime = creationTime
+				prevGroupData.hasFallbackCreationTime = true
+			}
+			uid, ok := GetUID(bodyReader)
+			if ok && uid != "" {
+				if _, exists := prevGroupData.creationTimePerUID[uid]; !exists {
+					prevGroupData.creationTimePerUID[uid] = creationTime
+				}
+			}
+		}
+	}
+	return prevGroupData, nil
 }
 
 // GroupedLogTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
@@ -100,7 +142,12 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) ResolveRelatedGroupSe
 // ProcessLog implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
 func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) ProcessLog(ctx context.Context, event commonlogk8saudit_contract.MultiGroupLogEvent, prevGroupData *resourceRevisionLogToTimelineMapperStateV2) (*khifilev6.TimelineChangeSet, *resourceRevisionLogToTimelineMapperStateV2, error) {
 	if prevGroupData == nil {
-		prevGroupData = &resourceRevisionLogToTimelineMapperStateV2{}
+		prevGroupData = &resourceRevisionLogToTimelineMapperStateV2{
+			creationTimePerUID: make(map[string]time.Time),
+		}
+	}
+	if prevGroupData.creationTimePerUID == nil {
+		prevGroupData.creationTimePerUID = make(map[string]time.Time)
 	}
 
 	cs := khifilev6.NewTimelineChangeSet(event.Log)
@@ -264,23 +311,49 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) handleTargetChange(ct
 		}
 	}
 
+	// Resolve resource creation time with fallbacks.
+	// 1. Try resolving creationTimestamp directly from the current log body.
+	// 2. Fallback to pre-processed creationTimestamp mapped to the resource UID.
+	// 3. Fallback to the first creationTimestamp observed in the entire log group.
 	var creationTime time.Time
-	var found bool
+	var hasCreationTime bool
 	if bodyReader != nil {
-		creationTime, found = GetCreationTimestamp(bodyReader)
+		creationTime, hasCreationTime = GetCreationTimestamp(bodyReader)
+		if !hasCreationTime {
+			uid, ok := GetUID(bodyReader)
+			if ok && uid != "" {
+				if t, exists := prevGroupData.creationTimePerUID[uid]; exists {
+					creationTime = t
+					hasCreationTime = true
+				}
+			}
+		}
 	}
-	if !found {
-		creationTime = commonFieldSet.Timestamp
+	if !hasCreationTime && prevGroupData.hasFallbackCreationTime {
+		creationTime = prevGroupData.fallbackCreationTime
+		hasCreationTime = true
 	}
 
-	if event.EventType == commonlogk8saudit_contract.ChangeEventTypeV2Creation && commonFieldSet.Timestamp.Sub(creationTime) > r.minimumDeltaTimeToCreateInferredCreationRevision {
-		cs.AddRevision(targetPath, &khifilev6.StagingRevision{
-			ChangedTime:  creationTime,
-			ResourceBody: nil,
-			Principal:    "N/A",
-			VerbType:     commonlogk8saudit_contract.VerbCreate,
-			StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
-		})
+	// For the initial observation of a resource without an explicit creation log (e.g. starting with patch),
+	// prepend an inferred creation revision indicating that the resource already existed prior to the logs.
+	if event.EventType == commonlogk8saudit_contract.ChangeEventTypeV2Creation && k8sFieldSet.Verb != commonlogk8saudit_contract.VerbCreate {
+		if hasCreationTime {
+			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
+				ChangedTime:  creationTime,
+				ResourceBody: nil,
+				Principal:    "N/A",
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+			})
+		} else {
+			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
+				ChangedTime:  time.Unix(0, 0),
+				ResourceBody: nil,
+				Principal:    "N/A",
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+			})
+		}
 	}
 
 	var bodyNode structured.Node

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2.go
@@ -44,10 +44,15 @@ type resourceRevisionLogToTimelineMapperStateV2 struct {
 	hasFallbackCreationTime bool
 }
 
+// newResourceRevisionLogToTimelineMapperStateV2 returns a new instance of resourceRevisionLogToTimelineMapperStateV2.
+func newResourceRevisionLogToTimelineMapperStateV2() *resourceRevisionLogToTimelineMapperStateV2 {
+	return &resourceRevisionLogToTimelineMapperStateV2{
+		creationTimePerUID: make(map[string]time.Time),
+	}
+}
+
 // ResourceRevisionLogToTimelineMapperTaskSettingV2 is the setting for the V2 resource revision timeline mapper task.
 type ResourceRevisionLogToTimelineMapperTaskSettingV2 struct {
-	// minimumDeltaTimeToCreateInferredCreationRevision is a threshold of a duration that controls if KHI should create an inferred creation revision from creationTimestamp.
-	minimumDeltaTimeToCreateInferredCreationRevision time.Duration
 	// kindsToWaitExactDeletionToDeterminDeletion is the map of kinds to wait exact deletion to determine deletion.
 	kindsToWaitExactDeletionToDeterminDeletion map[string]struct{}
 }
@@ -65,12 +70,7 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) PassCount() int {
 // PreProcessLog implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
 func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) PreProcessLog(ctx context.Context, passIndex int, event commonlogk8saudit_contract.MultiGroupLogEvent, prevGroupData *resourceRevisionLogToTimelineMapperStateV2) (*resourceRevisionLogToTimelineMapperStateV2, error) {
 	if prevGroupData == nil {
-		prevGroupData = &resourceRevisionLogToTimelineMapperStateV2{
-			creationTimePerUID: make(map[string]time.Time),
-		}
-	}
-	if prevGroupData.creationTimePerUID == nil {
-		prevGroupData.creationTimePerUID = make(map[string]time.Time)
+		prevGroupData = newResourceRevisionLogToTimelineMapperStateV2()
 	}
 	if event.GroupRole != "target" {
 		return prevGroupData, nil
@@ -142,12 +142,7 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) ResolveRelatedGroupSe
 // ProcessLog implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
 func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) ProcessLog(ctx context.Context, event commonlogk8saudit_contract.MultiGroupLogEvent, prevGroupData *resourceRevisionLogToTimelineMapperStateV2) (*khifilev6.TimelineChangeSet, *resourceRevisionLogToTimelineMapperStateV2, error) {
 	if prevGroupData == nil {
-		prevGroupData = &resourceRevisionLogToTimelineMapperStateV2{
-			creationTimePerUID: make(map[string]time.Time),
-		}
-	}
-	if prevGroupData.creationTimePerUID == nil {
-		prevGroupData.creationTimePerUID = make(map[string]time.Time)
+		prevGroupData = newResourceRevisionLogToTimelineMapperStateV2()
 	}
 
 	cs := khifilev6.NewTimelineChangeSet(event.Log)
@@ -164,7 +159,6 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) ProcessLog(ctx contex
 
 // ResourceRevisionLogToTimelineMapperTask is the V2 task to generate resource revision history.
 var ResourceRevisionLogToTimelineMapperTask = commonlogk8saudit_contract.NewManifestLogToTimelineMapperV2[*resourceRevisionLogToTimelineMapperStateV2](&ResourceRevisionLogToTimelineMapperTaskSettingV2{
-	minimumDeltaTimeToCreateInferredCreationRevision: 5 * time.Second,
 	kindsToWaitExactDeletionToDeterminDeletion: map[string]struct{}{
 		"core/v1#pod": {},
 	},
@@ -213,7 +207,7 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) handleTargetChange(ct
 	targetPath := MustResolveTimelinePath(ctx, k8sFieldSet.ClusterName, event.ResourceIdentity)
 
 	if prevGroupData == nil {
-		prevGroupData = &resourceRevisionLogToTimelineMapperStateV2{}
+		prevGroupData = newResourceRevisionLogToTimelineMapperStateV2()
 	}
 
 	if k8sFieldSet.Verb == commonlogk8saudit_contract.VerbDeleteCollection && prevGroupData.WasCompletelyRemoved {

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2_test.go
@@ -537,7 +537,6 @@ uid: "test-uid"`,
 	}
 
 	mapperSetting := &ResourceRevisionLogToTimelineMapperTaskSettingV2{
-		minimumDeltaTimeToCreateInferredCreationRevision: 5 * time.Second,
 		kindsToWaitExactDeletionToDeterminDeletion: map[string]struct{}{
 			"core/v1#pod": {},
 		},
@@ -858,9 +857,7 @@ func TestResourceRevisionLogToTimelineMapperTaskSettingV2_PreProcessAndProcessLo
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
-			mapperSetting := &ResourceRevisionLogToTimelineMapperTaskSettingV2{
-				minimumDeltaTimeToCreateInferredCreationRevision: 5 * time.Second,
-			}
+			mapperSetting := &ResourceRevisionLogToTimelineMapperTaskSettingV2{}
 
 			targetResource := &commonlogk8saudit_contract.ResourceIdentity{
 				APIVersion: "core/v1",

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2_test.go
@@ -27,6 +27,7 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestResourceRevisionLogToTimelineMapperTaskSettingV2_ProcessLog(t *testing.T) {
@@ -268,7 +269,70 @@ status:
 			},
 		},
 		{
-			name:       "Inferred creation revision",
+			name:       "Inferred creation revision with creationTimestamp",
+			inputState: nil,
+			verb:       commonlogk8saudit_contract.VerbUpdate,
+			bodyYAML: `metadata:
+  uid: "test-uid"
+  creationTimestamp: "2023-10-26T09:59:00Z"`,
+			role:      "target",
+			eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+			wantState: &resourceRevisionLogToTimelineMapperStateV2{
+				WasCompletelyRemoved: false,
+				DeletionStarted:      false,
+				PrevUID:              "test-uid",
+			},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, node structured.Node) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(parentPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: node,
+						Principal:    "admin",
+						VerbType:     commonlogk8saudit_contract.VerbUpdate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
+					}, nodeComparer).
+					HasRevision(parentPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Date(2023, 10, 26, 9, 59, 0, 0, time.UTC),
+						ResourceBody: nil,
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer)
+			},
+		},
+		{
+			name:       "Inferred creation revision without creationTimestamp",
+			inputState: nil,
+			verb:       commonlogk8saudit_contract.VerbUpdate,
+			bodyYAML: `metadata:
+  uid: "test-uid"`,
+			role:      "target",
+			eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+			wantState: &resourceRevisionLogToTimelineMapperStateV2{
+				WasCompletelyRemoved: false,
+				DeletionStarted:      false,
+				PrevUID:              "test-uid",
+			},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, node structured.Node) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(parentPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: node,
+						Principal:    "admin",
+						VerbType:     commonlogk8saudit_contract.VerbUpdate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
+					}, nodeComparer).
+					HasRevision(parentPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer)
+			},
+		},
+		{
+			name:       "First event with VerbCreate does not add inferred creation",
 			inputState: nil,
 			verb:       commonlogk8saudit_contract.VerbCreate,
 			bodyYAML: `metadata:
@@ -287,13 +351,6 @@ status:
 						ChangedTime:  testTime,
 						ResourceBody: node,
 						Principal:    "admin",
-						VerbType:     commonlogk8saudit_contract.VerbCreate,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
-					}, nodeComparer).
-					HasRevision(parentPath, &khifilev6.StagingRevision{
-						ChangedTime:  time.Date(2023, 10, 26, 9, 59, 0, 0, time.UTC),
-						ResourceBody: nil,
-						Principal:    "N/A",
 						VerbType:     commonlogk8saudit_contract.VerbCreate,
 						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
 					}, nodeComparer)
@@ -579,11 +636,304 @@ uid: "test-uid"`,
 				t.Fatalf("ProcessLog() failed: %v", err)
 			}
 
-			if diff := cmp.Diff(tc.wantState, nextState); diff != "" {
+			if diff := cmp.Diff(tc.wantState, nextState, cmp.AllowUnexported(resourceRevisionLogToTimelineMapperStateV2{}), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("state mismatch (-want +got):\n%s", diff)
 			}
 
 			tc.assert(t, cs, node)
+		})
+	}
+}
+
+func TestResourceRevisionLogToTimelineMapperTaskSettingV2_PreProcessAndProcessLog(t *testing.T) {
+	testTime1 := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
+	testTime2 := time.Date(2023, 10, 26, 10, 5, 0, 0, time.UTC)
+	testTime3 := time.Date(2023, 10, 26, 10, 10, 0, 0, time.UTC)
+	creationTimeUID1 := time.Date(2023, 10, 26, 9, 50, 0, 0, time.UTC)
+
+	builder := khifilev6.NewBuilder()
+	cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
+	api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
+	kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
+	ns := builder.TimelineAccumulator.GetPath(kind, khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace})
+	parentPath := builder.TimelineAccumulator.GetPath(ns, khifilev6.PathSegment{Name: "test", Type: inspectioncore_contract.TimelineTypeResource})
+
+	testCases := []struct {
+		name      string
+		eventLogs []struct {
+			verb     *pb.Verb
+			bodyYAML string
+			time     time.Time
+		}
+		assert func(t *testing.T, changeSets []*khifilev6.TimelineChangeSet)
+	}{
+		{
+			name: "patch without creationTimestamp followed by patch and update with creationTimestamp",
+			eventLogs: []struct {
+				verb     *pb.Verb
+				bodyYAML string
+				time     time.Time
+			}{
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					bodyYAML: `metadata:
+  name: "test"`,
+					time: testTime1,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					bodyYAML: `metadata:
+  name: "test"`,
+					time: testTime2,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbUpdate,
+					bodyYAML: `metadata:
+  uid: "uid-1"
+  creationTimestamp: "2023-10-26T09:50:00Z"`,
+					time: testTime3,
+				},
+			},
+			assert: func(t *testing.T, changeSets []*khifilev6.TimelineChangeSet) {
+				if len(changeSets) < 3 {
+					t.Fatalf("expected at least 3 change sets, got %d", len(changeSets))
+				}
+				testchangeset.AssertTimeline(t, changeSets[0]).
+					HasRevision(parentPath, &khifilev6.StagingRevision{
+						ChangedTime:  creationTimeUID1,
+						ResourceBody: nil,
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					})
+
+				var existingLogNotFoundCount int
+				for _, cs := range changeSets {
+					for _, revs := range cs.Revisions {
+						for _, r := range revs {
+							if r.StateType == commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound {
+								existingLogNotFoundCount++
+							}
+						}
+					}
+				}
+				if existingLogNotFoundCount != 1 {
+					t.Errorf("expected exactly 1 ExistingLogNotFound revision across all change sets, got %d", existingLogNotFoundCount)
+				}
+			},
+		},
+		{
+			name: "starts with create verb",
+			eventLogs: []struct {
+				verb     *pb.Verb
+				bodyYAML string
+				time     time.Time
+			}{
+				{
+					verb: commonlogk8saudit_contract.VerbCreate,
+					bodyYAML: `metadata:
+  uid: "uid-1"
+  creationTimestamp: "2023-10-26T10:00:00Z"`,
+					time: testTime1,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbUpdate,
+					bodyYAML: `metadata:
+  uid: "uid-1"
+  creationTimestamp: "2023-10-26T10:00:00Z"`,
+					time: testTime2,
+				},
+			},
+			assert: func(t *testing.T, changeSets []*khifilev6.TimelineChangeSet) {
+				var existingLogNotFoundCount int
+				for _, cs := range changeSets {
+					for _, revs := range cs.Revisions {
+						for _, r := range revs {
+							if r.StateType == commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound {
+								existingLogNotFoundCount++
+							}
+						}
+					}
+				}
+				if existingLogNotFoundCount != 0 {
+					t.Errorf("expected 0 ExistingLogNotFound revision when starting with create, got %d", existingLogNotFoundCount)
+				}
+			},
+		},
+		{
+			name: "patch followed by delete and recreation with create verb",
+			eventLogs: []struct {
+				verb     *pb.Verb
+				bodyYAML string
+				time     time.Time
+			}{
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					bodyYAML: `metadata:
+  name: "test"`,
+					time: testTime1,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbDelete,
+					bodyYAML: `metadata:
+  name: "test"
+  deletionGracePeriodSeconds: 0
+  deletionTimestamp: "2023-10-26T10:05:00Z"`,
+					time: testTime2,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbCreate,
+					bodyYAML: `metadata:
+  uid: "uid-2"
+  creationTimestamp: "2023-10-26T10:10:00Z"`,
+					time: testTime3,
+				},
+			},
+			assert: func(t *testing.T, changeSets []*khifilev6.TimelineChangeSet) {
+				var existingLogNotFoundCount int
+				for _, cs := range changeSets {
+					for _, revs := range cs.Revisions {
+						for _, r := range revs {
+							if r.StateType == commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound {
+								existingLogNotFoundCount++
+							}
+						}
+					}
+				}
+				if existingLogNotFoundCount != 1 {
+					t.Errorf("expected exactly 1 ExistingLogNotFound revision from initial patch, got %d", existingLogNotFoundCount)
+				}
+			},
+		},
+		{
+			name: "all patch logs without creationTimestamp",
+			eventLogs: []struct {
+				verb     *pb.Verb
+				bodyYAML string
+				time     time.Time
+			}{
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					bodyYAML: `metadata:
+  name: "test"`,
+					time: testTime1,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					bodyYAML: `metadata:
+  name: "test"`,
+					time: testTime2,
+				},
+			},
+			assert: func(t *testing.T, changeSets []*khifilev6.TimelineChangeSet) {
+				if len(changeSets) < 2 {
+					t.Fatalf("expected at least 2 change sets, got %d", len(changeSets))
+				}
+				testchangeset.AssertTimeline(t, changeSets[0]).
+					HasRevision(parentPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					})
+
+				var existingLogNotFoundCount int
+				for _, cs := range changeSets {
+					for _, revs := range cs.Revisions {
+						for _, r := range revs {
+							if r.StateType == commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound {
+								existingLogNotFoundCount++
+							}
+						}
+					}
+				}
+				if existingLogNotFoundCount != 1 {
+					t.Errorf("expected exactly 1 ExistingLogNotFound revision falling back to Unix(0,0), got %d", existingLogNotFoundCount)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			mapperSetting := &ResourceRevisionLogToTimelineMapperTaskSettingV2{
+				minimumDeltaTimeToCreateInferredCreationRevision: 5 * time.Second,
+			}
+
+			targetResource := &commonlogk8saudit_contract.ResourceIdentity{
+				APIVersion: "core/v1",
+				Kind:       "pod",
+				Namespace:  "default",
+				Name:       "test",
+			}
+
+			var events []commonlogk8saudit_contract.MultiGroupLogEvent
+			for _, el := range tc.eventLogs {
+				k8sFieldSet := &commonlogk8saudit_contract.K8sAuditLogFieldSet{
+					Principal:    "admin",
+					APIVersion:   "core/v1",
+					PluralKind:   "pods",
+					ResourceName: "test",
+					Namespace:    "default",
+					ClusterName:  "k8s",
+					Verb:         el.verb,
+				}
+				commonFs := &log.CommonFieldSet{
+					Timestamp: el.time,
+				}
+				logObj := log.NewLogWithFieldSetsForTest(k8sFieldSet, commonFs)
+				node, err := structured.FromYAML(el.bodyYAML)
+				if err != nil {
+					t.Fatalf("failed to parse test YAML: %v", err)
+				}
+				var nodeReader *structured.NodeReader
+				if node != nil {
+					nodeReader = structured.NewNodeReader(node)
+				}
+				groupSet := commonlogk8saudit_contract.RelatedGroupSet{
+					Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
+						"target": {
+							Resource: targetResource,
+							Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
+								{Log: logObj, ResourceBodyReader: nodeReader, ResourceBodyYAML: el.bodyYAML},
+							},
+						},
+					},
+				}
+				events = append(events, commonlogk8saudit_contract.MultiGroupLogEvent{
+					Log:              logObj,
+					GroupRole:        "target",
+					ResourceIdentity: targetResource,
+					EventType:        commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					GroupSet:         groupSet,
+				})
+			}
+
+			var state *resourceRevisionLogToTimelineMapperStateV2
+			for _, ev := range events {
+				var err error
+				state, err = mapperSetting.PreProcessLog(ctx, 0, ev, state)
+				if err != nil {
+					t.Fatalf("PreProcessLog() failed: %v", err)
+				}
+			}
+
+			var changeSets []*khifilev6.TimelineChangeSet
+			for idx, ev := range events {
+				if idx > 0 {
+					ev.EventType = commonlogk8saudit_contract.ChangeEventTypeV2Modification
+				}
+				cs, nextState, err := mapperSetting.ProcessLog(ctx, ev, state)
+				if err != nil {
+					t.Fatalf("ProcessLog() failed: %v", err)
+				}
+				state = nextState
+				changeSets = append(changeSets, cs)
+			}
+
+			tc.assert(t, changeSets)
 		})
 	}
 }


### PR DESCRIPTION
Previously KHI had created `inferred` revisions for k8s resource that didn't find in logs but its existence was inferred from the other logs. This change reintroduce this behavior.