### PR TITLE
refactor: return TimelineMapperResult from V2 timeline mappers and update tests

### DIFF
--- a/.agents/skills/khi_parser/SKILL.md
+++ b/.agents/skills/khi_parser/SKILL.md
@@ -122,7 +122,7 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPref
 
 // 5. Log Grouper & Timeline Mapper Task IDs
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "log-grouper")
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "timeline-mapper")
 ```
 
 #### `fieldset.go`
@@ -551,7 +551,7 @@ type MyManifestMapper struct {
  commonlogk8saudit_contract.ManifestSinglePassMapperBaseV2[*MyState]
 }
 
-func (m *MyManifestMapper) TaskID() taskid.TaskImplementationID[struct{}] {
+func (m *MyManifestMapper) TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult] {
  return mycontract.MyManifestMapperTaskID
 }
 

--- a/.agents/skills/log_timeline_mapper_v2/SKILL.md
+++ b/.agents/skills/log_timeline_mapper_v2/SKILL.md
@@ -241,7 +241,7 @@ var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*SimpleEventMapper)(
 
 ```go
 // Defined in 'contract' package:
-var MyTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}]("my-timeline-mapper")
+var MyTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult]("my-timeline-mapper")
 
 // Instantiated in 'impl' package:
 task := NewLogToTimelineMapperTaskV2(mycontract.MyTimelineMapperTaskID, &SimpleEventMapper{})

--- a/docs/en/khi-task-system-concept.md
+++ b/docs/en/khi-task-system-concept.md
@@ -705,13 +705,15 @@ var IngestLogsTask = inspectiontaskbase.NewLogIngesterTask(
 )
 ```
 
-### NewLogToTimelineMapperTask
+### NewLogToTimelineMapperTaskV2
 
-`LogToTimelineMapperTask` associates logs to multiple resources or sometimes overrides log summary.
+`LogToTimelineMapperTaskV2` associates logs to multiple resources or sometimes overrides log summary.
 
-To modify the history, you use the `ChangeSet` object passed to `ProcessLogByGroup`.
+To modify the history, you use the `TimelineChangeSet` object returned by `ProcessLogByGroup`.
 
-#### `ChangeSet` Operations
+The task returns a `TimelineMapperResult` containing the summary of the performed writes (e.g., which timeline paths received events, revisions, or aliases). Subsequent tasks can inspect this result to determine if specific timelines were populated, allowing for conditional behaviors such as generating fallback timelines from other log sources.
+
+#### `TimelineChangeSet` Operations
 
 - **`AddEvent(resourcePath)`**: Adds a point-in-time event to the timeline.
 - **`AddRevision(resourcePath, revision)`**: Adds a state at a specific time.
@@ -730,21 +732,22 @@ type MyGroupData struct {
 
 type MyMapper struct {}
 
-// Implement LogToTimelineMapper interface
-func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevData MyGroupData) (MyGroupData, error) {
-    // Modify history via ChangeSet
+// Implement LogToTimelineMapperV2 interface
+func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
+    cs := khifilev6.NewTimelineChangeSet()
+    // Modify history via TimelineChangeSet
     cs.SetLogSeverity(enum.SeverityInfo)
     
     // Add an event to a resource timeline
     cs.AddEvent(resourcepath.NameLayerGeneralItem("v1", "Pod", "default", "my-pod"))
 
     // Pass updated state to the next log in the group
-    return MyGroupData{Count: prevData.Count + 1}, nil
+    return cs, MyGroupData{Count: prevData.Count + 1}, nil
 }
 
-// ... Implement other interface methods (Dependencies, LogIngesterTask, GroupedLogTask) ...
+// ... Implement other interface methods (Dependencies, LogIngesterTask, GroupedLogTask, PassCount, PreProcessLogByGroup) ...
 
-var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
+var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
     MyMapperTaskID,
     &MyMapper{},
     inspectioncore_contract.FeatureTaskLabel("my-mapper",/*rest of the other parameters*/)  // LogToTimelineMapper is usually labeled with FeatureTaskLabel.

--- a/docs/ja/khi-task-system-concept.md
+++ b/docs/ja/khi-task-system-concept.md
@@ -706,13 +706,15 @@ var IngestLogsTask = inspectiontaskbase.NewLogIngesterTask(
 )
 ```
 
-### NewLogToTimelineMapperTask
+### NewLogToTimelineMapperTaskV2
 
-`LogToTimelineMapperTask` はログを複数のリソースに関連付けたり、ログサマリーを上書きしたりします。
+`LogToTimelineMapperTaskV2` はログを複数のリソースに関連付けたり、ログサマリーを上書きしたりします。
 
-履歴を変更するには、`ProcessLogByGroup` に渡される `ChangeSet` オブジェクトを使用します。
+履歴を変更するには、`ProcessLogByGroup` から返される `TimelineChangeSet` オブジェクトを使用します。
 
-#### `ChangeSet` の操作
+このタスクは、実行された書き込みのサマリー（どのタイムラインパスにイベント、リビジョン、またはエイリアスが追加されたか）を含む `TimelineMapperResult` を返します。後続のタスクはこの結果を参照して特定のタイムラインが構築されたかどうかを判定し、特定のタイムラインへの書き込みがない場合に別のログソースから代替のタイムラインを生成する、といった制御を行うことができます。
+
+#### `TimelineChangeSet` の操作
 
 - **`AddEvent(resourcePath)`**: タイムラインに特定の時点のイベントを追加します。
 - **`AddRevision(resourcePath, revision)`**: 特定の時間における状態を追加します。
@@ -731,21 +733,22 @@ type MyGroupData struct {
 
 type MyMapper struct {}
 
-// Implement LogToTimelineMapper interface
-func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, cs *history.ChangeSet, builder *history.Builder, prevData MyGroupData) (MyGroupData, error) {
-    // Modify history via ChangeSet
+// Implement LogToTimelineMapperV2 interface
+func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
+    cs := khifilev6.NewTimelineChangeSet()
+    // Modify history via TimelineChangeSet
     cs.SetLogSeverity(enum.SeverityInfo)
 
     // Add an event to a resource timeline
     cs.AddEvent(resourcepath.NameLayerGeneralItem("v1", "Pod", "default", "my-pod"))
 
     // Pass updated state to the next log in the group
-    return MyGroupData{Count: prevData.Count + 1}, nil
+    return cs, MyGroupData{Count: prevData.Count + 1}, nil
 }
 
-// ... Implement other interface methods (Dependencies, LogIngesterTask, GroupedLogTask) ...
+// ... Implement other interface methods (Dependencies, LogIngesterTask, GroupedLogTask, PassCount, PreProcessLogByGroup) ...
 
-var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
+var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2(
     MyMapperTaskID,
     &MyMapper{},
     inspectioncore_contract.FeatureTaskLabel("my-mapper",/*rest of the other parameters*/)  // LogToTimelineMapper is usually labeled with FeatureTaskLabel.

--- a/pkg/core/inspection/taskbase/mapper_task_v2.go
+++ b/pkg/core/inspection/taskbase/mapper_task_v2.go
@@ -36,6 +36,38 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// TimelineMapperResult holds the summary of writes performed by a timeline mapper.
+type TimelineMapperResult struct {
+	// Events maps timeline paths to the number of events written.
+	Events map[*khifilev6.TimelinePath]int
+	// Revisions maps timeline paths to the number of revisions written.
+	Revisions map[*khifilev6.TimelinePath]int
+	// Aliases maps alias paths to their target paths.
+	Aliases map[*khifilev6.TimelinePath]*khifilev6.TimelinePath
+}
+
+// NewTimelineMapperResult creates an initialized TimelineMapperResult.
+func NewTimelineMapperResult() TimelineMapperResult {
+	return TimelineMapperResult{
+		Events:    make(map[*khifilev6.TimelinePath]int),
+		Revisions: make(map[*khifilev6.TimelinePath]int),
+		Aliases:   make(map[*khifilev6.TimelinePath]*khifilev6.TimelinePath),
+	}
+}
+
+// Merge merges another TimelineMapperResult into this one.
+func (r *TimelineMapperResult) Merge(other TimelineMapperResult) {
+	for p, count := range other.Events {
+		r.Events[p] += count
+	}
+	for p, count := range other.Revisions {
+		r.Revisions[p] += count
+	}
+	for alias, target := range other.Aliases {
+		r.Aliases[alias] = target
+	}
+}
+
 // LogToTimelineMapperV2 defines the interface for mapping logs to timeline elements (events or revisions) in KHI file v6 format.
 type LogToTimelineMapperV2[T any] interface {
 	// LogIngesterTask is one of prerequisite task of LogToTimelineMapperV2 ingesting logs before processing with this mapper.
@@ -84,13 +116,13 @@ func (StatelessMapperBase) PreProcessLogByGroup(ctx context.Context, passIndex i
 
 // NewLogToTimelineMapperTaskV2 creates a task that modifies the KHI v6 TimelineRegistry based on grouped logs.
 // It processes logs in parallel and applies the logic from the provided LogToTimelineMapperV2.
-func NewLogToTimelineMapperTaskV2[T any](tid taskid.TaskImplementationID[struct{}], mapper LogToTimelineMapperV2[T], labels ...coretask.LabelOpt) coretask.Task[struct{}] {
+func NewLogToTimelineMapperTaskV2[T any](tid taskid.TaskImplementationID[TimelineMapperResult], mapper LogToTimelineMapperV2[T], labels ...coretask.LabelOpt) coretask.Task[TimelineMapperResult] {
 	groupedLogTaskID := mapper.GroupedLogTask()
 	dependencies := append([]taskid.UntypedTaskReference{mapper.LogIngesterTask(), mapper.GroupedLogTask()}, mapper.Dependencies()...)
-	return NewProgressReportableInspectionTask(tid, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, tp *inspectionmetadata.TaskProgressMetadata) (struct{}, error) {
+	return NewProgressReportableInspectionTask(tid, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, tp *inspectionmetadata.TaskProgressMetadata) (TimelineMapperResult, error) {
 		if taskMode == inspectioncore_contract.TaskModeDryRun {
 			slog.DebugContext(ctx, "Skipping task because this is dry run mode")
-			return struct{}{}, nil
+			return NewTimelineMapperResult(), nil
 		}
 
 		builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
@@ -137,6 +169,9 @@ func NewLogToTimelineMapperTaskV2[T any](tid taskid.TaskImplementationID[struct{
 			return sharedErr != nil
 		}
 
+		var resultMu sync.Mutex
+		finalResult := NewTimelineMapperResult()
+
 		pool := worker.NewPool(runtime.GOMAXPROCS(0))
 		for _, group := range groupedLogs {
 			if ctx.Err() != nil {
@@ -166,6 +201,8 @@ func NewLogToTimelineMapperTaskV2[T any](tid taskid.TaskImplementationID[struct{
 					}
 				}
 
+				localResult := NewTimelineMapperResult()
+
 				// 2. Final processing pass
 				for _, l := range group.Logs {
 					if hasErr() {
@@ -187,20 +224,33 @@ func NewLogToTimelineMapperTaskV2[T any](tid taskid.TaskImplementationID[struct{
 							setErr(err)
 							return
 						}
+						for p := range cs.Events {
+							localResult.Events[p]++
+						}
+						for p, revs := range cs.Revisions {
+							localResult.Revisions[p] += len(revs)
+						}
+						for alias, target := range cs.Aliases {
+							localResult.Aliases[alias] = target
+						}
 					} else {
 						skippedLogCount.Add(1)
 					}
 				}
+
+				resultMu.Lock()
+				finalResult.Merge(localResult)
+				resultMu.Unlock()
 			})
 		}
 		pool.Wait()
 		updator.Done()
 
 		if ctx.Err() != nil {
-			return struct{}{}, ctx.Err()
+			return NewTimelineMapperResult(), ctx.Err()
 		}
 		if sharedErr != nil {
-			return struct{}{}, sharedErr
+			return NewTimelineMapperResult(), sharedErr
 		}
 
 		slog.DebugContext(ctx, fmt.Sprintf("LogToTimelineMapperTaskV2 %s finished: processed %d logs (skipped %d logs)", tid.String(), totalLogCount, skippedLogCount.Load()))
@@ -212,7 +262,7 @@ func NewLogToTimelineMapperTaskV2[T any](tid taskid.TaskImplementationID[struct{
 			)
 		}
 
-		return struct{}{}, nil
+		return finalResult, nil
 	}, append([]coretask.LabelOpt{
 		// Tasks modifying history must be dependent from SerializerTask.
 		coretask.NewSubsequentTaskRefsTaskLabel(inspectioncore_contract.SerializerTaskID.Ref())}, labels...)...)

--- a/pkg/core/inspection/taskbase/mapper_task_v2_test.go
+++ b/pkg/core/inspection/taskbase/mapper_task_v2_test.go
@@ -28,6 +28,7 @@ import (
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/google/go-cmp/cmp"
 )
 
 var mockLogToTimelineMapperV2PrevTaskID = taskid.NewDefaultImplementationID[LogGroupMap]("mock-timeline-mapper-v2-prev")
@@ -104,6 +105,7 @@ func TestLogToTimelineMapperV2Task(t *testing.T) {
 		passCount       int
 		cancelContext   bool
 		wantError       bool
+		wantResult      func(path *khifilev6.TimelinePath) TimelineMapperResult
 	}{
 		{
 			desc:     "DryRun mode",
@@ -121,6 +123,9 @@ func TestLogToTimelineMapperV2Task(t *testing.T) {
 			},
 			passCount: 1,
 			wantError: false,
+			wantResult: func(path *khifilev6.TimelinePath) TimelineMapperResult {
+				return NewTimelineMapperResult()
+			},
 		},
 		{
 			desc:     "Normal execution with some skipped logs and 2 passes",
@@ -142,6 +147,11 @@ func TestLogToTimelineMapperV2Task(t *testing.T) {
 			},
 			passCount: 2,
 			wantError: false,
+			wantResult: func(path *khifilev6.TimelinePath) TimelineMapperResult {
+				res := NewTimelineMapperResult()
+				res.Events[path] = 1
+				return res
+			},
 		},
 		{
 			desc:     "Execution with error in one log",
@@ -163,6 +173,9 @@ func TestLogToTimelineMapperV2Task(t *testing.T) {
 			},
 			passCount: 0,
 			wantError: true,
+			wantResult: func(path *khifilev6.TimelinePath) TimelineMapperResult {
+				return NewTimelineMapperResult()
+			},
 		},
 		{
 			desc:     "Execution with context cancelled",
@@ -181,12 +194,15 @@ func TestLogToTimelineMapperV2Task(t *testing.T) {
 			passCount:     0,
 			cancelContext: true,
 			wantError:     true,
+			wantResult: func(path *khifilev6.TimelinePath) TimelineMapperResult {
+				return NewTimelineMapperResult()
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			tid := taskid.NewDefaultImplementationID[struct{}]("mock-timeline-mapper-v2")
+			tid := taskid.NewDefaultImplementationID[TimelineMapperResult]("mock-timeline-mapper-v2")
 
 			ctx := context.Background()
 			ctx = inspectiontest.WithDefaultTestInspectionTaskContext(ctx)
@@ -242,7 +258,7 @@ func TestLogToTimelineMapperV2Task(t *testing.T) {
 				cancel()
 			}
 
-			_, _, err := inspectiontest.RunInspectionTask(ctx, task, tc.taskMode, map[string]any{}, tasktest.NewTaskDependencyValuePair(mockLogToTimelineMapperV2PrevTaskID.Ref(), prevGroupMap))
+			gotResult, _, err := inspectiontest.RunInspectionTask(ctx, task, tc.taskMode, map[string]any{}, tasktest.NewTaskDependencyValuePair(mockLogToTimelineMapperV2PrevTaskID.Ref(), prevGroupMap))
 			if (err != nil) != tc.wantError {
 				t.Fatalf("RunInspectionTask() error = %v, wantError %v", err, tc.wantError)
 			}
@@ -252,6 +268,10 @@ func TestLogToTimelineMapperV2Task(t *testing.T) {
 				if err == nil || err.Error() != expectedErr.Error() {
 					t.Errorf("RunInspectionTask() error = %v, want %v", err, expectedErr)
 				}
+			}
+
+			if diff := cmp.Diff(tc.wantResult(path), gotResult); diff != "" {
+				t.Errorf("TimelineMapperResult mismatch (-want +got):\n%s", diff)
 			}
 
 			if !tc.wantError {

--- a/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper_v2.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper_v2.go
@@ -123,7 +123,7 @@ func (e *MultiGroupLogEvent) getLastManifestLog(role string) (*ResourceManifestL
 // ManifestLogToTimelineMapperV2 defines the interface for V2 manifest timeline mappers.
 type ManifestLogToTimelineMapperV2[T any] interface {
 	// TaskID returns the task ID.
-	TaskID() taskid.TaskImplementationID[struct{}]
+	TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult]
 	// LogIngesterTask returns the task reference for the log ingester task.
 	LogIngesterTask() taskid.TaskReference[[]*log.Log]
 	// GroupedLogTask returns the task reference for the grouped log task.
@@ -167,14 +167,14 @@ func (ManifestStatelessMapperBaseV2) PreProcessLog(ctx context.Context, passInde
 }
 
 // NewManifestLogToTimelineMapperV2 creates a new timeline mapper task utilizing the V2 mapper interface.
-func NewManifestLogToTimelineMapperV2[T any](setting ManifestLogToTimelineMapperV2[T]) coretask.Task[struct{}] {
+func NewManifestLogToTimelineMapperV2[T any](setting ManifestLogToTimelineMapperV2[T]) coretask.Task[inspectiontaskbase.TimelineMapperResult] {
 	groupedLogTaskID := setting.GroupedLogTask()
 	dependencies := append([]taskid.UntypedTaskReference{setting.LogIngesterTask(), setting.GroupedLogTask()}, setting.Dependencies()...)
 
-	return inspectiontaskbase.NewProgressReportableInspectionTask(setting.TaskID(), dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, tp *inspectionmetadata.TaskProgressMetadata) (struct{}, error) {
+	return inspectiontaskbase.NewProgressReportableInspectionTask(setting.TaskID(), dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, tp *inspectionmetadata.TaskProgressMetadata) (inspectiontaskbase.TimelineMapperResult, error) {
 		if taskMode == inspectioncore_contract.TaskModeDryRun {
 			slog.DebugContext(ctx, "Skipping task because this is dry run mode")
-			return struct{}{}, nil
+			return inspectiontaskbase.NewTimelineMapperResult(), nil
 		}
 
 		builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
@@ -183,7 +183,7 @@ func NewManifestLogToTimelineMapperV2[T any](setting ManifestLogToTimelineMapper
 		tp.MarkIndeterminate()
 		relatedGroupSets, err := setting.ResolveRelatedGroupSets(ctx, groupedLogs)
 		if err != nil {
-			return struct{}{}, err
+			return inspectiontaskbase.NewTimelineMapperResult(), err
 		}
 
 		var processedGroupCount atomic.Int32
@@ -215,6 +215,9 @@ func NewManifestLogToTimelineMapperV2[T any](setting ManifestLogToTimelineMapper
 			return sharedErr != nil
 		}
 
+		var resultMu sync.Mutex
+		finalResult := inspectiontaskbase.NewTimelineMapperResult()
+
 		pool := worker.NewPool(runtime.GOMAXPROCS(0))
 		passCount := setting.PassCount()
 
@@ -242,6 +245,8 @@ func NewManifestLogToTimelineMapperV2[T any](setting ManifestLogToTimelineMapper
 					}
 				}
 
+				localResult := inspectiontaskbase.NewTimelineMapperResult()
+
 				// 2. Final processing pass
 				for event := range iterateMultiGroupLog(groupSet) {
 					if hasErr() {
@@ -260,8 +265,21 @@ func NewManifestLogToTimelineMapperV2[T any](setting ManifestLogToTimelineMapper
 							setErr(err)
 							return
 						}
+						for p := range cs.Events {
+							localResult.Events[p]++
+						}
+						for p, revs := range cs.Revisions {
+							localResult.Revisions[p] += len(revs)
+						}
+						for alias, target := range cs.Aliases {
+							localResult.Aliases[alias] = target
+						}
 					}
 				}
+
+				resultMu.Lock()
+				finalResult.Merge(localResult)
+				resultMu.Unlock()
 			})
 		}
 
@@ -269,10 +287,10 @@ func NewManifestLogToTimelineMapperV2[T any](setting ManifestLogToTimelineMapper
 		updator.Done()
 
 		if sharedErr != nil {
-			return struct{}{}, sharedErr
+			return inspectiontaskbase.NewTimelineMapperResult(), sharedErr
 		}
 
-		return struct{}{}, nil
+		return finalResult, nil
 	})
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/contract/taskid.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/taskid.go
@@ -54,7 +54,7 @@ var NonSuccessLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontas
 var ChangeTargetGrouperTaskID = taskid.NewDefaultImplementationID[ResourceLogGroupMap](TaskIDPrefix + "change-target-grouper")
 
 // NamespaceRequestLogToTimelineMapperTaskID is the task ID for the task recording events for requests against entire resources in namespace.
-var NamespaceRequestLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "namespace-request-timeline-mapper")
+var NamespaceRequestLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "namespace-request-timeline-mapper")
 
 // ManifestGeneratorTaskID is the task ID for the task to generate manifests.
 var ManifestGeneratorTaskID = taskid.NewDefaultImplementationID[ResourceManifestLogGroupMap](TaskIDPrefix + "manifest-generator")
@@ -66,28 +66,28 @@ var K8sResourceMergeConfigTaskID = taskid.NewDefaultImplementationID[*k8s.K8sMan
 var ResourceLifetimeTrackerTaskID = taskid.NewDefaultImplementationID[ResourceManifestLogGroupMap](TaskIDPrefix + "resource-lifetime-tracker")
 
 // LogSummaryLogToTimelineMapperTaskID is the task ID for the task to generate log summary from given k8s audit log.
-var LogSummaryLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "log-summary-timeline-mapper")
+var LogSummaryLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "log-summary-timeline-mapper")
 
 // NonSuccessLogLogToTimelineMapperTaskID is the task ID for the task to generate history from non-success logs.
-var NonSuccessLogLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "non-success-timeline-mapper")
+var NonSuccessLogLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "non-success-timeline-mapper")
 
 // ResourceRevisionLogToTimelineMapperTaskID is the task ID for the task to map logs into resource revision history.
-var ResourceRevisionLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "resource-revision-timeline-mapper")
+var ResourceRevisionLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "resource-revision-timeline-mapper")
 
 // ResourceOwnerReferenceTimelineMapperTaskID is the task ID for the task to map logs into resource owner reference.
-var ResourceOwnerReferenceTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "resource-owner-reference-timeline-mapper")
+var ResourceOwnerReferenceTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "resource-owner-reference-timeline-mapper")
 
 // EndpointResourceLogToTimelineMapperTaskID is the task ID for the task to map logs into endpoint resource history.
-var EndpointResourceLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "endpoint-resource-timeline-mapper")
+var EndpointResourceLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "endpoint-resource-timeline-mapper")
 
 // PodPhaseLogToTimelineMapperTaskID is the task ID for the task to map logs into pod phase history.
-var PodPhaseLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "pod-phase-timeline-mapper")
+var PodPhaseLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "pod-phase-timeline-mapper")
 
 // ContainerLogToTimelineMapperTaskID is the task ID for the task to map logs into container history.
-var ContainerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "container-timeline-mapper")
+var ContainerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "container-timeline-mapper")
 
 // ConditionLogToTimelineMapperTaskID is the task ID for the task to generate condition history.
-var ConditionLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "condition-timeline-mapper")
+var ConditionLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "condition-timeline-mapper")
 
 // NodeNameDiscoveryTaskID is the task ID for extracting node names from audit logs.
 var NodeNameDiscoveryTaskID = taskid.NewDefaultImplementationID[[]string](TaskIDPrefix + "node-name-discovery")

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
@@ -86,7 +87,7 @@ func (c *conditionLogToTimelineMapperTaskSettingV2) LogIngesterTask() taskid.Tas
 }
 
 // TaskID implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
-func (c *conditionLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[struct{}] {
+func (c *conditionLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult] {
 	return commonlogk8saudit_contract.ConditionLogToTimelineMapperTaskID
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -81,7 +82,7 @@ func (c *containerLogToTimelineMapperTaskSettingV2) PassCount() int {
 }
 
 // TaskID implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
-func (c *containerLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[struct{}] {
+func (c *containerLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult] {
 	return commonlogk8saudit_contract.ContainerLogToTimelineMapperTaskID
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
@@ -75,7 +76,7 @@ func (e *endpointResourceLogToTimelineMapperTaskSettingV2) LogIngesterTask() tas
 }
 
 // TaskID implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
-func (e *endpointResourceLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[struct{}] {
+func (e *endpointResourceLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult] {
 	return commonlogk8saudit_contract.EndpointResourceLogToTimelineMapperTaskID
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/namespacerequestmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/namespacerequestmapper_task.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strings"
 
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -45,7 +46,7 @@ func (n *namespaceRequestLogToTimelineMapperTaskSettingV2) LogIngesterTask() tas
 }
 
 // TaskID implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
-func (n *namespaceRequestLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[struct{}] {
+func (n *namespaceRequestLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult] {
 	return commonlogk8saudit_contract.NamespaceRequestLogToTimelineMapperTaskID
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -56,7 +57,7 @@ func (r *resourceOwnerReferenceTimelineMapperTaskSettingV2) LogIngesterTask() ta
 }
 
 // TaskID implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
-func (r *resourceOwnerReferenceTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[struct{}] {
+func (r *resourceOwnerReferenceTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult] {
 	return commonlogk8saudit_contract.ResourceOwnerReferenceTimelineMapperTaskID
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task.go
@@ -22,6 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
@@ -95,7 +96,7 @@ func (c *podPhaseLogToTimelineMapperTaskSettingV2) LogIngesterTask() taskid.Task
 }
 
 // TaskID implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
-func (c *podPhaseLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[struct{}] {
+func (c *podPhaseLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult] {
 	return commonlogk8saudit_contract.PodPhaseLogToTimelineMapperTaskID
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_v2.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -106,7 +107,7 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) LogIngesterTask() tas
 }
 
 // TaskID implements commonlogk8saudit_contract.ManifestLogToTimelineMapperV2.
-func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[struct{}] {
+func (r *ResourceRevisionLogToTimelineMapperTaskSettingV2) TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult] {
 	return commonlogk8saudit_contract.ResourceRevisionLogToTimelineMapperTaskID
 }
 

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/taskid.go
@@ -78,7 +78,7 @@ var AirflowSchedulerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspect
 var AirflowSchedulerLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "ingester-scheduler")
 
 // AirflowSchedulerLogToTimelineMapperTaskID is the task id for the task that maps Airflow scheduler logs to timeline events.
-var AirflowSchedulerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudComposerTaskIDPrefix + "mapper-scheduler")
+var AirflowSchedulerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GoogleCloudComposerTaskIDPrefix + "mapper-scheduler")
 
 // AirflowDagProcessorManagerLogSorterTaskID is the task id for the task that sorts Airflow DAG processor manager logs.
 var AirflowDagProcessorManagerLogSorterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "sorter-dag-processor-manager")
@@ -90,7 +90,7 @@ var AirflowDagProcessorManagerLogGrouperTaskID = taskid.NewDefaultImplementation
 var AirflowDagProcessorManagerLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "ingester-dag-processor-manager")
 
 // AirflowDagProcessorManagerLogToTimelineMapperTaskID is the task id for the task that maps Airflow DAG processor manager logs to timeline events.
-var AirflowDagProcessorManagerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudComposerTaskIDPrefix + "mapper-dag-processor-manager")
+var AirflowDagProcessorManagerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GoogleCloudComposerTaskIDPrefix + "mapper-dag-processor-manager")
 
 // AirflowWorkerLogGrouperTaskID is the task id for the task that groups Airflow worker logs.
 var AirflowWorkerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GoogleCloudComposerTaskIDPrefix + "grouper-worker")
@@ -99,7 +99,7 @@ var AirflowWorkerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspection
 var AirflowWorkerLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "ingester-worker")
 
 // AirflowWorkerLogToTimelineMapperTaskID is the task id for the task that maps Airflow worker logs to timeline events.
-var AirflowWorkerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudComposerTaskIDPrefix + "mapper-worker")
+var AirflowWorkerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GoogleCloudComposerTaskIDPrefix + "mapper-worker")
 
 // AirflowOtherLogGrouperTaskID is the task id for the task that groups other Airflow logs.
 var AirflowOtherLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GoogleCloudComposerTaskIDPrefix + "grouper-other")
@@ -108,7 +108,7 @@ var AirflowOtherLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiont
 var AirflowOtherLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "ingester-other")
 
 // AirflowOtherLogToTimelineMapperTaskID is the task id for the task that maps other Airflow logs to timeline events.
-var AirflowOtherLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudComposerTaskIDPrefix + "mapper-other")
+var AirflowOtherLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GoogleCloudComposerTaskIDPrefix + "mapper-other")
 
 // ComposerEnvironmentListFetcherTaskID is the task id for injecting ComposerEnvironmentListFetcher instance.
 var ComposerEnvironmentListFetcherTaskID = taskid.NewDefaultImplementationID[ComposerEnvironmentListFetcher](GoogleCloudComposerTaskIDPrefix + "composer-environment-list-fetcher")

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract/taskid.go
@@ -41,4 +41,4 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](ComputeAPI
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](ComputeAPIAuditLogTaskIDPrefix + "grouper")
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](ComputeAPIAuditLogTaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](ComputeAPIAuditLogTaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
@@ -43,7 +43,7 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPref
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "grouper")
 
 // LogToTimelineMapperTaskID is the task ID for associating CSM access log events with resource timelines.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "timeline-mapper")
 
 // InputFleetProjectIDTaskID is the task ID for the form input that specifies the Fleet Project ID where CSM control plane logs are stored.
 var InputFleetProjectIDTaskID = taskid.NewDefaultImplementationID[string](TaskIDPrefix + "input/fleet-project-id")
@@ -64,4 +64,4 @@ var CSMTrafficDirectorLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*l
 var CSMTrafficDirectorLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "traffic-director/grouper")
 
 // CSMTrafficDirectorLogToTimelineMapperTaskID is the task ID for associating CSM Traffic Director logs with resource timelines.
-var CSMTrafficDirectorLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "traffic-director/timeline-mapper")
+var CSMTrafficDirectorLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "traffic-director/timeline-mapper")

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/contract/taskid.go
@@ -39,4 +39,4 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GKEAPIAudi
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GKEAPIAuditLogTaskIDPrefix + "grouper")
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](GKEAPIAuditLogTaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GKEAPIAuditLogTaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/contract/taskid.go
@@ -36,4 +36,4 @@ var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogG
 var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](gkeAutoscalerTaskIDPrefix + "log-serializer")
 
 // LogToTimelineMapperTaskID is the task id for the task that modifies the history based on GKE autoscaler logs.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](gkeAutoscalerTaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](gkeAutoscalerTaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/taskid.go
@@ -46,4 +46,4 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPref
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "grouper")
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/taskid.go
@@ -51,7 +51,7 @@ var SchedulerLogFieldSetReaderTaskID = taskid.NewDefaultImplementationID[[]*log.
 var SchedulerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](K8sControlPlaneLogTaskIDPrefix + "grouper-scheduler")
 
 // SchedulerLogToTimelineMapperTaskID is the task ID for adding events on history based on scheduler logs.
-var SchedulerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](K8sControlPlaneLogTaskIDPrefix + "timeline-mapper-scheduler")
+var SchedulerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](K8sControlPlaneLogTaskIDPrefix + "timeline-mapper-scheduler")
 
 // ControllerManagerLogFilterTaskID is the task ID for filtering controller manager logs.
 var ControllerManagerLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](K8sControlPlaneLogTaskIDPrefix + "controller-manager-log-filter")
@@ -63,7 +63,7 @@ var ControllerManagerLogFieldSetReaderTaskID = taskid.NewDefaultImplementationID
 var ControllerManagerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](K8sControlPlaneLogTaskIDPrefix + "grouper-controller-manager")
 
 // ControllerManagerLogToTimelineMapperTaskID is the task ID for adding events on history based on controller manager logs.
-var ControllerManagerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](K8sControlPlaneLogTaskIDPrefix + "timeline-mapper-controller-manager")
+var ControllerManagerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](K8sControlPlaneLogTaskIDPrefix + "timeline-mapper-controller-manager")
 
 // OtherLogFilterTaskID is the task ID for filtering logs from other control plane components.
 var OtherLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](K8sControlPlaneLogTaskIDPrefix + "other-log-filter")
@@ -75,7 +75,7 @@ var OtherLogFieldSetReaderTaskID = taskid.NewDefaultImplementationID[[]*log.Log]
 var OtherLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](K8sControlPlaneLogTaskIDPrefix + "grouper-other")
 
 // OtherLogToTimelineMapperTaskID is the task ID for adding events on history based on the other control plane components.
-var OtherLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](K8sControlPlaneLogTaskIDPrefix + "timeline-mapper-other")
+var OtherLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](K8sControlPlaneLogTaskIDPrefix + "timeline-mapper-other")
 
 // TailTaskID is the task ID for the final task in the control plane log processing pipeline.
 var TailTaskID = taskid.NewDefaultImplementationID[struct{}](K8sControlPlaneLogTaskIDPrefix + "tail")

--- a/pkg/task/inspection/googlecloudlogk8sevent/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/contract/taskid.go
@@ -40,7 +40,7 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GKEK8sEven
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GKEK8sEventLogTaskIDPrefix + "grouper")
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](GKEK8sEventLogTaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GKEK8sEventLogTaskIDPrefix + "timeline-mapper")
 
 // NEGToBackendServiceDiscoveryTaskID is the task ID for the discovery task that extracts NEG to BackendService mappings from Kubernetes Event logs.
 var NEGToBackendServiceDiscoveryTaskID = taskid.NewDefaultImplementationID[googlecloudk8scommon_contract.NEGToBackendServiceMap](GKEK8sEventLogTaskIDPrefix + "neg-discovery")

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/taskid.go
@@ -51,7 +51,7 @@ var ContainerdLogGroupTaskID = taskid.NewDefaultImplementationID[inspectiontaskb
 var PodSandboxIDDiscoveryTaskID = taskid.NewDefaultImplementationID[patternfinder.PatternFinder[*PodSandboxIDInfo]](TaskIDPrefix + "containerd-id-discovery")
 
 // ContainerdLogLogToTimelineMapperTaskID is the ID for a task to add events or revisions based on containerd logs.
-var ContainerdLogLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "containerd-log-timeline-mapper")
+var ContainerdLogLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "containerd-log-timeline-mapper")
 
 // KubeletLogFilterTaskID is the ID for a task to filter only the logs for kubelet.
 var KubeletLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "kubelet-log-filter")
@@ -60,7 +60,7 @@ var KubeletLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskI
 var KubeletLogGroupTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "kubelet-log-group")
 
 // KubeletLogLogToTimelineMapperTaskID is the ID for a task to add events or revisions based on kubelet logs.
-var KubeletLogLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "kubelet-log-timeline-mapper")
+var KubeletLogLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "kubelet-log-timeline-mapper")
 
 // OtherLogFilterTaskID is the task ID for filtering other logs.
 var OtherLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "other-log-filter")
@@ -69,7 +69,7 @@ var OtherLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDP
 var OtherLogGroupTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "other-log-group")
 
 // OtherLogLogToTimelineMapperTaskID is the task ID for a task to add events or revisions based on other logs.
-var OtherLogLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "other-log-timeline-mapper")
+var OtherLogLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "other-log-timeline-mapper")
 
 // TailTaskID is a nop task just to require all child parsers.
 var TailTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "tail")

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/taskid.go
@@ -39,4 +39,4 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](MultiCloud
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](MultiCloudAPIAuditLogTaskIDPrefix + "grouper")
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](MultiCloudAPIAuditLogTaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](MultiCloudAPIAuditLogTaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/contract/taskid.go
@@ -41,4 +41,4 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](NetworkAPI
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](NetworkAPILogTaskIDPrefix + "grouper")
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](NetworkAPILogTaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](NetworkAPILogTaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/contract/taskid.go
@@ -40,4 +40,4 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OnPremClou
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](OnPremCloudAPITaskIDPrefix + "grouper")
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](OnPremCloudAPITaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](OnPremCloudAPITaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudlogserialport/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/taskid.go
@@ -42,4 +42,4 @@ var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPref
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "log-grouper")
 
 // LogToTimelineMapperTaskID is the task id to relate serialized logs to events on timeline.
-var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "timeline-mapper")
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/ossclusterk8s/contract/taskid.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/taskid.go
@@ -32,7 +32,7 @@ var EventAuditLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OS
 var OSSK8sEventFieldSetReadTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "event-fieldset-read")
 var OSSK8sEventLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "event-log-ingester")
 var OSSK8sEventLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](OSSTaskPrefix + "event-log-grouper")
-var OSSK8sEventLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[struct{}](OSSTaskPrefix + "event-timeline-mapper")
+var OSSK8sEventLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](OSSTaskPrefix + "event-timeline-mapper")
 
 var OSSK8sAuditLogProviderTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogProviderRef, "oss")
 var OSSK8sAuditLogParserTailTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogParserTailRef, "oss")


### PR DESCRIPTION
## Summary
Updated the V2 timeline mapper tasks (`LogToTimelineMapperTaskV2`) to return `TimelineMapperResult`, which contains information about which timelines were written to (events, revisions, and aliases).

## Background & Motivation
There are cases where a subsequent task needs to know the write status of preceding timeline mappers to determine its own behavior. For example, if a specific `TimelinePath` has no writes after running a mapper, a subsequent task might want to fall back and generate the timeline from another log source.

Previously, V2 timeline mapper tasks returned an empty struct (`struct{}`), making it impossible for other tasks to inspect what changes were made. This refactoring allows subsequent tasks to inspect `TimelineMapperResult` and perform conditional logic based on which paths were actually written to.

## Key Changes

### 1. Introduced `TimelineMapperResult` and Updated Task Signature
* [pkg/core/inspection/taskbase/mapper_task_v2.go](file:///usr/local/google/home/ikakeru/workspace/khi/ws2/pkg/core/inspection/taskbase/mapper_task_v2.go)
    * Defined the `TimelineMapperResult` struct to hold the counts of events and revisions, as well as alias mappings for each `TimelinePath`.
    * Changed the return type of `NewLogToTimelineMapperTaskV2` from `coretask.Task[struct{}]` to `coretask.Task[TimelineMapperResult]`.
    * Implemented logic to aggregate the `ChangeSet` from each processed log and merge them into a single `TimelineMapperResult` during task execution.

### 2. Updated Task IDs Across Components
* Updated the type argument of various `LogToTimelineMapperTaskID` definitions from `struct{}` to `inspectiontaskbase.TimelineMapperResult`.
* Affected packages:
    * `commonlogk8saudit`
    * `googlecloudclustercomposer`
    * `googlecloudlogcomputeapiaudit`
    * `googlecloudlogcsm`
    * `googlecloudloggkeapiaudit`
    * `googlecloudloggkeautoscaler`
    * `googlecloudlogk8scontainer`
    * `googlecloudlogk8scontrolplane`
    * `googlecloudlogk8sevent`
    * `googlecloudlogk8snode`
    * `googlecloudlogmulticloudapiaudit`
    * `googlecloudlognetworkapiaudit`
    * `googlecloudlogonpremapiaudit`
    * `googlecloudlogserialport`
    * `ossclusterk8s`

### 3. Updated Tests
* [pkg/core/inspection/taskbase/mapper_task_v2_test.go](file:///usr/local/google/home/ikakeru/workspace/khi/ws2/pkg/core/inspection/taskbase/mapper_task_v2_test.go)
    * Added assertions to verify that the task returns the expected `TimelineMapperResult` showing the correct number of writes per timeline.
