### PR TITLE
feat: infer missing pod/binding resources and pod phase revisions from container log labels

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
@@ -125,7 +125,7 @@ func (g *GCPContainerLogNodeNameLabelFieldSetReader) Read(reader *structured.Nod
 	podLabels := make(map[string]string)
 	labelsReader, err := reader.GetReader("labels")
 	if err == nil {
-		labelsReader.Children()(func(key structured.NodeChildrenKey, value structured.NodeReader) bool {
+		for key, value := range labelsReader.Children() {
 			if strings.HasPrefix(key.Key, "k8s-pod/") {
 				valStr, err := value.ReadString("")
 				if err == nil {
@@ -133,8 +133,7 @@ func (g *GCPContainerLogNodeNameLabelFieldSetReader) Read(reader *structured.Nod
 					podLabels[trimmedKey] = valStr
 				}
 			}
-			return true
-		})
+		}
 	}
 
 	return &GCPContainerLogNodeNameLabelFieldSet{

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
@@ -16,6 +16,7 @@ package googlecloudlogk8scontainer_contract
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -99,7 +100,8 @@ var _ log.FieldSetReader = (*K8sContainerLogFieldSetReader)(nil)
 
 // GCPContainerLogNodeNameLabelFieldSet extracts the GCE resource name (Node name) if available.
 type GCPContainerLogNodeNameLabelFieldSet struct {
-	NodeName string
+	NodeName  string
+	PodLabels map[string]string
 }
 
 // Kind implements log.FieldSet.
@@ -119,7 +121,26 @@ func (g *GCPContainerLogNodeNameLabelFieldSetReader) FieldSetKind() string {
 // Read implements log.FieldSetReader.
 func (g *GCPContainerLogNodeNameLabelFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	nodeName := reader.ReadStringOrDefault(`labels.compute\.googleapis\.com/resource_name`, "")
-	return &GCPContainerLogNodeNameLabelFieldSet{NodeName: nodeName}, nil
+
+	podLabels := make(map[string]string)
+	labelsReader, err := reader.GetReader("labels")
+	if err == nil {
+		labelsReader.Children()(func(key structured.NodeChildrenKey, value structured.NodeReader) bool {
+			if strings.HasPrefix(key.Key, "k8s-pod/") {
+				valStr, err := value.ReadString("")
+				if err == nil {
+					trimmedKey := strings.TrimPrefix(key.Key, "k8s-pod/")
+					podLabels[trimmedKey] = valStr
+				}
+			}
+			return true
+		})
+	}
+
+	return &GCPContainerLogNodeNameLabelFieldSet{
+		NodeName:  nodeName,
+		PodLabels: podLabels,
+	}, nil
 }
 
 var _ log.FieldSetReader = (*GCPContainerLogNodeNameLabelFieldSetReader)(nil)

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset.go
@@ -96,3 +96,30 @@ func (k *K8sContainerLogFieldSetReader) Read(reader *structured.NodeReader) (log
 }
 
 var _ log.FieldSetReader = (*K8sContainerLogFieldSetReader)(nil)
+
+// GCPContainerLogNodeNameLabelFieldSet extracts the GCE resource name (Node name) if available.
+type GCPContainerLogNodeNameLabelFieldSet struct {
+	NodeName string
+}
+
+// Kind implements log.FieldSet.
+func (g *GCPContainerLogNodeNameLabelFieldSet) Kind() string {
+	return "gcp_container_log_node_name_label"
+}
+
+var _ log.FieldSet = (*GCPContainerLogNodeNameLabelFieldSet)(nil)
+
+type GCPContainerLogNodeNameLabelFieldSetReader struct{}
+
+// FieldSetKind implements log.FieldSetReader.
+func (g *GCPContainerLogNodeNameLabelFieldSetReader) FieldSetKind() string {
+	return (&GCPContainerLogNodeNameLabelFieldSet{}).Kind()
+}
+
+// Read implements log.FieldSetReader.
+func (g *GCPContainerLogNodeNameLabelFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
+	nodeName := reader.ReadStringOrDefault(`labels.compute\.googleapis\.com/resource_name`, "")
+	return &GCPContainerLogNodeNameLabelFieldSet{NodeName: nodeName}, nil
+}
+
+var _ log.FieldSetReader = (*GCPContainerLogNodeNameLabelFieldSetReader)(nil)

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
@@ -192,7 +192,8 @@ func TestGCPContainerLogNodeNameLabelFieldSetReader(t *testing.T) {
 		{
 			desc: "from labels",
 			want: &GCPContainerLogNodeNameLabelFieldSet{
-				NodeName: "test-node",
+				NodeName:  "test-node",
+				PodLabels: map[string]string{},
 			},
 			input: `labels:
   compute.googleapis.com/resource_name: test-node`,
@@ -200,10 +201,26 @@ func TestGCPContainerLogNodeNameLabelFieldSetReader(t *testing.T) {
 		{
 			desc: "missing labels",
 			want: &GCPContainerLogNodeNameLabelFieldSet{
-				NodeName: "",
+				NodeName:  "",
+				PodLabels: map[string]string{},
 			},
 			input: `labels:
   foo: bar`,
+		},
+		{
+			desc: "with k8s-pod labels",
+			want: &GCPContainerLogNodeNameLabelFieldSet{
+				NodeName: "test-node",
+				PodLabels: map[string]string{
+					"app":               "my-app",
+					"pod-template-hash": "12345",
+				},
+			},
+			input: `labels:
+  compute.googleapis.com/resource_name: test-node
+  k8s-pod/app: my-app
+  k8s-pod/pod-template-hash: "12345"
+  other-label: foo`,
 		},
 	}
 	for _, tc := range testCase {

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
@@ -182,3 +182,44 @@ func TestK8sContainerLogFieldSet_GroupKey(t *testing.T) {
 		t.Errorf("GroupKey() = %q, want %q", got, want)
 	}
 }
+
+func TestGCPContainerLogNodeNameLabelFieldSetReader(t *testing.T) {
+	testCase := []struct {
+		desc  string
+		want  *GCPContainerLogNodeNameLabelFieldSet
+		input string
+	}{
+		{
+			desc: "from labels",
+			want: &GCPContainerLogNodeNameLabelFieldSet{
+				NodeName: "test-node",
+			},
+			input: `labels:
+  compute.googleapis.com/resource_name: test-node`,
+		},
+		{
+			desc: "missing labels",
+			want: &GCPContainerLogNodeNameLabelFieldSet{
+				NodeName: "",
+			},
+			input: `labels:
+  foo: bar`,
+		},
+	}
+	for _, tc := range testCase {
+		t.Run(tc.desc, func(t *testing.T) {
+			l, err := log.NewLogFromYAMLString(tc.input)
+			if err != nil {
+				t.Fatalf("failed to parse log from yaml: %v", err)
+			}
+			l.SetFieldSetReader(&GCPContainerLogNodeNameLabelFieldSetReader{})
+			nodeFieldSet, err := log.GetFieldSet(l, &GCPContainerLogNodeNameLabelFieldSet{})
+			if err != nil {
+				t.Fatalf("failed to extract node field: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, nodeFieldSet); diff != "" {
+				t.Errorf("GCPContainerLogNodeNameLabelFieldSetReader mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/taskid.go
@@ -47,3 +47,9 @@ var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogG
 
 // LogToTimelineMapperTaskID is the task id for associating events/revisions with a given logs.
 var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "timeline-mapper")
+
+// PodPhaseTimelineMapperTaskID is the task id for associating container log node info with pod phase timelines.
+var PodPhaseTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "pod-phase-timeline-mapper")
+
+// TailTaskID is a nop task just to require all container log mappers.
+var TailTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "tail")

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
@@ -16,7 +16,10 @@ package googlecloudlogk8scontainer_impl
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -32,6 +35,7 @@ import (
 var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlogk8scontainer_contract.FieldSetReaderTaskID, googlecloudlogk8scontainer_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
 	&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSetReader{},
 	&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
+	&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSetReader{},
 })
 
 // containerLogIngester implements inspectiontaskbase.LogIngesterV2.
@@ -147,6 +151,117 @@ var _ inspectiontaskbase.LogToTimelineMapperV2[struct{}] = (*containerLogLogToTi
 var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[struct{}](
 	googlecloudlogk8scontainer_contract.LogToTimelineMapperTaskID,
 	&containerLogLogToTimelineMapper{},
+)
+
+type containerLogPodPhaseTimelineMapper struct {
+	inspectiontaskbase.SinglePassMapperBase[string]
+}
+
+func (m *containerLogPodPhaseTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogk8scontainer_contract.LogIngesterTaskID.Ref()
+}
+
+func (m *containerLogPodPhaseTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{
+		googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref(),
+		commonlogk8saudit_contract.ResourceRevisionLogToTimelineMapperTaskID.Ref(),
+	}
+}
+
+func (m *containerLogPodPhaseTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogk8scontainer_contract.LogGrouperTaskID.Ref()
+}
+
+func (m *containerLogPodPhaseTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevNodeName string) (*khifilev6.TimelineChangeSet, string, error) {
+	if prevNodeName == "AUDIT" {
+		return nil, "AUDIT", nil
+	}
+
+	nodeFields, err := log.GetFieldSet(l, &googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{})
+	if err != nil || nodeFields.NodeName == "" {
+		return nil, prevNodeName, nil
+	}
+
+	if prevNodeName == nodeFields.NodeName {
+		return nil, prevNodeName, nil
+	}
+
+	containerFields, err := log.GetFieldSet(l, &googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{})
+	if err != nil {
+		return nil, prevNodeName, nil
+	}
+
+	clusterName := containerFields.ClusterName
+	if clusterName == "" || clusterName == "unknown" {
+		clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref())
+		clusterName = clusterIdentity.ClusterName
+	}
+
+	// Construct paths for Pod and its binding
+	cluster := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	api := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, cluster, "core/v1")
+	kind := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, api, "pod")
+	ns := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kind, containerFields.Namespace)
+	podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, ns, containerFields.PodName)
+	bindingPath := commonlogk8saudit_contract.MustK8sSubresourceTimeline(ctx, podPath, "binding")
+
+	// Check if audit log has already written to the Pod or its binding timeline
+	resourceResult := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceRevisionLogToTimelineMapperTaskID.Ref())
+
+	_, hasPodRevision := resourceResult.Revisions[podPath]
+	_, hasBindingRevision := resourceResult.Revisions[bindingPath]
+
+	if hasPodRevision || hasBindingRevision {
+		return nil, "AUDIT", nil
+	}
+
+	// Generate Pod phase timeline path under the Node
+	podPhasePath := mustPodPhaseTimelinePath(ctx, clusterName, nodeFields.NodeName, containerFields.Namespace, containerFields.PodName, "unknown")
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+
+	cs.AddRevision(podPhasePath, &khifilev6.StagingRevision{
+		ChangedTime:  time.Unix(0, 0),
+		ResourceBody: nil,
+		Principal:    "N/A",
+		VerbType:     commonlogk8saudit_contract.VerbUnknown,
+		StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+	})
+
+	return cs, nodeFields.NodeName, nil
+}
+
+func mustPodPhaseTimelinePath(ctx context.Context, clusterName, nodeName, namespace, podName, uid string) *khifilev6.TimelinePath {
+	cluster := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterName)
+	api := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, cluster, "core/v1")
+	kind := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, api, "node")
+	nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kind, nodeName)
+
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(nodePath, khifilev6.PathSegment{
+		Name: fmt.Sprintf("%s/%s[%s]", namespace, podName, uid),
+		Type: commonlogk8saudit_contract.TimelineTypePodPhase,
+	})
+}
+
+var _ inspectiontaskbase.LogToTimelineMapperV2[string] = (*containerLogPodPhaseTimelineMapper)(nil)
+
+// PodPhaseTimelineMapperTask maps container logs to Pod phase timelines.
+var PodPhaseTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[string](
+	googlecloudlogk8scontainer_contract.PodPhaseTimelineMapperTaskID,
+	&containerLogPodPhaseTimelineMapper{},
+)
+
+// TailTask is a nop task that depends on all container log mappers.
+var TailTask = inspectiontaskbase.NewInspectionTask(
+	googlecloudlogk8scontainer_contract.TailTaskID,
+	[]taskid.UntypedTaskReference{
+		googlecloudlogk8scontainer_contract.LogToTimelineMapperTaskID.Ref(),
+		googlecloudlogk8scontainer_contract.PodPhaseTimelineMapperTaskID.Ref(),
+	},
+	func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) (struct{}, error) {
+		return struct{}{}, nil
+	},
 	inspectioncore_contract.FeatureTaskLabelV2(
 		"Kubernetes Container Logs",
 		"Gather stdout/stderr logs of containers to visualize application runtime behaviors under associated Pod timelines. Note: The log volume can be very large if the cluster contains many Pods.",

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -154,7 +155,7 @@ var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[st
 )
 
 type containerLogPodPhaseTimelineMapper struct {
-	inspectiontaskbase.SinglePassMapperBase[string]
+	inspectiontaskbase.SinglePassMapperBase[*containerLogPodPhaseMapperState]
 }
 
 func (m *containerLogPodPhaseTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
@@ -172,23 +173,37 @@ func (m *containerLogPodPhaseTimelineMapper) GroupedLogTask() taskid.TaskReferen
 	return googlecloudlogk8scontainer_contract.LogGrouperTaskID.Ref()
 }
 
-func (m *containerLogPodPhaseTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevNodeName string) (*khifilev6.TimelineChangeSet, string, error) {
-	if prevNodeName == "AUDIT" {
-		return nil, "AUDIT", nil
+type containerLogPodPhaseMapperState struct {
+	LastNodeName  string
+	LastLabels    map[string]string
+	AuditLogFound bool
+}
+
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || v != bv {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *containerLogPodPhaseTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, state *containerLogPodPhaseMapperState) (*khifilev6.TimelineChangeSet, *containerLogPodPhaseMapperState, error) {
+	if state != nil && state.AuditLogFound {
+		return nil, state, nil
 	}
 
 	nodeFields, err := log.GetFieldSet(l, &googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{})
 	if err != nil || nodeFields.NodeName == "" {
-		return nil, prevNodeName, nil
-	}
-
-	if prevNodeName == nodeFields.NodeName {
-		return nil, prevNodeName, nil
+		return nil, state, nil
 	}
 
 	containerFields, err := log.GetFieldSet(l, &googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{})
 	if err != nil {
-		return nil, prevNodeName, nil
+		return nil, state, nil
 	}
 
 	clusterName := containerFields.ClusterName
@@ -212,23 +227,94 @@ func (m *containerLogPodPhaseTimelineMapper) ProcessLogByGroup(ctx context.Conte
 	_, hasBindingRevision := resourceResult.Revisions[bindingPath]
 
 	if hasPodRevision || hasBindingRevision {
-		return nil, "AUDIT", nil
+		return nil, &containerLogPodPhaseMapperState{AuditLogFound: true}, nil
+	}
+
+	nodeNameChanged := state == nil || state.LastNodeName != nodeFields.NodeName
+	labelsChanged := state == nil || !mapsEqual(state.LastLabels, nodeFields.PodLabels)
+
+	if !nodeNameChanged && !labelsChanged {
+		return nil, state, nil
 	}
 
 	// Generate Pod phase timeline path under the Node
 	podPhasePath := mustPodPhaseTimelinePath(ctx, clusterName, nodeFields.NodeName, containerFields.Namespace, containerFields.PodName, "unknown")
 
+	labels := map[string]any{}
+	for k, v := range nodeFields.PodLabels {
+		labels[k] = v
+	}
+
+	podManifest := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      containerFields.PodName,
+			"namespace": containerFields.Namespace,
+			"labels":    labels,
+		},
+		"spec": map[string]any{
+			"nodeName": nodeFields.NodeName,
+		},
+	}
+	podNode, err := structured.FromGoValue(podManifest, &structured.AlphabeticalGoMapKeyOrderProvider{})
+	if err != nil {
+		return nil, state, fmt.Errorf("failed to generate pod manifest: %w", err)
+	}
+
+	bindingManifest := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Binding",
+		"metadata": map[string]any{
+			"name":      containerFields.PodName,
+			"namespace": containerFields.Namespace,
+		},
+		"target": map[string]any{
+			"kind": "Node",
+			"name": nodeFields.NodeName,
+		},
+	}
+	bindingNode, err := structured.FromGoValue(bindingManifest, &structured.AlphabeticalGoMapKeyOrderProvider{})
+	if err != nil {
+		return nil, state, fmt.Errorf("failed to generate binding manifest: %w", err)
+	}
+
 	cs := khifilev6.NewTimelineChangeSet(l)
 
-	cs.AddRevision(podPhasePath, &khifilev6.StagingRevision{
-		ChangedTime:  time.Unix(0, 0),
-		ResourceBody: nil,
-		Principal:    "N/A",
-		VerbType:     commonlogk8saudit_contract.VerbUnknown,
-		StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
-	})
+	if nodeNameChanged {
+		cs.AddRevision(podPhasePath, &khifilev6.StagingRevision{
+			ChangedTime:  time.Unix(0, 0),
+			ResourceBody: podNode,
+			Principal:    "N/A",
+			VerbType:     commonlogk8saudit_contract.VerbUnknown,
+			StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+		})
+	}
 
-	return cs, nodeFields.NodeName, nil
+	if nodeNameChanged || labelsChanged {
+		cs.AddRevision(podPath, &khifilev6.StagingRevision{
+			ChangedTime:  time.Unix(0, 0),
+			ResourceBody: podNode,
+			Principal:    "N/A",
+			VerbType:     commonlogk8saudit_contract.VerbUnknown,
+			StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+		})
+
+		cs.AddRevision(bindingPath, &khifilev6.StagingRevision{
+			ChangedTime:  time.Unix(0, 0),
+			ResourceBody: bindingNode,
+			Principal:    "N/A",
+			VerbType:     commonlogk8saudit_contract.VerbUnknown,
+			StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+		})
+	}
+
+	nextState := &containerLogPodPhaseMapperState{
+		LastNodeName: nodeFields.NodeName,
+		LastLabels:   nodeFields.PodLabels,
+	}
+
+	return cs, nextState, nil
 }
 
 func mustPodPhaseTimelinePath(ctx context.Context, clusterName, nodeName, namespace, podName, uid string) *khifilev6.TimelinePath {
@@ -244,10 +330,10 @@ func mustPodPhaseTimelinePath(ctx context.Context, clusterName, nodeName, namesp
 	})
 }
 
-var _ inspectiontaskbase.LogToTimelineMapperV2[string] = (*containerLogPodPhaseTimelineMapper)(nil)
+var _ inspectiontaskbase.LogToTimelineMapperV2[*containerLogPodPhaseMapperState] = (*containerLogPodPhaseTimelineMapper)(nil)
 
 // PodPhaseTimelineMapperTask maps container logs to Pod phase timelines.
-var PodPhaseTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[string](
+var PodPhaseTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTaskV2[*containerLogPodPhaseMapperState](
 	googlecloudlogk8scontainer_contract.PodPhaseTimelineMapperTaskID,
 	&containerLogPodPhaseTimelineMapper{},
 )

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
@@ -17,6 +17,7 @@ package googlecloudlogk8scontainer_impl
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
@@ -179,18 +180,6 @@ type containerLogPodPhaseMapperState struct {
 	AuditLogFound bool
 }
 
-func mapsEqual(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, v := range a {
-		if bv, ok := b[k]; !ok || v != bv {
-			return false
-		}
-	}
-	return true
-}
-
 func (m *containerLogPodPhaseTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, state *containerLogPodPhaseMapperState) (*khifilev6.TimelineChangeSet, *containerLogPodPhaseMapperState, error) {
 	if state != nil && state.AuditLogFound {
 		return nil, state, nil
@@ -231,7 +220,7 @@ func (m *containerLogPodPhaseTimelineMapper) ProcessLogByGroup(ctx context.Conte
 	}
 
 	nodeNameChanged := state == nil || state.LastNodeName != nodeFields.NodeName
-	labelsChanged := state == nil || !mapsEqual(state.LastLabels, nodeFields.PodLabels)
+	labelsChanged := state == nil || !maps.Equal(state.LastLabels, nodeFields.PodLabels)
 
 	if !nodeNameChanged && !labelsChanged {
 		return nil, state, nil
@@ -299,7 +288,9 @@ func (m *containerLogPodPhaseTimelineMapper) ProcessLogByGroup(ctx context.Conte
 			VerbType:     commonlogk8saudit_contract.VerbUnknown,
 			StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
 		})
+	}
 
+	if nodeNameChanged {
 		cs.AddRevision(bindingPath, &khifilev6.StagingRevision{
 			ChangedTime:  time.Unix(0, 0),
 			ResourceBody: bindingNode,

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
@@ -431,7 +431,7 @@ func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			},
 		},
 		{
-			name: "regenerate Pod and Binding when labels change",
+			name: "regenerate Pod when labels change",
 			inputLogs: []*log.Log{
 				log.NewLogWithFieldSetsForTest(
 					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
@@ -497,7 +497,7 @@ func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
 						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
 					}, nodeComparer)
 
-				// Second log generates only Pod and Binding (labels changed, node remained same)
+				// Second log generates only Pod (labels changed, node remained same)
 				testchangeset.AssertTimeline(t, css[1]).
 					HasRevision(podPath, &khifilev6.StagingRevision{
 						ChangedTime:  time.Unix(0, 0),
@@ -505,14 +505,11 @@ func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
 						Principal:    "N/A",
 						VerbType:     commonlogk8saudit_contract.VerbUnknown,
 						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
-					}, nodeComparer).
-					HasRevision(bindingPath, &khifilev6.StagingRevision{
-						ChangedTime:  time.Unix(0, 0),
-						ResourceBody: makeBindingNode("test-node"),
-						Principal:    "N/A",
-						VerbType:     commonlogk8saudit_contract.VerbUnknown,
-						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
 					}, nodeComparer)
+
+				if css[1].Revisions[bindingPath] != nil {
+					t.Errorf("expected no revision on bindingPath in second changeset, but got one")
+				}
 
 				// Verify PodPhase timeline does NOT have a revision in the second changeset
 				if css[1].Revisions[expectedPath] != nil {

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
@@ -142,6 +144,217 @@ func TestLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 				t.Fatalf("ProcessLogByGroup() returned unexpected error: %v", err)
 			}
 			tc.assert(t, ctx, cs)
+		})
+	}
+}
+
+// TestPodPhaseTimelineMapper_ProcessLogByGroup tests the containerLogPodPhaseTimelineMapper.ProcessLogByGroup function.
+func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+	apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+	kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+	namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "test-namespace")
+	podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "test-pod")
+	bindingPath := commonlogk8saudit_contract.MustK8sSubresourceTimeline(ctx, podPath, "binding")
+	expectedPath := mustPodPhaseTimelinePath(ctx, "test-cluster", "test-node", "test-namespace", "test-pod", "unknown")
+
+	testCases := []struct {
+		name                   string
+		inputLogs              []*log.Log
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		resourceRevisionResult inspectiontaskbase.TimelineMapperResult
+		assert                 func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet)
+	}{
+		{
+			name: "skipped because NodeName is empty",
+			inputLogs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "",
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
+					},
+				),
+			},
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			assert: func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet) {
+				if css[0] != nil {
+					t.Errorf("expected cs to be nil, got %v", css[0])
+				}
+			},
+		},
+		{
+			name: "mapped successfully (no audit log)",
+			inputLogs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node",
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
+					},
+				),
+			},
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			assert: func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, css[0]).
+					HasRevision(expectedPath, &khifilev6.StagingRevision{
+						ChangedTime: time.Unix(0, 0),
+						Principal:   "N/A",
+						VerbType:    nil,
+						StateType:   commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					})
+			},
+		},
+		{
+			name: "skipped because audit log has Pod resource timeline",
+			inputLogs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node",
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
+					},
+				),
+			},
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			resourceRevisionResult: inspectiontaskbase.TimelineMapperResult{
+				Revisions: map[*khifilev6.TimelinePath]int{
+					podPath: 1,
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet) {
+				if css[0] != nil {
+					t.Errorf("expected cs to be nil, got %v", css[0])
+				}
+			},
+		},
+		{
+			name: "skipped because audit log has Pod binding timeline",
+			inputLogs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node",
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
+					},
+				),
+			},
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			resourceRevisionResult: inspectiontaskbase.TimelineMapperResult{
+				Revisions: map[*khifilev6.TimelinePath]int{
+					bindingPath: 1,
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet) {
+				if css[0] != nil {
+					t.Errorf("expected cs to be nil, got %v", css[0])
+				}
+			},
+		},
+		{
+			name: "mapped once and skipped for subsequent logs with same node",
+			inputLogs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node",
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
+					},
+				),
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node",
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 1, 0, time.UTC),
+					},
+				),
+			},
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			assert: func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet) {
+				if len(css) != 2 {
+					t.Fatalf("expected 2 changesets, got %d", len(css))
+				}
+				testchangeset.AssertTimeline(t, css[0]).
+					HasRevision(expectedPath, &khifilev6.StagingRevision{
+						ChangedTime: time.Unix(0, 0),
+						Principal:   "N/A",
+						VerbType:    nil,
+						StateType:   commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					})
+				if css[1] != nil {
+					t.Errorf("expected second changeset to be nil, got %v", css[1])
+				}
+			},
+		},
+	}
+
+	mapper := &containerLogPodPhaseTimelineMapper{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref(), tc.cluster)
+			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.ResourceRevisionLogToTimelineMapperTaskID.Ref(), tc.resourceRevisionResult)
+
+			var css []*khifilev6.TimelineChangeSet
+			state := ""
+			for _, l := range tc.inputLogs {
+				cs, nextState, err := mapper.ProcessLogByGroup(ctx, l, state)
+				if err != nil {
+					t.Fatalf("ProcessLogByGroup() returned unexpected error: %v", err)
+				}
+				css = append(css, cs)
+				state = nextState
+			}
+			tc.assert(t, ctx, css)
 		})
 	}
 }

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
@@ -30,6 +31,7 @@ import (
 	googlecloudlogk8scontainer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontainer/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+	"github.com/google/go-cmp/cmp"
 )
 
 // TestLogIngester_ProcessLog tests the containerLogIngester.ProcessLog function.
@@ -161,6 +163,69 @@ func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	bindingPath := commonlogk8saudit_contract.MustK8sSubresourceTimeline(ctx, podPath, "binding")
 	expectedPath := mustPodPhaseTimelinePath(ctx, "test-cluster", "test-node", "test-namespace", "test-pod", "unknown")
 
+	nodeComparer := cmp.Comparer(func(x, y structured.Node) bool {
+		if x == nil && y == nil {
+			return true
+		}
+		if x == nil || y == nil {
+			return false
+		}
+		serializer := &structured.JSONNodeSerializer{}
+		xBytes, err := serializer.Serialize(x)
+		if err != nil {
+			return false
+		}
+		yBytes, err := serializer.Serialize(y)
+		if err != nil {
+			return false
+		}
+		return string(xBytes) == string(yBytes)
+	})
+
+	makePodNode := func(nodeName string, labels map[string]string) structured.Node {
+		labelsMap := map[string]any{}
+		for k, v := range labels {
+			labelsMap[k] = v
+		}
+		manifest := map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      "test-pod",
+				"namespace": "test-namespace",
+				"labels":    labelsMap,
+			},
+			"spec": map[string]any{
+				"nodeName": nodeName,
+			},
+		}
+		node, err := structured.FromGoValue(manifest, &structured.AlphabeticalGoMapKeyOrderProvider{})
+		if err != nil {
+			t.Fatalf("failed to generate expected pod manifest: %v", err)
+		}
+		return node
+	}
+
+	makeBindingNode := func(nodeName string) structured.Node {
+		manifest := map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Binding",
+			"metadata": map[string]any{
+				"name":      "test-pod",
+				"namespace": "test-namespace",
+			},
+			"target": map[string]any{
+				"kind": "Node",
+				"name": nodeName,
+			},
+		}
+		node, err := structured.FromGoValue(manifest, &structured.AlphabeticalGoMapKeyOrderProvider{})
+		if err != nil {
+			t.Fatalf("failed to generate expected binding manifest: %v", err)
+		}
+		return node
+	}
+
 	testCases := []struct {
 		name                   string
 		inputLogs              []*log.Log
@@ -217,11 +282,26 @@ func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			assert: func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet) {
 				testchangeset.AssertTimeline(t, css[0]).
 					HasRevision(expectedPath, &khifilev6.StagingRevision{
-						ChangedTime: time.Unix(0, 0),
-						Principal:   "N/A",
-						VerbType:    nil,
-						StateType:   commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
-					})
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node", nil),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					}, nodeComparer).
+					HasRevision(podPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node", nil),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer).
+					HasRevision(bindingPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makeBindingNode("test-node"),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer)
 			},
 		},
 		{
@@ -325,14 +405,208 @@ func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
 				}
 				testchangeset.AssertTimeline(t, css[0]).
 					HasRevision(expectedPath, &khifilev6.StagingRevision{
-						ChangedTime: time.Unix(0, 0),
-						Principal:   "N/A",
-						VerbType:    nil,
-						StateType:   commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
-					})
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node", nil),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					}, nodeComparer).
+					HasRevision(podPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node", nil),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer).
+					HasRevision(bindingPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makeBindingNode("test-node"),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer)
 				if css[1] != nil {
 					t.Errorf("expected second changeset to be nil, got %v", css[1])
 				}
+			},
+		},
+		{
+			name: "regenerate Pod and Binding when labels change",
+			inputLogs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node",
+						PodLabels: map[string]string{
+							"a": "1",
+						},
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
+					},
+				),
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node",
+						PodLabels: map[string]string{
+							"a": "2",
+						},
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 1, 0, time.UTC),
+					},
+				),
+			},
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			assert: func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet) {
+				if len(css) != 2 {
+					t.Fatalf("expected 2 changesets, got %d", len(css))
+				}
+				// First log generates all 3
+				testchangeset.AssertTimeline(t, css[0]).
+					HasRevision(expectedPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node", map[string]string{"a": "1"}),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					}, nodeComparer).
+					HasRevision(podPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node", map[string]string{"a": "1"}),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer).
+					HasRevision(bindingPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makeBindingNode("test-node"),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer)
+
+				// Second log generates only Pod and Binding (labels changed, node remained same)
+				testchangeset.AssertTimeline(t, css[1]).
+					HasRevision(podPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node", map[string]string{"a": "2"}),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer).
+					HasRevision(bindingPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makeBindingNode("test-node"),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer)
+
+				// Verify PodPhase timeline does NOT have a revision in the second changeset
+				if css[1].Revisions[expectedPath] != nil {
+					t.Errorf("expected no revision on podPhasePath in second changeset, but got one")
+				}
+			},
+		},
+		{
+			name: "regenerate all when node changes",
+			inputLogs: []*log.Log{
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node-1",
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC),
+					},
+				),
+				log.NewLogWithFieldSetsForTest(
+					&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+						Namespace:     "test-namespace",
+						PodName:       "test-pod",
+						ContainerName: "test-container",
+					},
+					&googlecloudlogk8scontainer_contract.GCPContainerLogNodeNameLabelFieldSet{
+						NodeName: "test-node-2",
+					},
+					&log.CommonFieldSet{
+						Timestamp: time.Date(2026, 5, 26, 12, 0, 1, 0, time.UTC),
+					},
+				),
+			},
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			},
+			assert: func(t *testing.T, ctx context.Context, css []*khifilev6.TimelineChangeSet) {
+				if len(css) != 2 {
+					t.Fatalf("expected 2 changesets, got %d", len(css))
+				}
+				expectedPath1 := mustPodPhaseTimelinePath(ctx, "test-cluster", "test-node-1", "test-namespace", "test-pod", "unknown")
+				expectedPath2 := mustPodPhaseTimelinePath(ctx, "test-cluster", "test-node-2", "test-namespace", "test-pod", "unknown")
+
+				// First log generates all 3 on node 1
+				testchangeset.AssertTimeline(t, css[0]).
+					HasRevision(expectedPath1, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node-1", nil),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					}, nodeComparer).
+					HasRevision(podPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node-1", nil),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer).
+					HasRevision(bindingPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makeBindingNode("test-node-1"),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer)
+
+				// Second log generates all 3 on node 2
+				testchangeset.AssertTimeline(t, css[1]).
+					HasRevision(expectedPath2, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node-2", nil),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStatePodPhaseUnknown,
+					}, nodeComparer).
+					HasRevision(podPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makePodNode("test-node-2", nil),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer).
+					HasRevision(bindingPath, &khifilev6.StagingRevision{
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: makeBindingNode("test-node-2"),
+						Principal:    "N/A",
+						VerbType:     commonlogk8saudit_contract.VerbUnknown,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExistingLogNotFound,
+					}, nodeComparer)
 			},
 		},
 	}
@@ -345,7 +619,7 @@ func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.ResourceRevisionLogToTimelineMapperTaskID.Ref(), tc.resourceRevisionResult)
 
 			var css []*khifilev6.TimelineChangeSet
-			state := ""
+			var state *containerLogPodPhaseMapperState
 			for _, l := range tc.inputLogs {
 				cs, nextState, err := mapper.ProcessLogByGroup(ctx, l, state)
 				if err != nil {

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/registration.go
@@ -48,5 +48,7 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 		LogGrouperTask,
 		LogIngesterTask,
 		LogToTimelineMapperTask,
+		PodPhaseTimelineMapperTask,
+		TailTask,
 	)
 }


### PR DESCRIPTION
## Summary
To reconstruct accurate timelines even in environments where audit logs are missing or insufficient, this PR introduces a feature to infer the following missing revision status using label information from container logs:
1. **Pod and Binding resource revisions**
2. **Pod phase revisions**
This allows KHI to partially restore timelines, such as showing which Pod was running on which Node, as long as container logs are available.
## Key Changes
### 1. Enhanced Metadata Extraction from Container Logs (`pkg/task/inspection/googlecloudlogk8scontainer`)
- Updated `fieldset.go` to extend fieldsets for extracting necessary label information (e.g., node name) from container logs.
- Modified `parser_task.go` to parse and retain these fields during log ingestion.
### 2. Added Timeline Mappers and Task Registration
- Implemented `containerLogPodPhaseTimelineMapper` (`PodPhaseTimelineMapperTask`) to map Pod Phase timelines based on container log metadata.
  - Added control logic to skip inference if the corresponding Pod or Binding timelines have already been generated from audit logs to prevent duplication.
- Registered `PodPhaseTimelineMapperTask` and `TailTask` in `registration.go`.
### 3. Added Unit Tests
- Added and updated unit tests for the extended `fieldset` and `parser_task`.
- Added comprehensive unit tests for the new mapper, covering various scenarios (e.g., empty node name, existing audit logs, and sequential logs on the same node).