### PR TITLE
showing tooltip based on managedField metadata

### DIFF
--- a/web/src/app/diff/components/diff-content.component.html
+++ b/web/src/app/diff/components/diff-content.component.html
@@ -48,6 +48,7 @@ limitations under the License.
         [searchQuery]="searchQuery()"
         [activeMatchIndex]="currentMatchIndex()"
         [activeDiffIndex]="currentDiffIndex()"
+        [annotationProviders]="annotationProviders()"
         (matchCount)="matchCount.set($event)"
         (diffCount)="diffCount.set($event)"
       ></khi-yaml-viewer>

--- a/web/src/app/diff/components/diff-content.component.ts
+++ b/web/src/app/diff/components/diff-content.component.ts
@@ -16,6 +16,7 @@
 
 import {
   Component,
+  computed,
   effect,
   HostListener,
   inject,
@@ -35,6 +36,8 @@ import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { SearchBarComponent } from 'src/app/shared/components/search-bar/search-bar.component';
 import { SearchScope } from 'src/app/services/view-state.service';
 import { YamlViewerComponent } from 'src/app/shared/components/yaml-viewer/yaml-viewer.component';
+import { ManagedFieldsAnnotationProvider } from 'src/app/shared/components/yaml-viewer/managed-fields-annotation.provider';
+import * as yaml from 'js-yaml';
 
 /**
  * Component for displaying the unified diff of a resource revision.
@@ -122,6 +125,49 @@ export class DiffContentComponent {
    * Signal holding the 1-based index of the active diff block.
    */
   public readonly currentDiffIndex = signal(0);
+
+  /**
+   * The timezone shift in hours from UTC.
+   */
+  readonly timezoneShift = input.required<number>();
+
+  /**
+   * Providers for YAML annotations like tooltips.
+   */
+  public readonly annotationProviders = computed(() => {
+    // If showManagedFields is true, the YAML viewer's parsed yaml will contain metadata.managedFields,
+    // so the provider can extract it naturally.
+    if (this.showManagedFields()) {
+      return [new ManagedFieldsAnnotationProvider(this.timezoneShift())];
+    }
+
+    // If showManagedFields is false, the managedFields are stripped from the displayed YAML.
+    // To still show tooltips on other fields, we extract the managedFields from the original unstripped YAML
+    // and provide them explicitly to the provider.
+    const revision = this.currentRevision();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let overrideFields: any[] | undefined = undefined;
+
+    if (revision && revision.bodyYAML) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const yamlData = yaml.load(revision.bodyYAML) as any;
+        if (
+          yamlData &&
+          yamlData['metadata'] &&
+          yamlData['metadata']['managedFields']
+        ) {
+          overrideFields = yamlData['metadata']['managedFields'];
+        }
+      } catch (e) {
+        console.warn('Failed to parse original YAML for managedFields:', e);
+      }
+    }
+
+    return [
+      new ManagedFieldsAnnotationProvider(this.timezoneShift(), overrideFields),
+    ];
+  });
 
   /**
    * Initializes the component.

--- a/web/src/app/diff/components/diff-content.stories.ts
+++ b/web/src/app/diff/components/diff-content.stories.ts
@@ -86,6 +86,7 @@ const meta: Meta<DiffContentComponent> = {
     currentRevision: mockCurrentRevision,
     currentRevisionContent: currentContent,
     previousRevisionContent: previousContent,
+    timezoneShift: 9,
     showManagedFields: false,
   },
 };
@@ -104,6 +105,7 @@ export const Default: Story = {
           [currentRevision]="currentRevision"
           [currentRevisionContent]="currentRevisionContent"
           [previousRevisionContent]="previousRevisionContent"
+          [timezoneShift]="timezoneShift"
           [(showManagedFields)]="showManagedFields"
           (openInNewTab)="openInNewTab($event)"></khi-diff-content>
       </div>

--- a/web/src/app/diff/diff-smart.component.html
+++ b/web/src/app/diff/diff-smart.component.html
@@ -40,6 +40,7 @@ limitations under the License.
           [currentRevision]="currentRevision()"
           [currentRevisionContent]="currentRevisionContent()"
           [previousRevisionContent]="previousRevisionContent()"
+          [timezoneShift]="timezoneShift()"
           [(showManagedFields)]="showManagedFields"
           (openInNewTab)="openDiffInAnotherWindow()"
           (scopeActiveChange)="onScopeActiveChange($event)"

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.html
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.html
@@ -1,3 +1,19 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 <div class="tooltip-header">
   <mat-icon>history</mat-icon>
   <span>Managed by:</span>

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.html
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.html
@@ -1,0 +1,11 @@
+<div class="tooltip-header">
+  <mat-icon>history</mat-icon>
+  <span>Managed by:</span>
+</div>
+<div class="tooltip-body">
+  <div><strong>Manager:</strong> {{ manager() }}</div>
+  <div>
+    <strong>Time:</strong>
+    {{ timeMs() | date: "yyyy-MM-dd HH:mm:ss" : timezoneString() }}
+  </div>
+</div>

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.scss
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.scss
@@ -1,0 +1,40 @@
+@use '@angular/material' as mat;
+@use '../../../../common.scss' as common;
+$tooltip-bg: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 700);
+$tooltip-text: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 50);
+
+:host {
+  display: inline-block;
+  width: max-content;
+  background-color: $tooltip-bg;
+  color: $tooltip-text;
+  padding: 8px 12px;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+  max-width: 250px;
+}
+
+.tooltip-header {
+  display: grid;
+  align-items: center;
+  gap: 4px;
+  grid-template:
+    'icon text' 1fr
+    / auto 1fr;
+  margin-bottom: 4px;
+
+  mat-icon {
+    grid-area: icon;
+    @include common.adjust-mat-icon-size(12px);
+  }
+
+  span {
+    grid-area: text;
+    font-size: 8px;
+  }
+}
+
+.tooltip-body {
+  font-size: 12px;
+}

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.scss
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use '@angular/material' as mat;
 @use '../../../../common.scss' as common;
 $tooltip-bg: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 700);
@@ -12,7 +28,8 @@ $tooltip-text: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 50);
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   pointer-events: none;
-  max-width: 250px;
+  max-width: 320px;
+  overflow-wrap: break-word;
 }
 
 .tooltip-header {

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.spec.ts
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ManagedFieldTooltipComponent } from './managed-field-tooltip.component';
+
+describe('ManagedFieldTooltipComponent', () => {
+  let component: ManagedFieldTooltipComponent;
+  let fixture: ComponentFixture<ManagedFieldTooltipComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ManagedFieldTooltipComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ManagedFieldTooltipComponent);
+    component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('manager', 'test-manager');
+    fixture.componentRef.setInput('time', 1609459200000000000n);
+    fixture.componentRef.setInput('timezoneShift', 9);
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.spec.ts
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.spec.ts
@@ -1,6 +1,22 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ManagedFieldTooltipComponent } from './managed-field-tooltip.component';
+import { ManagedFieldTooltipComponent } from 'src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component';
 
 describe('ManagedFieldTooltipComponent', () => {
   let component: ManagedFieldTooltipComponent;

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.ts
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { DatePipe } from '@angular/common';
 import { Component, computed, input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
@@ -45,7 +61,7 @@ export class ManagedFieldTooltipComponent {
     const sign = numShift >= 0 ? '+' : '-';
     const absShift = Math.abs(numShift);
     const hours = Math.floor(absShift).toString().padStart(2, '0');
-    const minutes = Math.floor((absShift % 1) * 60)
+    const minutes = Math.round((absShift % 1) * 60)
       .toString()
       .padStart(2, '0');
     return `${sign}${hours}${minutes}`;

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.ts
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component.ts
@@ -1,0 +1,53 @@
+import { DatePipe } from '@angular/common';
+import { Component, computed, input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+
+/**
+ * Displays detailed information about a managed field in a custom tooltip.
+ */
+@Component({
+  selector: 'khi-managed-field-tooltip',
+  standalone: true,
+  imports: [DatePipe, MatIconModule, KHIIconRegistrationModule],
+  templateUrl: './managed-field-tooltip.component.html',
+  styleUrl: './managed-field-tooltip.component.scss',
+})
+export class ManagedFieldTooltipComponent {
+  /** Receives the manager name from the annotation provider. */
+  readonly manager = input.required<string>();
+
+  /** Receives the timestamp from the annotation provider in nanoseconds. */
+  readonly time = input.required<bigint>();
+
+  /** The timezone shift in hours from UTC. */
+  readonly timezoneShift = input.required<number>();
+
+  /** The time converted to milliseconds for formatting. */
+  protected readonly timeMs = computed(() => {
+    const t = this.time();
+    if (t === undefined || t === null) return 0;
+    try {
+      return Number(BigInt(t) / 1000000n);
+    } catch {
+      return 0;
+    }
+  });
+
+  /** Converts the timezoneShift into a string format required by DatePipe (e.g. +0900). */
+  protected readonly timezoneString = computed(() => {
+    const shift = this.timezoneShift();
+    if (shift === undefined || shift === null) return '+0000';
+    const numShift = Number(shift);
+    if (isNaN(numShift)) return '+0000';
+
+    const sign = numShift >= 0 ? '+' : '-';
+    const absShift = Math.abs(numShift);
+    const hours = Math.floor(absShift).toString().padStart(2, '0');
+    const minutes = Math.floor((absShift % 1) * 60)
+      .toString()
+      .padStart(2, '0');
+    return `${sign}${hours}${minutes}`;
+  });
+}

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.stories.ts
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.stories.ts
@@ -1,6 +1,22 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
 
-import { ManagedFieldTooltipComponent } from './managed-field-tooltip.component';
+import { ManagedFieldTooltipComponent } from 'src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component';
 
 const meta: Meta<ManagedFieldTooltipComponent> = {
   title: 'Shared/YamlViewer/ManagedFieldTooltip',

--- a/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.stories.ts
+++ b/web/src/app/shared/components/yaml-viewer/components/managed-field-tooltip.stories.ts
@@ -1,0 +1,27 @@
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+
+import { ManagedFieldTooltipComponent } from './managed-field-tooltip.component';
+
+const meta: Meta<ManagedFieldTooltipComponent> = {
+  title: 'Shared/YamlViewer/ManagedFieldTooltip',
+  component: ManagedFieldTooltipComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [ManagedFieldTooltipComponent],
+    }),
+  ],
+  argTypes: {
+    manager: { control: 'text' },
+    timezoneShift: { control: 'number' },
+  },
+};
+export default meta;
+type Story = StoryObj<ManagedFieldTooltipComponent>;
+
+export const Default: Story = {
+  args: {
+    manager: 'kubectl-client-side-apply',
+    time: 1696939200000000000n, // 2023-10-10T12:00:00Z in ns
+    timezoneShift: 9,
+  },
+};

--- a/web/src/app/shared/components/yaml-viewer/diff-renderer.ts
+++ b/web/src/app/shared/components/yaml-viewer/diff-renderer.ts
@@ -25,6 +25,7 @@ import {
   getValueType,
   shouldHighlightEntireValue,
 } from 'src/app/shared/components/yaml-viewer/diff-util';
+import { YamlFieldAnnotation } from 'src/app/shared/components/yaml-viewer/yaml-annotation';
 
 /**
  * Represents a single rendered line of the YAML document.
@@ -46,8 +47,8 @@ export interface YamlLine {
   diffStatus: DiffStatus;
   /** The full JSON path of this property (e.g., "metadata.name"). */
   path: string;
-  /** Optional tooltip message to display on hover. */
-  tooltip?: string;
+  /** Optional annotation to display on hover (e.g., custom tooltip component). */
+  annotation?: YamlFieldAnnotation;
   /** For moved items, the original path or index before the move. */
   movedFrom?: string;
   /** For moved items, the destination path or index after the move. */

--- a/web/src/app/shared/components/yaml-viewer/dynamic-tooltip.directive.ts
+++ b/web/src/app/shared/components/yaml-viewer/dynamic-tooltip.directive.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   Directive,
   ElementRef,

--- a/web/src/app/shared/components/yaml-viewer/dynamic-tooltip.directive.ts
+++ b/web/src/app/shared/components/yaml-viewer/dynamic-tooltip.directive.ts
@@ -1,0 +1,91 @@
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  inject,
+  input,
+  ComponentRef,
+  OnDestroy,
+} from '@angular/core';
+import {
+  Overlay,
+  OverlayRef,
+  OverlayPositionBuilder,
+} from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { YamlFieldAnnotation } from 'src/app/shared/components/yaml-viewer/yaml-annotation';
+
+/**
+ * A directive to display a dynamic component as a tooltip.
+ */
+@Directive({
+  selector: '[khiDynamicTooltip]',
+})
+export class DynamicTooltipDirective implements OnDestroy {
+  /** The annotation definition containing the component to render and its inputs. */
+  readonly khiDynamicTooltip = input<YamlFieldAnnotation | undefined>();
+
+  private _overlayRef: OverlayRef | null = null;
+  private readonly _overlay = inject(Overlay);
+  private readonly _overlayPositionBuilder = inject(OverlayPositionBuilder);
+  private readonly _elementRef = inject(ElementRef);
+
+  @HostListener('mouseenter')
+  show() {
+    const annotation = this.khiDynamicTooltip();
+    if (!annotation) {
+      return;
+    }
+
+    if (this._overlayRef) {
+      return; // Already open
+    }
+
+    const positionStrategy = this._overlayPositionBuilder
+      .flexibleConnectedTo(this._elementRef.nativeElement)
+      .withFlexibleDimensions(false)
+      .withViewportMargin(8)
+      .withPositions([
+        {
+          originX: 'start',
+          originY: 'center',
+          overlayX: 'end',
+          overlayY: 'center',
+          offsetX: -20,
+        },
+      ]);
+
+    this._overlayRef = this._overlay.create({
+      positionStrategy,
+      scrollStrategy: this._overlay.scrollStrategies.close(),
+    });
+
+    const portal = new ComponentPortal(annotation.component);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const componentRef: ComponentRef<any> = this._overlayRef.attach(portal);
+
+    if (annotation.inputs) {
+      for (const [key, value] of Object.entries(annotation.inputs)) {
+        componentRef.setInput(key, value);
+      }
+    }
+
+    // Force change detection so that the component renders its content and acquires actual dimensions.
+    // This is required before updating the position, otherwise the overlay is positioned assuming 0x0 size.
+    componentRef.changeDetectorRef.detectChanges();
+    this._overlayRef.updatePosition();
+  }
+
+  @HostListener('mouseleave')
+  hide() {
+    if (this._overlayRef) {
+      this._overlayRef.detach();
+      this._overlayRef.dispose();
+      this._overlayRef = null;
+    }
+  }
+
+  ngOnDestroy() {
+    this.hide();
+  }
+}

--- a/web/src/app/shared/components/yaml-viewer/managed-fields-annotation.provider.spec.ts
+++ b/web/src/app/shared/components/yaml-viewer/managed-fields-annotation.provider.spec.ts
@@ -1,0 +1,293 @@
+import { ManagedFieldsAnnotationProvider } from 'src/app/shared/components/yaml-viewer/managed-fields-annotation.provider';
+import { ManagedFieldTooltipComponent } from 'src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component';
+
+describe('ManagedFieldsAnnotationProvider', () => {
+  let provider: ManagedFieldsAnnotationProvider;
+  const TIME_STRING = '2026-07-07T12:00:00Z';
+  const TIME_NS = BigInt(new Date(TIME_STRING).getTime()) * 1000000n;
+  const TIMEZONE_SHIFT = 9;
+
+  beforeEach(() => {
+    provider = new ManagedFieldsAnnotationProvider(TIMEZONE_SHIFT);
+  });
+
+  it('should extract paths for f: prefixes correctly', () => {
+    const parsedYaml = {
+      metadata: {
+        name: 'test',
+        managedFields: [
+          {
+            manager: 'test-manager',
+            time: TIME_NS,
+            operation: 'Update',
+            fieldsV1: {
+              'f:metadata': {
+                'f:name': {},
+              },
+              'f:spec': {
+                'f:replicas': {},
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const result = provider.getAnnotations(parsedYaml);
+
+    expect(result).toEqual([
+      {
+        path: ['metadata', 'name'],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+      {
+        path: ['spec', 'replicas'],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+    ]);
+  });
+
+  it('should extract paths for . prefixes correctly', () => {
+    const parsedYaml = {
+      metadata: {
+        labels: {
+          app: 'test',
+        },
+        managedFields: [
+          {
+            manager: 'test-manager',
+            time: TIME_NS,
+            operation: 'Update',
+            fieldsV1: {
+              'f:metadata': {
+                'f:labels': {
+                  '.': {},
+                  'f:app': {},
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const result = provider.getAnnotations(parsedYaml);
+
+    expect(result).toEqual([
+      {
+        path: ['metadata', 'labels'],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+      {
+        path: ['metadata', 'labels', 'app'],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+    ]);
+  });
+
+  it('should extract paths for k: prefixes (map list) correctly', () => {
+    const parsedYaml = {
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'True' },
+          { type: 'NetworkUnavailable', status: 'False' },
+        ],
+      },
+      metadata: {
+        managedFields: [
+          {
+            manager: 'test-manager',
+            time: TIME_NS,
+            operation: 'Update',
+            fieldsV1: {
+              'f:status': {
+                'f:conditions': {
+                  'k:{"type":"NetworkUnavailable"}': {
+                    '.': {},
+                    'f:status': {},
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const result = provider.getAnnotations(parsedYaml);
+
+    expect(result).toEqual([
+      {
+        path: ['status', 'conditions', 1],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+      {
+        path: ['status', 'conditions', 1, 'status'],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+    ]);
+  });
+
+  it('should extract paths for v: prefixes (set list) correctly', () => {
+    const parsedYaml = {
+      spec: {
+        podCIDRs: ['10.0.0.0/24', '10.160.2.0/24'],
+      },
+      metadata: {
+        managedFields: [
+          {
+            manager: 'test-manager',
+            time: TIME_NS,
+            operation: 'Update',
+            fieldsV1: {
+              'f:spec': {
+                'f:podCIDRs': {
+                  '.': {},
+                  'v:"10.160.2.0/24"': {},
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const result = provider.getAnnotations(parsedYaml);
+
+    expect(result).toEqual([
+      {
+        path: ['spec', 'podCIDRs'],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+      {
+        path: ['spec', 'podCIDRs', 1],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+    ]);
+  });
+
+  it('should use overrideManagedFields if provided and not read from parsedYaml', () => {
+    const providerWithOverride = new ManagedFieldsAnnotationProvider(
+      TIMEZONE_SHIFT,
+      [
+        {
+          manager: 'override-manager',
+          time: TIME_NS,
+          operation: 'Update',
+          fieldsV1: {
+            'f:spec': {
+              'f:replicas': {},
+            },
+          },
+        },
+      ],
+    );
+
+    const parsedYaml = {
+      metadata: {},
+      spec: {
+        replicas: 3,
+      },
+    };
+
+    const result = providerWithOverride.getAnnotations(parsedYaml);
+
+    expect(result).toEqual([
+      {
+        path: ['spec', 'replicas'],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'override-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+    ]);
+  });
+
+  it('should fallback to original string key if array element matching fails', () => {
+    // Providing k: index but the array is empty in actual YAML
+    const parsedYaml = {
+      status: {
+        conditions: [],
+      },
+      metadata: {
+        managedFields: [
+          {
+            manager: 'test-manager',
+            time: TIME_NS,
+            operation: 'Update',
+            fieldsV1: {
+              'f:status': {
+                'f:conditions': {
+                  'k:{"type":"NetworkUnavailable"}': {
+                    'f:status': {},
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const result = provider.getAnnotations(parsedYaml);
+
+    expect(result).toEqual([
+      {
+        path: [
+          'status',
+          'conditions',
+          'k:{"type":"NetworkUnavailable"}',
+          'status',
+        ],
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'test-manager',
+          time: TIME_NS,
+          timezoneShift: TIMEZONE_SHIFT,
+        },
+      },
+    ]);
+  });
+});

--- a/web/src/app/shared/components/yaml-viewer/managed-fields-annotation.provider.spec.ts
+++ b/web/src/app/shared/components/yaml-viewer/managed-fields-annotation.provider.spec.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ManagedFieldsAnnotationProvider } from 'src/app/shared/components/yaml-viewer/managed-fields-annotation.provider';
 import { ManagedFieldTooltipComponent } from 'src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component';
 

--- a/web/src/app/shared/components/yaml-viewer/managed-fields-annotation.provider.ts
+++ b/web/src/app/shared/components/yaml-viewer/managed-fields-annotation.provider.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   YamlAnnotationProvider,
   YamlFieldAnnotation,
@@ -60,7 +76,10 @@ export class ManagedFieldsAnnotationProvider implements YamlAnnotationProvider {
         if (timeVal instanceof Date) {
           timeNs = BigInt(timeVal.getTime()) * 1000000n;
         } else if (typeof timeVal === 'string' || typeof timeVal === 'number') {
-          timeNs = BigInt(new Date(timeVal).getTime()) * 1000000n;
+          const ms = new Date(timeVal).getTime();
+          if (!isNaN(ms)) {
+            timeNs = BigInt(ms) * 1000000n;
+          }
         } else if (typeof timeVal === 'bigint') {
           timeNs = timeVal;
         }
@@ -148,7 +167,7 @@ export class ManagedFieldsAnnotationProvider implements YamlAnnotationProvider {
           } else {
             fieldName = key;
           }
-        } catch (e) {
+        } catch {
           fieldName = key;
         }
       } else if (key.startsWith('v:')) {
@@ -167,7 +186,7 @@ export class ManagedFieldsAnnotationProvider implements YamlAnnotationProvider {
           } else {
             fieldName = key;
           }
-        } catch (e) {
+        } catch {
           fieldName = key;
         }
       }

--- a/web/src/app/shared/components/yaml-viewer/managed-fields-annotation.provider.ts
+++ b/web/src/app/shared/components/yaml-viewer/managed-fields-annotation.provider.ts
@@ -1,0 +1,205 @@
+import {
+  YamlAnnotationProvider,
+  YamlFieldAnnotation,
+} from 'src/app/shared/components/yaml-viewer/yaml-annotation';
+import { ManagedFieldTooltipComponent } from 'src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component';
+
+/**
+ * Represents the structure of an entry in Kubernetes metadata.managedFields.
+ */
+interface ManagedFieldEntry {
+  readonly manager: string;
+  readonly time: bigint;
+  readonly operation: string;
+  readonly fieldsV1?: Record<string, unknown>;
+}
+
+/**
+ * Provides tooltips indicating when and by whom each field was last edited.
+ *
+ * It parses the Kubernetes metadata.managedFields structure to map fields to their managers.
+ */
+export class ManagedFieldsAnnotationProvider implements YamlAnnotationProvider {
+  /**
+   * @param timezoneShift The timezone shift in hours from UTC to pass to tooltips.
+   * @param overrideManagedFields Optional explicit managedFields to use when parsedYaml does not contain them.
+   */
+  constructor(
+    private readonly timezoneShift: number,
+    private readonly overrideManagedFields?: ManagedFieldEntry[],
+  ) {}
+
+  /**
+   * Generates annotations by extracting paths from the fieldsV1 structure.
+   */
+  getAnnotations(parsedYaml: unknown): YamlFieldAnnotation[] {
+    const annotations: YamlFieldAnnotation[] = [];
+
+    if (typeof parsedYaml !== 'object' || parsedYaml === null) {
+      return annotations;
+    }
+
+    const yamlRecord = parsedYaml as Record<string, unknown>;
+    const metadata = yamlRecord['metadata'] as
+      | Record<string, unknown>
+      | undefined;
+
+    const managedFields =
+      this.overrideManagedFields ??
+      (metadata?.['managedFields'] as ManagedFieldEntry[] | undefined);
+
+    if (!Array.isArray(managedFields)) {
+      return annotations;
+    }
+
+    for (const entry of managedFields) {
+      if (entry.fieldsV1) {
+        // Convert the time field from string/Date to bigint (nanoseconds since epoch).
+        let timeNs = 0n;
+        const timeVal = entry.time as unknown;
+        if (timeVal instanceof Date) {
+          timeNs = BigInt(timeVal.getTime()) * 1000000n;
+        } else if (typeof timeVal === 'string' || typeof timeVal === 'number') {
+          timeNs = BigInt(new Date(timeVal).getTime()) * 1000000n;
+        } else if (typeof timeVal === 'bigint') {
+          timeNs = timeVal;
+        }
+
+        this.extractPaths(
+          entry.fieldsV1 as Record<string, unknown>,
+          parsedYaml,
+          [],
+          entry.manager,
+          timeNs,
+          annotations,
+        );
+      }
+    }
+
+    return annotations;
+  }
+
+  /**
+   * Traverses the fieldsV1 structure recursively to build JSON paths.
+   *
+   * Kubernetes uses prefixes like 'f:' to denote fields. This method strips those
+   * prefixes to generate standard paths that match the actual YAML document.
+   * For 'k:' (map list keys) and 'v:' (set values), it resolves the matching index
+   * against the actual YAML document.
+   */
+  private extractPaths(
+    current: Record<string, unknown>,
+    currentYamlData: unknown,
+    currentPath: readonly (string | number)[],
+    manager: string,
+    time: bigint,
+    annotations: YamlFieldAnnotation[],
+  ): void {
+    if (typeof current !== 'object' || current === null) {
+      return;
+    }
+
+    for (const key of Object.keys(current)) {
+      if (key === '.') {
+        // The '.' key indicates that the current object itself is managed.
+        // We push an annotation for the currentPath.
+        annotations.push({
+          path: currentPath,
+          component: ManagedFieldTooltipComponent,
+          inputs: {
+            manager: manager,
+            time: time,
+            timezoneShift: this.timezoneShift,
+          },
+        });
+        continue;
+      }
+
+      let fieldName: string | number = key;
+      let nextYamlData: unknown = undefined;
+
+      if (key.startsWith('f:')) {
+        fieldName = key.substring(2);
+        nextYamlData = (currentYamlData as Record<string, unknown>)?.[
+          fieldName
+        ];
+      } else if (key.startsWith('k:')) {
+        try {
+          const matchKeys = JSON.parse(key.substring(2)) as Record<
+            string,
+            unknown
+          >;
+          if (Array.isArray(currentYamlData)) {
+            const index = currentYamlData.findIndex((item) => {
+              if (typeof item !== 'object' || item === null) return false;
+              for (const [mKey, mVal] of Object.entries(matchKeys)) {
+                if ((item as Record<string, unknown>)[mKey] !== mVal) {
+                  return false;
+                }
+              }
+              return true;
+            });
+            if (index !== -1) {
+              fieldName = index;
+              nextYamlData = currentYamlData[index];
+            } else {
+              fieldName = key;
+            }
+          } else {
+            fieldName = key;
+          }
+        } catch (e) {
+          fieldName = key;
+        }
+      } else if (key.startsWith('v:')) {
+        try {
+          const matchVal = JSON.parse(key.substring(2));
+          if (Array.isArray(currentYamlData)) {
+            const index = currentYamlData.findIndex(
+              (item) => item === matchVal,
+            );
+            if (index !== -1) {
+              fieldName = index;
+              nextYamlData = currentYamlData[index];
+            } else {
+              fieldName = key;
+            }
+          } else {
+            fieldName = key;
+          }
+        } catch (e) {
+          fieldName = key;
+        }
+      }
+
+      const newPath = [...currentPath, fieldName];
+      const childObject = current[key] as Record<string, unknown>;
+
+      const hasChildren =
+        childObject &&
+        typeof childObject === 'object' &&
+        Object.keys(childObject).some((k) => k !== '.');
+
+      if (!hasChildren) {
+        annotations.push({
+          path: newPath,
+          component: ManagedFieldTooltipComponent,
+          inputs: {
+            manager: manager,
+            time: time,
+            timezoneShift: this.timezoneShift,
+          },
+        });
+      } else {
+        this.extractPaths(
+          childObject,
+          nextYamlData,
+          newPath,
+          manager,
+          time,
+          annotations,
+        );
+      }
+    }
+  }
+}

--- a/web/src/app/shared/components/yaml-viewer/yaml-annotation.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-annotation.ts
@@ -1,0 +1,27 @@
+import { Type } from '@angular/core';
+
+/**
+ * Represents a visual annotation attached to a specific YAML path.
+ *
+ * This architecture guarantees that a dynamic component is always rendered.
+ */
+export interface YamlFieldAnnotation {
+  /** Defines the exact location in the YAML structure (e.g., ['metadata', 'labels', 'app']). */
+  readonly path: readonly (string | number)[];
+
+  /** Specifies the component class to render dynamically in the tooltip. */
+  readonly component: Type<unknown>;
+
+  /** Provides the data to bind to the dynamically instantiated component's inputs. */
+  readonly inputs?: Record<string, unknown>;
+}
+
+/**
+ * Defines the contract for providing field-level annotations to the YAML viewer.
+ */
+export interface YamlAnnotationProvider {
+  /**
+   * Generates a list of annotations based on the parsed YAML structure.
+   */
+  getAnnotations(parsedYaml: unknown): YamlFieldAnnotation[];
+}

--- a/web/src/app/shared/components/yaml-viewer/yaml-annotation.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-annotation.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Type } from '@angular/core';
 
 /**

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.html
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.html
@@ -116,9 +116,8 @@ limitations under the License.
               @if (seg.isKey) {
                 <span
                   class="yaml-key"
-                  [matTooltip]="line.tooltip || ''"
-                  [matTooltipDisabled]="!line.tooltip"
-                  [class.has-tooltip]="!!line.tooltip"
+                  [khiDynamicTooltip]="line.annotation"
+                  [class.has-tooltip]="!!line.annotation"
                 >
                   @if (seg.isMatch) {
                     <mark class="search-highlight">{{ seg.text }}</mark>
@@ -135,7 +134,12 @@ limitations under the License.
                   }
                 </span>
               } @else if (seg.isValue) {
-                <span class="yaml-value" [ngClass]="'yaml-' + line.valueType">
+                <span
+                  class="yaml-value"
+                  [ngClass]="'yaml-' + line.valueType"
+                  [khiDynamicTooltip]="line.annotation"
+                  [class.has-tooltip]="!!line.annotation"
+                >
                   <span
                     [class.diff-char-added]="
                       seg.diffStatus === DiffStatus.Added

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.scss
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.scss
@@ -55,7 +55,7 @@ $syntax-boolean-color: mat.m2-get-color-from-palette(
 $syntax-null-color: mat.m2-get-color-from-palette(mat.$m2-pink-palette, 800);
 $syntax-colon-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 700);
 
-$tooltip-border-color: mat.m2-get-color-from-palette(mat.$m2-blue-palette, 400);
+$tooltip-border-color: mat.m2-get-color-from-palette(mat.$m2-blue-palette, 100);
 
 $search-highlight-bg-color: mat.m2-get-color-from-palette(
   mat.$m2-yellow-palette,
@@ -69,6 +69,8 @@ $search-highlight-active-text-color: mat.m2-get-color-from-palette(
   mat.$m2-gray-palette,
   50
 );
+
+$tooltip-border-thickness: 0.5px;
 
 :host {
   display: block;
@@ -264,11 +266,10 @@ $moved-out-chip-text: mat.m2-get-color-from-palette(
 .yaml-key {
   color: $syntax-key-color;
   font-weight: bold;
-  display: contents;
   white-space: normal;
 
   &.has-tooltip {
-    border-bottom: 1px dashed $tooltip-border-color;
+    border-bottom: $tooltip-border-thickness dashed $tooltip-border-color;
     cursor: help;
   }
 
@@ -283,8 +284,12 @@ $moved-out-chip-text: mat.m2-get-color-from-palette(
 }
 
 .yaml-value {
-  display: contents;
   white-space: normal;
+
+  &.has-tooltip {
+    border-bottom: $tooltip-border-thickness dashed $tooltip-border-color;
+    cursor: help;
+  }
 
   &.yaml-string {
     color: $syntax-string-color;

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.spec.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.spec.ts
@@ -117,17 +117,29 @@ describe('YamlViewerComponent', () => {
     expect(nsLine?.lineNumber).toBe(3); // Line number 3: namespace
   });
 
-  it('should bind tooltips to specified JSON paths', () => {
+  it('should bind annotations to specified JSON paths', () => {
     fixture.componentRef.setInput('rightYaml', 'metadata:\n  name: my-pod');
-    fixture.componentRef.setInput('tooltips', {
-      'metadata.name': 'Specifies resource name',
-    });
+    
+    class FakeProvider {
+      getAnnotations() {
+        return [
+          {
+            path: ['metadata', 'name'],
+            component: {} as any,
+            inputs: { testData: 'Specifies resource name' },
+          }
+        ];
+      }
+    }
+    
+    fixture.componentRef.setInput('annotationProviders', [new FakeProvider()]);
     fixture.detectChanges();
 
     const lines = component.lines();
     const nameLine = lines.find((l) => l.key === 'name');
     expect(nameLine).toBeTruthy();
-    expect(nameLine?.tooltip).toBe('Specifies resource name');
+    expect(nameLine?.annotation).toBeTruthy();
+    expect(nameLine?.annotation?.inputs?.['testData']).toBe('Specifies resource name');
   });
 
   it('should split text into highlighted segments matching the query across key and value', () => {

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.spec.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.spec.ts
@@ -119,19 +119,20 @@ describe('YamlViewerComponent', () => {
 
   it('should bind annotations to specified JSON paths', () => {
     fixture.componentRef.setInput('rightYaml', 'metadata:\n  name: my-pod');
-    
+
     class FakeProvider {
       getAnnotations() {
         return [
           {
             path: ['metadata', 'name'],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             component: {} as any,
             inputs: { testData: 'Specifies resource name' },
-          }
+          },
         ];
       }
     }
-    
+
     fixture.componentRef.setInput('annotationProviders', [new FakeProvider()]);
     fixture.detectChanges();
 
@@ -139,7 +140,9 @@ describe('YamlViewerComponent', () => {
     const nameLine = lines.find((l) => l.key === 'name');
     expect(nameLine).toBeTruthy();
     expect(nameLine?.annotation).toBeTruthy();
-    expect(nameLine?.annotation?.inputs?.['testData']).toBe('Specifies resource name');
+    expect(nameLine?.annotation?.inputs?.['testData']).toBe(
+      'Specifies resource name',
+    );
   });
 
   it('should split text into highlighted segments matching the query across key and value', () => {

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.ts
@@ -28,7 +28,6 @@ import {
   OnDestroy,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import * as yaml from 'js-yaml';
 import * as jsondiffpatch from 'jsondiffpatch';
 import { DiffStatus } from 'src/app/shared/components/yaml-viewer/lcs';
@@ -45,6 +44,11 @@ import {
   postRender,
   getRenderSegments as diffGetRenderSegments,
 } from 'src/app/shared/components/yaml-viewer/diff-renderer';
+import {
+  YamlAnnotationProvider,
+  YamlFieldAnnotation,
+} from 'src/app/shared/components/yaml-viewer/yaml-annotation';
+import { DynamicTooltipDirective } from 'src/app/shared/components/yaml-viewer/dynamic-tooltip.directive';
 
 /**
  * Component for displaying YAML content with preview and diff capabilities.
@@ -54,7 +58,7 @@ import {
   selector: 'khi-yaml-viewer',
   templateUrl: './yaml-viewer.component.html',
   styleUrls: ['./yaml-viewer.component.scss'],
-  imports: [CommonModule, MatTooltipModule],
+  imports: [CommonModule, DynamicTooltipDirective],
 })
 export class YamlViewerComponent implements AfterViewInit, OnDestroy {
   protected readonly DiffStatus = DiffStatus;
@@ -94,10 +98,9 @@ export class YamlViewerComponent implements AfterViewInit, OnDestroy {
   readonly rightYaml = input.required<string>();
 
   /**
-   * Map of JSON paths to tooltip messages.
-   * e.g., { 'metadata.name': 'Unique name of this resource' }
+   * Providers to generate field-level annotations (like tooltips).
    */
-  readonly tooltips = input<{ [path: string]: string }>({});
+  readonly annotationProviders = input<YamlAnnotationProvider[]>([]);
 
   /**
    * Search query string. Occurrences of this query in the rendered YAML
@@ -128,7 +131,7 @@ export class YamlViewerComponent implements AfterViewInit, OnDestroy {
   readonly rawLines = computed<YamlLine[]>(() => {
     const leftRaw = this.leftYaml();
     const rightRaw = this.rightYaml();
-    const tooltipsMap = this.tooltips();
+    const providers = this.annotationProviders();
 
     let leftObj: unknown = null;
     let rightObj: unknown = null;
@@ -184,12 +187,32 @@ export class YamlViewerComponent implements AfterViewInit, OnDestroy {
     renderNode(mergeTree, 0, false, flatLines);
     postRender(flatLines);
 
-    // Apply tooltips and line numbers
+    // Apply annotations and line numbers
     let currentLineNumber = 1;
+
+    // Compute annotations from rightObj.
+    const annotationMap = new Map<string, YamlFieldAnnotation>();
+    for (const provider of providers) {
+      if (rightObj) {
+        for (const ann of provider.getAnnotations(rightObj)) {
+          // Join the path array to match diff-util's string format (e.g. "metadata.name")
+          const pathStr = ann.path
+            .map((p) =>
+              typeof p === 'number' ||
+              (typeof p === 'string' && p.startsWith('['))
+                ? `[${p}]`
+                : p,
+            )
+            .join('.');
+          annotationMap.set(pathStr, ann);
+        }
+      }
+    }
+
     return flatLines.map((line) => {
       const lineCopy = { ...line };
-      if (lineCopy.path && tooltipsMap[lineCopy.path]) {
-        lineCopy.tooltip = tooltipsMap[lineCopy.path];
+      if (lineCopy.path && annotationMap.has(lineCopy.path)) {
+        lineCopy.annotation = annotationMap.get(lineCopy.path);
       }
       if (
         lineCopy.diffStatus !== DiffStatus.Deleted &&

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.component.ts
@@ -196,14 +196,20 @@ export class YamlViewerComponent implements AfterViewInit, OnDestroy {
       if (rightObj) {
         for (const ann of provider.getAnnotations(rightObj)) {
           // Join the path array to match diff-util's string format (e.g. "metadata.name")
-          const pathStr = ann.path
-            .map((p) =>
-              typeof p === 'number' ||
-              (typeof p === 'string' && p.startsWith('['))
-                ? `[${p}]`
-                : p,
-            )
-            .join('.');
+          const pathStr = (() => {
+            let pStr = '';
+            for (const p of ann.path) {
+              if (
+                typeof p === 'number' ||
+                (typeof p === 'string' && p.startsWith('['))
+              ) {
+                pStr += `[${p}]`;
+              } else {
+                pStr = pStr ? `${pStr}.${p}` : String(p);
+              }
+            }
+            return pStr;
+          })();
           annotationMap.set(pathStr, ann);
         }
       }

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.stories.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.stories.ts
@@ -16,6 +16,28 @@
 
 import { Meta, StoryObj } from '@storybook/angular';
 import { YamlViewerComponent } from './yaml-viewer.component';
+import { YamlAnnotationProvider, YamlFieldAnnotation } from './yaml-annotation';
+import { ManagedFieldTooltipComponent } from 'src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component';
+
+class MockAnnotationProvider implements YamlAnnotationProvider {
+  constructor(private readonly tooltipMap: Record<string, string>) {}
+  getAnnotations(rightObj: any): YamlFieldAnnotation[] {
+    const annotations: YamlFieldAnnotation[] = [];
+    for (const [pathStr] of Object.entries(this.tooltipMap)) {
+      const path = pathStr.split('.');
+      annotations.push({
+        path: path,
+        component: ManagedFieldTooltipComponent,
+        inputs: {
+          manager: 'mock-manager',
+          operation: 'Update',
+          time: '2026-06-29T11:00:00Z',
+        },
+      });
+    }
+    return annotations;
+  }
+}
 
 const leftYamlMock = `apiVersion: v1
 kind: Pod
@@ -94,7 +116,7 @@ const meta: Meta<YamlViewerComponent> = {
   args: {
     leftYaml: null,
     rightYaml: rightYamlMock,
-    tooltips: {},
+    annotationProviders: [],
     searchQuery: '',
   },
 };
@@ -132,10 +154,12 @@ export const TooltipsDemo: Story = {
     leftYaml:
       'apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-pod\n  namespace: default\n  annotations:\n    description: |\n      This is a pod description.\n      It has multiple lines.\n      Old content here.\nspec:\n  replicas: 1\n  containers:\n    - name: nginx\n      image: nginx:1.14.22',
     rightYaml: rightYamlMock,
-    tooltips: {
-      'metadata.name': 'This is the unique name of the Kubernetes resource.',
-      'spec.replicas': 'Defines the number of desired pod replicas.',
-    },
+    annotationProviders: [
+      new MockAnnotationProvider({
+        'metadata.name': 'This is the unique name of the Kubernetes resource.',
+        'spec.replicas': 'Defines the number of desired pod replicas.',
+      }),
+    ],
   },
 };
 

--- a/web/src/app/shared/components/yaml-viewer/yaml-viewer.stories.ts
+++ b/web/src/app/shared/components/yaml-viewer/yaml-viewer.stories.ts
@@ -16,12 +16,15 @@
 
 import { Meta, StoryObj } from '@storybook/angular';
 import { YamlViewerComponent } from './yaml-viewer.component';
-import { YamlAnnotationProvider, YamlFieldAnnotation } from './yaml-annotation';
+import {
+  YamlAnnotationProvider,
+  YamlFieldAnnotation,
+} from 'src/app/shared/components/yaml-viewer/yaml-annotation';
 import { ManagedFieldTooltipComponent } from 'src/app/shared/components/yaml-viewer/components/managed-field-tooltip.component';
 
 class MockAnnotationProvider implements YamlAnnotationProvider {
   constructor(private readonly tooltipMap: Record<string, string>) {}
-  getAnnotations(rightObj: any): YamlFieldAnnotation[] {
+  getAnnotations(): YamlFieldAnnotation[] {
     const annotations: YamlFieldAnnotation[] = [];
     for (const [pathStr] of Object.entries(this.tooltipMap)) {
       const path = pathStr.split('.');


### PR DESCRIPTION
Managed field is sometime informative to know who modified a specific field of a manifest. But it's quite hard to read manually. This change added a tooltip showing the managed field value as a tooltip on diff views.

<img width="1214" height="1184" alt="image" src="https://github.com/user-attachments/assets/115f7a8f-bcef-47f8-800c-8c1dcb376a47" />
