### PR TITLE
show ??:??:?? when the given timestamp is a placeholder

### DIFF
--- a/web/src/app/diff/components/diff-list.component.spec.ts
+++ b/web/src/app/diff/components/diff-list.component.spec.ts
@@ -45,6 +45,10 @@ describe('DiffListComponent utils', () => {
       const timeInMs = Date.UTC(2024, 0, 1, 9, 5, 1);
       expect(formatTimeLabel(timeInMs, 0)).toBe('09:05:01');
     });
+
+    it('returns ??:??:?? if timeInMs is 0', () => {
+      expect(formatTimeLabel(0, 0)).toBe('??:??:??');
+    });
   });
 
   describe('parsePrincipal', () => {

--- a/web/src/app/diff/components/diff-list.component.ts
+++ b/web/src/app/diff/components/diff-list.component.ts
@@ -82,6 +82,9 @@ export function formatTimeLabel(
   timeInMs: number,
   timezoneShiftHours: number,
 ): string {
+  if (timeInMs === 0) {
+    return '??:??:??';
+  }
   const d = new Date(timeInMs + timezoneShiftHours * 60 * 60 * 1000);
   const h = d.getUTCHours().toString().padStart(2, '0');
   const m = d.getUTCMinutes().toString().padStart(2, '0');


### PR DESCRIPTION
Now some parsers can add revision at UnixTime=0 when the parser knows the resource exists but doesn't know when it was created.