### PR TITLE
fixed pod phase mapper bug

### DIFF
--- a/pkg/common/timeseries.go
+++ b/pkg/common/timeseries.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"slices"
+	"time"
+)
+
+// TimeSeriesEntry represents a value associated with a specific timestamp.
+type TimeSeriesEntry[V comparable] struct {
+	T   time.Time
+	Val V
+}
+
+// TimeSeries tracks the value of a single variable over time.
+// It is useful for cases where a value can change at different points in time.
+type TimeSeries[V comparable] struct {
+	Entries []TimeSeriesEntry[V]
+}
+
+// NewTimeSeries creates a new TimeSeries.
+func NewTimeSeries[V comparable]() *TimeSeries[V] {
+	return &TimeSeries[V]{}
+}
+
+// Set records that the value is associated starting from time t.
+// It preserves chronological order using binary search insertion.
+func (s *TimeSeries[V]) Set(t time.Time, val V) {
+	if len(s.Entries) == 0 {
+		s.Entries = []TimeSeriesEntry[V]{{T: t, Val: val}}
+		return
+	}
+	lastIdx := len(s.Entries) - 1
+	// Optimization: if entries are added chronologically (the most common case),
+	// we can just append without binary searching or inserting.
+	if t.After(s.Entries[lastIdx].T) {
+		s.Entries = append(s.Entries, TimeSeriesEntry[V]{T: t, Val: val})
+		return
+	}
+	if t.Equal(s.Entries[lastIdx].T) {
+		s.Entries[lastIdx].Val = val
+		return
+	}
+
+	idx, found := s.binarySearch(t)
+	if found {
+		s.Entries[idx].Val = val
+		return
+	}
+	// Insert preserving sorted order
+	s.Entries = slices.Insert(s.Entries, idx, TimeSeriesEntry[V]{T: t, Val: val})
+}
+
+// GetLastBeforeOrEqual returns the value of the last entry whose timestamp is <= t.
+func (s *TimeSeries[V]) GetLastBeforeOrEqual(t time.Time) (V, bool) {
+	if len(s.Entries) == 0 {
+		var zero V
+		return zero, false
+	}
+	idx, found := s.binarySearch(t)
+	if found {
+		return s.Entries[idx].Val, true
+	}
+	if idx > 0 {
+		return s.Entries[idx-1].Val, true
+	}
+	var zero V
+	return zero, false
+}
+
+// GetFirstAfterOrEqual returns the value of the first entry whose timestamp is >= t.
+func (s *TimeSeries[V]) GetFirstAfterOrEqual(t time.Time) (V, bool) {
+	if len(s.Entries) == 0 {
+		var zero V
+		return zero, false
+	}
+	idx, found := s.binarySearch(t)
+	if found {
+		return s.Entries[idx].Val, true
+	}
+	if idx < len(s.Entries) {
+		return s.Entries[idx].Val, true
+	}
+	var zero V
+	return zero, false
+}
+
+// Get returns the value associated at time t.
+// It tries to find the value active at t (using GetLastBeforeOrEqual).
+// If no such entry exists (t is before all entries), it falls back to the earliest value seen (GetFirstAfterOrEqual).
+func (s *TimeSeries[V]) Get(t time.Time) (V, bool) {
+	val, ok := s.GetLastBeforeOrEqual(t)
+	if ok {
+		return val, true
+	}
+	return s.GetFirstAfterOrEqual(t)
+}
+
+func (s *TimeSeries[V]) binarySearch(t time.Time) (int, bool) {
+	return slices.BinarySearchFunc(s.Entries, t, func(e TimeSeriesEntry[V], target time.Time) int {
+		if e.T.Before(target) {
+			return -1
+		}
+		if e.T.After(target) {
+			return 1
+		}
+		return 0
+	})
+}

--- a/pkg/common/timeseries_test.go
+++ b/pkg/common/timeseries_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTimeSeries_Set(t *testing.T) {
+	t0 := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		if len(ts.Entries) != 0 {
+			t.Errorf("expected empty series, got %d entries", len(ts.Entries))
+		}
+	})
+
+	t.Run("chronological", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		ts.Set(t1, "A")
+		ts.Set(t3, "B")
+
+		wantEntries := []TimeSeriesEntry[string]{
+			{T: t1, Val: "A"},
+			{T: t3, Val: "B"},
+		}
+		if diff := cmp.Diff(wantEntries, ts.Entries); diff != "" {
+			t.Errorf("Entries mismatch after chronological sets (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("out of order", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		ts.Set(t1, "A")
+		ts.Set(t3, "B")
+		ts.Set(t2, "C")
+
+		wantEntries := []TimeSeriesEntry[string]{
+			{T: t1, Val: "A"},
+			{T: t2, Val: "C"},
+			{T: t3, Val: "B"},
+		}
+		if diff := cmp.Diff(wantEntries, ts.Entries); diff != "" {
+			t.Errorf("Entries mismatch after out-of-order set (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("overwrite same timestamp", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		ts.Set(t1, "A")
+		ts.Set(t2, "B")
+		ts.Set(t2, "C") // Overwrite
+
+		wantEntries := []TimeSeriesEntry[string]{
+			{T: t1, Val: "A"},
+			{T: t2, Val: "C"},
+		}
+		if diff := cmp.Diff(wantEntries, ts.Entries); diff != "" {
+			t.Errorf("Entries mismatch after overwrite (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestTimeSeries_GetLastBeforeOrEqual(t *testing.T) {
+	t0 := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+	t4 := t0.Add(4 * time.Second)
+
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		if _, ok := ts.GetLastBeforeOrEqual(t0); ok {
+			t.Errorf("GetLastBeforeOrEqual on empty series should return false")
+		}
+	})
+
+	t.Run("lookups", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		ts.Set(t1, "A")
+		ts.Set(t2, "B")
+		ts.Set(t3, "C")
+
+		testCases := []struct {
+			name      string
+			queryTime time.Time
+			wantVal   string
+			wantOk    bool
+		}{
+			{name: "before first entry", queryTime: t0, wantVal: "", wantOk: false},
+			{name: "exact match first", queryTime: t1, wantVal: "A", wantOk: true},
+			{name: "between first and second", queryTime: t1.Add(500 * time.Millisecond), wantVal: "A", wantOk: true},
+			{name: "exact match second", queryTime: t2, wantVal: "B", wantOk: true},
+			{name: "after last entry", queryTime: t4, wantVal: "C", wantOk: true},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				gotVal, gotOk := ts.GetLastBeforeOrEqual(tc.queryTime)
+				if gotOk != tc.wantOk || gotVal != tc.wantVal {
+					t.Errorf("GetLastBeforeOrEqual(%s) = (%q, %v), want (%q, %v)", tc.queryTime, gotVal, gotOk, tc.wantVal, tc.wantOk)
+				}
+			})
+		}
+	})
+}
+
+func TestTimeSeries_GetFirstAfterOrEqual(t *testing.T) {
+	t0 := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+	t4 := t0.Add(4 * time.Second)
+
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		if _, ok := ts.GetFirstAfterOrEqual(t0); ok {
+			t.Errorf("GetFirstAfterOrEqual on empty series should return false")
+		}
+	})
+
+	t.Run("lookups", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		ts.Set(t1, "A")
+		ts.Set(t2, "B")
+		ts.Set(t3, "C")
+
+		testCases := []struct {
+			name      string
+			queryTime time.Time
+			wantVal   string
+			wantOk    bool
+		}{
+			{name: "before first entry", queryTime: t0, wantVal: "A", wantOk: true},
+			{name: "exact match first", queryTime: t1, wantVal: "A", wantOk: true},
+			{name: "between first and second", queryTime: t1.Add(500 * time.Millisecond), wantVal: "B", wantOk: true},
+			{name: "exact match second", queryTime: t2, wantVal: "B", wantOk: true},
+			{name: "after last entry", queryTime: t4, wantVal: "", wantOk: false},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				gotVal, gotOk := ts.GetFirstAfterOrEqual(tc.queryTime)
+				if gotOk != tc.wantOk || gotVal != tc.wantVal {
+					t.Errorf("GetFirstAfterOrEqual(%s) = (%q, %v), want (%q, %v)", tc.queryTime, gotVal, gotOk, tc.wantVal, tc.wantOk)
+				}
+			})
+		}
+	})
+}
+
+func TestTimeSeries_Get(t *testing.T) {
+	t0 := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+	t4 := t0.Add(4 * time.Second)
+
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		if _, ok := ts.Get(t0); ok {
+			t.Errorf("Get on empty series should return false")
+		}
+	})
+
+	t.Run("lookups with fallback", func(t *testing.T) {
+		ts := NewTimeSeries[string]()
+		ts.Set(t2, "A")
+		ts.Set(t3, "B")
+
+		testCases := []struct {
+			name      string
+			queryTime time.Time
+			wantVal   string
+			wantOk    bool
+		}{
+			{name: "fallback to earliest (t0 < t2)", queryTime: t0, wantVal: "A", wantOk: true},
+			{name: "fallback to earliest (t1 < t2)", queryTime: t1, wantVal: "A", wantOk: true},
+			{name: "exact match", queryTime: t2, wantVal: "A", wantOk: true},
+			{name: "active before t3", queryTime: t2.Add(500 * time.Millisecond), wantVal: "A", wantOk: true},
+			{name: "exact match B", queryTime: t3, wantVal: "B", wantOk: true},
+			{name: "active after t3", queryTime: t4, wantVal: "B", wantOk: true},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				gotVal, gotOk := ts.Get(tc.queryTime)
+				if gotOk != tc.wantOk || gotVal != tc.wantVal {
+					t.Errorf("Get(%s) = (%q, %v), want (%q, %v)", tc.queryTime, gotVal, gotOk, tc.wantVal, tc.wantOk)
+				}
+			})
+		}
+	})
+}
+
+func TestTimeSeries_AlternatingValues(t *testing.T) {
+	t0 := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+
+	ts := NewTimeSeries[string]()
+	ts.Set(t1, "A")
+	ts.Set(t2, "B")
+	ts.Set(t3, "A") // Alternates back to A
+
+	wantEntries := []TimeSeriesEntry[string]{
+		{T: t1, Val: "A"},
+		{T: t2, Val: "B"},
+		{T: t3, Val: "A"},
+	}
+	if diff := cmp.Diff(wantEntries, ts.Entries); diff != "" {
+		t.Errorf("Entries mismatch for alternating values (-want +got):\n%s", diff)
+	}
+
+	// Verify alternating lookups are correct
+	t.Run("query t1.5", func(t *testing.T) {
+		val, _ := ts.Get(t1.Add(500 * time.Millisecond))
+		if val != "A" {
+			t.Errorf("expected A, got %q", val)
+		}
+	})
+	t.Run("query t2.5", func(t *testing.T) {
+		val, _ := ts.Get(t2.Add(500 * time.Millisecond))
+		if val != "B" {
+			t.Errorf("expected B, got %q", val)
+		}
+	})
+	t.Run("query t3.5", func(t *testing.T) {
+		val, _ := ts.Get(t3.Add(500 * time.Millisecond))
+		if val != "A" {
+			t.Errorf("expected A, got %q", val)
+		}
+	})
+}

--- a/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
@@ -339,7 +339,7 @@ var (
 		`The condition status is undetermined due to insufficient log information in the selected range.
 
 **Tip**: Consider expanding the query time range to capture complete condition reports.`,
-		style.MustForceConvertSRGBHex("#997700"),
-		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+		style.MustForceConvertSRGBHex("#666666"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)
 )

--- a/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -27,6 +28,11 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+const (
+	podPhasePassCollectUID      = 0
+	podPhasePassCollectNodeName = 1
 )
 
 var phaseToState = map[string]*pb.RevisionState{
@@ -44,11 +50,28 @@ type podPhaseTaskState struct {
 	lastNode string
 	// uidToNodeNameMap is the map of UID to node name.
 	uidToNodeNameMap map[string]string
+	// parentPathToUIDMap is the map of parent pod path to UID history.
+	parentPathToUIDMap map[string]*common.TimeSeries[string]
+	// uidToCreationTimestampMap maps pod UID to its creationTimestamp.
+	uidToCreationTimestampMap map[string]time.Time
 }
 
+func newPodPhaseTaskState() *podPhaseTaskState {
+	return &podPhaseTaskState{
+		uidToNodeNameMap:          map[string]string{},
+		parentPathToUIDMap:        map[string]*common.TimeSeries[string]{},
+		uidToCreationTimestampMap: map[string]time.Time{},
+	}
+}
+
+// podPhaseLogToTimelineMapperTaskSettingV2 handles pod phase timeline generation.
+// This mapper runs in 2 passes during PreProcessLog to associate pod UIDs with node names,
+// even when scheduling (binding) logs and pod status logs appear out of order or when pod logs are missing:
+//   - Pass 0 (podPhasePassCollectUID): Collects the mapping from parent pod path to its UID from "pod" role logs.
+//   - Pass 1 (podPhasePassCollectNodeName): Resolves the node name from either "pod" or "binding" logs and
+//     stores the mapping from UID to node name. A 2-pass approach is necessary because a chronological log stream
+//     might process "binding" logs (which lack pod UID) before "pod" logs (where the UID is first observed).
 type podPhaseLogToTimelineMapperTaskSettingV2 struct {
-	// minimumDeltaTimeToCreateInferredCreationRevision is a threshold of a duration that controls if KHI should create an inferred creation revision from creationTimestamp.
-	minimumDeltaTimeToCreateInferredCreationRevision time.Duration
 }
 
 // Dependencies implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
@@ -58,7 +81,7 @@ func (c *podPhaseLogToTimelineMapperTaskSettingV2) Dependencies() []taskid.Untyp
 
 // PassCount implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
 func (c *podPhaseLogToTimelineMapperTaskSettingV2) PassCount() int {
-	return 1
+	return 2
 }
 
 // GroupedLogTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
@@ -79,66 +102,150 @@ func (c *podPhaseLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplement
 // ResolveRelatedGroupSets implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
 func (c *podPhaseLogToTimelineMapperTaskSettingV2) ResolveRelatedGroupSets(ctx context.Context, groupedLogs commonlogk8saudit_contract.ResourceManifestLogGroupMap) ([]commonlogk8saudit_contract.RelatedGroupSet, error) {
 	result := []commonlogk8saudit_contract.RelatedGroupSet{}
+	processedPods := map[string]struct{}{}
+
 	for _, group := range groupedLogs {
-		if group.Resource.Type() == commonlogk8saudit_contract.Resource && group.Resource.APIVersion == "core/v1" && group.Resource.Kind == "pod" {
-			bindingGroup := groupedLogs[group.Resource.SubresourceIdentity("binding").String()]
-			result = append(result, commonlogk8saudit_contract.RelatedGroupSet{
-				Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
-					"pod":     group,
-					"binding": bindingGroup,
-				},
-			})
+		var podPath string
+		var podGroup *commonlogk8saudit_contract.ResourceManifestLogGroup
+		var bindingGroup *commonlogk8saudit_contract.ResourceManifestLogGroup
+
+		if group.Resource.APIVersion == "core/v1" && group.Resource.Kind == "pod" {
+			if group.Resource.Type() == commonlogk8saudit_contract.Resource {
+				podPath = group.Resource.String()
+				podGroup = group
+				bindingGroup = groupedLogs[group.Resource.SubresourceIdentity("binding").String()]
+			} else if group.Resource.Type() == commonlogk8saudit_contract.Subresource && group.Resource.SubresourceName == "binding" {
+				parent := *group.Resource
+				parent.SubresourceName = ""
+				podPath = parent.String()
+				podGroup = groupedLogs[podPath]
+				bindingGroup = group
+			}
+		}
+
+		if podPath != "" {
+			if _, processed := processedPods[podPath]; !processed {
+				processedPods[podPath] = struct{}{}
+				result = append(result, commonlogk8saudit_contract.RelatedGroupSet{
+					Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
+						"pod":     podGroup,
+						"binding": bindingGroup,
+					},
+				})
+			}
 		}
 	}
 	return result, nil
 }
 
+// resolveUID returns the active pod UID at time t.
+func (c *podPhaseLogToTimelineMapperTaskSettingV2) resolveUID(ts *common.TimeSeries[string], t time.Time) string {
+	uid, ok := ts.Get(t)
+	if ok && uid != "" {
+		return uid
+	}
+	return ""
+}
+
 // PreProcessLog implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
 func (c *podPhaseLogToTimelineMapperTaskSettingV2) PreProcessLog(ctx context.Context, passIndex int, event commonlogk8saudit_contract.MultiGroupLogEvent, prevGroupData *podPhaseTaskState) (*podPhaseTaskState, error) {
 	if prevGroupData == nil {
-		prevGroupData = &podPhaseTaskState{
-			uidToNodeNameMap: map[string]string{},
-		}
+		prevGroupData = newPodPhaseTaskState()
 	}
-	if event.GroupRole != "pod" {
-		return prevGroupData, nil
-	}
-	bodyReader, ok := event.GetLastBodyReader("pod")
-	if !ok || bodyReader == nil {
-		return prevGroupData, nil
-	}
-	nodeName, found := GetNodeNameOfPod(bodyReader)
-	if !found {
-		return prevGroupData, nil
-	}
-	uid, _ := GetUID(bodyReader)
 
-	if nodeName != "" && uid != "" {
-		prevGroupData.uidToNodeNameMap[uid] = nodeName
+	commonLogFieldSet := log.MustGetFieldSet(event.Log, &log.CommonFieldSet{})
+	eventTime := commonLogFieldSet.Timestamp
+
+	switch passIndex {
+	// The first pass to collect UIDs & creationTimestamps from Pods.
+	case podPhasePassCollectUID:
+		if event.GroupRole == "pod" {
+			path := event.ResourceIdentity.String()
+			ts, found := prevGroupData.parentPathToUIDMap[path]
+			if !found {
+				ts = common.NewTimeSeries[string]()
+				prevGroupData.parentPathToUIDMap[path] = ts
+			}
+
+			if event.EventType == commonlogk8saudit_contract.ChangeEventTypeV2Deletion {
+				ts.Set(eventTime, "")
+			} else {
+				bodyReader, ok := event.GetLastBodyReader("pod")
+				if ok && bodyReader != nil {
+					uid, _ := GetUID(bodyReader)
+					if uid != "" {
+						ts.Set(eventTime, uid)
+						creationTime, found := GetCreationTimestamp(bodyReader)
+						if found {
+							prevGroupData.uidToCreationTimestampMap[uid] = creationTime
+						}
+					}
+				}
+			}
+		}
+	// Secound pass to gather node names for Pods for each uids.
+	// This step can't be merged with the first pass for the case when the first log is binding and it has no Pod uid in it.
+	case podPhasePassCollectNodeName:
+		switch event.GroupRole {
+		case "pod":
+			bodyReader, ok := event.GetLastBodyReader("pod")
+			if ok && bodyReader != nil {
+				uid, found := GetUID(bodyReader)
+				if found && uid != "" {
+					nodeName, found := GetNodeNameOfPod(bodyReader)
+					if found && nodeName != "" {
+						prevGroupData.uidToNodeNameMap[uid] = nodeName
+					}
+				}
+			}
+		case "binding":
+			bodyReader, ok := event.GetLastBodyReader("binding")
+			if ok && bodyReader != nil {
+				parent := *event.ResourceIdentity
+				parent.SubresourceName = ""
+				parentPath := parent.String()
+				uid := ""
+				if ts, found := prevGroupData.parentPathToUIDMap[parentPath]; found {
+					uid = c.resolveUID(ts, eventTime)
+				}
+				if uid != "" {
+					nodeName, found := GetNodeNameOfBinding(bodyReader)
+					if found && nodeName != "" {
+						prevGroupData.uidToNodeNameMap[uid] = nodeName
+					}
+				}
+			}
+		}
 	}
 	return prevGroupData, nil
 }
 
 // ProcessLog implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
 func (c *podPhaseLogToTimelineMapperTaskSettingV2) ProcessLog(ctx context.Context, event commonlogk8saudit_contract.MultiGroupLogEvent, prevGroupData *podPhaseTaskState) (*khifilev6.TimelineChangeSet, *podPhaseTaskState, error) {
-	if prevGroupData == nil {
-		prevGroupData = &podPhaseTaskState{
-			uidToNodeNameMap: map[string]string{},
-		}
-	}
-
 	cs := khifilev6.NewTimelineChangeSet(event.Log)
 
 	commonLogFieldSet := log.MustGetFieldSet(event.Log, &log.CommonFieldSet{})
 	k8sFieldSet := log.MustGetFieldSet(event.Log, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+	eventTime := commonLogFieldSet.Timestamp
 
 	var targetBodyReader *structured.NodeReader
 	if reader, ok := event.GetLastBodyReader("pod"); ok {
 		targetBodyReader = reader
 	}
 
-	uid, found := GetUID(targetBodyReader)
+	var uid string
+	var found bool
+	if targetBodyReader != nil {
+		uid, found = GetUID(targetBodyReader)
+	}
 	if !found {
+		parent := *event.ResourceIdentity
+		parent.SubresourceName = ""
+		if ts, found := prevGroupData.parentPathToUIDMap[parent.String()]; found {
+			uid = c.resolveUID(ts, eventTime)
+		}
+	}
+	if uid == "" {
 		return cs, prevGroupData, nil
 	}
 
@@ -147,9 +254,32 @@ func (c *podPhaseLogToTimelineMapperTaskSettingV2) ProcessLog(ctx context.Contex
 		return cs, prevGroupData, nil
 	}
 
-	if event.GroupRole == "binding" {
+	// Place the first revision into the changeset.
+	if event.EventType == commonlogk8saudit_contract.ChangeEventTypeV2Creation {
+		nonCreationForPod := event.GroupRole == "pod" && k8sFieldSet.Verb != commonlogk8saudit_contract.VerbCreate
+		if nonCreationForPod {
+			creationTime, found := prevGroupData.uidToCreationTimestampMap[uid]
+			var changedTime time.Time
+			if found {
+				changedTime = creationTime
+			} else {
+				changedTime = time.Unix(0, 0).UTC()
+			}
+			targetPath := MustPodPhaseTimelinePath(ctx, k8sFieldSet.ClusterName, nodeName, event.ResourceIdentity.Namespace, event.ResourceIdentity.Name, uid)
+			cs.AddRevision(targetPath, &khifilev6.StagingRevision{
+				ChangedTime:  changedTime,
+				ResourceBody: nil,
+				Principal:    "N/A",
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+			})
+		}
+	}
+
+	switch event.GroupRole {
+	case "binding":
 		if event.EventType == commonlogk8saudit_contract.ChangeEventTypeV2Creation {
-			targetPath := MustPodPhaseTimelinePath(ctx, k8sFieldSet.ClusterName, nodeName, event.GroupSet.Roles["pod"].Resource.Namespace, event.GroupSet.Roles["pod"].Resource.Name, uid)
+			targetPath := MustPodPhaseTimelinePath(ctx, k8sFieldSet.ClusterName, nodeName, event.ResourceIdentity.Namespace, event.ResourceIdentity.Name, uid)
 			var bodyNode structured.Node
 			if targetBodyReader != nil {
 				bodyNode = targetBodyReader.Node
@@ -163,23 +293,7 @@ func (c *podPhaseLogToTimelineMapperTaskSettingV2) ProcessLog(ctx context.Contex
 			})
 		}
 		return cs, prevGroupData, nil
-	}
-
-	if event.GroupRole == "pod" {
-		if event.EventType == commonlogk8saudit_contract.ChangeEventTypeV2Creation {
-			creationTime, found := GetCreationTimestamp(targetBodyReader)
-			if found && commonLogFieldSet.Timestamp.Sub(creationTime) > c.minimumDeltaTimeToCreateInferredCreationRevision {
-				targetPath := MustPodPhaseTimelinePath(ctx, k8sFieldSet.ClusterName, nodeName, event.ResourceIdentity.Namespace, event.ResourceIdentity.Name, uid)
-				cs.AddRevision(targetPath, &khifilev6.StagingRevision{
-					ChangedTime:  creationTime,
-					ResourceBody: nil,
-					Principal:    "N/A",
-					VerbType:     commonlogk8saudit_contract.VerbCreate,
-					StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
-				})
-			}
-		}
-
+	case "pod":
 		phase, found := GetPodPhase(targetBodyReader)
 		if !found {
 			return cs, prevGroupData, nil
@@ -201,9 +315,10 @@ func (c *podPhaseLogToTimelineMapperTaskSettingV2) ProcessLog(ctx context.Contex
 		}
 		prevGroupData.lastPhase = phase
 		prevGroupData.lastNode = nodeName
+		return cs, prevGroupData, nil
+	default:
+		panic("unreachable: unexpected group role: " + event.GroupRole)
 	}
-
-	return cs, prevGroupData, nil
 }
 
 // MustPodPhaseTimelinePath resolves TimelinePath for PodPhase under Node timeline.
@@ -224,6 +339,4 @@ func MustPodPhaseTimelinePath(ctx context.Context, clusterName, nodeName, namesp
 var _ commonlogk8saudit_contract.ManifestLogToTimelineMapperV2[*podPhaseTaskState] = (*podPhaseLogToTimelineMapperTaskSettingV2)(nil)
 
 // PodPhaseLogToTimelineMapperTask is the V2 task to generate pod phase history.
-var PodPhaseLogToTimelineMapperTask = commonlogk8saudit_contract.NewManifestLogToTimelineMapperV2[*podPhaseTaskState](&podPhaseLogToTimelineMapperTaskSettingV2{
-	minimumDeltaTimeToCreateInferredCreationRevision: 5 * time.Second,
-})
+var PodPhaseLogToTimelineMapperTask = commonlogk8saudit_contract.NewManifestLogToTimelineMapperV2[*podPhaseTaskState](&podPhaseLogToTimelineMapperTaskSettingV2{})

--- a/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task_test.go
@@ -15,6 +15,7 @@
 package commonlogk8saudit_impl
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -29,15 +30,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestPodPhaseTask_ProcessLog(t *testing.T) {
-	testTime := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
+func TestPodPhaseLogToTimelineMapperTaskSettingV2_ProcessLog(t *testing.T) {
+	baseTime := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
 
-	// 1. Set up the mock Builder and construct comparison paths hierarchically.
-	builder := khifilev6.NewBuilder()
-	ctxForPath := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
-	podPhasePath := MustPodPhaseTimelinePath(ctxForPath, "k8s", "node-1", "default", "test", "test-uid")
-
-	// Comparer for structured.Node using semantical YAML serializations to bypass unexported fields.
 	nodeComparer := cmp.Comparer(func(a, b structured.Node) bool {
 		if a == nil || b == nil {
 			return a == b
@@ -50,7 +45,6 @@ func TestPodPhaseTask_ProcessLog(t *testing.T) {
 		return string(aYAML) == string(bYAML)
 	})
 
-	// Helper to parse YAML into structured.Node.
 	parseYAML := func(yamlStr string) structured.Node {
 		if yamlStr == "" {
 			return nil
@@ -63,517 +57,569 @@ func TestPodPhaseTask_ProcessLog(t *testing.T) {
 	}
 
 	type step struct {
-		verb             *pb.Verb
-		resourceBodyYAML string
-		role             string
-		eventType        commonlogk8saudit_contract.ChangeEventTypeV2
+		role      string
+		yaml      string
+		eventType commonlogk8saudit_contract.ChangeEventTypeV2
+		verb      *pb.Verb
+		time      time.Time
+	}
+
+	type wantRevision struct {
+		uid          string
+		nodeName     string
+		changedTime  time.Time
+		stateType    *pb.RevisionState
+		verbType     *pb.Verb
+		resourceBody structured.Node
+		principal    string
 	}
 
 	testCases := []struct {
-		name         string
-		targetPass   int
-		initialState *podPhaseTaskState
-		steps        []step
-		wantState    *podPhaseTaskState
-		assert       func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option)
+		name          string
+		podName       string
+		namespace     string
+		clusterName   string
+		steps         []step
+		wantRevisions []wantRevision
 	}{
 		{
-			name:       "Standard Pod Lifecycle - Pass 0",
-			targetPass: 0,
+			// Input:
+			// 1. A pod creation event at t=5s, verb: Create, phase: Pending. Unscheduled at this point.
+			// 2. A binding creation log event at t=10s, mapping the pod to node-1.
+			//    The binding log contains a binding-specific UID and creationTimestamp, which should be ignored by the pod phase mapper.
+			// 3. A pod status update event at t=20s, specifying uid-1, nodeName as node-1, and phase as Succeeded.
+			//
+			// Expected Output:
+			// - A single pod phase timeline path: k8s-cluster/node-1/default/my-pod[uid-1]
+			// - Revision at t=5s: StateType=PodPhasePending, Verb=Create, body=pod creation body.
+			// - Revision at t=10s: StateType=PodPhaseScheduled, Verb=Create, body=nil.
+			// - Revision at t=20s: StateType=PodPhaseSucceeded, Verb=Update, body=pod Succeeded body.
+			name:        "Standard lifecycle starting with pod creation followed by binding with binding metadata and Succeeded update",
+			podName:     "my-pod",
+			namespace:   "default",
+			clusterName: "k8s-cluster",
 			steps: []step{
 				{
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-spec:
-  nodeName: "node-1"
+					role: "pod",
+					yaml: `
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:05Z"
+spec: {}
 status:
-  phase: Pending`,
-					role:      "pod",
+  phase: Pending
+`,
 					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					verb:      commonlogk8saudit_contract.VerbCreate,
+					time:      baseTime.Add(5 * time.Second),
 				},
 				{
-					verb: commonlogk8saudit_contract.VerbPatch,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
+					role: "binding",
+					yaml: `
+metadata:
+  uid: binding-uid
+  creationTimestamp: "2026-06-26T12:00:10Z"
+target:
+  name: node-1
+`,
+					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					verb:      commonlogk8saudit_contract.VerbCreate,
+					time:      baseTime.Add(10 * time.Second),
+				},
+				{
+					role: "pod",
+					yaml: `
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:05Z"
 spec:
-  nodeName: "node-1"
+  nodeName: node-1
 status:
-  phase: Running`,
-					role:      "pod",
+  phase: Succeeded
+`,
 					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Modification,
+					verb:      commonlogk8saudit_contract.VerbUpdate,
+					time:      baseTime.Add(20 * time.Second),
 				},
 			},
-			wantState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
+			wantRevisions: []wantRevision{
+				{
+					uid:         "uid-1",
+					nodeName:    "node-1",
+					changedTime: baseTime.Add(5 * time.Second),
+					stateType:   commonlogk8saudit_contract.RevisionStatePodPhasePending,
+					verbType:    commonlogk8saudit_contract.VerbCreate,
+					resourceBody: parseYAML(`
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:05Z"
+spec: {}
+status:
+  phase: Pending
+`),
+					principal: "admin",
 				},
-				lastPhase: "",
-				lastNode:  "",
-			},
-			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option) {
-				testchangeset.AssertTimeline(t, cs).
-					HasNoRevision(podPhasePath)
+				{
+					uid:         "uid-1",
+					nodeName:    "node-1",
+					changedTime: baseTime.Add(10 * time.Second),
+					stateType:   commonlogk8saudit_contract.RevisionStatePodPhaseScheduled,
+					verbType:    commonlogk8saudit_contract.VerbCreate,
+					resourceBody: parseYAML(`
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:05Z"
+spec: {}
+status:
+  phase: Pending
+`),
+					principal: "admin",
+				},
+				{
+					uid:         "uid-1",
+					nodeName:    "node-1",
+					changedTime: baseTime.Add(20 * time.Second),
+					stateType:   commonlogk8saudit_contract.RevisionStatePodPhaseSucceeded,
+					verbType:    commonlogk8saudit_contract.VerbUpdate,
+					resourceBody: parseYAML(`
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:05Z"
+spec:
+  nodeName: node-1
+status:
+  phase: Succeeded
+`),
+					principal: "admin",
+				},
 			},
 		},
 		{
-			name:       "Standard Pod Lifecycle - Pass 1",
-			targetPass: 1,
-			initialState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
-				},
-			},
+			// Input:
+			// 1. A binding creation log event at t=10s, mapping the pod to node-1.
+			//    The binding log contains a binding-specific UID and creationTimestamp, which should be ignored.
+			// 2. A pod update event at t=20s, specifying uid-1, nodeName node-1, and phase Failed.
+			//    The pod metadata includes creationTimestamp = 12:00:00Z.
+			//
+			// Expected Output:
+			// - An inferred creation revision at the creationTimestamp (12:00:00Z) with StateType=PodPhaseUnknown, Verb=Create.
+			// - A revision at t=20s: StateType=PodPhaseFailed, Verb=Update.
+			name:        "Inferred creation revision when the first pod event is an update, preceded by binding with binding metadata",
+			podName:     "my-pod",
+			namespace:   "default",
+			clusterName: "k8s-cluster",
 			steps: []step{
 				{
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-spec:
-  nodeName: "node-1"
-status:
-  phase: Pending`,
-					role:      "pod",
+					role: "binding",
+					yaml: `
+metadata:
+  uid: binding-uid
+  creationTimestamp: "2026-06-26T12:00:10Z"
+target:
+  name: node-1
+`,
 					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					verb:      commonlogk8saudit_contract.VerbCreate,
+					time:      baseTime.Add(10 * time.Second),
 				},
 				{
-					verb: commonlogk8saudit_contract.VerbPatch,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
+					role: "pod",
+					yaml: `
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:00Z"
 spec:
-  nodeName: "node-1"
+  nodeName: node-1
 status:
-  phase: Running`,
-					role:      "pod",
+  phase: Failed
+`,
+					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					verb:      commonlogk8saudit_contract.VerbUpdate,
+					time:      baseTime.Add(20 * time.Second),
+				},
+			},
+			wantRevisions: []wantRevision{
+				{
+					uid:          "uid-1",
+					nodeName:     "node-1",
+					changedTime:  time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC),
+					stateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					verbType:     commonlogk8saudit_contract.VerbCreate,
+					resourceBody: nil,
+					principal:    "N/A",
+				},
+				{
+					uid:         "uid-1",
+					nodeName:    "node-1",
+					changedTime: baseTime.Add(20 * time.Second),
+					stateType:   commonlogk8saudit_contract.RevisionStatePodPhaseFailed,
+					verbType:    commonlogk8saudit_contract.VerbUpdate,
+					resourceBody: parseYAML(`
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:00Z"
+spec:
+  nodeName: node-1
+status:
+  phase: Failed
+`),
+					principal: "admin",
+				},
+			},
+		},
+		{
+			// Input:
+			// 1. A binding creation log event at t=10s, mapping the pod to node-1.
+			//    The binding log contains a binding-specific UID and creationTimestamp, which should be ignored.
+			// 2. A pod patch event at t=20s, specifying phase Running. This event lacks pod metadata (uid and creationTimestamp).
+			// 3. A pod status update event at t=30s, specifying uid-1, nodeName as node-1, and phase as Succeeded.
+			//    The pod metadata includes creationTimestamp = 12:00:00Z.
+			//
+			// Expected Output:
+			// - A single pod phase timeline path: k8s-cluster/node-1/default/my-pod[uid-1]
+			// - Revision at t=0s (12:00:00Z): StateType=PodPhaseUnknown, Verb=Create, body=nil.
+			// - Revision at t=10s: StateType=PodPhaseScheduled, Verb=Create, body=nil.
+			// - Revision at t=20s: StateType=PodPhaseRunning, Verb=Patch, body=patch body.
+			// - Revision at t=30s: StateType=PodPhaseSucceeded, Verb=Update, body=pod update body.
+			name:        "Resolve pod lifecycle stages with chronological fallback when metadata is missing in early events",
+			podName:     "my-pod",
+			namespace:   "default",
+			clusterName: "k8s-cluster",
+			steps: []step{
+				{
+					role: "binding",
+					yaml: `
+metadata:
+  uid: binding-uid
+  creationTimestamp: "2026-06-26T12:00:10Z"
+target:
+  name: node-1
+`,
+					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					verb:      commonlogk8saudit_contract.VerbCreate,
+					time:      baseTime.Add(10 * time.Second),
+				},
+				{
+					role: "pod",
+					yaml: `
+status:
+  phase: Running
+`,
+					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					verb:      commonlogk8saudit_contract.VerbPatch,
+					time:      baseTime.Add(20 * time.Second),
+				},
+				{
+					role: "pod",
+					yaml: `
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:00Z"
+spec:
+  nodeName: node-1
+status:
+  phase: Succeeded
+`,
 					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Modification,
+					verb:      commonlogk8saudit_contract.VerbUpdate,
+					time:      baseTime.Add(30 * time.Second),
 				},
 			},
-			wantState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
+			wantRevisions: []wantRevision{
+				{
+					uid:          "uid-1",
+					nodeName:     "node-1",
+					changedTime:  time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC),
+					stateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					verbType:     commonlogk8saudit_contract.VerbCreate,
+					resourceBody: nil,
+					principal:    "N/A",
 				},
-				lastPhase: "Running",
-				lastNode:  "node-1",
-			},
-			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option) {
-				testchangeset.AssertTimeline(t, cs).
-					HasRevision(podPhasePath, &khifilev6.StagingRevision{
-						ChangedTime: testTime,
-						ResourceBody: parseYAML(`metadata:
-  uid: "test-uid"
-spec:
-  nodeName: "node-1"
+				{
+					uid:          "uid-1",
+					nodeName:     "node-1",
+					changedTime:  baseTime.Add(10 * time.Second),
+					stateType:    commonlogk8saudit_contract.RevisionStatePodPhaseScheduled,
+					verbType:     commonlogk8saudit_contract.VerbCreate,
+					resourceBody: nil,
+					principal:    "admin",
+				},
+				{
+					uid:         "uid-1",
+					nodeName:    "node-1",
+					changedTime: baseTime.Add(20 * time.Second),
+					stateType:   commonlogk8saudit_contract.RevisionStatePodPhaseRunning,
+					verbType:    commonlogk8saudit_contract.VerbPatch,
+					resourceBody: parseYAML(`
 status:
-  phase: Pending`),
-						Principal: "admin",
-						VerbType:  commonlogk8saudit_contract.VerbCreate,
-						StateType: commonlogk8saudit_contract.RevisionStatePodPhasePending,
-					}, nodeComparer).
-					HasRevision(podPhasePath, &khifilev6.StagingRevision{
-						ChangedTime: testTime.Add(1 * time.Second),
-						ResourceBody: parseYAML(`metadata:
-  uid: "test-uid"
+  phase: Running
+`),
+					principal: "admin",
+				},
+				{
+					uid:         "uid-1",
+					nodeName:    "node-1",
+					changedTime: baseTime.Add(30 * time.Second),
+					stateType:   commonlogk8saudit_contract.RevisionStatePodPhaseSucceeded,
+					verbType:    commonlogk8saudit_contract.VerbUpdate,
+					resourceBody: parseYAML(`
+metadata:
+  uid: uid-1
+  creationTimestamp: "2026-06-26T12:00:00Z"
 spec:
-  nodeName: "node-1"
+  nodeName: node-1
 status:
-  phase: Running`),
-						Principal: "admin",
-						VerbType:  commonlogk8saudit_contract.VerbPatch,
-						StateType: commonlogk8saudit_contract.RevisionStatePodPhaseRunning,
-					}, nodeComparer)
+  phase: Succeeded
+`),
+					principal: "admin",
+				},
 			},
 		},
 		{
-			name:       "Pod scheduled later - Pass 0",
-			targetPass: 0,
+			// Input:
+			// 1. A binding creation log event at t=10s, mapping the pod to node-1.
+			//    The binding log contains a binding-specific UID and creationTimestamp, which should be ignored.
+			// 2. A pod patch event at t=20s, specifying uid-1 and phase Running.
+			//    The pod metadata does NOT include creationTimestamp.
+			//
+			// Expected Output:
+			// - An inferred creation revision at Unix Epoch (1970-01-01T00:00:00Z) with StateType=PodPhaseUnknown, Verb=Create.
+			// - Revision at t=10s: StateType=PodPhaseScheduled, Verb=Create, body=nil.
+			// - Revision at t=20s: StateType=PodPhaseRunning, Verb=Patch, body=patch body.
+			name:        "Inferred creation revision fallback to Unix Epoch when creationTimestamp is missing",
+			podName:     "my-pod",
+			namespace:   "default",
+			clusterName: "k8s-cluster",
 			steps: []step{
 				{
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-spec:
-  nodeName: ""
-status:
-  phase: Pending`,
-					role:      "pod",
+					role: "binding",
+					yaml: `
+metadata:
+  uid: binding-uid
+  creationTimestamp: "2026-06-26T12:00:10Z"
+target:
+  name: node-1
+`,
 					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					verb:      commonlogk8saudit_contract.VerbCreate,
+					time:      baseTime.Add(10 * time.Second),
 				},
 				{
-					verb: commonlogk8saudit_contract.VerbPatch,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-spec:
-  nodeName: "node-1"
+					role: "pod",
+					yaml: `
+metadata:
+  uid: uid-1
 status:
-  phase: Pending`,
-					role:      "pod",
-					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Modification,
+  phase: Running
+`,
+					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
+					verb:      commonlogk8saudit_contract.VerbPatch,
+					time:      baseTime.Add(20 * time.Second),
 				},
 			},
-			wantState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
+			wantRevisions: []wantRevision{
+				{
+					uid:          "uid-1",
+					nodeName:     "node-1",
+					changedTime:  time.Unix(0, 0).UTC(),
+					stateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					verbType:     commonlogk8saudit_contract.VerbCreate,
+					resourceBody: nil,
+					principal:    "N/A",
 				},
-				lastPhase: "",
-				lastNode:  "",
-			},
-			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option) {
-				testchangeset.AssertTimeline(t, cs).
-					HasNoRevision(podPhasePath)
+				{
+					uid:          "uid-1",
+					nodeName:     "node-1",
+					changedTime:  baseTime.Add(10 * time.Second),
+					stateType:    commonlogk8saudit_contract.RevisionStatePodPhaseScheduled,
+					verbType:     commonlogk8saudit_contract.VerbCreate,
+					resourceBody: nil,
+					principal:    "admin",
+				},
+				{
+					uid:         "uid-1",
+					nodeName:    "node-1",
+					changedTime: baseTime.Add(20 * time.Second),
+					stateType:   commonlogk8saudit_contract.RevisionStatePodPhaseRunning,
+					verbType:    commonlogk8saudit_contract.VerbPatch,
+					resourceBody: parseYAML(`
+metadata:
+  uid: uid-1
+status:
+  phase: Running
+`),
+					principal: "admin",
+				},
 			},
 		},
-		{
-			name:       "Pod scheduled later - Pass 1",
-			targetPass: 1,
-			initialState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
-				},
-			},
-			steps: []step{
-				{
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-spec:
-  nodeName: ""
-status:
-  phase: Pending`,
-					role:      "pod",
-					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
-				},
-				{
-					verb: commonlogk8saudit_contract.VerbPatch,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-spec:
-  nodeName: "node-1"
-status:
-  phase: Pending`,
-					role:      "pod",
-					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Modification,
-				},
-			},
-			wantState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
-				},
-				lastPhase: "Pending",
-				lastNode:  "node-1",
-			},
-			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option) {
-				testchangeset.AssertTimeline(t, cs).
-					HasRevision(podPhasePath, &khifilev6.StagingRevision{
-						ChangedTime: testTime,
-						ResourceBody: parseYAML(`metadata:
-  uid: "test-uid"
-spec:
-  nodeName: ""
-status:
-  phase: Pending`),
-						Principal: "admin",
-						VerbType:  commonlogk8saudit_contract.VerbCreate,
-						StateType: commonlogk8saudit_contract.RevisionStatePodPhasePending,
-					}, nodeComparer)
-			},
-		},
-		{
-			name:       "Missing NodeName - Pass 0",
-			targetPass: 0,
-			steps: []step{
-				{
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-status:
-  phase: Pending`,
-					role:      "pod",
-					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
-				},
-			},
-			wantState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{},
-				lastPhase:        "",
-				lastNode:         "",
-			},
-			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option) {
-				testchangeset.AssertTimeline(t, cs).
-					HasNoRevision(podPhasePath)
-			},
-		},
-		{
-			name:       "Missing NodeName - Pass 1",
-			targetPass: 1,
-			initialState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{},
-			},
-			steps: []step{
-				{
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-status:
-  phase: Pending`,
-					role:      "pod",
-					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
-				},
-			},
-			wantState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{},
-				lastPhase:        "",
-				lastNode:         "",
-			},
-			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option) {
-				testchangeset.AssertTimeline(t, cs).
-					HasNoRevision(podPhasePath)
-			},
-		},
-		{
-			name:       "Pod scheduled by binding - Pass 1",
-			targetPass: 1,
-			initialState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
-				},
-			},
-			steps: []step{
-				{
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-status:
-  phase: Pending`,
-					role:      "pod",
-					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
-				},
-				{
-					// Binding resource creation
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-status:
-  phase: Pending`,
-					role:      "binding",
-					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
-				},
-			},
-			wantState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
-				},
-				lastPhase: "Pending",
-				lastNode:  "node-1",
-			},
-			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option) {
-				testchangeset.AssertTimeline(t, cs).
-					HasRevision(podPhasePath, &khifilev6.StagingRevision{
-						ChangedTime: testTime,
-						ResourceBody: parseYAML(`metadata:
-  uid: "test-uid"
-status:
-  phase: Pending`),
-						Principal: "admin",
-						VerbType:  commonlogk8saudit_contract.VerbCreate,
-						StateType: commonlogk8saudit_contract.RevisionStatePodPhasePending,
-					}, nodeComparer).
-					HasRevision(podPhasePath, &khifilev6.StagingRevision{
-						ChangedTime: testTime.Add(1 * time.Second),
-						ResourceBody: parseYAML(`metadata:
-  uid: "test-uid"
-status:
-  phase: Pending`),
-						Principal: "admin",
-						VerbType:  commonlogk8saudit_contract.VerbCreate,
-						StateType: commonlogk8saudit_contract.RevisionStatePodPhaseScheduled,
-					}, nodeComparer)
-			},
-		},
-		{
-			name:       "Pod creation log is missing but complemented from creationTime - Pass 1",
-			targetPass: 1,
-			initialState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
-				},
-			},
-			steps: []step{
-				{
-					verb: commonlogk8saudit_contract.VerbCreate,
-					resourceBodyYAML: `metadata:
-  uid: "test-uid"
-  creationTimestamp: "2023-10-26T09:00:00Z"
-status:
-  phase: Running`,
-					role:      "pod",
-					eventType: commonlogk8saudit_contract.ChangeEventTypeV2Creation,
-				},
-			},
-			wantState: &podPhaseTaskState{
-				uidToNodeNameMap: map[string]string{
-					"test-uid": "node-1",
-				},
-				lastPhase: "Running",
-				lastNode:  "node-1",
-			},
-			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, podPhasePath *khifilev6.TimelinePath, nodeComparer cmp.Option) {
-				testchangeset.AssertTimeline(t, cs).
-					HasRevision(podPhasePath, &khifilev6.StagingRevision{
-						ChangedTime:  testTime.Add(-1 * time.Hour),
-						ResourceBody: nil,
-						Principal:    "N/A",
-						VerbType:     commonlogk8saudit_contract.VerbCreate,
-						StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
-					}, nodeComparer).
-					HasRevision(podPhasePath, &khifilev6.StagingRevision{
-						ChangedTime: testTime,
-						ResourceBody: parseYAML(`metadata:
-  uid: "test-uid"
-  creationTimestamp: "2023-10-26T09:00:00Z"
-status:
-  phase: Running`),
-						Principal: "admin",
-						VerbType:  commonlogk8saudit_contract.VerbCreate,
-						StateType: commonlogk8saudit_contract.RevisionStatePodPhaseRunning,
-					}, nodeComparer)
-			},
-		},
-	}
-
-	taskSetting := &podPhaseLogToTimelineMapperTaskSettingV2{
-		minimumDeltaTimeToCreateInferredCreationRevision: 5 * time.Second,
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Reset the builder for each test case to clear internal state.
-			builder = khifilev6.NewBuilder()
+			builder := khifilev6.NewBuilder()
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
-			podPhasePath = MustPodPhaseTimelinePath(ctx, "k8s", "node-1", "default", "test", "test-uid")
+			mapperSetting := &podPhaseLogToTimelineMapperTaskSettingV2{}
 
-			var state = tc.initialState
-			var err error
-
-			// Create a dummy initial log for NewTimelineChangeSet
-			dummyFs := &commonlogk8saudit_contract.K8sAuditLogFieldSet{
-				Principal:    "admin",
-				APIVersion:   "core/v1",
-				PluralKind:   "pods",
-				ResourceName: "test",
-				Namespace:    "default",
-				ClusterName:  "k8s",
-				Verb:         commonlogk8saudit_contract.VerbCreate,
+			podResource := &commonlogk8saudit_contract.ResourceIdentity{
+				APIVersion: "core/v1",
+				Kind:       "pod",
+				Namespace:  tc.namespace,
+				Name:       tc.podName,
 			}
-			dummyCommon := &log.CommonFieldSet{
-				Timestamp: testTime,
+			bindingResource := &commonlogk8saudit_contract.ResourceIdentity{
+				APIVersion:      "core/v1",
+				Kind:            "pod",
+				Namespace:       tc.namespace,
+				Name:            tc.podName,
+				SubresourceName: "binding",
 			}
-			dummyLog := log.NewLogWithFieldSetsForTest(dummyFs, dummyCommon)
 
-			accumulatedCS := khifilev6.NewTimelineChangeSet(dummyLog)
+			podGroup := &commonlogk8saudit_contract.ResourceManifestLogGroup{
+				Resource: podResource,
+				Logs:     []*commonlogk8saudit_contract.ResourceManifestLog{},
+			}
+			bindingGroup := &commonlogk8saudit_contract.ResourceManifestLogGroup{
+				Resource: bindingResource,
+				Logs:     []*commonlogk8saudit_contract.ResourceManifestLog{},
+			}
 
-			for i, s := range tc.steps {
+			type stepLogInfo struct {
+				manifestLog *commonlogk8saudit_contract.ResourceManifestLog
+				role        string
+				identity    *commonlogk8saudit_contract.ResourceIdentity
+				eventType   commonlogk8saudit_contract.ChangeEventTypeV2
+				verb        *pb.Verb
+			}
+			var stepInfos []stepLogInfo
+
+			for _, step := range tc.steps {
 				k8sFieldSet := &commonlogk8saudit_contract.K8sAuditLogFieldSet{
 					Principal:    "admin",
 					APIVersion:   "core/v1",
 					PluralKind:   "pods",
-					ResourceName: "test",
-					Namespace:    "default",
-					ClusterName:  "k8s",
-					Verb:         s.verb,
+					ResourceName: tc.podName,
+					Namespace:    tc.namespace,
+					ClusterName:  tc.clusterName,
+					Verb:         step.verb,
 				}
-				stepTime := testTime.Add(time.Duration(i) * time.Second)
 				commonFs := &log.CommonFieldSet{
-					Timestamp: stepTime,
+					Timestamp: step.time,
 				}
 				logObj := log.NewLogWithFieldSetsForTest(k8sFieldSet, commonFs)
-
-				node := parseYAML(s.resourceBodyYAML)
+				node, err := structured.FromYAML(step.yaml)
+				if err != nil {
+					t.Fatalf("failed to parse test YAML: %v", err)
+				}
 				var nodeReader *structured.NodeReader
 				if node != nil {
 					nodeReader = structured.NewNodeReader(node)
 				}
 
-				var sourceResource *commonlogk8saudit_contract.ResourceIdentity
-				var targetResource *commonlogk8saudit_contract.ResourceIdentity
+				mLog := &commonlogk8saudit_contract.ResourceManifestLog{
+					Log:                logObj,
+					ResourceBodyReader: nodeReader,
+					ResourceBodyYAML:   step.yaml,
+				}
 
-				if s.role == "binding" {
-					sourceResource = &commonlogk8saudit_contract.ResourceIdentity{
-						APIVersion: "core/v1",
-						Kind:       "pod",
-						Namespace:  "default",
-						Name:       "test",
-					}
-					targetResource = &commonlogk8saudit_contract.ResourceIdentity{
-						APIVersion:      "core/v1",
-						Kind:            "pod",
-						Namespace:       "default",
-						Name:            "test",
-						SubresourceName: "binding",
-					}
+				var identity *commonlogk8saudit_contract.ResourceIdentity
+				if step.role == "pod" {
+					identity = podResource
+					podGroup.Logs = append(podGroup.Logs, mLog)
 				} else {
-					targetResource = &commonlogk8saudit_contract.ResourceIdentity{
-						APIVersion: "core/v1",
-						Kind:       "pod",
-						Namespace:  "default",
-						Name:       "test",
-					}
+					identity = bindingResource
+					bindingGroup.Logs = append(bindingGroup.Logs, mLog)
 				}
 
-				groupSet := commonlogk8saudit_contract.RelatedGroupSet{
-					Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
-						"pod": {
-							Resource: targetResource,
-							Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-								{Log: logObj, ResourceBodyReader: nodeReader, ResourceBodyYAML: s.resourceBodyYAML},
-							},
-						},
-					},
-				}
-				if sourceResource != nil {
-					groupSet.Roles["binding"] = &commonlogk8saudit_contract.ResourceManifestLogGroup{
-						Resource: sourceResource,
-						Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-							{Log: logObj},
-						},
-					}
-				}
+				stepInfos = append(stepInfos, stepLogInfo{
+					manifestLog: mLog,
+					role:        step.role,
+					identity:    identity,
+					eventType:   step.eventType,
+					verb:        step.verb,
+				})
+			}
 
-				event := commonlogk8saudit_contract.MultiGroupLogEvent{
-					Log:              logObj,
-					GroupRole:        s.role,
-					ResourceIdentity: targetResource,
-					EventType:        s.eventType,
+			groupSet := commonlogk8saudit_contract.RelatedGroupSet{
+				Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
+					"pod":     podGroup,
+					"binding": bindingGroup,
+				},
+			}
+
+			var events []commonlogk8saudit_contract.MultiGroupLogEvent
+			for _, info := range stepInfos {
+				events = append(events, commonlogk8saudit_contract.MultiGroupLogEvent{
+					Log:              info.manifestLog.Log,
+					GroupRole:        info.role,
+					ResourceIdentity: info.identity,
+					EventType:        info.eventType,
 					GroupSet:         groupSet,
-				}
+				})
+			}
 
-				if tc.targetPass == 0 {
-					state, err = taskSetting.PreProcessLog(ctx, 0, event, state)
-					if err != nil {
-						t.Fatalf("PreProcessLog failed: %v", err)
-					}
-				} else {
-					var stepCS *khifilev6.TimelineChangeSet
-					stepCS, state, err = taskSetting.ProcessLog(ctx, event, state)
-					if err != nil {
-						t.Fatalf("ProcessLog failed: %v", err)
-					}
-					if stepCS != nil {
-						for path, ev := range stepCS.Events {
-							accumulatedCS.Events[path] = ev
+			// 1. Pass 0 of PreProcessLog
+			var state *podPhaseTaskState
+			for _, ev := range events {
+				var err error
+				state, err = mapperSetting.PreProcessLog(ctx, 0, ev, state)
+				if err != nil {
+					t.Fatalf("PreProcessLog(pass=0) failed: %v", err)
+				}
+			}
+
+			// 2. Pass 1 of PreProcessLog
+			for _, ev := range events {
+				var err error
+				state, err = mapperSetting.PreProcessLog(ctx, 1, ev, state)
+				if err != nil {
+					t.Fatalf("PreProcessLog(pass=1) failed: %v", err)
+				}
+			}
+
+			// 3. ProcessLog
+			var changeSets []*khifilev6.TimelineChangeSet
+			for _, ev := range events {
+				cs, nextState, err := mapperSetting.ProcessLog(ctx, ev, state)
+				if err != nil {
+					t.Fatalf("ProcessLog() failed: %v", err)
+				}
+				state = nextState
+				changeSets = append(changeSets, cs)
+			}
+
+			mergedCS := khifilev6.NewTimelineChangeSet(log.NewLogWithFieldSetsForTest())
+			for _, cs := range changeSets {
+				if cs != nil {
+					for path, revs := range cs.Revisions {
+						for _, r := range revs {
+							mergedCS.AddRevision(path, r)
 						}
-						for path, revs := range stepCS.Revisions {
-							accumulatedCS.Revisions[path] = append(accumulatedCS.Revisions[path], revs...)
-						}
+					}
+					for path := range cs.Events {
+						mergedCS.AddEvent(path)
+					}
+					for aliasPath, targetPath := range cs.Aliases {
+						mergedCS.AddAlias(aliasPath, targetPath)
 					}
 				}
 			}
 
-			if diff := cmp.Diff(tc.wantState, state, cmp.AllowUnexported(podPhaseTaskState{})); diff != "" {
-				t.Errorf("state mismatch (-want +got):\n%s", diff)
-			}
-
-			if tc.targetPass != 0 && tc.assert != nil {
-				tc.assert(t, accumulatedCS, podPhasePath, nodeComparer)
+			for _, want := range tc.wantRevisions {
+				path := MustResolvePodPhaseTimelinePath(ctx, tc.clusterName, want.nodeName, tc.namespace, tc.podName, want.uid)
+				wantStagingRev := &khifilev6.StagingRevision{
+					ChangedTime:  want.changedTime,
+					ResourceBody: want.resourceBody,
+					Principal:    want.principal,
+					VerbType:     want.verbType,
+					StateType:    want.stateType,
+				}
+				testchangeset.AssertTimeline(t, mergedCS).HasRevision(path, wantStagingRev, nodeComparer)
 			}
 		})
 	}
+}
+
+// MustResolvePodPhaseTimelinePath resolves the TimelinePath for the pod phase.
+func MustResolvePodPhaseTimelinePath(ctx context.Context, clusterName, nodeName, namespace, podName, uid string) *khifilev6.TimelinePath {
+	return MustPodPhaseTimelinePath(ctx, clusterName, nodeName, namespace, podName, uid)
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/resource_helpers.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resource_helpers.go
@@ -132,6 +132,20 @@ func GetNodeNameOfPod(reader *structured.NodeReader) (string, bool) {
 	return val, true
 }
 
+// GetNodeNameOfBinding returns the value of target.name.
+// It returns the value and true if the field exists and is a string.
+// Otherwise, it returns empty string and false.
+func GetNodeNameOfBinding(reader *structured.NodeReader) (string, bool) {
+	if reader == nil {
+		return "", false
+	}
+	val, err := reader.ReadString("target.name")
+	if err != nil {
+		return "", false
+	}
+	return val, true
+}
+
 // GetCreationTimestamp returns the value of metadata.creationTimestamp.
 // It returns the value and true if the field exists and is a valid timestamp.
 // Otherwise, it returns time.Time{} and false.

--- a/pkg/task/inspection/commonlogk8saudit/impl/resource_helpers_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resource_helpers_test.go
@@ -311,6 +311,47 @@ spec:
 	}
 }
 
+func TestGetNodeNameOfBinding(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		want      string
+		wantFound bool
+	}{
+		{
+			name: "exists",
+			yaml: `
+target:
+  name: "test-node"
+`,
+			want:      "test-node",
+			wantFound: true,
+		},
+		{
+			name: "not exists",
+			yaml: `
+target:
+  kind: Node
+`,
+			want:      "",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := mustParseYAML(t, tt.yaml)
+			got, found := GetNodeNameOfBinding(reader)
+			if got != tt.want {
+				t.Errorf("GetNodeNameOfBinding() got = %v, want %v", got, tt.want)
+			}
+			if found != tt.wantFound {
+				t.Errorf("GetNodeNameOfBinding() found = %v, want %v", found, tt.wantFound)
+			}
+		})
+	}
+}
+
 func TestGetCreationTimestamp(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Pod phase mapper didn't handle `creationTimestamp` correctly.
This would improve precision when the log query duration didn't include the creation log for the pod resource.