### PR TITLE
fix(web): resolve selection issues in SelectionManager and History view

### DIFF
--- a/web/src/app/diff/diff-smart.component.ts
+++ b/web/src/app/diff/diff-smart.component.ts
@@ -92,9 +92,23 @@ export class DiffSmartComponent implements OnInit, OnDestroy {
     this.selectionManager.highlightLogIndices;
 
   /**
-   * Signal containing the currently selected resource timeline.
+   * Signal containing the timeline of the currently selected revision/log, or the selected timeline if none is selected.
    */
-  protected readonly selectedTimeline = this.selectionManager.selectedTimeline;
+  protected readonly selectedTimeline = computed(() => {
+    const revision = this.currentRevision();
+    if (revision) {
+      return revision.timeline;
+    }
+    const log = this.selectionManager.selectedLog();
+    if (log) {
+      for (const t of this.selectionManager.selectedTimelinesWithChildren()) {
+        if (t.lookupRevisionFromLog(log) || t.lookupEventFromLog(log)) {
+          return t;
+        }
+      }
+    }
+    return this.selectionManager.selectedTimeline();
+  });
 
   /**
    * Signal containing the currently selected resource revision.

--- a/web/src/app/services/selection-manager.service.spec.ts
+++ b/web/src/app/services/selection-manager.service.spec.ts
@@ -195,8 +195,16 @@ describe('SelectionManager', () => {
           revisionIds: [1],
           eventIds: [1],
         },
+        {
+          id: 5,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: 0,
+          revisionIds: [],
+          eventIds: [],
+        },
       ],
-      4,
+      5,
       [
         {
           id: 1,
@@ -349,6 +357,20 @@ describe('SelectionManager', () => {
     service.onSelectLog(targetLog);
 
     expect(service.selectedTimeline()?.id).toBe(3);
+    expect(service.selectedLog()?.id).toBe(targetLog.id);
+    expect(service.selectedRevision()?.logIndex).toBe(targetLog.logIndex);
+  });
+
+  it('should update selected timeline when selecting an unrelated log while another timeline is selected', () => {
+    const logs = Array.from(logStore.logs());
+    const targetLog = logs[0]; // Log 1 belongs to Timeline 4
+    const timelines = timelineStore.timelines;
+    const unrelatedTimeline = timelines.find((t) => t.id === 5)!; // Timeline 5 is unrelated to Timeline 4
+
+    service.onSelectTimeline(unrelatedTimeline);
+    service.onSelectLog(targetLog);
+
+    expect(service.selectedTimeline()?.id).toBe(4);
     expect(service.selectedLog()?.id).toBe(targetLog.id);
     expect(service.selectedRevision()?.logIndex).toBe(targetLog.logIndex);
   });

--- a/web/src/app/services/selection-manager.service.spec.ts
+++ b/web/src/app/services/selection-manager.service.spec.ts
@@ -277,8 +277,8 @@ describe('SelectionManager', () => {
     service.onSelectLog(targetLog);
 
     expect(service.selectedLog()?.id).toBe(targetLog.id);
-    // Under new spec, log selection does not automatically select the timeline
-    expect(service.selectedTimeline()).toBeNull();
+    // When no timeline is initially selected, selecting a log automatically selects its corresponding timeline
+    expect(service.selectedTimeline()?.id).toBe(4);
     expect(service.selectedRevision()?.logIndex).toBe(targetLog.logIndex);
   });
 
@@ -289,6 +289,7 @@ describe('SelectionManager', () => {
     const timeline4 = timelines.find((t) => t.id === 4)!;
     const unrelatedTimeline = timelines.find((t) => t.id === 1)!;
 
+    service.timelineSelectionShouldIncludeChildren.set(false);
     // Select log (will select Log 1, Revision 1)
     service.onSelectLog(targetLog);
     expect(service.selectedLog()?.id).toBe(targetLog.id);
@@ -307,5 +308,48 @@ describe('SelectionManager', () => {
     // Since Log 1 is not in Timeline 1, selections must be cleared
     expect(service.selectedLog()).toBeNull();
     expect(service.selectedRevision()).toBeNull();
+  });
+
+  it('should prioritize currently selected timeline when selecting a log present in that timeline', () => {
+    const logs = Array.from(logStore.logs());
+    const targetLog = logs[0];
+    const timelines = timelineStore.timelines;
+    const timeline4 = timelines.find((t) => t.id === 4)!;
+
+    service.onSelectTimeline(timeline4);
+    service.onSelectLog(targetLog);
+
+    expect(service.selectedTimeline()?.id).toBe(4);
+    expect(service.selectedLog()?.id).toBe(targetLog.id);
+    expect(service.selectedRevision()?.logIndex).toBe(targetLog.logIndex);
+  });
+
+  it('should clear log and revision selection when timeline is set to null', () => {
+    const logs = Array.from(logStore.logs());
+    const targetLog = logs[0];
+
+    service.onSelectLog(targetLog);
+    expect(service.selectedLog()?.id).toBe(targetLog.id);
+
+    service.onSelectTimeline(null);
+
+    expect(service.selectedTimeline()).toBeNull();
+    expect(service.selectedLog()).toBeNull();
+    expect(service.selectedRevision()).toBeNull();
+  });
+
+  it('should allow selecting a log belonging to a child timeline when parent timeline is selected and shouldIncludeChildren is true', () => {
+    const logs = Array.from(logStore.logs());
+    const targetLog = logs[0]; // Log 1 belongs to Timeline 4
+    const timelines = timelineStore.timelines;
+    const timeline3 = timelines.find((t) => t.id === 3)!; // Timeline 3 is parent of Timeline 4
+
+    service.timelineSelectionShouldIncludeChildren.set(true);
+    service.onSelectTimeline(timeline3);
+    service.onSelectLog(targetLog);
+
+    expect(service.selectedTimeline()?.id).toBe(3);
+    expect(service.selectedLog()?.id).toBe(targetLog.id);
+    expect(service.selectedRevision()?.logIndex).toBe(targetLog.logIndex);
   });
 });

--- a/web/src/app/services/selection-manager.service.ts
+++ b/web/src/app/services/selection-manager.service.ts
@@ -243,12 +243,10 @@ export class SelectionManager {
           return;
         }
       }
-      this.selectedLogId.set(null);
-      this.selectedRevision.set(null);
-      return;
     }
 
-    // When no timeline is selected, automatically select the first timeline containing the log.
+    // When no timeline is selected or the log is not found in the currently selected timelines,
+    // automatically select the first timeline containing the log.
     this.selectedLogId.set(log.id);
     for (const timeline of this.filteredTimelines()) {
       const revision = timeline.lookupRevisionFromLog(log);

--- a/web/src/app/services/selection-manager.service.ts
+++ b/web/src/app/services/selection-manager.service.ts
@@ -151,8 +151,8 @@ export class SelectionManager {
   public readonly previousOfSelectedRevision =
     computed<ReadonlyDomainElement<Revision> | null>(() => {
       const revision = this.selectedRevision();
-      const timeline = this.selectedTimeline();
-      if (revision === null || timeline === null) return null;
+      if (revision === null) return null;
+      const timeline = revision.timeline;
       const revisionIndex = timeline.revisions.indexOf(revision);
       return revisionIndex > 0 ? timeline.revisions[revisionIndex - 1] : null;
     });
@@ -193,8 +193,9 @@ export class SelectionManager {
    * If the timeline is missing or null, the selection is cleared.
    */
   public onSelectTimeline(timeline?: ReadonlyDomainElement<Timeline> | null) {
-    this.selectedTimeline.set(timeline ?? null);
-    this.synchronizeSelection();
+    const nextTimeline = timeline ?? null;
+    this.selectedTimeline.set(nextTimeline);
+    this.validateSelectionAgainstTimeline(nextTimeline);
   }
 
   /**
@@ -218,16 +219,61 @@ export class SelectionManager {
    * Selects a log entry and updates dependent selections.
    */
   public onSelectLog(log: ReadonlyDomainElement<Log> | null) {
-    this.changeSelectionByLogInternal(log, false);
-    this.synchronizeSelection();
+    if (!log) {
+      this.selectedLogId.set(null);
+      this.selectedRevision.set(null);
+      return;
+    }
+
+    const currentTimelines = this.selectedTimelinesWithChildren();
+
+    // When a timeline is already selected, prioritize searching within that timeline and its children.
+    if (currentTimelines.length > 0) {
+      for (const timeline of currentTimelines) {
+        const revision = timeline.lookupRevisionFromLog(log);
+        if (revision) {
+          this.selectedLogId.set(log.id);
+          this.selectedRevision.set(revision);
+          return;
+        }
+        const event = timeline.lookupEventFromLog(log);
+        if (event) {
+          this.selectedLogId.set(log.id);
+          this.selectedRevision.set(null);
+          return;
+        }
+      }
+      this.selectedLogId.set(null);
+      this.selectedRevision.set(null);
+      return;
+    }
+
+    // When no timeline is selected, automatically select the first timeline containing the log.
+    this.selectedLogId.set(log.id);
+    for (const timeline of this.filteredTimelines()) {
+      const revision = timeline.lookupRevisionFromLog(log);
+      if (revision) {
+        this.selectedTimeline.set(timeline);
+        this.selectedRevision.set(revision);
+        return;
+      }
+      const event = timeline.lookupEventFromLog(log);
+      if (event) {
+        this.selectedTimeline.set(timeline);
+        this.selectedRevision.set(null);
+        return;
+      }
+    }
+    this.selectedRevision.set(null);
   }
 
   /**
    * Selects an event and updates timeline and log selections.
    */
   public onSelectEvent(event: ReadonlyDomainElement<Event>) {
-    this.changeSelectionByEventInternal(event.timeline, event, false);
-    this.synchronizeSelection();
+    this.selectedTimeline.set(event.timeline);
+    this.selectedLogId.set(event.log.id);
+    this.selectedRevision.set(null);
   }
 
   /**
@@ -236,105 +282,43 @@ export class SelectionManager {
   public onSelectRevision(revision: ReadonlyDomainElement<Revision> | null) {
     if (revision === null) {
       this.selectedRevision.set(null);
-      this.synchronizeSelection();
       return;
     }
-    this.changeSelectionByRevisionInternal(revision.timeline, revision, false);
-    this.synchronizeSelection();
+    this.selectedTimeline.set(revision.timeline);
+    this.selectedLogId.set(revision.log.id);
+    this.selectedRevision.set(revision);
   }
 
   /**
-   * Synchronizes and validates selection status when any dependent signals change.
-   *
-   * Clears the log or revision selection if they are not part of the currently selected timeline.
+   * Validates that the current log/revision selection is within the target timeline or its children.
    */
-  private synchronizeSelection() {
-    const timeline = this.selectedTimeline();
-    if (!timeline) return;
+  private validateSelectionAgainstTimeline(
+    timeline: ReadonlyDomainElement<Timeline> | null,
+  ) {
+    if (!timeline) {
+      this.selectedLogId.set(null);
+      this.selectedRevision.set(null);
+      return;
+    }
 
     const log = this.selectedLog();
     const revision = this.selectedRevision();
+    const validTimelines = this.selectedTimelinesWithChildren();
 
-    if (
-      log &&
-      timeline.lookupEventFromLog(log) === null &&
-      timeline.lookupRevisionFromLog(log) === null
-    ) {
-      // Clear log selection if it is not part of the newly selected timeline.
-      this.onSelectLog(null);
-    }
+    const isLogValid =
+      !log ||
+      validTimelines.some(
+        (t) => t.lookupRevisionFromLog(log) || t.lookupEventFromLog(log),
+      );
+    const isRevisionValid =
+      !revision ||
+      validTimelines.some((t) => t.lookupRevisionFromLog(revision.log));
 
-    if (revision && timeline.lookupRevisionFromLog(revision.log) === null) {
+    if (!isLogValid) {
+      this.selectedLogId.set(null);
+      this.selectedRevision.set(null);
+    } else if (!isRevisionValid) {
       this.selectedRevision.set(null);
     }
-  }
-
-  private changeSelectionByLogInternal(
-    log: ReadonlyDomainElement<Log> | null,
-    ignoreResourceSelect: boolean,
-  ) {
-    this.selectedLogId.set(log ? log.id : null);
-    if (ignoreResourceSelect || !log) return;
-
-    const timelines = this.filteredTimelines();
-
-    // Find the timeline and the matching revision or event in a single pass using binary search
-    let relatedRevision: ReadonlyDomainElement<Revision> | null = null;
-    let relatedEvent: ReadonlyDomainElement<Event> | null = null;
-    let targetTimeline: ReadonlyDomainElement<Timeline> | null = null;
-    for (const timeline of timelines) {
-      relatedRevision = timeline.lookupRevisionFromLog(log);
-      if (relatedRevision !== null) {
-        targetTimeline = timeline;
-        break;
-      }
-      relatedEvent = timeline.lookupEventFromLog(log);
-      if (relatedEvent !== null) {
-        targetTimeline = timeline;
-        break;
-      }
-    }
-    if (!targetTimeline) return;
-
-    if (relatedRevision) {
-      this.changeSelectionByRevisionInternal(
-        targetTimeline,
-        relatedRevision,
-        true,
-        true,
-      );
-      return;
-    }
-
-    if (relatedEvent) {
-      this.changeSelectionByEventInternal(
-        targetTimeline,
-        relatedEvent,
-        true,
-        true,
-      );
-      return;
-    }
-  }
-
-  private changeSelectionByEventInternal(
-    timeline: ReadonlyDomainElement<Timeline>,
-    event: ReadonlyDomainElement<Event>,
-    ignoreLogSelect: boolean,
-    ignoreTimelineSelect: boolean = false,
-  ) {
-    if (!ignoreTimelineSelect) this.selectedTimeline.set(timeline);
-    if (!ignoreLogSelect) this.changeSelectionByLogInternal(event.log, true);
-  }
-
-  private changeSelectionByRevisionInternal(
-    timeline: ReadonlyDomainElement<Timeline>,
-    revision: ReadonlyDomainElement<Revision>,
-    ignoreLogSelect: boolean,
-    ignoreTimelineSelect: boolean = false,
-  ) {
-    this.selectedRevision.set(revision);
-    if (!ignoreTimelineSelect) this.selectedTimeline.set(timeline);
-    if (!ignoreLogSelect) this.changeSelectionByLogInternal(revision.log, true);
   }
 }


### PR DESCRIPTION
## Related Issue
Fixes #858
## Summary
This PR addresses several non-intuitive selection behaviors in `SelectionManager` and the History (Diff) view when interacting with logs and revisions across timeline hierarchies.
Previously, `SelectionManager` relied on bidirectional synchronization loops and multiple `ignoreXxxSelect` control flags, which caused log selections to be inadvertently cleared—especially when a log belonged to multiple timelines or a descendant timeline. Furthermore, the History view did not update its target timeline when inspecting a revision belonging to a child resource.
## Key Changes
* **`SelectionManager` Refactoring & Simplification**
  * Removed circular synchronization methods (`synchronizeSelection`, `changeSelectionByXxxInternal`) and over 100 lines of complex control flags (`ignoreLogSelect`, `ignoreResourceSelect`, `ignoreTimelineSelect`).
  * Rebuilt selection methods (`onSelectTimeline`, `onSelectLog`, `onSelectRevision`, `onSelectEvent`) into clear, unidirectional state updates.
* **Support for Selecting Logs in Child Timelines**
  * Expanded the lookup and validation scope from the single `selectedTimeline` to `selectedTimelinesWithChildren()`.
  * Users can now seamlessly click and select any log belonging to a descendant timeline while a parent timeline is selected, without the selection being rejected or cleared.
* **History View Context-Aware Rendering**
  * Updated `previousOfSelectedRevision` to compute from `revision.timeline` rather than `selectedTimeline()`, correctly resolving the previous revision even for child timeline elements.
  * Updated `DiffSmartComponent` (`selectedTimeline`) to prioritize the timeline of the currently selected revision or log. Consequently, the History view now accurately displays the revision history and diffs of selected child resources.
* **Unit Tests**
  * Added unit test coverage in `selection-manager.service.spec.ts` verifying log selection within child timelines and proper selection cleanup behavior.
## Verification
* **Automated Tests:**
  * Ran `make test-web`: All 724 unit tests passed successfully.
  * Ran `make format-web`, `make lint-web`, and `make build-storybook`: All checks passed with 0 issues.
* **Pre-commit Check:**
  * Ran `make pre-commit`: Verified formatting and static analysis across all modified files (`0 issues`).
