### PR TITLE
chore(storybook): unify and reorganize storybook folder hierarchy

### DIFF
--- a/.agents/rules/storybook-guideline.md
+++ b/.agents/rules/storybook-guideline.md
@@ -1,0 +1,41 @@
+# Storybook Title Guidelines
+
+When creating or updating Storybook files (`*.stories.ts`), you MUST adhere to the following rules for defining the `title` property in the default export. This ensures a consistent folder structure in the Storybook UI.
+
+## Structure
+
+The `title` should follow a maximum 3-level hierarchy:
+`[Feature Area] / [Sub Area (if applicable)] / [Component Name]`
+
+### 1. Feature Area (Root Level)
+
+- Represents the main feature module (based on the `web/src/app` directory structure).
+- Use **PascalCase**.
+- Examples: `Log`, `Timeline`, `Diff`, `Graph`, `Shared`, `Dialogs`.
+- **Exception**: Global singleton components (like `Header`) can be placed at the root level without nesting (e.g., `title: 'Header'`).
+
+### 2. Sub Area (Optional)
+
+- Use only when the feature is large and has clear subdivisions.
+- Use **PascalCase**.
+- Examples:
+  - Dialogs: Use the specific dialog name (e.g., `Dialogs/Startup`, `Dialogs/Progress`).
+  - Timeline: Place main components under `Timeline/Main` and toolbar components under `Timeline/Toolbar`.
+- **Rule**: NEVER use generic intermediary folders like `Components` (e.g., `Shared/Components/YamlViewer` is WRONG; `Shared/YamlViewer` is CORRECT).
+
+### 3. Component Name
+
+- The name of the component in **PascalCase**.
+- **Rule**: Omit the `Component` suffix from the name. (e.g., `TimelineChartComponent` -> `TimelineChart`).
+
+### 4. Individual Stories (Leaf Nodes)
+
+- The individually exported variables in the `*.stories.ts` file will automatically become the leaf nodes (the actual stories) under the folder defined by the `title`. You don't need to specify the story name in the `title` itself.
+
+## Examples
+
+- `src/app/shared/components/search-bar/search-bar.stories.ts` -> `title: 'Shared/SearchBar'`
+- `src/app/timeline-toolbar/components/cel-input.stories.ts` -> `title: 'Timeline/Toolbar/CelInput'`
+- `src/app/dialogs/new-inspection/components/set-parameter.stories.ts` -> `title: 'Dialogs/NewInspection/SetParameter'`
+- `src/app/header/components/header.component.stories.ts` -> `title: 'Header'`
+- `src/app/log/components/type-severity.stories.ts` -> `title: 'Log/TypeSeverity'`

--- a/web/src/app/dialogs/new-inspection/components/set-parameter.stories.ts
+++ b/web/src/app/dialogs/new-inspection/components/set-parameter.stories.ts
@@ -30,7 +30,7 @@ const createParameterStoreMock = (initialValue: string[] = []) => ({
 });
 
 const meta: Meta<SetParameterComponent> = {
-  title: 'Dialogs/NewInspection/Components/SetParameter',
+  title: 'Dialogs/NewInspection/SetParameter',
   component: SetParameterComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/dialogs/progress/progress.component.stories.ts
+++ b/web/src/app/dialogs/progress/progress.component.stories.ts
@@ -35,7 +35,7 @@ const createProgressDecorator = (progress: CurrentProgress) =>
   });
 
 const meta: Meta<ProgressDialogComponent> = {
-  title: 'Dialogs/Progress/Progress',
+  title: 'Dialogs/Progress/ProgressDialog',
   component: ProgressDialogComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/dialogs/progress/progress.component.stories.ts
+++ b/web/src/app/dialogs/progress/progress.component.stories.ts
@@ -35,7 +35,7 @@ const createProgressDecorator = (progress: CurrentProgress) =>
   });
 
 const meta: Meta<ProgressDialogComponent> = {
-  title: 'Dialogs/ProgressDialog',
+  title: 'Dialogs/Progress/Progress',
   component: ProgressDialogComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/dialogs/release-notes/components/release-notes-layout.stories.ts
+++ b/web/src/app/dialogs/release-notes/components/release-notes-layout.stories.ts
@@ -35,7 +35,7 @@ Welcome to the latest version of KHI! This update significantly improves the eff
 `;
 
 export default {
-  title: 'Dialogs/ReleaseNotesLayout',
+  title: 'Dialogs/ReleaseNotes/ReleaseNotesLayout',
   component: ReleaseNotesLayoutComponent,
   decorators: [
     moduleMetadata({

--- a/web/src/app/dialogs/startup/components/inspection-list.stories.ts
+++ b/web/src/app/dialogs/startup/components/inspection-list.stories.ts
@@ -19,7 +19,7 @@ import { InspectionListComponent } from './inspection-list.component';
 import { InspectionListItemViewModel } from '../types/inspection-activity.model';
 
 const meta: Meta<InspectionListComponent> = {
-  title: 'Dialogs/Startup/InspectionListComponent',
+  title: 'Dialogs/Startup/InspectionList',
   component: InspectionListComponent,
   tags: ['autodocs'],
 };

--- a/web/src/app/dialogs/style-override/components/style-override-layout.component.stories.ts
+++ b/web/src/app/dialogs/style-override/components/style-override-layout.component.stories.ts
@@ -19,7 +19,7 @@ import { StyleOverrideLayoutComponent } from 'src/app/dialogs/style-override/com
 import { RevisionStateStyle } from 'src/app/store/domain/style';
 
 const meta: Meta<StyleOverrideLayoutComponent> = {
-  title: 'Dialogs/StyleOverrideLayout',
+  title: 'Dialogs/StyleOverride/StyleOverrideLayout',
   component: StyleOverrideLayoutComponent,
   tags: ['autodocs'],
 };

--- a/web/src/app/log/components/log-view-log-line.stories.ts
+++ b/web/src/app/log/components/log-view-log-line.stories.ts
@@ -20,7 +20,7 @@ import { createMockInspectionData } from 'src/app/store/mock/inspection-data.moc
 import { InspectionData } from 'src/app/store/domain/inspection-data';
 
 const meta: Meta<LogViewLogLineComponent> = {
-  title: 'Log/LogViewLogLineComponent',
+  title: 'Log/LogViewLogLine',
   component: LogViewLogLineComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/log/components/type-severity.stories.ts
+++ b/web/src/app/log/components/type-severity.stories.ts
@@ -20,7 +20,7 @@ import { createMockInspectionData } from 'src/app/store/mock/inspection-data.moc
 import { InspectionData } from 'src/app/store/domain/inspection-data';
 
 const meta: Meta<TypeSeverityComponent> = {
-  title: 'Log/TypeSeverityComponent',
+  title: 'Log/TypeSeverity',
   component: TypeSeverityComponent,
   tags: ['autodocs'],
   args: {},

--- a/web/src/app/shared/components/icon-toggle-button/icon-toggle-button.stories.ts
+++ b/web/src/app/shared/components/icon-toggle-button/icon-toggle-button.stories.ts
@@ -18,7 +18,7 @@ import { Meta, StoryObj } from '@storybook/angular';
 import { IconToggleButtonComponent } from './icon-toggle-button.component';
 
 const meta: Meta<IconToggleButtonComponent> = {
-  title: 'Shared/Components/IconToggleButton',
+  title: 'Shared/IconToggleButton',
   component: IconToggleButtonComponent,
   tags: ['autodocs'],
   args: {

--- a/web/src/app/shared/components/search-bar/search-bar.stories.ts
+++ b/web/src/app/shared/components/search-bar/search-bar.stories.ts
@@ -18,7 +18,7 @@ import { Meta, StoryObj } from '@storybook/angular';
 import { SearchBarComponent } from 'src/app/shared/components/search-bar/search-bar.component';
 
 export default {
-  title: 'shared/SearchBar',
+  title: 'Shared/SearchBar',
   component: SearchBarComponent,
 } as Meta<SearchBarComponent>;
 

--- a/web/src/app/shared/components/set-input/set-input.stories.ts
+++ b/web/src/app/shared/components/set-input/set-input.stories.ts
@@ -18,7 +18,7 @@ import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
 import { SetInputComponent, SetInputItem } from './set-input.component';
 
 const meta: Meta<SetInputComponent> = {
-  title: 'Shared/Components/SetInput',
+  title: 'Shared/SetInput',
   component: SetInputComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.stories.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.stories.ts
@@ -74,7 +74,7 @@ status:
       lastTransitionTime: "2026-06-29T11:15:00Z"`;
 
 const meta: Meta<YamlViewerComponent> = {
-  title: 'Shared/Components/YamlViewer',
+  title: 'Shared/YamlViewer',
   component: YamlViewerComponent,
   tags: ['autodocs'],
   argTypes: {

--- a/web/src/app/timeline-toolbar/components/cel-guide-log-cel.stories.ts
+++ b/web/src/app/timeline-toolbar/components/cel-guide-log-cel.stories.ts
@@ -20,7 +20,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CelGuideLogCelComponent } from 'src/app/timeline-toolbar/components/cel-guide-log-cel.component';
 
 const meta: Meta<CelGuideLogCelComponent> = {
-  title: 'Timeline/Components/CelGuideLogCel',
+  title: 'Timeline/Toolbar/CelGuideLogCel',
   component: CelGuideLogCelComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline-toolbar/components/cel-guide-overview.stories.ts
+++ b/web/src/app/timeline-toolbar/components/cel-guide-overview.stories.ts
@@ -20,7 +20,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CelGuideOverviewComponent } from 'src/app/timeline-toolbar/components/cel-guide-overview.component';
 
 const meta: Meta<CelGuideOverviewComponent> = {
-  title: 'Timeline/Components/CelGuideOverview',
+  title: 'Timeline/Toolbar/CelGuideOverview',
   component: CelGuideOverviewComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline-toolbar/components/cel-guide-popup.stories.ts
+++ b/web/src/app/timeline-toolbar/components/cel-guide-popup.stories.ts
@@ -24,7 +24,7 @@ import {
 } from 'src/app/timeline-toolbar/components/cel-guide-popup.component';
 
 const meta: Meta<CelGuidePopupComponent> = {
-  title: 'Timeline/Components/CelGuidePopup',
+  title: 'Timeline/Toolbar/CelGuidePopup',
   component: CelGuidePopupComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline-toolbar/components/cel-guide-timeline-cel.stories.ts
+++ b/web/src/app/timeline-toolbar/components/cel-guide-timeline-cel.stories.ts
@@ -20,7 +20,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CelGuideTimelineCelComponent } from 'src/app/timeline-toolbar/components/cel-guide-timeline-cel.component';
 
 const meta: Meta<CelGuideTimelineCelComponent> = {
-  title: 'Timeline/Components/CelGuideTimelineCel',
+  title: 'Timeline/Toolbar/CelGuideTimelineCel',
   component: CelGuideTimelineCelComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline-toolbar/components/cel-input.stories.ts
+++ b/web/src/app/timeline-toolbar/components/cel-input.stories.ts
@@ -20,7 +20,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CelInputComponent } from 'src/app/timeline-toolbar/components/cel-input.component';
 
 const meta: Meta<CelInputComponent> = {
-  title: 'Timeline/Components/CelInput',
+  title: 'Timeline/Toolbar/CelInput',
   component: CelInputComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline-toolbar/components/timeline-filter-builder.stories.ts
+++ b/web/src/app/timeline-toolbar/components/timeline-filter-builder.stories.ts
@@ -55,7 +55,7 @@ const MOCK_TIMELINE_TYPES: TimelineType[] = [
 ];
 
 const meta: Meta<TimelineFilterBuilderComponent> = {
-  title: 'Timeline/Components/TimelineFilterBuilder',
+  title: 'Timeline/Toolbar/TimelineFilterBuilder',
   component: TimelineFilterBuilderComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.stories.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.stories.ts
@@ -20,7 +20,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ToolbarAdvancedComponent } from 'src/app/timeline-toolbar/components/toolbar-advanced.component';
 
 const meta: Meta<ToolbarAdvancedComponent> = {
-  title: 'Timeline/Components/ToolbarAdvanced',
+  title: 'Timeline/Toolbar/ToolbarAdvanced',
   component: ToolbarAdvancedComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline-toolbar/components/toolbar-settings.stories.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-settings.stories.ts
@@ -20,7 +20,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ToolbarSettingsComponent } from 'src/app/timeline-toolbar/components/toolbar-settings.component';
 
 const meta: Meta<ToolbarSettingsComponent> = {
-  title: 'Timeline/Components/ToolbarSettings',
+  title: 'Timeline/Toolbar/ToolbarSettings',
   component: ToolbarSettingsComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline/components/markdown-popup.stories.ts
+++ b/web/src/app/timeline/components/markdown-popup.stories.ts
@@ -18,7 +18,7 @@ import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { MarkdownPopupComponent } from 'src/app/timeline/components/markdown-popup.component';
 
 export default {
-  title: 'Timeline/MarkdownPopup',
+  title: 'Timeline/Main/MarkdownPopup',
   component: MarkdownPopupComponent,
   decorators: [
     moduleMetadata({

--- a/web/src/app/timeline/components/timeline-chart.stories.ts
+++ b/web/src/app/timeline/components/timeline-chart.stories.ts
@@ -157,7 +157,7 @@ class TimelineChartStoriesComponent {
 }
 
 const meta: Meta<TimelineChartStoriesComponent> = {
-  title: 'Timeline/TimelineChart',
+  title: 'Timeline/Main/TimelineChart',
   component: TimelineChartStoriesComponent,
   tags: ['autodocs'],
   decorators: [

--- a/web/src/app/timeline/components/timeline-corner-indicator.stories.ts
+++ b/web/src/app/timeline/components/timeline-corner-indicator.stories.ts
@@ -18,7 +18,7 @@ import { componentWrapperDecorator, Meta, StoryObj } from '@storybook/angular';
 import { TimelineCornerIndicatorComponent } from './timeline-corner-indicator.component';
 
 const meta: Meta<TimelineCornerIndicatorComponent> = {
-  title: 'Timeline/CornerIndicator',
+  title: 'Timeline/Main/TimelineCornerIndicator',
   component: TimelineCornerIndicatorComponent,
   tags: ['autodocs'],
   parameters: {

--- a/web/src/app/timeline/components/timeline-frame.component.stories.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.stories.ts
@@ -304,7 +304,7 @@ class TimelineFrameStoriesComponent {
 }
 
 const meta: Meta<TimelineFrameStoriesComponent> = {
-  title: 'Timeline/Frame',
+  title: 'Timeline/Main/TimelineFrame',
   component: TimelineFrameStoriesComponent,
   tags: ['autodocs'],
   parameters: {

--- a/web/src/app/timeline/components/timeline-hover-overlay.stories.ts
+++ b/web/src/app/timeline/components/timeline-hover-overlay.stories.ts
@@ -26,7 +26,7 @@ import { Timeline, Revision, Event } from 'src/app/store/domain/timeline';
 import { Log } from 'src/app/store/domain/log';
 
 const meta: Meta<TimelineHoverOverlayComponent> = {
-  title: 'Timeline/Hover Overlay',
+  title: 'Timeline/Main/TimelineHoverOverlay',
   component: TimelineHoverOverlayComponent,
   tags: ['autodocs'],
 };

--- a/web/src/app/timeline/components/timeline-index.stories.ts
+++ b/web/src/app/timeline/components/timeline-index.stories.ts
@@ -25,7 +25,7 @@ import { LogStore } from 'src/app/store/domain/log-store';
 import { Timeline } from 'src/app/store/domain/timeline';
 
 const meta: Meta<TimelineIndexComponent> = {
-  title: 'Timeline/Index',
+  title: 'Timeline/Main/TimelineIndex',
   component: TimelineIndexComponent,
   tags: ['autodocs'],
   parameters: {

--- a/web/src/app/timeline/components/timeline-legend.stories.ts
+++ b/web/src/app/timeline/components/timeline-legend.stories.ts
@@ -24,7 +24,7 @@ import { LogStore } from 'src/app/store/domain/log-store';
 import { RevisionStateStyle } from 'src/app/store/domain/style';
 
 const meta: Meta<TimelineLegendComponent> = {
-  title: 'Timeline/Legend',
+  title: 'Timeline/Main/TimelineLegend',
   component: TimelineLegendComponent,
   tags: ['autodocs'],
   args: {

--- a/web/src/app/timeline/components/timeline-ruler.stories.ts
+++ b/web/src/app/timeline/components/timeline-ruler.stories.ts
@@ -104,7 +104,7 @@ sharedStyleStore.addLogTypes([
 ]);
 
 const meta: Meta<TimelineRulerComponent> = {
-  title: 'Timeline/TimelineRuler',
+  title: 'Timeline/Main/TimelineRuler',
   component: TimelineRulerComponent,
   tags: ['autodocs'],
   decorators: [


### PR DESCRIPTION
## Overview
This PR standardizes and reorganizes the Storybook folder hierarchy (defined by the `title` property in `*.stories.ts` files) to improve the navigability and consistency of our UI components. 

Additionally, it introduces an AI guideline rule so that autonomous agents can consistently apply this structure in the future.

## What's Changed
* **Defined a new hierarchy rule**: Established a maximum 3-level folder structure: `[Feature Area] / [Sub Area (if applicable)] / [Component Name]`.
* **Refactored existing stories**: 
  * Removed redundant intermediate folders like `Components` (e.g., `Shared/Components/...` -> `Shared/...`).
  * Grouped related components into semantic sub-areas (e.g., `Timeline/Main`, `Timeline/Toolbar`, `Dialogs/Startup`, `Dialogs/Progress`).
  * Enforced PascalCase naming conventions and removed the `Component` suffix from component names.
* **Added AI Guidelines**: Created `.agents/rules/storybook-guideline.md` to instruct AI assistants on how to assign Storybook titles moving forward.
* **Formatting**: Ran `make format-web` and `make format-md` to ensure code style compliance.

## Why
Previously, the Storybook titles suffered from inconsistent casing, varying depths, and ad-hoc naming conventions. This unification makes it much easier for developers to find components in the Storybook UI and ensures a scalable structure as the project grows.
