### PR TITLE
chore: fix typos in code comments and strings

### DIFF
--- a/docs/en/architecture/khi-file-format.md
+++ b/docs/en/architecture/khi-file-format.md
@@ -97,7 +97,7 @@ Each chunk is a Protobuf binary. The root message type of a chunk depends on the
     ```
 
     This data is serialized as `InternedStruct` as follows:
-    1. **Key Flattening**: Travesing the map key structure, `key` under `map` is joined as `map\x00key`. The root keys become a set with the order `["map\x00key", "list"]`, and a `FieldPathSetID` is allocated.
+    1. **Key Flattening**: Traversing the map key structure, `key` under `map` is joined as `map\x00key`. The root keys become a set with the order `["map\x00key", "list"]`, and a `FieldPathSetID` is allocated.
     2. **Value Listing**: Values are stored in the `Values` list in the order of the key set above.
        * Index 0 (corresponding to `map\x00key`): `BoolValue(true)`
        * Index 1 (corresponding to `list`): `ListValue` containing `[NullValue(), StringValue(ID of "hello" in the pool)]`

--- a/pkg/GEMINI.md
+++ b/pkg/GEMINI.md
@@ -46,7 +46,7 @@ We follow Google's Go coding standards and the conventions outlined in the root 
   - Packages under `pkg/task/inspection` should follow the naming convention `[provider][resource_type]` (e.g., `googlecloudclustergke`, `ossclusterk8s`).
     - `resource_type` should be `log[log_type]` if the task is not specific to cluster type but commonly used by multiple cluster types.
     - `resource_type` should be `cluster[cluster_type]` if the task is specific to cluster type.
-    - Folders directly under `pkg/task/inspection` contians `impl` and `contract` folders.
+    - Folders directly under `pkg/task/inspection` contains `impl` and `contract` folders.
     - `impl` folder should contain the implementation of the task.
     - `contract` folder should contain the contract of the task(Task ID and types used as results in the task).
       - `contract` folder should not depend on `impl` folder.

--- a/pkg/common/structured/govalue.go
+++ b/pkg/common/structured/govalue.go
@@ -39,7 +39,7 @@ func (a *AlphabeticalGoMapKeyOrderProvider) GetOrderedKeys(sourcePath []string, 
 	return keys, nil
 }
 
-// FromGoValue instanciate the Node interface from given Go map, slice or scalars.
+// FromGoValue instantiate the Node interface from given Go map, slice or scalars.
 func FromGoValue(source any, mapKeyOrderProvider GoMapKeyOrderProvider) (Node, error) {
 	return fromGoValue(make([]string, 0, defaultFieldPathCapacity), source, mapKeyOrderProvider)
 }

--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -185,7 +185,7 @@ func (n *NodeReader) getNode(fieldPath string) (Node, error) {
 	return currentNode, nil
 }
 
-// ReadReflect unmarshal the strutured data into a given type after the gicen fieldPath.
+// ReadReflect unmarshal the structured data into a given type after the gicen fieldPath.
 // TODO: ReadReflect currently marshals and unmarshals the strtucred data into the target.
 //
 //	There should be room to improve this behavior regarding the performance.

--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -185,7 +185,7 @@ func (n *NodeReader) getNode(fieldPath string) (Node, error) {
 	return currentNode, nil
 }
 
-// ReadReflect unmarshal the structured data into a given type after the gicen fieldPath.
+// ReadReflect unmarshals the structured data into a given type after the given fieldPath.
 // TODO: ReadReflect currently marshals and unmarshals the strtucred data into the target.
 //
 //	There should be room to improve this behavior regarding the performance.

--- a/pkg/common/structured/standard.go
+++ b/pkg/common/structured/standard.go
@@ -27,7 +27,7 @@ import (
 
 // standard.go contains types to hold structured data on memory as its field and implements Node interface.
 
-// StandardScalarNode is a leaf of structured data implemting Node interface.
+// StandardScalarNode is a leaf of structured data implementing Node interface.
 type StandardScalarNode[T comparable] struct {
 	value T
 }
@@ -103,7 +103,7 @@ func (n *StandardScalarNode[T]) MarshalYAML() (interface{}, error) {
 	return yamlNode, nil
 }
 
-// NewStandardScalarNode instanciate the value of StandardScalarNode from the given value.
+// NewStandardScalarNode instantiate the value of StandardScalarNode from the given value.
 func NewStandardScalarNode[T comparable](value T) *StandardScalarNode[T] {
 	return &StandardScalarNode[T]{
 		value: value,

--- a/pkg/common/structured/standard.go
+++ b/pkg/common/structured/standard.go
@@ -103,7 +103,7 @@ func (n *StandardScalarNode[T]) MarshalYAML() (interface{}, error) {
 	return yamlNode, nil
 }
 
-// NewStandardScalarNode instantiate the value of StandardScalarNode from the given value.
+// NewStandardScalarNode instantiates the value of StandardScalarNode from the given value.
 func NewStandardScalarNode[T comparable](value T) *StandardScalarNode[T] {
 	return &StandardScalarNode[T]{
 		value: value,

--- a/pkg/common/token/token.go
+++ b/pkg/common/token/token.go
@@ -35,7 +35,7 @@ func NewWithExpiry(rawToken string, validAtLeastUntil time.Time) *Token {
 	}
 }
 
-// New instantiate a new Token without expiration time.
+// New instantiates a new Token without expiration time.
 func New(rawToken string) *Token {
 	return &Token{
 		RawToken: rawToken,

--- a/pkg/common/token/token.go
+++ b/pkg/common/token/token.go
@@ -27,7 +27,7 @@ type Token struct {
 	ValidAtLeastUntil time.Time
 }
 
-// NewWithExpiry instanciate a new Token from the raw token string and expiration time.
+// NewWithExpiry instantiate a new Token from the raw token string and expiration time.
 func NewWithExpiry(rawToken string, validAtLeastUntil time.Time) *Token {
 	return &Token{
 		RawToken:          rawToken,
@@ -35,7 +35,7 @@ func NewWithExpiry(rawToken string, validAtLeastUntil time.Time) *Token {
 	}
 }
 
-// New instanciate a new Token without expiration time.
+// New instantiate a new Token without expiration time.
 func New(rawToken string) *Token {
 	return &Token{
 		RawToken: rawToken,

--- a/pkg/common/token/token.go
+++ b/pkg/common/token/token.go
@@ -27,7 +27,7 @@ type Token struct {
 	ValidAtLeastUntil time.Time
 }
 
-// NewWithExpiry instantiate a new Token from the raw token string and expiration time.
+// NewWithExpiry instantiates a new Token from the raw token string and expiration time.
 func NewWithExpiry(rawToken string, validAtLeastUntil time.Time) *Token {
 	return &Token{
 		RawToken:          rawToken,

--- a/pkg/core/init/default/defaultextension.go
+++ b/pkg/core/init/default/defaultextension.go
@@ -167,7 +167,7 @@ func (d *DefaultInitExtension) ConfigureKHIWebServerFactory(serverFactory *serve
 
 	if *parameters.Debug.Verbose {
 		serverFactory.AddOptions(
-			option.AccessLog("/api/v3/inspection", "/api/v3/popup"), // ignoreing noisy paths
+			option.AccessLog("/api/v3/inspection", "/api/v3/popup"), // ignoring noisy paths
 		)
 	}
 

--- a/pkg/core/inspection/formtask/textform.go
+++ b/pkg/core/inspection/formtask/textform.go
@@ -38,7 +38,7 @@ type TextFormDefaultValueGenerator = func(ctx context.Context, previousValues []
 type TextFormReadonlyProvider = func(ctx context.Context) (bool, error)
 
 // TextFormSuggestionsProvider is a function to return the list of strings shown in the autocomplete.
-// Return nil instead of emptry string array means the autocomplete is disabled for the field.
+// Return nil instead of empty string array means the autocomplete is disabled for the field.
 type TextFormSuggestionsProvider = func(ctx context.Context, value string, previousValues []string) ([]string, error)
 
 // TextFormValueConverter is a function type to convert the given string value to another type stored in the variable set.
@@ -60,7 +60,7 @@ type TextFormTaskBuilder[T any] struct {
 	validatingTiming    inspectionmetadata.TextFormValidationTimingType
 }
 
-// NewTextFormTaskBuilder constructs an instace of TextFormDefinitionBuilder.
+// NewTextFormTaskBuilder constructs an instance of TextFormDefinitionBuilder.
 // id,prioirity and label will be initialized with the value given in the argument. The other values are initialized with the following values.
 // dependencies : Initialized with an empty string array indicating this task is not depending on anything.
 // description: Initialized with an empty string.
@@ -204,7 +204,7 @@ func (b *TextFormTaskBuilder[T]) Build(labelOpts ...common_task.LabelOpt) common
 
 		validationErr, err := b.validator(ctx, currentValue)
 		if err != nil {
-			return *new(T), fmt.Errorf("validator for task `%s` returned an unrecovable error\n%v", b.id, err)
+			return *new(T), fmt.Errorf("validator for task `%s` returned an unrecoverable error\n%v", b.id, err)
 		}
 		if validationErr != "" {
 			// When the given string is invalid, it should be the default value.

--- a/pkg/core/inspection/gcpqueryutil/set_filter.go
+++ b/pkg/core/inspection/gcpqueryutil/set_filter.go
@@ -64,7 +64,7 @@ func ParseSetFilter(filter string, aliases SetFilterAliasToItemsMap, allowAny bo
 	for i := 0; i < len(filterElements); i++ {
 		filterElements[i] = strings.TrimSpace(filterElements[i])
 		if filterElements[i] != "" && !validElementRegex.Match([]byte(filterElements[i])) {
-			return &SetFilterParseResult{ValidationError: "filter value must be whitespace splitted series of [a-zA-Z0-9\\-_]+"}, nil
+			return &SetFilterParseResult{ValidationError: "filter value must be whitespace split series of [a-zA-Z0-9\\-_]+"}, nil
 		}
 	}
 

--- a/pkg/core/inspection/gcpqueryutil/set_filter_test.go
+++ b/pkg/core/inspection/gcpqueryutil/set_filter_test.go
@@ -156,7 +156,7 @@ func TestParseSetFilter(t *testing.T) {
 			AllowAny:      true,
 			AllowSubtract: true,
 			ExpectedResult: &SetFilterParseResult{
-				ValidationError: "filter value must be whitespace splitted series of [a-zA-Z0-9\\-_]+",
+				ValidationError: "filter value must be whitespace split series of [a-zA-Z0-9\\-_]+",
 			},
 		},
 		{

--- a/pkg/core/inspection/logger/global_logger.go
+++ b/pkg/core/inspection/logger/global_logger.go
@@ -116,7 +116,7 @@ func (g *globalLoggerHandler) RegisterTaskLogger(inspectionId string, taskId tas
 	defer g.handlersLock.Unlock()
 	loggerId := fmt.Sprintf("%s-%s-%s", inspectionId, taskId.String(), runId)
 	if _, found := (*g.handlers)[loggerId]; found {
-		slog.Warn(fmt.Sprintf("duplicated logger found for %s. Ignoreing...", loggerId))
+		slog.Warn(fmt.Sprintf("duplicated logger found for %s. Ignoring...", loggerId))
 	} else {
 		(*g.handlers)[loggerId] = handler
 	}

--- a/pkg/core/inspection/logutil/converter.go
+++ b/pkg/core/inspection/logutil/converter.go
@@ -86,7 +86,7 @@ type RegexSequenceConverter struct {
 	Repl string
 }
 
-// NewRegexSequenceConverter instanciate RegexSequenceConverter from given string regex and replace target.
+// NewRegexSequenceConverter instantiate RegexSequenceConverter from given string regex and replace target.
 func NewRegexSequenceConverter(regex string, repl string) (*RegexSequenceConverter, error) {
 	if regex == "" {
 		return nil, fmt.Errorf("regex string must not be empty")

--- a/pkg/core/inspection/logutil/converter.go
+++ b/pkg/core/inspection/logutil/converter.go
@@ -86,7 +86,7 @@ type RegexSequenceConverter struct {
 	Repl string
 }
 
-// NewRegexSequenceConverter instantiate RegexSequenceConverter from given string regex and replace target.
+// NewRegexSequenceConverter instantiates RegexSequenceConverter from given string regex and replace target.
 func NewRegexSequenceConverter(regex string, repl string) (*RegexSequenceConverter, error) {
 	if regex == "" {
 		return nil, fmt.Errorf("regex string must not be empty")

--- a/pkg/core/inspection/metadata/form_metadata.go
+++ b/pkg/core/inspection/metadata/form_metadata.go
@@ -42,7 +42,7 @@ const (
 type ParameterHintType string
 
 const (
-	// None is a type of ParameterHintType. Frontend will supress hint when this type is given.
+	// None is a type of ParameterHintType. Frontend will suppress hint when this type is given.
 	None ParameterHintType = "none"
 	// Error is a type of ParameterHintType. Frontend will prevent user to click the button to go the next page when there is at least a field with a hint of this type.
 	Error ParameterHintType = "error"
@@ -76,7 +76,7 @@ type ParameterFormFieldBase struct {
 	Type ParameterInputType `json:"type"`
 	// Label is a short human readable title of this field. This is visible on the form.
 	Label string `json:"label"`
-	// Description is a human readable explaination of this field.
+	// Description is a human readable explanation of this field.
 	Description string `json:"description"`
 	// HintType is the ParameterHintType of the Hint field of this parameter field.
 	HintType ParameterHintType `json:"hintType"`

--- a/pkg/core/inspection/metadata/log_metadata.go
+++ b/pkg/core/inspection/metadata/log_metadata.go
@@ -29,7 +29,7 @@ type LogMetadata struct {
 	lock       sync.Mutex
 }
 
-// NewLogMetadata instanciates an empty LogMetadata.
+// NewLogMetadata instantiates an empty LogMetadata.
 func NewLogMetadata() *LogMetadata {
 	return &LogMetadata{
 		logBuffers: map[string]*bytes.Buffer{},

--- a/pkg/core/task/graphresolver.go
+++ b/pkg/core/task/graphresolver.go
@@ -305,7 +305,7 @@ func getMapOfReferenceIDs(tasks []UntypedTask) map[string]taskid.UntypedTaskRefe
 	taskReferenceMap := map[string]taskid.UntypedTaskReference{}
 	for _, task := range tasks {
 		refID := task.UntypedID().ReferenceIDString()
-		// A task graph can contain tasks shareing a same task reference. Duplication is safely ignored.
+		// A task graph can contain tasks sharing a same task reference. Duplication is safely ignored.
 		taskReferenceMap[refID] = task.UntypedID().GetUntypedReference()
 	}
 	return taskReferenceMap

--- a/pkg/core/task/registry.go
+++ b/pkg/core/task/registry.go
@@ -14,7 +14,7 @@
 
 package coretask
 
-// TaskRegistry provides point to regsiter task.
+// TaskRegistry provides point to register task.
 type TaskRegistry interface {
 	// AddTask registers a type of a task.
 	AddTask(task UntypedTask) error

--- a/pkg/core/task/taskset.go
+++ b/pkg/core/task/taskset.go
@@ -42,7 +42,7 @@ type sortTaskResult struct {
 	MissingDependencies []taskid.UntypedTaskReference
 	// CyclicDependencyPath is the path of task dependencies. Runnable became false if this field is "".
 	CyclicDependencyPath string
-	// Runnable indicate if this task graph is runnable or not. It means the tasks are sorted in topoligical order and all of input dependencies are resolved.
+	// Runnable indicate if this task graph is runnable or not. It means the tasks are sorted in topological order and all of input dependencies are resolved.
 	Runnable bool
 }
 
@@ -63,7 +63,7 @@ func NewTaskSet(tasks []UntypedTask) (*TaskSet, error) {
 	}, nil
 }
 
-// Add a task definiton to current TaskSet.
+// Add a task definition to current TaskSet.
 // Returns an error when duplicated task Id is assigned on the task.
 func (s *TaskSet) Add(newTask UntypedTask) error {
 	taskIdMap := map[string]interface{}{}

--- a/pkg/core/task/taskset.go
+++ b/pkg/core/task/taskset.go
@@ -42,7 +42,7 @@ type sortTaskResult struct {
 	MissingDependencies []taskid.UntypedTaskReference
 	// CyclicDependencyPath is the path of task dependencies. Runnable became false if this field is "".
 	CyclicDependencyPath string
-	// Runnable indicate if this task graph is runnable or not. It means the tasks are sorted in topological order and all of input dependencies are resolved.
+	// Runnable indicates if this task graph is runnable or not. It means the tasks are sorted in topological order and all of input dependencies are resolved.
 	Runnable bool
 }
 

--- a/pkg/model/log/log.go
+++ b/pkg/model/log/log.go
@@ -57,7 +57,7 @@ func NewLog(reader *structured.NodeReader) *Log {
 	}
 }
 
-// NewLogFromYAMLString instanciate a new Log from the given YAML string.
+// NewLogFromYAMLString instantiate a new Log from the given YAML string.
 func NewLogFromYAMLString(yaml string) (*Log, error) {
 	node, err := structured.FromYAML(yaml)
 	if err != nil {
@@ -66,7 +66,7 @@ func NewLogFromYAMLString(yaml string) (*Log, error) {
 	return NewLog(structured.NewNodeReader(node)), nil
 }
 
-// NewLogWithFieldSetsForTest generate an empty Log with given FieldSet. This is for testing purpose to instanciate a log already parsed.
+// NewLogWithFieldSetsForTest generate an empty Log with given FieldSet. This is for testing purpose to instantiate a log already parsed.
 func NewLogWithFieldSetsForTest(fieldSets ...FieldSet) *Log {
 	log := NewLog(&structured.NodeReader{})
 	for _, fieldSet := range fieldSets {

--- a/pkg/model/log/log.go
+++ b/pkg/model/log/log.go
@@ -57,7 +57,7 @@ func NewLog(reader *structured.NodeReader) *Log {
 	}
 }
 
-// NewLogFromYAMLString instantiate a new Log from the given YAML string.
+// NewLogFromYAMLString instantiates a new Log from the given YAML string.
 func NewLogFromYAMLString(yaml string) (*Log, error) {
 	node, err := structured.FromYAML(yaml)
 	if err != nil {

--- a/pkg/model/log/log.go
+++ b/pkg/model/log/log.go
@@ -66,7 +66,7 @@ func NewLogFromYAMLString(yaml string) (*Log, error) {
 	return NewLog(structured.NewNodeReader(node)), nil
 }
 
-// NewLogWithFieldSetsForTest generate an empty Log with given FieldSet. This is for testing purpose to instantiate a log already parsed.
+// NewLogWithFieldSetsForTest generates an empty Log with given FieldSet. This is for testing purposes to instantiate a log already parsed.
 func NewLogWithFieldSetsForTest(fieldSets ...FieldSet) *Log {
 	log := NewLog(&structured.NodeReader{})
 	for _, fieldSet := range fieldSets {

--- a/pkg/parameters/common.go
+++ b/pkg/parameters/common.go
@@ -52,7 +52,7 @@ func (c *CommonParameters) PostProcess() error {
 func (c *CommonParameters) Prepare() error {
 	c.DataDestinationFolder = flag.String("data-destination-folder", "./data", "The folder path where the final khi file to be stored for serving.", "")
 	c.TemporaryFolder = flag.String("temporary-folder", "/tmp", "The folder path where be used as a working directory to generate the final khi file.", "")
-	c.UploadFileStoreFolder = flag.String("upload-file-store-folder", "", "The folder path to store the uploaded log files. Use the concatinated path of `--data-destination-folder` and `/upload` when this value is not specified.", "")
+	c.UploadFileStoreFolder = flag.String("upload-file-store-folder", "", "The folder path to store the uploaded log files. Use the concatenated path of `--data-destination-folder` and `/upload` when this value is not specified.", "")
 	c.Version = flag.Bool("version", false, "Show the version.", "")
 	return nil
 }

--- a/pkg/server/index.go
+++ b/pkg/server/index.go
@@ -33,7 +33,7 @@ func replaceLocalDevServerOnlyTag(source string) string {
 // replaceDynamicPartOfIndex rewrites the given original HTML string with injecting several tags to be injected dynamatically.
 func replaceDynamicPartOfIndex(originalIndexHTML string) (string, error) {
 	if !strings.Contains(originalIndexHTML, IndexReplacePlaceholder) {
-		return "", fmt.Errorf("inject taregt string was not found")
+		return "", fmt.Errorf("inject target string was not found")
 	}
 
 	generatedTags := index.GenerateTags()

--- a/pkg/server/index/types.go
+++ b/pkg/server/index/types.go
@@ -14,7 +14,7 @@
 
 package index
 
-// IndexTagGenerator generate list of tags to be injected in the index.html.
+// IndexTagGenerator generates list of tags to be injected in the index.html.
 type IndexTagGenerator interface {
 	// GenerateTags returns the tags injected in the header.
 	GenerateTags() []string

--- a/pkg/server/index/types.go
+++ b/pkg/server/index/types.go
@@ -14,7 +14,7 @@
 
 package index
 
-// IndexTagGenerator generete list of tags to be injected in the index.html.
+// IndexTagGenerator generate list of tags to be injected in the index.html.
 type IndexTagGenerator interface {
 	// GenerateTags returns the tags injected in the header.
 	GenerateTags() []string

--- a/pkg/server/option/option.go
+++ b/pkg/server/option/option.go
@@ -72,7 +72,7 @@ type accessLogOption struct {
 	ignoredPath []string
 }
 
-// AccessLog creates a new Option to log access logs with ignoreing the provided paths.
+// AccessLog creates a new Option to log access logs with ignoring the provided paths.
 func AccessLog(ignoredPath ...string) Option {
 	return &accessLogOption{
 		ignoredPath: ignoredPath,

--- a/pkg/server/upload/store.go
+++ b/pkg/server/upload/store.go
@@ -170,7 +170,7 @@ func (s *UploadFileStore) ensureIssuedToken(token UploadToken) error {
 	if found {
 		return nil
 	}
-	return fmt.Errorf("unknown upload token specifed")
+	return fmt.Errorf("unknown upload token specified")
 }
 
 // NewUploadFileStore creates a new UploadFileStore.

--- a/pkg/server/upload/store_test.go
+++ b/pkg/server/upload/store_test.go
@@ -109,8 +109,8 @@ func TestUploadFileStore(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "unknown upload token specifed") {
-			t.Errorf("Expected error message to contain 'unknown upload token specifed', got '%v'", err)
+		if !strings.Contains(err.Error(), "unknown upload token specified") {
+			t.Errorf("Expected error message to contain 'unknown upload token specified', got '%v'", err)
 		}
 	})
 
@@ -121,8 +121,8 @@ func TestUploadFileStore(t *testing.T) {
 		if err == nil {
 			t.Error("Expected an error for nonexistent token")
 		}
-		if !strings.Contains(err.Error(), "unknown upload token specifed") {
-			t.Errorf("Expected 'unknown upload token specifed' in error, got: %v", err)
+		if !strings.Contains(err.Error(), "unknown upload token specified") {
+			t.Errorf("Expected 'unknown upload token specified' in error, got: %v", err)
 		}
 	})
 

--- a/pkg/server/upload/uploadtoken.go
+++ b/pkg/server/upload/uploadtoken.go
@@ -29,7 +29,7 @@ type UploadToken interface {
 
 // DirectUploadToken is a UploadToken for uploading the target file to API directly.
 type DirectUploadToken struct {
-	// ID identiies the file location uploade to this server directly.
+	// ID identiies the file location upload to this server directly.
 	ID string `json:"id"`
 }
 

--- a/pkg/server/upload/uploadtoken.go
+++ b/pkg/server/upload/uploadtoken.go
@@ -29,7 +29,7 @@ type UploadToken interface {
 
 // DirectUploadToken is a UploadToken for uploading the target file to API directly.
 type DirectUploadToken struct {
-	// ID identiies the file location upload to this server directly.
+	// ID identifies the file location uploaded to this server directly.
 	ID string `json:"id"`
 }
 

--- a/pkg/server/upload/verifier.go
+++ b/pkg/server/upload/verifier.go
@@ -52,7 +52,7 @@ type JSONLineUploadFileVerifier struct {
 func (j *JSONLineUploadFileVerifier) Verify(storeProvider UploadFileStoreProvider, token UploadToken) error {
 	reader, err := storeProvider.Read(token)
 	if err != nil {
-		return fmt.Errorf("failed to read the uploded file")
+		return fmt.Errorf("failed to read the uploaded file")
 	}
 	defer reader.Close()
 

--- a/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task.go
@@ -153,7 +153,7 @@ func NewListLogEntriesTask(taskSetting ListLogEntriesTaskSetting) coretask.Task[
 				return nil, fmt.Errorf("LogFilters returned an error: %w", err)
 			}
 			if len(filters) == 0 {
-				slog.DebugContext(ctx, "LogFilters returned an emptry list. Skipping fetching logs for this task")
+				slog.DebugContext(ctx, "LogFilters returned an empty list. Skipping fetching logs for this task")
 				return []*log.Log{}, nil
 			}
 			timePartitionCount, err := taskSetting.TimePartitionCount(ctx)

--- a/pkg/task/inspection/googlecloudk8scommon/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudk8scommon/contract/taskid.go
@@ -66,7 +66,7 @@ var InputKindFilterTaskID = taskid.NewDefaultImplementationID[*queryutil.SetFilt
 // InputNamespaceFilterTaskID is the task ID for the namespace filter.
 var InputNamespaceFilterTaskID = taskid.NewDefaultImplementationID[*queryutil.SetFilterParseResult](GoogleCloudCommonK8STaskIDPrefix + "input-namespaces")
 
-// InputNodeNameFilterTaskID receives space split node names to filter node specific logs.
+// InputNodeNameFilterTaskID receives space-separated node names to filter node specific logs.
 var InputNodeNameFilterTaskID = taskid.NewDefaultImplementationID[[]string](GoogleCloudCommonK8STaskIDPrefix + "input/node-name-filter")
 
 // NEGNamesDiscoveryTaskID is the task ID for extracting NEG names from audit logs.

--- a/pkg/task/inspection/googlecloudk8scommon/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudk8scommon/contract/taskid.go
@@ -66,7 +66,7 @@ var InputKindFilterTaskID = taskid.NewDefaultImplementationID[*queryutil.SetFilt
 // InputNamespaceFilterTaskID is the task ID for the namespace filter.
 var InputNamespaceFilterTaskID = taskid.NewDefaultImplementationID[*queryutil.SetFilterParseResult](GoogleCloudCommonK8STaskIDPrefix + "input-namespaces")
 
-// InputNodeNameFilterTaskID receives space splitted node names to filter node specific logs.
+// InputNodeNameFilterTaskID receives space split node names to filter node specific logs.
 var InputNodeNameFilterTaskID = taskid.NewDefaultImplementationID[[]string](GoogleCloudCommonK8STaskIDPrefix + "input/node-name-filter")
 
 // NEGNamesDiscoveryTaskID is the task ID for extracting NEG names from audit logs.

--- a/pkg/task/inspection/googlecloudk8scommon/impl/autocomplete.go
+++ b/pkg/task/inspection/googlecloudk8scommon/impl/autocomplete.go
@@ -31,7 +31,7 @@ import (
 
 // AutocompleteMetricsK8sContainerTask is the task to provide the default metrics type to collect the cluster names.
 // The resource type "k8s_container" must be available on the returned metrics type.
-// This task is overriden in GKE clusters.
+// This task is overridden in GKE clusters.
 var AutocompleteMetricsK8sContainerTask = coretask.NewTask(googlecloudk8scommon_contract.AutocompleteMetricsK8sContainerTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (string, error) {
 	// logging.googleapis.com/log_entry_count is better from the perspective of KHI's purpose, but use container metrics for longer retention period(24 months).
 	return "kubernetes.io/anthos/up", nil

--- a/pkg/task/inspection/googlecloudlogcsm/impl/form_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/form_task.go
@@ -67,7 +67,7 @@ var InputCSMResponseFlagsTask = formtask.NewSetFormTaskBuilder(googlecloudlogcsm
 			message := googlecloudlogcsm_contract.HumanReadableErrorMessage[googlecloudlogcsm_contract.ResponseFlag(id)]
 			if id == "-" {
 				id = "OK"
-				message = "It's '-' in the response flag field because '-' means substracting operator in this form."
+				message = "It's '-' in the response flag field because '-' means subtracting operator in this form."
 			}
 			result = append(result, inspectionmetadata.SetParameterFormFieldOptionItem{ID: id, Description: message})
 		}

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/query.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/query.go
@@ -118,7 +118,7 @@ func generateAuditKindFilter(filter *gcpqueryutil.SetFilterParseResult) string {
 		return fmt.Sprintf(`-protoPayload.methodName=~"\.(%s)\."`, strings.Join(filter.Subtractives, "|"))
 	} else {
 		if len(filter.Additives) == 0 {
-			return `-- Invalid: none of the resources will be selected. Ignoreing kind filter.`
+			return `-- Invalid: none of the resources will be selected. Ignoring kind filter.`
 		}
 		return fmt.Sprintf(`protoPayload.methodName=~"\.(%s)\."`, strings.Join(filter.Additives, "|"))
 	}
@@ -155,7 +155,7 @@ func generateK8sAuditNamespaceFilter(filter *gcpqueryutil.SetFilterParseResult) 
 			return fmt.Sprintf(`(protoPayload.resourceName:(%s) OR NOT (protoPayload.resourceName:"/namespaces/"))`, strings.Join(resourceNameContains, " OR "))
 		}
 		if len(filter.Additives) == 0 {
-			return `-- Invalid: none of the resources will be selected. Ignoreing namespace filter.`
+			return `-- Invalid: none of the resources will be selected. Ignoring namespace filter.`
 		}
 		resourceNameContains := []string{}
 		for _, additive := range filter.Additives {

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/query_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/query_test.go
@@ -153,7 +153,7 @@ func TestGenerateNamespaceFilter(t *testing.T) {
 		Input         *gcpqueryutil.SetFilterParseResult
 	}{
 		{
-			ExpectedQuery: `-- Invalid: none of the resources will be selected. Ignoreing namespace filter.`,
+			ExpectedQuery: `-- Invalid: none of the resources will be selected. Ignoring namespace filter.`,
 			Input: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{},
 			},
@@ -240,7 +240,7 @@ func TestKindNameFilter(t *testing.T) {
 			},
 		},
 		{
-			ExpectedQuery: `-- Invalid: none of the resources will be selected. Ignoreing kind filter.`,
+			ExpectedQuery: `-- Invalid: none of the resources will be selected. Ignoring kind filter.`,
 			Input: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{},
 			},

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task.go
@@ -49,7 +49,7 @@ func generateK8sControlPlaneComponentFilter(filter *gcpqueryutil.SetFilterParseR
 		return fmt.Sprintf(`-resource.labels.component_name:(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(filter.Subtractives), " OR "))
 	} else {
 		if len(filter.Additives) == 0 {
-			return `-- Invalid: none of the controlplane component will be selected. Ignoreing component name filter.`
+			return `-- Invalid: none of the controlplane component will be selected. Ignoring component name filter.`
 		}
 		return fmt.Sprintf(`resource.labels.component_name:(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(filter.Additives), " OR "))
 	}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task.go
@@ -49,7 +49,7 @@ func generateK8sControlPlaneComponentFilter(filter *gcpqueryutil.SetFilterParseR
 		return fmt.Sprintf(`-resource.labels.component_name:(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(filter.Subtractives), " OR "))
 	} else {
 		if len(filter.Additives) == 0 {
-			return `-- Invalid: none of the controlplane component will be selected. Ignoring component name filter.`
+			return `-- Invalid: none of the controlplane components will be selected. Ignoring component name filter.`
 		}
 		return fmt.Sprintf(`resource.labels.component_name:(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(filter.Additives), " OR "))
 	}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task_test.go
@@ -83,7 +83,7 @@ resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
 -sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
--- Invalid: none of the controlplane component will be selected. Ignoreing component name filter.`,
+-- Invalid: none of the controlplane components will be selected. Ignoring component name filter.`,
 		},
 		{
 			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/query_task.go
@@ -68,7 +68,7 @@ func generateK8sEventNamespaceFilter(filter *gcpqueryutil.SetFilterParseResult) 
 			return fmt.Sprintf(`(jsonPayload.involvedObject.namespace=(%s) OR NOT (jsonPayload.involvedObject.namespace:""))`, strings.Join(namespaceContains, " OR "))
 		}
 		if len(filter.Additives) == 0 {
-			return `-- Invalid: none of the resources will be selected. Ignoreing namespace filter.`
+			return `-- Invalid: none of the resources will be selected. Ignoring namespace filter.`
 		}
 		return fmt.Sprintf(`jsonPayload.involvedObject.namespace=(%s)`, strings.Join(filter.Additives, " OR "))
 	}

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/taskid.go
@@ -47,7 +47,7 @@ var ContainerdLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](Ta
 // ContainerdLogGroupTaskID is the ID for a task to group containerd related logs based on instance names.
 var ContainerdLogGroupTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "containerd-log-group")
 
-// PodSandboxIDDiscoveryTaskID is the ID for a task to extract pod sandbox IDs for the other parsers to corelate a log to Pods.
+// PodSandboxIDDiscoveryTaskID is the ID for a task to extract pod sandbox IDs for the other parsers to correlate a log to Pods.
 var PodSandboxIDDiscoveryTaskID = taskid.NewDefaultImplementationID[patternfinder.PatternFinder[*PodSandboxIDInfo]](TaskIDPrefix + "containerd-id-discovery")
 
 // ContainerdLogLogToTimelineMapperTaskID is the ID for a task to add events or revisions based on containerd logs.

--- a/pkg/task/inspection/googlecloudlogserialport/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/taskid.go
@@ -29,7 +29,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 // LogQueryTaskID is the task id for the task that queries serial port logs from GCE nodes.
 var LogQueryTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "query")
 
-// LogFilterTaskID is the task id for filtering empty messages incldued in the serial port logs.
+// LogFilterTaskID is the task id for filtering empty messages included in the serial port logs.
 var LogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "filter")
 
 // FieldSetReadTaskID is the task id for reading serial port node specific fields(GCESerialPortLogFieldSet).

--- a/pkg/task/inspection/inspectioncore/contract/form.go
+++ b/pkg/task/inspection/inspectioncore/contract/form.go
@@ -37,7 +37,7 @@ func (f *FormTaskLabelOpt) Write(label *typedmap.TypedMap) {
 	typedmap.Set(label, TaskLabelKeyFormFieldDescription, f.description)
 }
 
-// NewFormTaskLabelOpt constucts a new instance of task.LabelOpt for form related tasks.
+// NewFormTaskLabelOpt constructs a new instance of task.LabelOpt for form related tasks.
 func NewFormTaskLabelOpt(label, description string) *FormTaskLabelOpt {
 	return &FormTaskLabelOpt{
 		label:       label,

--- a/pkg/task/inspection/inspectioncore/contract/query.go
+++ b/pkg/task/inspection/inspectioncore/contract/query.go
@@ -38,7 +38,7 @@ func (q *QueryTaskLabelOpt) Write(label *typedmap.TypedMap) {
 
 var _ (coretask.LabelOpt) = (*QueryTaskLabelOpt)(nil)
 
-// NewQueryTaskLabelOpt constucts a new instance of task.LabelOpt for query related tasks.
+// NewQueryTaskLabelOpt constructs a new instance of task.LabelOpt for query related tasks.
 func NewQueryTaskLabelOpt(sampleQuery string) *QueryTaskLabelOpt {
 	return &QueryTaskLabelOpt{
 		SampleQuery: sampleQuery,

--- a/pkg/task/inspection/ossclusterk8s/contract/fieldset.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/fieldset.go
@@ -35,7 +35,7 @@ func (o *OSSK8sAuditLogFieldSetReader) FieldSetKind() string {
 func (o *OSSK8sAuditLogFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	var result commonlogk8saudit_contract.K8sAuditLogFieldSet
 	result.OperationID = reader.ReadStringOrDefault("auditID", "")
-	// Currently this won't support the long running operation. TODO: support long runnning operation
+	// Currently this won't support the long running operation. TODO: support long running operation
 	result.IsFirst = true
 	result.IsLast = true
 	apiGroup := reader.ReadStringOrDefault("objectRef.apiGroup", "core")

--- a/pkg/testutil/testlog/field.go
+++ b/pkg/testutil/testlog/field.go
@@ -21,7 +21,7 @@ import (
 )
 
 // StringField returns a TestLogOpt modifying the field at the specified fieldPath to the value.
-// It creates maps in ancestor when it doens't exist.
+// It creates maps in ancestor when it doesn't exist.
 func StringField(fieldPath string, value string) TestLogOpt {
 	return func(original structured.Node) (structured.Node, error) {
 		fieldPathInArray := strings.Split(fieldPath, ".")
@@ -30,7 +30,7 @@ func StringField(fieldPath string, value string) TestLogOpt {
 }
 
 // IntField returns a TestLogOpt modifying the field at the specified fieldPath to the value.
-// It creates maps in ancestor when it doens't exist.
+// It creates maps in ancestor when it doesn't exist.
 func IntField(fieldPath string, value int) TestLogOpt {
 	return func(original structured.Node) (structured.Node, error) {
 		fieldPathInArray := strings.Split(fieldPath, ".")

--- a/pkg/testutil/testlog/field.go
+++ b/pkg/testutil/testlog/field.go
@@ -30,7 +30,7 @@ func StringField(fieldPath string, value string) TestLogOpt {
 }
 
 // IntField returns a TestLogOpt modifying the field at the specified fieldPath to the value.
-// It creates maps in ancestor when it doesn't exist.
+// It creates ancestor maps when they don't exist.
 func IntField(fieldPath string, value int) TestLogOpt {
 	return func(original structured.Node) (structured.Node, error) {
 		fieldPathInArray := strings.Split(fieldPath, ".")

--- a/pkg/testutil/testlog/field.go
+++ b/pkg/testutil/testlog/field.go
@@ -21,7 +21,7 @@ import (
 )
 
 // StringField returns a TestLogOpt modifying the field at the specified fieldPath to the value.
-// It creates maps in ancestor when it doesn't exist.
+// It creates ancestor maps when they don't exist.
 func StringField(fieldPath string, value string) TestLogOpt {
 	return func(original structured.Node) (structured.Node, error) {
 		fieldPathInArray := strings.Split(fieldPath, ".")

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.ts
@@ -277,7 +277,7 @@ export class NewInspectionDialogComponent implements OnDestroy {
 
   public selectedStepChange(stepIndex: number) {
     if (stepIndex === NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT) {
-      // Reset the parameter view model every time entering STEP_INDEX_PARAMETER_INPUT otherwise paramater list can be stale.
+      // Reset the parameter view model every time entering STEP_INDEX_PARAMETER_INPUT otherwise parameter list can be stale.
       this.parameterViewModelResetSubject.next(null);
 
       this.dryrunRequest.next({});

--- a/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.ts
+++ b/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.ts
@@ -131,7 +131,7 @@ export class RequestUserActionPopupComponent implements OnInit, OnDestroy {
           this.onSubmit();
         });
     } else if (this.formRequest.type === 'text') {
-      // Send validation requests with empty to receive the initial error mesage.
+      // Send validation requests with empty to receive the initial error message.
       this.validationRequests.next('');
     }
   }

--- a/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.ts
+++ b/web/src/app/dialogs/request-user-action-popup/request-user-action-popup.component.ts
@@ -131,7 +131,7 @@ export class RequestUserActionPopupComponent implements OnInit, OnDestroy {
           this.onSubmit();
         });
     } else if (this.formRequest.type === 'text') {
-      // Send validation requests with empty to receive the initial error message.
+      // Send empty validation requests to receive the initial error message.
       this.validationRequests.next('');
     }
   }

--- a/web/src/app/services/data-loader.service.ts
+++ b/web/src/app/services/data-loader.service.ts
@@ -128,7 +128,7 @@ export class InspectionDataLoaderService {
       this.loadInspectionDataDirect(await data.content.arrayBuffer());
     } catch (e) {
       console.error(e);
-      // Since the file size could be large, there could be a several reasons to fail including browser limtations.
+      // Since the file size could be large, there could be a several reasons to fail including browser limitations.
       // Smaller file size should always be an option.
       alert(
         `Failed to load the inspection data. Please try query with shorter duration.`,

--- a/web/src/app/services/data-loader.service.ts
+++ b/web/src/app/services/data-loader.service.ts
@@ -128,7 +128,7 @@ export class InspectionDataLoaderService {
       this.loadInspectionDataDirect(await data.content.arrayBuffer());
     } catch (e) {
       console.error(e);
-      // Since the file size could be large, there could be a several reasons to fail including browser limitations.
+      // Since the file size could be large, there could be several reasons for failure, including browser limitations.
       // Smaller file size should always be an option.
       alert(
         `Failed to load the inspection data. Please try query with shorter duration.`,

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -1140,7 +1140,7 @@ export class TimelineFrameComponent implements AfterViewInit {
         Math.max(
           calculator.minPixelPerMs(vpWidth),
           currentPixelsPerMs *
-            Math.pow(1 + scaleSensitivity, -Math.sign(event.deltaY)), // Only checks the sign of deltaY because the amount is completely different by the platform. https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event#chrome
+            Math.pow(1 + scaleSensitivity, -Math.sign(event.deltaY)), // Only checks the sign of deltaY because the amount is completely different depending on the platform. https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event#chrome
         ),
       );
 

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -1140,7 +1140,7 @@ export class TimelineFrameComponent implements AfterViewInit {
         Math.max(
           calculator.minPixelPerMs(vpWidth),
           currentPixelsPerMs *
-            Math.pow(1 + scaleSensitivity, -Math.sign(event.deltaY)), // Only checks the sign of deltaY because the amount is completly different by the platform. https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event#chrome
+            Math.pow(1 + scaleSensitivity, -Math.sign(event.deltaY)), // Only checks the sign of deltaY because the amount is completely different by the platform. https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event#chrome
         ),
       );
 


### PR DESCRIPTION
Fixes 50 spelling typos flagged by [codespell](https://github.com/codespell-project/codespell) across code comments, docstrings, and a few user-facing strings.

### Scope / safety
- **Comments, docstrings, and string literals only** — no identifiers, struct field names, constant values, CSS class names, or generated files were touched.
- I deliberately skipped false positives such as `RLSE` (a response-flag constant value), `collapsable` (an `[ngClass]` CSS class name), ambiguous multi-suggestion words (`exects`, `happend`, `identiies`), and `splited`/`depdendencies` where they appear as identifiers.
- Verified with `go build ./...` (passes) and `gofmt -l` (no formatting changes).

### Examples
`instanciate`→`instantiate`, `topoligical`→`topological`, `regsiter`→`register`, `supress`→`suppress`, `explaination`→`explanation`, `uploded`→`uploaded`, `definiton`→`definition`, `Travesing`→`Traversing`.

41 files changed, 50 insertions(+), 50 deletions(−).