### PR TITLE
supported multiple response flag on csm access log

### DIFF
--- a/pkg/task/inspection/googlecloudlogcsm/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/fieldset.go
@@ -124,10 +124,17 @@ type IstioAccessLogFieldSet struct {
 
 // ResponseFlagMessage returns a human readable message describing response flag.
 func (i *IstioAccessLogFieldSet) ResponseFlagMessage() string {
-	if message, ok := HumanReadableErrorMessage[i.ResponseFlag]; ok {
-		return message
+	rawFlags := strings.Split(string(i.ResponseFlag), ",")
+	var messages []string
+	for _, rawFlag := range rawFlags {
+		trimmed := strings.TrimSpace(rawFlag)
+		if message, ok := HumanReadableErrorMessage[ResponseFlag(trimmed)]; ok {
+			messages = append(messages, message)
+		} else {
+			messages = append(messages, trimmed)
+		}
 	}
-	return string(i.ResponseFlag)
+	return strings.Join(messages, ", ")
 }
 
 // Kind implements log.FieldSet.

--- a/pkg/task/inspection/googlecloudlogcsm/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/fieldset_test.go
@@ -145,6 +145,16 @@ func TestIstioAccessLogFieldSet_ResponseFlagMessage(t *testing.T) {
 			flag: "SOME_UNKNOWN_FLAG",
 			want: "SOME_UNKNOWN_FLAG",
 		},
+		{
+			desc: "comma separated known flags",
+			flag: "UH,URX",
+			want: "No healthy upstream, Upstream retry limit exceeded",
+		},
+		{
+			desc: "comma separated containing unknown flags",
+			flag: "UH,UNKNOWN,URX",
+			want: "No healthy upstream, UNKNOWN, Upstream retry limit exceeded",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
@@ -62,6 +62,19 @@ func TestCSMAccessLogLogIngester_ProcessLog(t *testing.T) {
 			},
 			wantSummary: "【No healthy upstream(UH)】503 GET /productpage",
 		},
+		{
+			desc: "server access log with multiple error response flags",
+			inputGCPAccessLog: &googlecloudcommon_contract.GCPAccessLogFieldSet{
+				Status:     503,
+				Method:     "GET",
+				RequestURL: "/productpage",
+			},
+			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
+				Type:         googlecloudlogcsm_contract.AccessLogTypeServer,
+				ResponseFlag: "UH,URX",
+			},
+			wantSummary: "【No healthy upstream, Upstream retry limit exceeded(UH,URX)】503 GET /productpage",
+		},
 	}
 
 	ingester := &CSMAccessLogLogIngester{}


### PR DESCRIPTION
CSM Access log may contain multiple response flags in the response_flags field. KHI haven't supported it before.
This PR adds the support for multiple response flags correctly.