### PR TITLE
Fix #836: Refine global keyboard shortcuts to prevent unexpected focus loss

### DIFF
--- a/web/.storybook/tsconfig.json
+++ b/web/.storybook/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.app.json",
   "compilerOptions": {
-    "types": ["node", "chai"],
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true
   },

--- a/web/src/app/common/dom-util.spec.ts
+++ b/web/src/app/common/dom-util.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isMac, isSearchShortcut, isEventFromOverlay } from './dom-util';
+
+describe('dom-util', () => {
+  describe('isMac', () => {
+    let originalUserAgent: string;
+    beforeEach(() => {
+      originalUserAgent = navigator.userAgent;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: originalUserAgent,
+        configurable: true,
+      });
+    });
+
+    it('should return true if userAgent contains Mac OS X', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+        configurable: true,
+      });
+      expect(isMac()).toBeTrue();
+    });
+
+    it('should return false if userAgent is Windows', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        configurable: true,
+      });
+      expect(isMac()).toBeFalse();
+    });
+  });
+
+  describe('isSearchShortcut', () => {
+    let originalUserAgent: string;
+    beforeEach(() => {
+      originalUserAgent = navigator.userAgent;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: originalUserAgent,
+        configurable: true,
+      });
+    });
+
+    it('should return true for Cmd+F on Mac', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mac OS X',
+        configurable: true,
+      });
+      expect(
+        isSearchShortcut(
+          new KeyboardEvent('keydown', { key: 'f', metaKey: true }),
+        ),
+      ).toBeTrue();
+    });
+
+    it('should return false for Ctrl+F on Mac', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mac OS X',
+        configurable: true,
+      });
+      expect(
+        isSearchShortcut(
+          new KeyboardEvent('keydown', { key: 'f', ctrlKey: true }),
+        ),
+      ).toBeFalse();
+    });
+
+    it('should return true for Ctrl+F on Windows', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Windows NT',
+        configurable: true,
+      });
+      expect(
+        isSearchShortcut(
+          new KeyboardEvent('keydown', { key: 'f', ctrlKey: true }),
+        ),
+      ).toBeTrue();
+    });
+
+    it('should return false for Cmd+F on Windows', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Windows NT',
+        configurable: true,
+      });
+      expect(
+        isSearchShortcut(
+          new KeyboardEvent('keydown', { key: 'f', metaKey: true }),
+        ),
+      ).toBeFalse();
+    });
+
+    it('should return false for non-F keys', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Windows NT',
+        configurable: true,
+      });
+      expect(
+        isSearchShortcut(
+          new KeyboardEvent('keydown', { key: 'g', ctrlKey: true }),
+        ),
+      ).toBeFalse();
+    });
+  });
+
+  describe('isEventFromOverlay', () => {
+    it('should return true if target is inside an overlay pane', () => {
+      const target = document.createElement('div');
+      const pane = document.createElement('div');
+      pane.classList.add('cdk-overlay-pane');
+      pane.appendChild(target);
+      expect(isEventFromOverlay({ target } as unknown as Event)).toBeTrue();
+    });
+
+    it('should return false if target is not inside an overlay pane', () => {
+      const target = document.createElement('div');
+      expect(isEventFromOverlay({ target } as unknown as Event)).toBeFalse();
+    });
+
+    it('should return false if target is null', () => {
+      expect(
+        isEventFromOverlay({ target: null } as unknown as Event),
+      ).toBeFalse();
+    });
+  });
+});

--- a/web/src/app/common/dom-util.spec.ts
+++ b/web/src/app/common/dom-util.spec.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { isMac, isSearchShortcut, isEventFromOverlay } from './dom-util';
+import {
+  isMac,
+  isSearchShortcut,
+  isEventFromOverlay,
+} from 'src/app/common/dom-util';
 
 describe('dom-util', () => {
   describe('isMac', () => {
@@ -44,6 +48,22 @@ describe('dom-util', () => {
         configurable: true,
       });
       expect(isMac()).toBeFalse();
+    });
+
+    it('should return false if navigator is undefined', () => {
+      const originalNavigator = globalThis.navigator;
+      try {
+        Object.defineProperty(globalThis, 'navigator', {
+          value: undefined,
+          configurable: true,
+        });
+        expect(isMac()).toBeFalse();
+      } finally {
+        Object.defineProperty(globalThis, 'navigator', {
+          value: originalNavigator,
+          configurable: true,
+        });
+      }
     });
   });
 

--- a/web/src/app/common/dom-util.ts
+++ b/web/src/app/common/dom-util.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Checks if the current platform is macOS.
+ * @returns true if the platform is macOS.
+ */
+export function isMac(): boolean {
+  return (
+    navigator.userAgent.includes('Mac OS X') ||
+    navigator.userAgent.includes('Macintosh')
+  );
+}
+
+/**
+ * Checks if the given keyboard event is a standard search shortcut.
+ * Uses Cmd+F on macOS and Ctrl+F on Windows/Linux.
+ * @param event The keyboard event.
+ * @returns true if it is the platform's search shortcut.
+ */
+export function isSearchShortcut(event: KeyboardEvent): boolean {
+  if (event.key.toLowerCase() !== 'f') {
+    return false;
+  }
+  if (isMac()) {
+    return event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+  }
+  return event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+}
+
+/**
+ * Checks if the event is originating from a dialog or overlay (e.g., Material Dialog).
+ * @param event The keyboard event.
+ * @returns true if the event originated from an overlay.
+ */
+export function isEventFromOverlay(event: Event): boolean {
+  const target = event.target as Element | null;
+  return !!target?.closest?.('.cdk-overlay-pane');
+}

--- a/web/src/app/common/dom-util.ts
+++ b/web/src/app/common/dom-util.ts
@@ -19,6 +19,9 @@
  * @returns true if the platform is macOS.
  */
 export function isMac(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
   return (
     navigator.userAgent.includes('Mac OS X') ||
     navigator.userAgent.includes('Macintosh')

--- a/web/src/app/common/misc-util.spec.ts
+++ b/web/src/app/common/misc-util.spec.ts
@@ -19,7 +19,7 @@ import {
   bisectLeft,
   bisectRight,
   defaultNumberComparator,
-} from './misc-util';
+} from 'src/app/common/misc-util';
 
 describe('misc-util', () => {
   describe('bisectLeft', () => {

--- a/web/src/app/diff/components/diff-content.component.ts
+++ b/web/src/app/diff/components/diff-content.component.ts
@@ -39,6 +39,7 @@ import { YamlViewerComponent } from 'src/app/shared/components/yaml-viewer/yaml-
 import { ManagedFieldsAnnotationProvider } from 'src/app/shared/components/yaml-viewer/managed-fields-annotation.provider';
 import { RevisionFieldAnnotationProvider } from 'src/app/shared/components/yaml-viewer/revision-field-annotation.provider';
 import * as yaml from 'js-yaml';
+import { isEventFromOverlay, isSearchShortcut } from 'src/app/common/dom-util';
 
 /**
  * Component for displaying the unified diff of a resource revision.
@@ -204,10 +205,13 @@ export class DiffContentComponent {
    */
   @HostListener('window:keydown', ['$event'])
   onKeyDown(event: KeyboardEvent) {
+    if (isEventFromOverlay(event)) {
+      return;
+    }
     if (this.activeSearchScope() !== SearchScope.Diff) {
       return;
     }
-    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'f') {
+    if (isSearchShortcut(event)) {
       event.preventDefault();
       this.openSearch();
     } else if (event.key === 'Escape' && this.isSearchOpen()) {

--- a/web/src/app/log/components/log-content.component.ts
+++ b/web/src/app/log/components/log-content.component.ts
@@ -40,6 +40,7 @@ import { ResourceRefAnnotationViewModel } from 'src/app/log/components/resource-
 import { SearchBarComponent } from 'src/app/shared/components/search-bar/search-bar.component';
 import { SearchScope } from 'src/app/services/view-state.service';
 import { YamlViewerComponent } from 'src/app/shared/components/yaml-viewer/yaml-viewer.component';
+import { isEventFromOverlay, isSearchShortcut } from 'src/app/common/dom-util';
 
 /**
  * View model aggregating the full detailed data required to render the log content and header.
@@ -210,10 +211,13 @@ timestamp="${timestampString}"
    */
   @HostListener('window:keydown', ['$event'])
   onKeyDown(event: KeyboardEvent) {
+    if (isEventFromOverlay(event)) {
+      return;
+    }
     if (this.activeSearchScope() !== SearchScope.Log) {
       return;
     }
-    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'f') {
+    if (isSearchShortcut(event)) {
       event.preventDefault();
       this.openSearch();
     } else if (event.key === 'Escape' && this.isSearchOpen()) {

--- a/web/src/app/services/layout/layout.service.ts
+++ b/web/src/app/services/layout/layout.service.ts
@@ -37,6 +37,7 @@ import {
   MenuItemType,
 } from 'src/app/services/menu/menu-manager.service';
 import { StyleOverrideSmartComponent } from 'src/app/dialogs/style-override/style-override-smart.component';
+import { isEventFromOverlay } from 'src/app/common/dom-util';
 
 /**
  * LayoutService manages the GoldenLayout instance and component registration.
@@ -287,6 +288,9 @@ export class LayoutService implements OnDestroy {
    * Handles keyboard shortcuts for switching layout mode.
    */
   private readonly handleKeyDown = (event: KeyboardEvent) => {
+    if (isEventFromOverlay(event)) {
+      return;
+    }
     if ((event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey) {
       if (event.key === '1') {
         event.preventDefault();

--- a/web/src/app/timeline-toolbar/components/toolbar-advanced.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-advanced.component.ts
@@ -35,6 +35,7 @@ import {
   CelGuidePopupComponent,
   CelGuideTab,
 } from 'src/app/timeline-toolbar/components/cel-guide-popup.component';
+import { isEventFromOverlay, isSearchShortcut } from 'src/app/common/dom-util';
 
 /**
  * Provides an advanced toolbar for the timeline view featuring two-row CEL expression text fields.
@@ -176,7 +177,10 @@ export class ToolbarAdvancedComponent {
    */
   @HostListener('window:keydown', ['$event'])
   public onKeyDown(event: KeyboardEvent): void {
-    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
+    if (isEventFromOverlay(event)) {
+      return;
+    }
+    if (isSearchShortcut(event)) {
       if (event.defaultPrevented) {
         return;
       }

--- a/web/src/app/timeline-toolbar/components/toolbar.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.ts
@@ -40,6 +40,7 @@ import { SearchScope } from 'src/app/services/view-state.service';
 import { TimelineFilterConfig } from '../types/filter-config';
 import { TimelineType } from 'src/app/store/domain/style';
 import { RendererConvertUtil } from 'src/app/timeline/components/canvas/convertutil';
+import { isEventFromOverlay, isSearchShortcut } from 'src/app/common/dom-util';
 
 /**
  * Visual theme representation for a timeline type chip and row.
@@ -336,7 +337,10 @@ export class ToolbarComponent {
    */
   @HostListener('window:keydown', ['$event'])
   public onKeyDown(event: KeyboardEvent): void {
-    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
+    if (isEventFromOverlay(event)) {
+      return;
+    }
+    if (isSearchShortcut(event)) {
       if (event.defaultPrevented) {
         return;
       }


### PR DESCRIPTION
- Dynamically detect the search shortcut (`Cmd-F` on macOS, `Ctrl-F` on Windows/Linux) to avoid capturing `Ctrl-F` (cursor forward) for macOS/Emacs users.
- Ignore global shortcut keydowns (`Ctrl-1/2/3`, `Cmd-F`/`Ctrl-F`) when the event originates from a Material dialog (`.cdk-overlay-pane`). This allows users to type naturally inside dialog inputs without triggering layout changes or losing focus.
- Add utility functions and corresponding unit tests in `misc-util`.