### PR TITLE
Fix cluster name normalization for GKE on AWS/Azure in node log parsers (#838)

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task.go
@@ -259,7 +259,7 @@ type containerdNodeLogLogToTimelineMapperSetting struct {
 // Dependencies implements inspectiontaskbase.LogToTimelineMapper.
 func (c *containerdNodeLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
-		googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(),
+		googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref(),
 		googlecloudlogk8snode_contract.PodSandboxIDDiscoveryTaskID.Ref(),
 		commonlogk8saudit_contract.ContainerIDPatternFinderTaskID.Ref(),
 	}
@@ -277,7 +277,8 @@ func (c *containerdNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.T
 
 // ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
 func (c *containerdNodeLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
-	clusterName := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref())
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref())
+	clusterName := clusterIdentity.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster)
 	podSandboxIDFinder := coretask.GetTaskResult(ctx, googlecloudlogk8snode_contract.PodSandboxIDDiscoveryTaskID.Ref())
 	containerIDPatternFinder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ContainerIDPatternFinderTaskID.Ref())
 	nodeLogFieldSet := log.MustGetFieldSet(l, &googlecloudlogk8snode_contract.K8sNodeLogCommonFieldSet{})

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task_test.go
@@ -301,6 +301,7 @@ func TestContainerdLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 		desc                 string
 		inputMessage         string
 		inputNodeLogFieldSet *googlecloudlogk8snode_contract.K8sNodeLogCommonFieldSet
+		inputClusterIdentity *googlecloudk8scommon_contract.GoogleCloudClusterIdentity
 		inputPodIDInfo       map[string]*googlecloudlogk8snode_contract.PodSandboxIDInfo
 		inputContainerIDInfo map[string]*commonlogk8saudit_contract.ContainerIdentity
 		assert               func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
@@ -404,6 +405,30 @@ func TestContainerdLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					HasEvent(wantContainerPath)
 			},
 		},
+		{
+			desc:         "applies cluster prefix policy for GKE on AWS/Azure",
+			inputMessage: `time="2025-09-29T06:34:07.973711745Z" level=info msg="starting containerd"`,
+			inputNodeLogFieldSet: &googlecloudlogk8snode_contract.K8sNodeLogCommonFieldSet{
+				Component: "containerd",
+				NodeName:  "node-1",
+			},
+			inputClusterIdentity: &googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "awsClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sCluster,
+					},
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantNodePath := MustK8sNodeTimeline(ctx, "awsClusters/test-cluster", "node-1")
+				wantComponentPath := googlecloudlogk8snode_contract.MustNodeComponentTimeline(ctx, wantNodePath, "containerd")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantComponentPath)
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -421,8 +446,15 @@ func TestContainerdLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 				}
 			}
 
+			clusterIdent := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			}
+			if tc.inputClusterIdentity != nil {
+				clusterIdent = *tc.inputClusterIdentity
+			}
+
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
-			ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(), "test-cluster")
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref(), clusterIdent)
 			ctx = tasktest.WithTaskResult(ctx, googlecloudlogk8snode_contract.PodSandboxIDDiscoveryTaskID.Ref(), podIDFinder)
 			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.ContainerIDPatternFinderTaskID.Ref(), containerIDFinder)
 

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/kubelet_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/kubelet_task.go
@@ -43,7 +43,7 @@ type kubeletNodeLogLogToTimelineMapperSetting struct {
 // Dependencies implements inspectiontaskbase.LogToTimelineMapper.
 func (k *kubeletNodeLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
-		googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(),
+		googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref(),
 		googlecloudlogk8snode_contract.PodSandboxIDDiscoveryTaskID.Ref(),
 		commonlogk8saudit_contract.ContainerIDPatternFinderTaskID.Ref(),
 		commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(),
@@ -62,7 +62,8 @@ func (k *kubeletNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.Task
 
 // ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
 func (k *kubeletNodeLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
-	clusterName := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref())
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref())
+	clusterName := clusterIdentity.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster)
 	componentFieldSet := log.MustGetFieldSet(l, &googlecloudlogk8snode_contract.K8sNodeLogCommonFieldSet{})
 	containerIDPatternFinder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ContainerIDPatternFinderTaskID.Ref())
 	podIDFinder := coretask.GetTaskResult(ctx, googlecloudlogk8snode_contract.PodSandboxIDDiscoveryTaskID.Ref())

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/kubelet_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/kubelet_task_test.go
@@ -42,6 +42,7 @@ func TestKubeletLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 		desc                 string
 		inputMessage         string
 		inputNodeLogFieldSet *googlecloudlogk8snode_contract.K8sNodeLogCommonFieldSet
+		inputClusterIdentity *googlecloudk8scommon_contract.GoogleCloudClusterIdentity
 		inputPodIDInfo       map[string]*googlecloudlogk8snode_contract.PodSandboxIDInfo
 		inputContainerIDInfo map[string]*commonlogk8saudit_contract.ContainerIdentity
 		inputResourceUIDInfo map[string]*commonlogk8saudit_contract.ResourceIdentity
@@ -135,6 +136,30 @@ func TestKubeletLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					HasEvent(wantResourcePath)
 			},
 		},
+		{
+			desc:         "applies cluster prefix policy for GKE on AWS/Azure",
+			inputMessage: `I0929 08:30:43.794472    1949 generic.go:334] "Generic (PLEG): container finished" podID="6123c6aacf0c78dc38ec4f0ff72edd3cf04eb82ca0e3e7dddd3950ea9753bdf1"`,
+			inputNodeLogFieldSet: &googlecloudlogk8snode_contract.K8sNodeLogCommonFieldSet{
+				Component: "kubelet",
+				NodeName:  "node-1",
+			},
+			inputClusterIdentity: &googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "awsClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sCluster,
+					},
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantNodePath := MustK8sNodeTimeline(ctx, "awsClusters/test-cluster", "node-1")
+				wantComponentPath := googlecloudlogk8snode_contract.MustNodeComponentTimeline(ctx, wantNodePath, "kubelet")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantComponentPath)
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -158,8 +183,15 @@ func TestKubeletLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 				}
 			}
 
+			clusterIdent := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			}
+			if tc.inputClusterIdentity != nil {
+				clusterIdent = *tc.inputClusterIdentity
+			}
+
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
-			ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(), "test-cluster")
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref(), clusterIdent)
 			ctx = tasktest.WithTaskResult(ctx, googlecloudlogk8snode_contract.PodSandboxIDDiscoveryTaskID.Ref(), podIDFinder)
 			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.ContainerIDPatternFinderTaskID.Ref(), containerIDFinder)
 			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(), finder)

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/other_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/other_task.go
@@ -41,7 +41,7 @@ type otherNodeLogLogToTimelineMapperSetting struct {
 // Dependencies implements inspectiontaskbase.LogToTimelineMapper.
 func (o *otherNodeLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
-		googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(),
+		googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref(),
 	}
 }
 
@@ -57,7 +57,8 @@ func (o *otherNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskRe
 
 // ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
 func (o *otherNodeLogLogToTimelineMapperSetting) ProcessLogByGroup(ctx context.Context, l *log.Log, prevGroupData struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
-	clusterName := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref())
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref())
+	clusterName := clusterIdentity.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster)
 	componentFieldSet := log.MustGetFieldSet(l, &googlecloudlogk8snode_contract.K8sNodeLogCommonFieldSet{})
 
 	cs := khifilev6.NewTimelineChangeSet(l)

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/other_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/other_task_test.go
@@ -46,11 +46,12 @@ func TestOtherLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	builder := khifilev6.NewBuilder()
 
 	testCases := []struct {
-		desc         string
-		inputMessage string
-		component    string
-		nodeName     string
-		assert       func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+		desc                 string
+		inputMessage         string
+		component            string
+		nodeName             string
+		inputClusterIdentity *googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		assert               func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc:         "starting log for component-A adds Create revision and event",
@@ -90,6 +91,28 @@ func TestOtherLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					})
 			},
 		},
+		{
+			desc:         "applies cluster prefix policy for GKE on AWS/Azure",
+			inputMessage: "component-A start",
+			component:    "component-A",
+			nodeName:     "node-1",
+			inputClusterIdentity: &googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "awsClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sCluster,
+					},
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantNodePath := MustK8sNodeTimeline(ctx, "awsClusters/test-cluster", "node-1")
+				wantComponentPath := googlecloudlogk8snode_contract.MustNodeComponentTimeline(ctx, wantNodePath, "component-A")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantComponentPath)
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -106,9 +129,16 @@ func TestOtherLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 				},
 			)
 
+			clusterIdent := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "test-cluster",
+			}
+			if tc.inputClusterIdentity != nil {
+				clusterIdent = *tc.inputClusterIdentity
+			}
+
 			// 2. Setup context with SAME builder and mock tasks
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
-			ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(), "test-cluster")
+			ctx = tasktest.WithTaskResult(ctx, googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref(), clusterIdent)
 
 			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
 			if err != nil {


### PR DESCRIPTION
## Summary

Fixes #838 where Kubernetes node logs (`kubelet`, `containerd`, `other`) for GKE on AWS / Azure were displayed under a separate, un-prefixed cluster timeline (`<cluster-name>`) instead of the unified prefixed cluster timeline (`awsClusters/<cluster-name>` or `azureClusters/<cluster-name>`).

## Cause

In `googlecloudlogk8snode` mapper tasks (`kubelet_task.go`, `containerd_task.go`, `other_task.go`), cluster names were retrieved directly from `InputClusterNameTaskID` (raw user input string without prefix policy) rather than `ClusterIdentityTaskID`. Consequently, the cluster prefix policy (`ClusterPrefixPolicy`) defined for multicloud clusters was bypassed during timeline path generation.

## Changes

- **`googlecloudlogk8snode/impl` (`kubelet_task.go`, `containerd_task.go`, `other_task.go`)**:
  - Changed task dependency from `InputClusterNameTaskID` to `ClusterIdentityTaskID`.
  - Resolved the cluster name using `clusterIdentity.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster)` to ensure the prefix policy is correctly applied.
- **Unit Tests (`kubelet_task_test.go`, `containerd_task_test.go`, `other_task_test.go`)**:
  - Updated mock task results in unit tests to inject `ClusterIdentityTaskID`.
  - Added test cases verifying that `awsClusters/` prefix policy is correctly reflected in the generated node timeline paths.

## Verification

- Ran `go test ./pkg/task/inspection/googlecloudlogk8snode/impl/...` (Pass)
- Ran `make build-go` (Pass)
- Ran `make test-go` (Pass)
- Ran `make lint-go` (0 issues)
- Ran `make pre-commit` (Pass)
