### PR TITLE
test: add task graph resolution conformance test for all inspection types

### DIFF
--- a/pkg/core/inspection/runner.go
+++ b/pkg/core/inspection/runner.go
@@ -300,7 +300,7 @@ func (i *InspectionTaskRunner) Run(ctx context.Context, req *inspectioncore_cont
 		return fmt.Errorf("this task is already started")
 	}
 	currentInspectionType := i.inspectionServer.GetInspectionType(i.currentInspectionType)
-	runnableTaskGraph, err := i.resolveTaskGraph()
+	runnableTaskGraph, err := i.ResolveTaskGraph()
 	if err != nil {
 		return err
 	}
@@ -435,7 +435,7 @@ func (i *InspectionTaskRunner) Metadata() (map[string]any, error) {
 // DryRun performs a dry run of the inspection.
 // It resolves the task graph and runs it in dry-run mode to collect metadata without executing tasks.
 func (i *InspectionTaskRunner) DryRun(ctx context.Context, req *inspectioncore_contract.InspectionRequest) (*InspectionDryRunResult, error) {
-	runnableTaskGraph, err := i.resolveTaskGraph()
+	runnableTaskGraph, err := i.ResolveTaskGraph()
 	if err != nil {
 		slog.ErrorContext(ctx, err.Error())
 		return nil, err
@@ -511,7 +511,8 @@ func (i *InspectionTaskRunner) Wait() <-chan struct{} {
 	return i.runComplete
 }
 
-func (i *InspectionTaskRunner) resolveTaskGraph() (*coretask.TaskSet, error) {
+// ResolveTaskGraph resolves the task graph for the current inspection runner and returns the runnable TaskSet.
+func (i *InspectionTaskRunner) ResolveTaskGraph() (*coretask.TaskSet, error) {
 	if i.featureTasks == nil || i.availableTasks == nil {
 		return nil, fmt.Errorf("this runner is not ready for resolving graph")
 	}

--- a/pkg/task/inspection/ossclusterk8s/impl/auditlog_parsers.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/auditlog_parsers.go
@@ -35,7 +35,6 @@ var OSSK8sAuditLogFieldExtractorTask = inspectiontaskbase.NewFieldSetReadTask(
 var OSSK8sAuditLogParserTailTask = inspectiontaskbase.NewInspectionTask(
 	ossclusterk8s_contract.OSSK8sAuditLogParserTailTaskID,
 	[]taskid.UntypedTaskReference{
-		commonlogk8saudit_contract.LogSummaryLogToTimelineMapperTaskID.Ref(),
 		commonlogk8saudit_contract.NonSuccessLogLogToTimelineMapperTaskID.Ref(),
 		commonlogk8saudit_contract.NamespaceRequestLogToTimelineMapperTaskID.Ref(),
 		commonlogk8saudit_contract.ResourceRevisionLogToTimelineMapperTaskID.Ref(),

--- a/pkg/testutil/inspection/conformance.go
+++ b/pkg/testutil/inspection/conformance.go
@@ -20,12 +20,20 @@ import (
 	"testing"
 
 	coreinspection "github.com/GoogleCloudPlatform/khi/pkg/core/inspection"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logger"
 	"github.com/GoogleCloudPlatform/khi/pkg/generated"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+	"github.com/GoogleCloudPlatform/khi/pkg/server/upload"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
 func ConformanceTestForInspectionTypes(t *testing.T) {
+	logger.InitGlobalKHILogger()
+	oldStore := upload.DefaultUploadFileStore
+	upload.DefaultUploadFileStore = upload.NewUploadFileStore(upload.NewLocalUploadFileStoreProvider(t.TempDir()))
+	t.Cleanup(func() {
+		upload.DefaultUploadFileStore = oldStore
+	})
 	ioConfig, err := inspectioncore_contract.NewIOConfigForTest()
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -64,6 +72,29 @@ func ConformanceTestForInspectionTypes(t *testing.T) {
 		t.Run(fmt.Sprintf("%s-icon-must-be-relative-path", inspectionType.Name), func(t *testing.T) {
 			if strings.HasPrefix(inspectionType.Icon, "/") {
 				t.Errorf("icon path must be relative path, got %s", inspectionType.Icon)
+			}
+		})
+
+		t.Run(fmt.Sprintf("%s-resolves-task-graph-with-all-features-enabled", inspectionType.Name), func(t *testing.T) {
+			taskId, err := testServer.CreateInspection(inspectionType.Id)
+			if err != nil {
+				t.Fatalf("unexpected error creating inspection: %v", err)
+			}
+			runner := testServer.GetInspection(taskId)
+			features, err := runner.FeatureList()
+			if err != nil {
+				t.Fatalf("unexpected error getting feature list: %v", err)
+			}
+			allFeatureIds := make([]string, len(features))
+			for i, feature := range features {
+				allFeatureIds[i] = feature.Id
+			}
+			if err := runner.SetFeatureList(allFeatureIds); err != nil {
+				t.Fatalf("unexpected error setting feature list: %v", err)
+			}
+			_, err = runner.DryRun(t.Context(), &inspectioncore_contract.InspectionRequest{})
+			if err != nil {
+				t.Errorf("failed to resolve task graph with all features enabled: %v", err)
 			}
 		})
 	}

--- a/pkg/testutil/inspection/conformance.go
+++ b/pkg/testutil/inspection/conformance.go
@@ -92,7 +92,7 @@ func ConformanceTestForInspectionTypes(t *testing.T) {
 			if err := runner.SetFeatureList(allFeatureIds); err != nil {
 				t.Fatalf("unexpected error setting feature list: %v", err)
 			}
-			_, err = runner.DryRun(t.Context(), &inspectioncore_contract.InspectionRequest{})
+			_, err = runner.ResolveTaskGraph()
 			if err != nil {
 				t.Errorf("failed to resolve task graph with all features enabled: %v", err)
 			}


### PR DESCRIPTION
Adds a subtest to ConformanceTestForInspectionTypes that enables all available feature tasks for each InspectionType and verifies task graph resolution via DryRun. Also fixes a missing dependency error in OSSK8sAuditLogParserTailTask and initializes DefaultUploadFileStore in tests.

Fixes #823
