### PR TITLE
fixed owner timelines sorted by log time

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/contract/timeline_type.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/timeline_type.go
@@ -59,7 +59,7 @@ var (
 		style.ColorBlack,
 		true,
 		7000,
-		style.AlphabeticalSortPolicy(),
+		style.GroupedChronologicalSortPolicy("-"),
 	)
 	TimelineTypePodPhase = style.MustRegisterTimelineType(
 		"pod",


### PR DESCRIPTION
The owner reference timeline was sorted by alphabetical order. This is not convenient. 
Use the grouped sort policy for the owner reference timelines.