### PR TITLE
docs: modernize and split KHI task system conceptual guide into modular files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -114,7 +114,7 @@ gcr.io/kubernetes-history-inspector/release:latest
   - [GDCV for VMWare](https://cloud.google.com/kubernetes-engine/distributed-cloud/vmware/docs/overview)
 
 - その他環境
-  - JSONlines 形式の kube-apiserver 監査ログ ([チュートリアル (Using KHI with OSS Kubernetes Clusters - Example with Loki | 英語のみ)](/docs/en/setup-guide/oss-kubernetes-clusters.md))
+  - JSONlines 形式の kube-apiserver 監査ログ ([チュートリアル (OSS Kubernetesクラスタのログの可視化（Loki）)](/docs/ja/setup-guide/oss-kubernetes-clusters.md))
 
 ### ログバックエンド
 
@@ -123,7 +123,7 @@ gcr.io/kubernetes-history-inspector/release:latest
   - Cloud Logging（Google Cloud 上のすべてのクラスタ）
 
 - その他環境
-  - ファイルによるログアップロード([チュートリアル (Using KHI with OSS Kubernetes Clusters - Example with Loki | 英語のみ)](/docs/en/setup-guide/oss-kubernetes-clusters.md))
+  - ファイルによるログアップロード([チュートリアル (OSS Kubernetesクラスタのログの可視化（Loki）)](/docs/ja/setup-guide/oss-kubernetes-clusters.md))
 
 ### 動作環境
 

--- a/docs/en/architecture/khi-backend-serializer.md
+++ b/docs/en/architecture/khi-backend-serializer.md
@@ -14,21 +14,18 @@ flowchart TD
     subgraph AccumulatorLayer ["Accumulator layer"]
         TimelineAccumulator
         LogAccumulator
-        TimelineStyleAccumulator
+        MetadataAccumulator
         OtherAccumulators["Other Accumulators"]
     end
-
-    Register["Register()"]
 
     %% Inflow to Accumulators
     TimelineMapper -->|TimelineChangeSet| TimelineAccumulator
     LogIngestor -->|LogChangeSet| LogAccumulator
-    Register --> TimelineStyleAccumulator
 
     %% Outflow from Accumulators to Pools/Generators
     TimelineAccumulator --> IDGenerator
     LogAccumulator --> IDGenerator
-    TimelineStyleAccumulator --> IDGenerator
+    MetadataAccumulator --> IDGenerator
     OtherAccumulators --> IDGenerator
 
     TimelineAccumulator --> InternPool
@@ -37,7 +34,7 @@ flowchart TD
 
     TimelineAccumulator --> FileBuilder
     LogAccumulator --> FileBuilder
-    TimelineStyleAccumulator --> FileBuilder
+    MetadataAccumulator --> FileBuilder
     IDGenerator --> FileBuilder
     InternPool --> FileBuilder
     OtherAccumulators --> FileBuilder
@@ -46,8 +43,8 @@ flowchart TD
     ChunkGenerator -.-> FinalFile[(".khi file")]
 ```
 
-- **Tasks**: Each task adds analyzed elements and logs to the Accumulator layer. TimelineStyle does not change from startup, so various styles are appended in the Register function during initialization.
-- **Accumulator Layer**: Generates IDs, handles deduplication, and converts data to Proto types.
+- **Tasks**: Each task adds analyzed elements and logs to the Accumulator layer.
+- **Accumulator Layer**: Generates IDs, handles deduplication, and converts data to Proto types (`LogAccumulator`, `TimelineAccumulator`, `MetadataAccumulator`, etc.). Timeline styles are registered separately via the registry during initialization.
 - **IDGenerator / InternPool**: Centrally handles ID allocation, string interning, and structured data flattening. These are called from the Accumulator side.
 - **FileBuilder / ChunkGenerator**: Builds the Protobuf chunk binaries based on the aggregated data and pools, then writes them to the final `.khi` file.
 

--- a/docs/en/architecture/khi-frontend-parser.md
+++ b/docs/en/architecture/khi-frontend-parser.md
@@ -45,18 +45,18 @@ flowchart TD
 
 Instead of depending on nested factories, KHI registers a `ParserBlueprint` for each file version, mapping chunk types to their respective assemblers.
 
-### 1.1 DataAssembler
+### 1.1 IDataAssembler
 
-The ParserBlueprint registers a DataAssembler interface implementation for each Proto type. First, each DataAssembler receives data via `ingest` whenever a new Proto message is decoded. Finally, `assembleInto` is called with InspectionData, attaching the converted DTO values to InspectionData.
+The ParserBlueprint registers an IDataAssembler interface implementation for each Proto type. First, each IDataAssembler receives data via `ingest` whenever a new Proto message is decoded. Finally, `assembleInto` is called with InspectionDataBuilder, integrating the converted DTO values into the builder's domain stores.
 
 ```typescript
-// Assembler holding states to collect decoded Protobuf and build the final model
-interface DataAssembler<TProto> {
+// Stateful assembler that collects decoded Protobufs and mutates the final model via builder
+interface IDataAssembler<TProto = unknown> {
     // Receive a decoded chunk (may be called multiple times due to chunk splitting)
     ingest(proto: TProto): void;
     
-    // Integrate the collected data into the final InspectionData
-    assembleInto(model: InspectionData): void;
+    // Integrate the collected data into the final model through InspectionDataBuilder
+    assembleInto(builder: InspectionDataBuilder): void;
 }
 ```
 
@@ -66,14 +66,16 @@ Defines chunk parsing strategies for each file version.
 
 ```typescript
 // Definition of the processing method for a specific chunk type
-interface ChunkDefinition<TProto = any> {
-    typeId: number;
+interface ChunkDefinition<TProto = unknown> {
+    readonly typeId: number;
+    // Human-readable label/name for the chunk type (used in progress reports)
+    readonly label: string;
     // Pure function to decode raw byte arrays into Protobuf objects
-    decode: (bytes: Uint8Array) => TProto; 
+    readonly decode: (bytes: Uint8Array) => TProto; 
     // Factory method for stateful assemblers
-    createAssembler: () => DataAssembler<TProto>;
+    readonly createAssembler: () => IDataAssembler<TProto>;
     // Execution priority for dependency resolution (smaller values assemble earlier)
-    priority: number; 
+    readonly priority: number; 
 }
 
 // Registry of chunk definitions specific to each version

--- a/docs/en/khi-task-system-concept.md
+++ b/docs/en/khi-task-system-concept.md
@@ -25,7 +25,7 @@ flowchart LR
 1. **[Task System Syntax and Execution Modes](./task-system/01-syntax-and-modes.md)**
    - Covers DAG basics, task type (`Task[T]`) declarations, reading values from dependencies (`GetTaskResult`), structured logging (`slog`), package structures and naming conventions (`_contract`/`_impl`), **inspection execution modes (`Run` and `DryRun`)**, and **unit testing (`tasktest`)**.
 2. **[Log Processing Task Implementation Patterns (Cookbook)](./task-system/02-log-processing-cookbook.md)**
-   - Covers the overall log processing pipeline, practical recipes for the **6 major task creation utilities (`FieldSetReadTask`, `LogGrouperTask`, `LogFilterTask`, `LogIngesterTask`, `LogToTimelineMapperTask`)**, and timeline mapping using modern `*khifilev6.TimelinePath` and `testchangeset.AssertTimeline` objects.
+   - Covers the overall log processing pipeline, practical recipes for the **5 major task creation utilities (`FieldSetReadTask`, `LogGrouperTask`, `LogFilterTask`, `LogIngesterTask`, `LogToTimelineMapperTask`)**, and timeline mapping using modern `*khifilev6.TimelinePath` and `testchangeset.AssertTimeline` objects.
 3. **[Advanced Task Patterns and Utilities](./task-system/03-advanced-and-form-tasks.md)**
    - Covers automatic inspection server registration (`Register`), label selectors (`LabelSelector`, `FeatureTask`), the **`Inventory`-`Discovery` task pattern (`InventoryTaskBuilder` and merge strategies)** for resolving names across multiple log sources, **form tasks (`formtask` / autocomplete)** for rich UI input fields, and **progress reporting / cache control (`NewGlobalCachedTask`, `NewInspectionCachedTask`)**.
 

--- a/docs/en/khi-task-system-concept.md
+++ b/docs/en/khi-task-system-concept.md
@@ -1,976 +1,113 @@
-# KHI Task system concept
+# KHI Task System Concepts (Overview)
 
-## The complexity in log visualization system
+Kubernetes History Inspector (KHI) uses a powerful and flexible **Directed Acyclic Graph (DAG) task system** to automatically build timeline-based history files from massive and diverse container and cloud logs.
 
-Before discussing how to extend KHI, let's explain the complexity inherent in log visualization systems.
-KHI takes a large volume of logs as input and associates each log with one or more "events" or "revisions" on a timeline.
-At first glance, this might seem like a simple function that takes a log as input and outputs an array of locations on timelines.
+This documentation suite covers everything from fundamental concepts of the task system—the core of KHI's architecture—to practical syntax and cookbooks for developers implementing plugins and log parsers.
 
-However, in reality, there are logs that cannot be associated without first examining other logs.
+---
 
-- The "revisions" of resources generated from PATCH requests cannot be reconstructed at that point without first parsing previous requests to restore the state of the resource.
-- Container IDs included in Containerd logs cannot be linked to specific Pods without examining the logs that associate Pod names, which are only output once during Pod sandbox creation.
-- IPs appearing in various logs can be associated with different resources depending on timing, and logs containing only IPs cannot be linked to resources without first parsing logs that confirm the association between resource names and IPs.
+## Task System Guide Index
 
-Linking a large volume of logs to resources in a meaningful way is a meticulous operation that requires dividing the logs into groups, parsing them in a predetermined order, and linking them to resources.
-To efficiently handle these complex dependencies, KHI implements a system described by a unique DAG (Directed Acyclic Graph) that encompasses "generating input fields for user input," "generating log queries," "collecting logs," and "executing various parsers."
+Refer to the following specialized guides depending on your learning stage or development goal:
 
 ```mermaid
-flowchart TD
-    A[Containerd logs] --> B[filter logs containing <br> Container ID and Pod Name]
-    A --> C[The other Logs <br> with Container ID only]
-    B --> D[Record Container ID <br> and Pod Name]
-    D --> C
-    C --> E[Associate Logs to Pods]
-    D --> F[Timeline associations]
-    E --> F
+flowchart LR
+    Portal["Overview (This Document)<br>• Why DAG<br>• UI flow & task graphs"]
+    P1["1. Syntax and Modes<br>• Task[T] & dependencies<br>• Run/DryRun modes<br>• Unit testing"]
+    P2["2. Log Processing Guide<br>• 6 major task cookbooks<br>• Timeline APIs & assertions"]
+    P3["3. Advanced Patterns<br>• Inventory-Discovery pattern<br>• Input forms (formtask)<br>• Caching & progress"]
 
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
-    classDef highlight fill:#d4f4fa,stroke:#333,stroke-width:1px;
-    class A,F highlight;
+    Portal --> P1
+    P1 --> P2
+    P2 --> P3
 ```
 
-> Example: a sub-graph of a DAG parsing containerd logs to associate these logs to pod names.
+1. **[Task System Syntax and Execution Modes](./task-system/01-syntax-and-modes.md)**
+   - Covers DAG basics, task type (`Task[T]`) declarations, reading values from dependencies (`GetTaskResult`), structured logging (`slog`), package structures and naming conventions (`_contract`/`_impl`), **inspection execution modes (`Run` and `DryRun`)**, and **unit testing (`tasktest`)**.
+2. **[Log Processing Task Implementation Patterns (Cookbook)](./task-system/02-log-processing-cookbook.md)**
+   - Covers the overall log processing pipeline, practical recipes for the **6 major task creation utilities (`FieldSetReadTask`, `LogGrouperTask`, `LogFilterTask`, `LogIngesterTask`, `LogToTimelineMapperTask`)**, and timeline mapping using modern `*khifilev6.TimelinePath` and `testchangeset.AssertTimeline` objects.
+3. **[Advanced Task Patterns and Utilities](./task-system/03-advanced-and-form-tasks.md)**
+   - Covers automatic inspection server registration (`Register`), label selectors (`LabelSelector`, `FeatureTask`), the **`Inventory`-`Discovery` task pattern (`InventoryTaskBuilder` and merge strategies)** for resolving names across multiple log sources, **form tasks (`formtask` / autocomplete)** for rich UI input fields, and **progress reporting / cache control (`NewGlobalCachedTask`, `NewInspectionCachedTask`)**.
 
-To learn how to extend KHI, you need to understand this DAG system.
+---
 
-## Basic Forms Used in DAG
+## 1. Basic Concepts of the KHI Task System
 
-A Directed Acyclic Graph (DAG) is a graph that flows in one direction without cycles. In KHI's context, this represents a workflow where tasks are executed in a specific order based on their dependencies. Each node in the graph is a task, and edges represent dependencies between tasks.
+### 1.1 Complexity of Log Visualization Systems
 
-### The task type
+To diagnose issues in Kubernetes clusters, you need to collect many different types of logs from various systems (e.g., Kubernetes Control Plane logs, cluster node logs, Kubelet logs, container runtime logs, host kernel logs, etc.).
 
-In the DAG task system used by KHI, each task is created to implement the `task.Task[T]` interface.
-(See `pkg/core/task/task.go` for detailed implementation.)
+A single log alone cannot explain what happened. To get from a symptom to the actual root cause, you must combine and link relationships between logs from multiple systems.
+This introduces several challenges for log analysis and visualization tools:
 
-This interface is defined roughly as the following type:
-(In reality, elements where you don't need to worry about the TaskResult type are implemented in the `UntypedTask` interface, and there is a slightly more complex type definition to handle any `task.Task[T]` uniformly, but the following fields are sufficient for a general understanding.)
+- **Asynchrony and uncertain ordering**: Logs in distributed systems do not guarantee strict time ordering.
+- **Complex data dependencies**: To interpret one log, you often need metadata extracted from another log (e.g., mapping tables between container IDs and Pod names).
+- **Customization and plugin needs**: Not all users use the same environments or log types (e.g., on-premises vs. cloud-managed clusters).
 
-```go
-type Task[TaskResult any] interface {
-    // ID returns the unique identifier of the task.
-    ID() taskid.TaskImplementationID[TaskResult]
+To address these challenges, KHI uses a **Directed Acyclic Graph (DAG)** task system that explicitly declares data flow dependencies rather than relying on sequential scripts or static procedural code. This achieves both high concurrency performance and loosely coupled plugin design.
 
-    // Labels returns the labels associated with the task. KHI uses this value for various purposes (e.g. document generation, filtering tasks by cluster types, ...etc)
-    Labels() *typedmap.ReadonlyTypedMap
+### 1.2 Relationship Between UI Flow and Task Graphs in KHI
 
-    // Dependencies returns the IDs of tasks that need to be done before this task.
-    Dependencies() []taskid.UntypedTaskReference
+In KHI, the task system dynamically controls overall system state and execution flow from inspection environment initialization through user interactions in the UI to analysis execution.
 
-    // Run is the actual function called to run this task.
-    Run(ctx context.Context) (TaskResult, error)
-}
-```
-
-Normally, you don't need to implement this interface directly. You can create a task using the task.NewTask function.
-For example, let's say there is an IntGeneratorTask that generates a fixed integer value and a DoubleIntTask that doubles the value from the previous task.
-
-```go
-var IntGeneratorTaskID = taskid.NewDefaultImplementationID[int]("example.khi.google.com/int-generator")
-var DoubleIntTaskID = taskid.NewDefaultImplementationID[int]("example.khi.google.com/double-int")
-
-var IntGeneratorTask = task.NewTask(IntGeneratorTaskID,[]taskid.UntypedTaskReference{}, func(ctx context.Context) (int, error){
-    return 1, nil
-})
-
-var DoubleIntTask = task.NewTask(DoubleIntTaskID,[]taskid.UntypedTaskReference{IntGeneratorTaskID.Ref()}, func(ctx context.Context) (int, error){
-    intGeneratorResult := task.GetTaskResult(ctx, IntGeneratorTaskID.Ref())
-    return intGeneratorResult * 2, nil
-})
-```
+![Diagram showing how the task structure is used in the inspection flow presented to the user](./images/inspection-task-structure.png)
 
 ```mermaid
-flowchart TD
-    A[IntGeneratorTask] -->|returns 1| B[DoubleIntTask]
-    B -->|multiplies by 2| C[result: 2]
+sequenceDiagram
+    autonumber
+    actor U as User (UI)
+    participant S as InspectionServer
+    participant R as InspectionTaskRunner
+    participant G as Task Graph
 
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
-    classDef task fill:#d4f4fa,stroke:#333,stroke-width:1px;
-    classDef result fill:#e1f5e1,stroke:#333,stroke-width:1px;
-    class A,B task;
-    class C result;
+    Note over S,R: 1. Pool narrowing by platform and log types
+    U->>S: Open "New Inspection" dialog<br>and select Inspection Type
+    S->>S: Filter tasks with LabelSelector (availableTasks)
+    S->>U: Present toggleable list of FeatureTasks
+
+    Note over U,G: 2. Input forms and feature selection (DryRun mode)
+    U->>R: Enter/change parameters or request autocomplete
+    R->>G: Execute lightweight graph in DryRun mode
+    G->>R: Write form definitions & suggestions to Metadata
+    R->>U: Render input form and autocomplete list
+
+    Note over U,G: 3. Analysis execution and metadata communication (Run mode)
+    U->>R: Click "Start Inspection" button
+    R->>S: Recursively resolve dependencies of selected FeatureTasks
+    S->>G: Topologically sort and build final graph
+    R->>G: Execute task graph concurrently in Run mode
+    G->>R: Send progress updates (Progress) via Metadata
+    R->>U: Display real-time progress bar
+    G->>U: Generate final history file (KHI file)
 ```
 
-#### Task ID and Task Reference
+#### 1. Task Graph Construction from Platform and Feature Selection (Build Phase)
 
-In KHI, each task has a unique ID of type `taskid.TaskImplementationID[T]`.
-Typically, this is generated by the user calling `taskid.NewDefaultImplementationID[T](id string)`.
+1. **Narrowing the entire pool by platform and log types**:
+   All tasks used for log processing are registered in the root task set of `InspectionServer` during initialization.
+   When the user clicks the "New Inspection" button and selects an **Inspection Type** in the first dropdown, KHI evaluates label selector expressions across all registered tasks to filter only those compatible with the selected inspection environment (`availableTasks`).
+2. **Presenting feature selection UI based on FeatureTask labels**:
+   Next, KHI extracts tasks tagged with **`FeatureTask`** labels (feature flags) from `availableTasks` and presents them on the screen.
+   Users can toggle these checkboxes to choose which log parsing features to include in the inspection.
+3. **Recursively resolving dependency tasks and building the task graph**:
+   Starting from the `FeatureTask`s selected by the user, KHI recursively resolves all dependency tasks required for processing (such as log collection tasks, parsers, and inventory tasks) from `availableTasks`. It then topologically sorts them to build the final execution task graph.
 
-The type parameter is the type returned by the task using this ID. The `taskid.TaskImplementationID[T]` type needs to be created by the person defining the task,
-but those referencing the task need to use `taskid.TaskReference[T]`.
+#### 2. UI Communication and Metadata Sharing During Task Execution (Runtime Phase)
 
-This is used to specify the dependency list of a task, and also in `GetTaskResult[T](ctx context.Context, reference taskid.TaskReference[T])` to retrieve the value from a previous task it depends on.
+After the task graph is built, KHI passes a JSON-serializable shared data store called **`Metadata`** to each task through the context.
+You can access this `Metadata` from outside the server or from the frontend (UI) during and after task execution. It is used primarily for the following purposes:
 
-In many cases, TaskReference[T] will be obtained from TaskImplementationID[T] through Ref().
-However, KHI's task system has a mechanism to abstract inputs in the ID itself.
-For example, let's say we want to create a task graph that processes "logs collected from Cloud Logging" or "logs uploaded from a file" with "a certain parser".
+- **Real-time progress display**:
+  Tasks that perform long log queries or heavy parsing continuously update progress information (`Progress`) in `Metadata` during execution. When the frontend polls task status periodically, it reads these values to update progress bars.
+- **Rendering dynamic input forms and autocomplete lists**:
+  During form interactions on the "New Inspection" screen (`DryRun` mode), parameter input tasks and autocomplete tasks write required field definitions and suggestion lists to `Metadata`. The frontend reads this information to render interactive input forms.
 
-```go
-var LogsInputTaskReference = taskid.NewTaskReference[[]Log]("example.khi.google.com/log-input")
-var LogsInputFromCloudLoggingTaskID = taskid.NewImplementationID(LogsInputTaskReference, "cloud-logging")
-var LogsInputFromFileTaskID = taskid.NewImplementationID(LogsInputTaskReference, "file")
+---
 
-var LogParserTaskID = taskid.NewDefaultImplementationID[[]ParsedLog]("example.khi.google.com/log-parser")
+## 2. Next Steps
 
-var LogsInputFromCloudLoggingTask = task.NewTask(LogsInputFromCloudLoggingTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) ([]Log, error) {
- // Get logs from Cloud Logging
- return logs, nil
-})
+To learn task syntax and see practical code examples, proceed to the following specialized guides:
 
-var LogsInputFromFileTask = task.NewTask(LogsInputFromFileTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) ([]Log, error) {
- // Get logs from file
- return logs, nil
-})
-
-var LogParserTask = task.NewTask(LogParserTaskID, []taskid.UntypedTaskReference{LogsInputTaskReference}, func(ctx context.Context) ([]ParsedLog, error) {
- logs := task.GetTaskResult(ctx, LogsInputTaskReference)
- // Parse logs
- return parsedLogs, nil
-})
-```
-
-```mermaid
-flowchart TD
-    A[LogsInputFromCloudLogging] -.->|logs from Cloud Logging| E[LogParserTask]
-    B[LogsInputFromFile] -.->|logs from file| E
-
-    E(LogsInputTaskReference)-->|logs from something|C[LogParserTask]
-    C --> D[Parsed logs]
-
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
-    classDef task fill:#d4f4fa,stroke:#333,stroke-width:1px;
-    classDef abst fill:#f4c4ca,stroke:#333,stroke-width:1px;
-    classDef result fill:#e1f5e1,stroke:#333,stroke-width:1px;
-    class A,B,C task;
-    class D result;
-    class E abst;
-```
-
-A TaskReference does not specify a particular concrete implementation of a task, allowing you to reuse parts of a DAG graph by simply rearranging the tasks included in the task graph.
-
-### Getting a value from task inside
-
-#### Getting a result from a previous task
-
-Values output by your task's dependencies can be retrieved using the `task.GetTaskResult` function, with the context passed to the task and the TaskReference.
-The context must be the exact context value passed to the task function itself.
-
-```go
-taskResult := coretask.GetTaskResult(ctx, SomeTaskID.Ref())
-// The taskResult type is T when SomeTaskID is taskid.TaskImplementationID[T]
-```
-
-#### Getting a value outside from task graph
-
-In KHI, values are passed to the task graph by including them in the context.
-Additionally, to treat values provided in the context in a type-safe manner, we use functions defined in the `khictx` package.
-
-```go
-contextValueID := typedmap.NewTypedKey[string]("a-string-value") // This is a key associating string value.
-theValue := typedmap.GetOrDefault(ctx, contextValueID, "default-value")
-```
-
-### Logging in a task
-
-KHI uses the `log/slog` package for logging. KHI's logging handlers automatically associate logs with task names by extracting information from the task context, making it clear which task generated each log entry. For this reason, you should always use context-aware logging methods such as `slog.InfoContext`, `slog.WarnContext`, or `slog.ErrorContext` rather than their non-context counterparts when logging within tasks.
-
-Example:
-
-```go
-task.NewTask(TaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (Result, error) {
-    // Good: Using context-aware logging
-    slog.InfoContext(ctx, "Processing started")
-    
-    // Bad: Using non context-aware logging
-    // slog.Info("Processing started")
-    // fmt.Printf("Processing started")
-    
-    // ... task implementation ...
-    return result, nil
-})
-```
-
-### Package structure for tasks
-
-Tasks are often defined as package-level global variables. However, the initialization order of global variables within the same package is not guaranteed by the Go language. [reference: The Go Programming Language Specification](https://go.dev/ref/spec#Package_initialization) This can lead to errors where a task is initialized with a reference to another `TaskID` that is still `nil`.
-
-To solve this issue reliably, we separate a task's **"contract"** (including task IDs and types used by them) from its **"implementation"** into distinct packages. Because the implementation package imports the contract package, Go guarantees that the contract (and its `TaskID`s) is fully initialized before the implementation.
-
-We use the following standard structure. For example, for a feature named `foo`:
-
-```plaintext
-pkg/task/inspection/foo/
-├── contract/
-│   └── ids.go          // package foocontract
-├── impl/
-│   └── parsertask.go   // package fooimpl
-└── registration.go     // package foo
-```
-
-Role of Each Component
-
-- `contract/` (package foocontract)
-
-    It contains the TaskID variables and defines the result types used as type parameters for the TaskIDs. The contract package may contain task label keys and types used in its type parameters.
-    The contract package must not depend on the implementation package.
-- `impl/` (package fooimpl)
-
-    This package contains the actual implementation logic of the task.
-    It imports the contract package to safely reference the TaskID.
-- `registration.go` (package foo)
-
-    It typically contains a function registering the task instance (from the fooimpl package) with a central task registry. This function is called from an upper layer package or initialization step of a file in `cmd/kubernetes-history-inspector/`.
-
-### Testing tasks
-
-For testing tasks, use one of the following two helper functions:
-
-- `tasktest.RunTask`: Used to call a specific task and receive the resulting value and error
-- `tasktest.RunTaskWithDependency`: Used to resolve dependencies with the given task list, execute a specific task, and receive the resulting value and error
-
-#### tasktest.RunTask
-
-Use `tasktest.RunTask` when you simply want to execute a task with specific inputs and test its result.
-
-```go
-
-var ReturnSomeNumberReference = taskid.NewTaskReference[int]("example.khi.google.com/some-number")
-var DoubleNumberTaskID = taskid.NewDefaultImplementationID[int]("example.khi.google.com/double-number")
-
-var DoubleNumberTask = task.NewTask(DoubleNumberTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (int, error) {
-    number := task.GetTaskResult(ctx, ReturnSomeNumberReference)
- return number * 2, nil
-})
-
-func TestRunTask(t *testing.T) {
- result,err := tasktest.RunTask(context.Background(), DoubleNumberTaskID, tasktest.NewTaskDependencyValuePair(ReturnSomeNumberReference, 5))
- if err != nil {
-  t.Fatalf("failed to run task: %v", err)
- }
- if result != 10 {
-  t.Fatalf("unexpected result: %v", result)
- }
-}
-```
-
-#### tasktest.RunTaskWithDependency
-
-In some cases, tasks may have inputs that are difficult to create for test cases, and you may want to actually execute the dependent tasks as well.
-
-```go
-var SimpleInputTaskReference = taskid.NewTaskReference[int]("example.khi.google.com/simple-input")
-var ComplexOutputTaskID = taskid.NewDefaultImplementationID[ComplexOutput]("example.khi.google.com/complex-output")
-var TestingTargetTaskID = taskid.NewDefaultImplementationID[int]("example.khi.google.com/testing-target") 
-
-var ComplexOutputTask = task.NewTask(ComplexOutputTaskID, []taskid.UntypedTaskReference{SimpleInputTaskReference}, func(ctx context.Context) ([]int, error) {
- input := task.GetTaskResult(ctx, SimpleInputTaskReference)
-    // Do the complex processing
- return complex,nil
-})
-
-var TestingTargetTask = task.NewTask(TestingTargetTaskID, []taskid.UntypedTaskReference{ComplexOutputTaskID.Ref()}, func(ctx context.Context) (int, error) {
- complexOutput := task.GetTaskResult(ctx, ComplexOutputTaskID.Ref())
-    // Consume the complex output and produce a comperable output
-    return testOutput, nil
-})
-
-func TestRunTaskWithDependency(t *testing.T) {
- result, err := tasktest.RunTaskWithDependency(context.Background(), TestingTargetTaskID,[]coretask.UntypedTask{ComplexOutputTask,tasktest.StubTaskFromReferenceID(SimpleInputTaskReference, 5, nil)})
- if err != nil {
-  t.Fatalf("failed to run task: %v", err)
- }
- if result != EXPECTED_VALUE {
-  t.Fatalf("unexpected result: %v", result)
- }
-}
-```
-
-In the example above, we create a test task that returns the fixed value 5 as `SimpleInputTaskReference` and passed this stub task as a dependency.
-
-With `RunTaskWithDependency`, the stub task generated by `task_test.StubTaskFromReferenceID` is executed, then ComplexOutputTask is actually executed, and finally TestingTargetTask is executed to obtain and compare the execution results.
-
-## Running a task graph
-
-### Resolving the task graph dependency and order
-
-When extending KHI, you typically don't need to be concerned with the execution of task graphs. However, understanding how KHI executes task graphs will make subsequent explanations clearer.
-In KHI, multiple tasks are grouped and executed together as a `TaskSet` type.
-
-```go
-taskSet := task.NewTaskSet([]task.UntypedTask{
-    Task1,
-    Task2,
-    Task3
-})
-```
-
-Typically, a `TaskSet` cannot be executed directly. It needs to be processed through topological sorting and have necessary dependent tasks added to construct an executable graph.
-
-```go
-dependencyTaskSet := task.NewTaskSet([]task.UntypedTask{
-    DependencyTask1,
-    DependencyTask2,
-    DependencyTask3
-})
-taskSet := task.NewTaskSet([]task.UntypedTask{
-    Task1,
-    Task2
-})
-
-resolvedTaskSet, err := taskSet.ResolveTask(dependencyTaskSet)
-```
-
-The `ResolveTask` method of the `TaskSet` type sorts its contained tasks into an executable order. If there are missing dependencies for these tasks, it includes only the necessary tasks from another `TaskSet` passed as an argument. If tasks have circular references or if the provided `TaskSet` doesn't satisfy necessary dependencies, `ResolveTask` will return an error.
-
-Let's assume these tasks have the following dependency relationships:
-
-```mermaid
-flowchart TD
-    Task1 --> DependencyTask1
-    Task1 --> DependencyTask2
-    Task2 --> DependencyTask1
-
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
-```
-
-In this case, since `DependencyTask1` and `DependencyTask2` have no dependencies between them, they are executed first and can run in parallel. After `DependencyTask1` completes, `Task2` is executed, and after `DependencyTask2` completes, `Task1` is executed, forming the complete graph structure.
-`DependencyTask3` is not referenced by either `Task1` or `Task2`, so it is not included in the `resolvedTaskSet`.
-
-### Running the task graph
-
-A `TaskSet` with resolved dependencies and execution order can be executed by a type that implements the `TaskRunner` interface.
-Currently, only `LocalRunner` is implemented, so you can execute a resolved `TaskSet` as follows:
-
-```go
-taskRunner := task.NewLocalRunner(resolvedTaskSet)
-
-err := taskRunner.Run(context.Background())
-
-<- taskRunner.Wait()
-
-result, err := taskRunner.Result()
-```
-
-As shown above, you can execute tasks, wait for their completion, and retrieve the results.
-The result is returned as a `typedmap` containing the output of each task, but if you want the result of a specific task, use `task.GetTaskResultFromLocalRunner`.
-
-```go
-taskRunner := task.NewLocalRunner(resolvedTaskSet)
-
-err := taskRunner.Run(context.Background())
-
-<- taskRunner.Wait()
-
-_, err := taskRunner.Result() // make sure the task graph ended without error
-
-result := task.GetTaskResultFromLocalRunner(taskRunner, TaskID)
-```
-
-## Inspection tasks
-
-The task mechanism explained so far is not solely dependent on KHI's log analysis purpose.
-However, KHI analyzes various types of logs while maintaining extensibility through a log processing task graph mechanism implemented on top of this system specifically for KHI.
-
-### Relationship between UI Flow and Task Graph in KHI
-
-When using KHI, users follow a workflow like the one shown below:
-
-![Diagram showing how task structure is used in the inspection flow shown to users](./images/inspection-task-structure.png)
-
-Various tasks used for actual log processing are registered to the `InspectionServer` during KHI's initialization.
-When a user clicks the `New Inspection` button, they first need to select an `Inspection Type`. KHI then filters the registered tasks to include only those that can operate with the selected `Inspection Type`. This includes not only the tasks that users can enable or disable but also all tasks used in their dependency relationships.
-Next, users select log types, which internally in KHI are represented as a list of special tasks called Feature tasks. KHI displays only those tasks that are Feature tasks and are available for the selected Inspection type, allowing users to choose whether to include each task.
-
-To execute the tasks selected by the user, KHI first resolves dependencies using the set of available tasks filtered by the Inspection Type, performs topological sorting, and constructs a task graph.
-When executing a task graph for log analysis, KHI passes a JSON-serializable value called `Metadata` through the context. This `Metadata` can be accessed from outside the execution at any point during task execution.
-For example, when a task is performing time-consuming processing, it can edit the Progress metadata stored in this `Metadata`. When the frontend retrieves the task list, this `Metadata` is read, and the progress status is displayed on the frontend.
-The same applies to form editing. Each task executed in Dryrun mode during form editing embeds the information needed for the frontend to display the form in the `Metadata`. The frontend retrieves this information to render the actual frontend.
-
-### Registering tasks on the inspection task server
-
-KHI build system automatically generates a code to call `Register()` function defined in `impl` package under `task/inspection/<some package name>/impl` when `registration.go` is stored in the folder.
-To define new tasks, developer must register defined tasks and inspection types from this `Register()` function.
-
-example:
-
-```go
-// Register registers all googlecloudlogserialport inspection tasks to the registry.
-func Register(registry coreinspection.InspectionTaskRegistry) error {
- err := registry.AddInspectionType(ossclusterk8s_contract.OSSKubernetesLogFilesInspectionType)
- if err != nil {
-  return err
- }
-
- return coretask.RegisterTasks(registry,
-  InputAuditLogFilesTask,
-  AuditLogFileReaderTask,
-  EventAuditLogFilterTask,
-  NonEventAuditLogFilterTask,
-  OSSK8sEventLogParserTask,
-  OSSK8sAuditLogFieldExtractorTask,
-  OSSK8sAuditLogParserTailTask,
- )
-}
-```
-
-### Labels on inspection tasks
-
-When discussing tasks earlier, we did not go into depth about Labels, but each task in KHI has a map of labels.
-KHI utilize this feature to select specific set of tasks from the set of all tasks registered on KHI.
-
-#### Restricting Inspection Types (LabelSelector / InspectionType Label)
-
-To specify which Inspection Types a task is compatible with, KHI provides two mechanisms: **LabelSelector (Recommended)** and **InspectionType Label (Legacy)**.
-
-KHI first evaluates compatibility using the LabelSelector. If no selector is configured, it falls back to the legacy InspectionType ID list. If neither is specified, it is interpreted as a global task usable with any InspectionType.
-
-##### 1. Using LabelSelector (Recommended)
-
-A `LabelSelector` allows you to specify conditions using a map of labels (`map[string]string`). A task is enabled only if the current InspectionType **contains all** the labels defined in the selector (i.e., the InspectionType's labels are a superset of the selector's labels). The InspectionType may have additional labels not specified in the selector.
-
-This is useful for enabling tasks across a whole platform (e.g., `platform: gke`).
-
-```go
-var MyTask = task.NewTask(MyTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (any, error) {
-    return nil, nil
-}, inspectioncore_contract.InspectionTypeLabelSelector(map[string]string{
-    "platform": "gke",
-})) // Enabled only on Inspection Types with the label platform: gke
-```
-
-##### 2. Using InspectionType Label (Legacy)
-
-The InspectionType label applied to tasks has a value of `[]string` type. These are hardcoded arrays of InspectionType IDs, and they determine compatibility based on the following criteria:
-
-- The task does not have any InspectionType labels (interpreted as a global task usable with any InspectionType).
-- The task includes the ID of the user-selected InspectionType within its list.
-
-```go
-var IntGeneratorTask = task.NewTask(IntGeneratorTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (int, error) {
-    return 1, nil
-}, inspectioncore_contract.InspectionTypeLabel("gcp-gke", "gcp-gdcv-for-baremetal")) // Matches exact IDs only
-```
-
-#### FeatureTask Label
-
-In KHI, tasks that users can enable or disable are called Feature tasks. These are also just regular tasks, but with specific labels attached to them.
-Since Feature tasks need to be selected by users in the UI, they are given additional labels such as title and description. These can be assigned all at once using the `task.FeatureTaskLabel` function.
-
-```go
-
-var ContainerdLogFeatureTaskID = taskid.NewDefaultImplementationID[[]Log]("example.khi.google.com/containerd-log-feature")
-
-var ContainerdLogFeatureTask = task.NewTask(ContainerdLogFeatureTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) ([]Log, error) {
- // Get logs from containerd
- return logs, nil
-}, inspectioncore_contract.FeatureTaskLabel("title","description",/*Log type*/,/*is default feature or not */, "gcp-gke","gcp-gdcv-for-baremetal"))
-
-```
-
-When implementing a new parser, you will often need to register tasks with labels generated by this `FeatureTaskLabel` function.
-Note that in FeatureTaskLabel, the InspectionTaskType must be specified as a required variadic parameter at the end.
-
-### Task mode
-
-KHI runs tasks for inspection in `run` or `dryrun` mode. Once the graph is built, KHI periodically runs the task graph as `dryrun` mode during user editing the form values. Tasks only running on the `run` mode need to read this task mode from the context value to skip processing when it is in `dryrun` mode.
-
-```go
-taskMode := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionTaskMode)
-// taskMode should be inspectioncore_contract.TaskModeDryRun or inspectioncore_contract.TaskModeRun
-```
-
-Users typically don't need to get task mode from the context with using `inspection_task.NewInspectionTask()` which is a wrapper of `task.NewTask`.
-
-```go
-var Task = inspection_task.NewInspectionTask(TestTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context, taskMode inspection_task_interface.TaskMode) (Result, error) {
- if taskMode == inspection_task_interface.TaskModeDryRun { // Skip the task processing when the mode is dryrun.
-  return nil, nil
- }
- // ...
-})
-```
-
-### The task metadata
-
-Each task in KHI can output various additional information beyond just the task results.
-For example, this might include queries used for log collection or logs output by the task.
-
-In KHI, data that is not the main output of a task is managed in a single map called Metadata. When a task graph is executed, an empty map is initially passed, and each task adds values as needed.
-Metadata can be read even while a task is executing. This is important because, for example, progress bar values are continuously written by tasks and need to be retrievable as task metadata even during execution.
-
-To get the metadata map, you can retrieve it from the context using `khictx` as follows:
-
-```go
-metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
-```
-
-Developers performing normal extensions do not need to be aware of the existence of metadata. Typically, these are wrapped by various utilities, and values are set automatically.
-
-#### Input fields
-
-One major use of Metadata is for forms when creating log filters.
-Each task writes the metadata required for its form to the form metadata, which the frontend receives to render the form.
-
-However, users do not need to understand the specifics of handling metadata. For example, if it's a text form, use `formtask.NewTextFormTaskBuilder`.
-
-Below is a practical example of a form task for entering a Duration value. Since forms are also tasks, they can have prerequisite tasks.
-
-```go
-var InputDurationTask = formtask.NewTextFormTaskBuilder(InputDurationTaskID, PriorityForQueryTimeGroup+4000, "Duration").
- WithDependencies([]taskid.UntypedTaskReference{
-  InspectionTimeTaskID,
-  InputEndTimeTaskID,
-  TimeZoneShiftInputTaskID,
- }).
- WithDescription("The duration of time range to gather logs. Supported time units are `h`,`m` or `s`. (Example: `3h30m`)").
- WithDefaultValueFunc(func(ctx context.Context, previousValues []string) (string, error) {
-  if len(previousValues) > 0 {
-   return previousValues[0], nil
-  } else {
-   return "1h", nil
-  }
- }).
- WithHintFunc(func(ctx context.Context, value string, convertedValue any) (string, form_metadata.ParameterHintType, error) {
-  inspectionTime := task.GetTaskResult(ctx, InspectionTimeTaskID.Ref())
-  endTime := task.GetTaskResult(ctx, InputEndTimeTaskID.Ref())
-  timezoneShift := task.GetTaskResult(ctx, TimeZoneShiftInputTaskID.Ref())
-
-  duration := convertedValue.(time.Duration)
-  startTime := endTime.Add(-duration)
-  startToNow := inspectionTime.Sub(startTime)
-  hintString := ""
-  if startToNow > time.Hour*24*30 {
-   hintString += "Specified time range starts from over than 30 days ago, maybe some logs are missing and the generated result could be incomplete.\n"
-  }
-  if duration > time.Hour*3 {
-   hintString += "This duration can be too long for big clusters and lead OOM. Please retry with shorter duration when your machine crashed.\n"
-  }
-  hintString += fmt.Sprintf("Query range:\n%s\n", toTimeDurationWithTimezone(startTime, endTime, timezoneShift, true))
-  hintString += fmt.Sprintf("(UTC: %s)\n", toTimeDurationWithTimezone(startTime, endTime, time.UTC, false))
-  hintString += fmt.Sprintf("(PDT: %s)", toTimeDurationWithTimezone(startTime, endTime, time.FixedZone("PDT", -7*3600), false))
-  return hintString, form_metadata.Info, nil
- }).
- WithSuggestionsConstant([]string{"1m", "10m", "1h", "3h", "12h", "24h"}).
- WithValidator(func(ctx context.Context, value string) (string, error) {
-  d, err := time.ParseDuration(value)
-  if err != nil {
-   return err.Error(), nil
-  }
-  if d <= 0 {
-   return "duration must be positive", nil
-  }
-  return "", nil
- }).
- WithConverter(func(ctx context.Context, value string) (time.Duration, error) {
-  d, err := time.ParseDuration(value)
-  if err != nil {
-   return 0, err
-  }
-  return d, nil
- }).
- Build()
-```
-
-These form field configurations are stored in the form metadata.
-
-```go
-metadata := khictx.MustGetValue(ctx, inspection_task_contextkey.InspectionRunMetadata)
-formFields, found := typedmap.Get(metadata, form_metadata.FormFieldSetMetadataKey)
-```
-
-## Task utilities to parse logs
-
-KHI uses its robust task system to perform log parsing. This architecture makes KHI highly extensible—new capabilities can be added simply by creating new tasks—and allows it to fully utilize Go's concurrency features. However, as there are many common patterns when parsing logs, log parsing tasks should be implemented using the high-level task creation utilities provided by KHI.
-
-KHI provides the following high-level task creation utilities to cover basic log parsing use cases:
-
-- FieldSetReadTask : Parse fields of structured log into a typed struct.
-- LogGrouperTask : Group logs by a specific field.
-- LogFilterTask : Filter logs based on a condition.
-- LogIngesterTask : Ingest logs into the final history data.
-- LogToTimelineMapperTask : Map ingested logs to a timeline.
-
-These tasks are usually connected as the following diagram:
-
-```mermaid
-flowchart TD
-    QueryTask --> FieldSetReadTask
-    FieldSetReadTask --> LogFilterTask
-    LogFilterTask --> LogGrouperTask
-    LogFilterTask --> LogIngesterTask
-    LogIngesterTask --> LogToTimelineMapperTask
-    LogGrouperTask --> LogToTimelineMapperTask
-```
-
-Note that KHI needs to ingest logs at first place before associating these logs with resources.
-
-### FieldSetReadTask
-
-A common and critical step in parsing is reading specific fields from a single log entry. Since this operation is typically independent of other logs, it can be performed in parallel. Instead of having a monolithic parser read fields sequentially, KHI uses the `FieldSetReadTask` to process them concurrently. This task reads predefined fields from each log in parallel and attaches the strongly-typed results (called FieldSets) to the corresponding log object.
-
-For example, you can define `FieldSet` types and their corresponding readers to extract specific data:
-
-```go
-// Define a struct for the data you want to extract.
-type PodInfoFieldSet struct {
-    PodName      string
-    ContainerID  string
-}
-func (fs *PodInfoFieldSet) Kind() string { return "PodInfo" }
-
-// Create a reader that implements the log.FieldSetReader interface.
-type PodInfoReader struct{}
-func (r *PodInfoReader) FieldSetKind() string { return "PodInfo" }
-func (r *PodInfoReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
-    // Logic to read from the log's structured data.
-    return &PodInfoFieldSet{
-        PodName:      reader.ReadStringOrDefault("podName", ""),
-        ContainerID:  reader.ReadStringOrDefault("containerID", ""),
-    }, nil
-}
-
-// In your task graph, create a FieldSetReadTask.
-var ReadPodInfoTask = inspectiontaskbase.NewFieldSetReadTask(
-    ReadPodInfoTaskID,
-    SourceLogsTaskID.Ref(), // Depends on a task that returns []*log.Log, likely from a Query.
-    []log.FieldSetReader{&PodInfoReader{}},
-)
-```
-
- Subsequent tasks in the graph can now access the parsed `PodInfoFieldSet` from each log object, ensuring that the expensive parsing step is done only once and in parallel.
-
- Subsequent tasks can read the PodInfoFieldSet struct from the log instance with the following code.
-
-```go
-func FieldSetConsumer(l *log.Log){
-  p := log.MustGetFieldSet(l, &PodInfoFieldSet{})
-}
-```
-
-Multiple fieldset readers can be defined for a single field set. The fieldSet abstracts how to access the actual field by the reader but actual readers can be injected as a FieldSetReadTask depending on its cluster type. For example, the OSS kube-apiserver audit logs and GKE kubernetes audit logs depends on the same field set, but the readers are different because some field names are unique in GKE.
-
-### NewLogGrouperTask
-
-While log parsing often needs to follow a chronological order, operations on different resources (like two different Pods) can usually be processed independently and in parallel. To enable this, `NewLogGrouperTask` is used to group logs based on a specific field, such as a resource name or ID.
-
-```go
-// This task takes a list of logs and a grouper function.
-var GroupLogsByPodTask = inspectiontaskbase.NewLogGrouperTask(
-    GroupLogsByPodTaskID,
-    SourceLogsTaskID.Ref(), // Depends on the source logs
-    func(ctx context.Context, l *log.Log) string {
-        // Group by Pod name. Assumes FieldSetReadTask has already run.
-        if podInfo, ok := log.GetFieldSet(l, &PodInfoFieldSet{}); ok {
-            return podInfo.PodName
-        }
-  return "unknown-pod"
-    },
-)
-```
-
-This allows downstream tasks to process the logs for each Pod in parallel, significantly improving performance.
-
-### NewLogFilterTask
-
-Often, a parser only needs to operate on a subset of logs. `NewLogFilterTask` provides a simple way to filter a list of logs based on a predicate function. This is useful for narrowing down the scope of subsequent, more expensive processing tasks.
-
-```go
-// This task takes a list of logs and a filter function.
-var FilterPodLogsTask = inspectiontaskbase.NewLogFilterTask(
-    FilterPodLogsTaskID,
-    SourceLogsTaskID.Ref(), // Depends on the source logs
-    func(ctx context.Context, l *log.Log) bool {
-        // Keep only logs related to Pods. Assumes FieldSetReadTask has run.
-        if podInfo, ok := log.GetFieldSet(l, &PodInfoFieldSet{}); ok {
-            return podInfo.PodName != ""
-        }
-        return false
-    },
-)
-```
-
-### NewLogIngesterTask
-
-`LogIngesterTask` is responsible for ingesting logs into the KHI history file before adding other data sourced from these logs.
-
-> [!IMPORTANT]
-> Only logs processed by `LogIngesterTask` are written to the final KHI file. If you want to exclude some queried logs from the final result, you **MUST** filter them before passing them to `LogIngesterTask`. Use `NewLogFilterTask` for this purpose.
->
-> Tasks that generate result data linked to logs (e.g., `LogToTimelineMapperTask`) cannot save information for logs that have not been processed by `LogIngesterTask`. Ensure your target logs are ingested first.
-
-```go
-var IngestLogsTask = inspectiontaskbase.NewLogIngesterTask(
-    IngestLogsTaskID,
-    SourceLogsTaskID.Ref(), // taskid.TaskReference[[]log.Log]
-)
-```
-
-### NewLogToTimelineMapperTask
-
-`LogToTimelineMapperTask` associates logs to multiple resources or sometimes overrides log summary.
-
-To modify the history, you use the `TimelineChangeSet` object returned by `ProcessLogByGroup`.
-
-The task returns a `TimelineMapperResult` containing the summary of the performed writes (e.g., which timeline paths received events, revisions, or aliases). Subsequent tasks can inspect this result to determine if specific timelines were populated, allowing for conditional behaviors such as generating fallback timelines from other log sources.
-
-#### `TimelineChangeSet` Operations
-
-- **`AddEvent(resourcePath)`**: Adds a point-in-time event to the timeline.
-- **`AddRevision(resourcePath, revision)`**: Adds a state at a specific time.
-- **`AddResourceAlias(source, dest)`**: Links resources (e.g., Pod -> Owner).
-- **`SetLogSummary(summary)` / `SetLogSeverity(severity)`**: Overrides log metadata.
-
-### Mapping log associations with resources
-
-It processes logs after grouping logs by resources and allows you to maintain state across logs in the same group using the `prevGroupData` argument in `ProcessLogByGroup`.
-
-```go
-// Define a custom struct to hold state between logs in the same group.
-type MyGroupData struct {
-    Count int
-}
-
-type MyMapper struct {}
-
-// Implement LogToTimelineMapper interface
-func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
-    cs := khifilev6.NewTimelineChangeSet()
-    // Modify history via TimelineChangeSet
-    cs.SetLogSeverity(enum.SeverityInfo)
-    
-    // Add an event to a resource timeline
-    cs.AddEvent(resourcepath.NameLayerGeneralItem("v1", "Pod", "default", "my-pod"))
-
-    // Pass updated state to the next log in the group
-    return cs, MyGroupData{Count: prevData.Count + 1}, nil
-}
-
-// ... Implement other interface methods (Dependencies, LogIngesterTask, GroupedLogTask, PassCount, PreProcessLogByGroup) ...
-
-var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
-    MyMapperTaskID,
-    &MyMapper{},
-    inspectioncore_contract.FeatureTaskLabel("my-mapper",/*rest of the other parameters*/)  // LogToTimelineMapper is usually labeled with FeatureTaskLabel.
-)
-```
-
-#### Testing the result of ChangeSet
-
-You should test your mapper logic using `testchangeset.ChangeSetAsserter` in a simple unit test. This allows you to verify `ChangeSet` modifications declaratively.
-
-```go
-func TestMyMapper_ProcessLogByGroup(t *testing.T) {
-    // 1. Setup Inputs
-    l := log.NewLogWithFieldSetsForTest(&log.CommonFieldSet{Timestamp: time.Now()}, /* ... */)
-    cs := history.NewChangeSet(l)
-    mapper := &MyMapper{}
-
-    // 2. Run Logic
-    _, err := mapper.ProcessLogByGroup(t.Context(), l, cs, nil, MyGroupData{})
-    if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-
-    // 3. Verify using ChangeSetAsserter
-    asserters := []testchangeset.ChangeSetAsserter{
-        &testchangeset.HasEvent{
-            ResourcePath: "v1#Pod#default#my-pod",
-        },
-        &testchangeset.HasLogSeverity{
-            WantLogSummary: "expected summary",
-        },
-    }
-
-    for _, a := range asserters {
-        a.Assert(t, cs)
-    }
-}
-```
-
-## Task utilities to discover information from logs
-
-Log parser may want to have information like (`who obtained "x.y.z.w" at a time T`, `which pod associates with a container ID "6123c6aacf0c78dc38ec4f0ff72edd3cf04eb82ca0e3e7dddd3950ea9753bdf1"`) to associate them with resources. This information can be from multiple log sources but users can turn on/off which logs to process in KHI.
-
-KHI provides the `Discovery-Inventory` pattern task utility to gather information from multiple sources.
-
-### Inventory Task
-
-The `InventoryTask` framework solves the problem of aggregating information from multiple, optional log sources into a single, consolidated view. This decouples data consumers (who just need the final mapping, e.g., ContainerID to Pod) from the data providers (specific log parsers).
-
-#### Usage
-
-1. **Define a Builder**: Create an `InventoryTaskBuilder` with a unique ID for the consolidated inventory.
-2. **Create Discovery Tasks**: Use the builder's `DiscoveryTask` method to create tasks that extract partial inventory data from different sources.
-3. **Create Inventory Task**: Use the builder's `InventoryTask` method to create the final task that aggregates all discovery results using a merge strategy.
-
-#### Example: Container ID Inventory
-
-```go
-// 1. Define the Builder
-var ContainerIDInventoryBuilder = inspectiontaskbase.NewInventoryTaskBuilder[ContainerIDToContainerIdentity](ContainerIDInventoryTaskID)
-
-// 2. Define Discovery Tasks (e.g., from Audit Logs)
-// This task discovers container ID to container identity mappings from manifests.
-// Discovery tasks must be depend from a task labeled with FeatureTaskLabel. Then the discovery task is activated when the feature task is selected by the user.
-var ContainerIDDiscoveryTask = ContainerIDInventoryBuilder.DiscoveryTask(
-    ContainerIDDiscoveryTaskID,
-    []taskid.UntypedTaskReference{ManifestGeneratorTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ContainerIDToContainerIdentity, error) {
-        if taskMode != inspectioncore.InspectionTaskModeRun {
-            return nil, nil
-        }
-        // ... extract container IDs and their identities from manifests ...
-        // For example:
-        manifests := coretask.GetTaskResult(ctx, ManifestGeneratorTaskID.Ref())
-        partialResult := make(ContainerIDToContainerIdentity)
-        for _, manifest := range manifests {
-            if containerID, identity := extractContainerInfo(manifest); containerID != "" {
-                partialResult[containerID] = identity
-            }
-        }
-        return partialResult, nil
-    },
-)
-
-// 3. Define the Inventory Task with a Merger Strategy
-// The merger strategy defines how to combine results from multiple discovery tasks.
-type ContainerIDMergeStrategy struct{}
-
-// Merge combines two ContainerIDToContainerIdentity maps.
-func (s *ContainerIDMergeStrategy) Merge(identities []ContainerIDToContainerIdentity) ContainerIDToContainerIdentity {
-    // logic to merge given identities from DiscoveryTask into a single identity instance
-}
-
-var ContainerIDInventoryTask = ContainerIDInventoryBuilder.InventoryTask(&ContainerIDMergeStrategy{})
-```
-
-## Low-Level Task Utilities
-
-When high-level task utilities are insufficient for your needs, KHI provides several low-level utilities to define tasks from scratch.
-
-### NewProgressReportableInspectionTask
-
-Even if your task completes quickly, `NewProgressReportableInspectionTask` should be used when defining a low-level task.
-It provides a `progress` argument, allowing the task to report its status to the user.
-
-```go
-var HeavyProcessingTask = inspectiontaskbase.NewProgressReportableInspectionTask(
-    HeavyProcessingTaskID,
-    []taskid.UntypedTaskReference{SourceLogsTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
-        if taskMode != inspectioncore_contract.TaskModeRun {
-            return ResultType{}, nil
-        }
-
-        logs := coretask.GetTaskResult(ctx, SourceLogsTaskID.Ref())
-        total := len(logs)
-        processed := 0
-
-        // Create a ProgressUpdater that updates the progress metadata every second.
-        updater := progressutil.NewProgressUpdater(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
-            tp.Percentage = float32(processed) / float32(total)
-            tp.Message = fmt.Sprintf("Processed %d/%d logs", processed, total)
-        })
-
-        updater.Start(ctx)
-        defer updater.Done()
-
-        for _, l := range logs {
-            // Do heavy processing...
-            processed++
-        }
-
-        return result, nil
-    },
-)
-```
-
-#### Indeterminate Progress Reporting
-
-When the total amount of work is unknown, you can use `MarkIndeterminate()` to mark the current task progress as indeterminate.
-
-```go
-var UnknownLengthTask = inspectiontaskbase.NewProgressReportableInspectionTask(
-    UnknownLengthTaskID,
-    []taskid.UntypedTaskReference{SomeDependencyTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
-        if taskMode != inspectioncore_contract.TaskModeRun {
-            return ResultType{}, nil
-        }
-
-        progress.MarkIndeterminate()
-
-        // Do work where items are discovered dynamically...
-        for item := range dynamicItemsChannel {
-            process(item)
-        }
-
-        return result, nil
-    },
-)
-```
-
-### Caching Task Results
-
-For tasks that are computationally expensive and whose results depend only on their inputs, you can use `NewCachedTask`. This task caches its result in the shared metadata map and reuses it in subsequent runs (e.g., during "dry-run" execution updates) if the input digest hasn't changed.
-
-```go
-var CachedHeavyTask = inspectiontaskbase.NewCachedTask(
-    CachedHeavyTaskID,
-    []taskid.UntypedTaskReference{InputParamsTaskID.Ref()},
-    func(ctx context.Context, prevResult inspectiontaskbase.CacheableTaskResult[ResultType]) (inspectiontaskbase.CacheableTaskResult[ResultType], error) {
-        params := coretask.GetTaskResult(ctx, InputParamsTaskID.Ref())
-        // Calculate a digest from the input parameters.
-        digest := calculateDigest(params)
-
-        // If the digest matches the previous run, return the cached value.
-        if prevResult.DependencyDigest == digest {
-            return prevResult, nil
-        }
-
-        // Re-calculate if digest changed or it's the first run.
-        newValue := doHeavyCalculation(params)
-        return inspectiontaskbase.CacheableTaskResult[ResultType]{
-            Value:            newValue,
-            DependencyDigest: digest,
-        }, nil
-    },
-)
-```
-
-### NewAliasTask
-
-Sometimes you need multiple tasks to depend on a common task, but you want to override the dependency for only one of them. In KHI's DAG task system, if you completely override the common task's implementation using its `TaskImplementationID`, it affects all tasks that depend on it.
-
-To solve this, KHI provides `NewAliasTask` in the `pkg/core/task` package. An Alias Task acts as a proxy, depending on a single task reference and directly returning its result. By making a specific task depend on the Alias Task instead of the common task, you can selectively override the Alias Task's implementation without affecting other dependents of the original common task.
-
-```go
-var OriginalTaskID = taskid.NewDefaultImplementationID[string]("example.khi.google.com/original-task")
-
-// Create an alias task ID
-var AliasTaskID = taskid.NewDefaultImplementationID[string]("example.khi.google.com/alias-task")
-
-// The proxy task maps the execution of the Original task but keeps its own dependency identity
-var AliasTask = coretask.NewAliasTask(
-    AliasTaskID,           // The ID for the new Alias Task
-    OriginalTaskID.Ref(),  // The TaskReference to proxy
-)
-
-// A task that depends on the original task will not be affected by Alias overrides
-var TaskA = coretask.NewTask(
-    TaskAID,
-    []taskid.UntypedTaskReference{OriginalTaskID.Ref()},
-    func(ctx context.Context) (string, error) {
-        return coretask.GetTaskResult(ctx, OriginalTaskID.Ref()), nil
-    },
-)
-
-// A task that depends on the Alias Task CAN be overridden independently
-var TaskB = coretask.NewTask(
-    TaskBID,
-    []taskid.UntypedTaskReference{AliasTaskID.Ref()},
-    func(ctx context.Context) (string, error) {
-        return coretask.GetTaskResult(ctx, AliasTaskID.Ref()), nil
-    },
-)
-```
+- **[1. Task System Syntax and Execution Modes](./task-system/01-syntax-and-modes.md)** — Task (`Task[T]`) syntax, `Run`/`DryRun` modes, and unit testing
+- **[2. Log Processing Task Implementation Patterns (Cookbook)](./task-system/02-log-processing-cookbook.md)** — Log processing pipeline and 6 major task cookbooks
+- **[3. Advanced Task Patterns and Utilities](./task-system/03-advanced-and-form-tasks.md)** — Automatic registration, labels, Inventory-Discovery, and form tasks (`formtask`)

--- a/docs/en/task-system/01-syntax-and-modes.md
+++ b/docs/en/task-system/01-syntax-and-modes.md
@@ -1,0 +1,179 @@
+# KHI Task System Syntax and Execution Modes
+
+[< Back to Index](../khi-task-system-concept.md) | [Next: Log Processing Cookbook >](./02-log-processing-cookbook.md)
+
+---
+
+This document explains the **basic syntax, execution lifecycle modes (`Run` and `DryRun`), and testing methods** required to understand and develop tasks in KHI.
+
+## 1. Directed Acyclic Graph (DAG) Basics
+
+A DAG (Directed Acyclic Graph) is a graph that flows in one direction without any cycles. In KHI, this represents a workflow where tasks run in a specific order based on their dependencies. Each node in the graph is a task, and each edge represents a dependency between tasks.
+
+## 2. Task Types (`Task[T]`)
+
+Every task in KHI has an associated "type" for its output. These are written using Go generics and verified at compile time.
+The following example shows how to declare a task that returns an `int` value:
+
+```go
+var IntGeneratorTask = task.NewTask(
+    IntGeneratorTaskID,
+    []taskid.UntypedTaskReference{},
+    func(ctx context.Context) (int, error) {
+        return 1, nil
+    },
+)
+```
+
+In this example, the following key elements are declared:
+
+1. **`IntGeneratorTask` type**: The Go compiler infers the task type as `task.Task[int]` using generic inference.
+2. **First argument (`IntGeneratorTaskID`)**: This indicates the ID of the task implementation in the task graph. It must have the type `taskid.TaskImplementationID[int]`. You can use this ID to reference the task from other tasks.
+3. **Second argument (`[]taskid.UntypedTaskReference`)**: This is the list of task references that this task depends on. It is used to order the task graph and read values from other tasks in the graph.
+4. **Third argument (execution function)**: The return value of this function must match the task's type parameter (`int` in this case), and it must always return an error as the second return value.
+
+## 3. Reading Values from Tasks
+
+To read a value from a task, you must include a reference to that target task in the dependency list.
+This allows the task execution function to safely get the return value from the dependency task using `coretask.GetTaskResult(ctx, dependencyTaskRef)`:
+
+```go
+var DoubleIntTask = task.NewTask(
+    DoubleIntTaskID,
+    []taskid.UntypedTaskReference{IntGeneratorTaskID.Ref()}, // Specify the dependency task reference
+    func(ctx context.Context) (int, error) {
+        // Pass the context and reference ID to get the result
+        value := coretask.GetTaskResult(ctx, IntGeneratorTaskID.Ref())
+        return value * 2, nil
+    },
+)
+```
+
+> [!IMPORTANT]
+> **Do not access undeclared dependencies**
+> Calling `coretask.GetTaskResult` for a task that is not declared in the dependency list causes a runtime panic. Always include the target task reference in the dependency list passed as the second argument.
+
+## 4. Logging Inside Tasks (`slog`)
+
+When debugging tasks or analyzing errors, use `slog` (a structured logger with context, such as `slog.InfoContext` or `slog.ErrorContext`) instead of standard `fmt.Println`.
+
+```go
+slog.InfoContext(ctx, "processing int value", "intValue", value)
+```
+
+This automatically includes the inspection trace ID and execution context information in the log message, making it easy to trace logs in Cloud Logging or local debugging logs.
+
+## 5. Task Package Structure and Naming Conventions
+
+All inspection tasks in KHI follow an architectural principle of **isolating each feature into a dedicated package**.
+Define each task in its own folder under `pkg/task/inspection/<package-name>/`, and separate the contents into two distinct directories:
+
+```text
+pkg/task/inspection/<package-name>/
+├── contract/  # Contains only public interfaces, task IDs, and type definitions (no implementation logic)
+└── impl/      # Contains actual task definitions and log processing logic (implementation)
+```
+
+### 1. Responsibilities of `contract` Folder
+
+- It defines only **task IDs**, **interfaces**, and **public data structures (such as structs or enums)** that the feature exposes to other tasks.
+- **It must not contain any functions with actual processing logic or task definitions (`task.NewTask(...)`).**
+- It is the only public layer that can be imported by any other task packages.
+
+### 2. Responsibilities of `impl` Folder
+
+- It contains the actual tasks (`var SomeTask = task.NewTask(...)`) and parser or mapper logic bound to the task IDs defined in `contract`.
+- It contains `init()` or initialization functions (such as `Register(...)`).
+- **You must not import the `impl` package of other features.** When depending on another feature, import only its `contract` package and connect via task dependencies on the task graph.
+
+### 3. Naming Conventions for Package Names (`package` declaration)
+
+In Go, declaring packages simply as `contract` or `impl` causes name collisions when importing multiple packages and obscures where code originates.
+Therefore, Go source files under `contract` and `impl` directories must **use the parent feature name combined with `_contract` or `_impl` as the package name**:
+
+- **Files under `contract/`**: `package <feature-name>_contract` (e.g., `package example_contract`)
+- **Files under `impl/`**: `package <feature-name>_impl` (e.g., `package example_impl`)
+
+When referencing types or IDs from other tasks, always import only this `<feature-name>_contract` package.
+
+## 6. Inspection Task Execution Modes (`Run` and `DryRun`)
+
+Inspection tasks in KHI are invoked in either **`Run` mode** or **`DryRun` mode** depending on the execution situation. This is a fundamental lifecycle feature in task graph execution, designed to cleanly separate heavy analysis logic from lightweight UI interactions.
+
+- **`Run` mode (`TaskModeRun`)**: The normal execution mode used when the user clicks the "Start Inspection" button to start an analysis. It executes actual log queries, syntax parsing, and serialization to generate the history file (KHI file).
+- **`DryRun` mode (`TaskModeDryRun`)**: A lightweight execution mode used when the user changes input parameters or dynamically fetches form fields and autocomplete suggestions in the "New Inspection" screen. To maintain responsive UI interactions, time-consuming log queries and parsing operations are skipped in this mode.
+
+### Example Code for Checking Execution Mode
+
+Every inspection task (or low-level task utility) should check `inspectioncore_contract.InspectionTaskModeType` (`taskMode`) passed as an argument and switch its behavior based on the current mode.
+The following is a standard Go implementation example that returns an empty result or necessary UI metadata without heavy processing during `DryRun`, and executes actual parsing only in `Run` mode:
+
+```go
+var ExampleInspectionTask = inspectiontaskbase.NewProgressReportableInspectionTask(
+    ExampleInspectionTaskID,
+    []taskid.UntypedTaskReference{SourceLogsTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
+        // 1. Check DryRun mode: Return immediately to skip heavy log fetching and parsing for form setup or lightweight runs
+        if taskMode == inspectioncore_contract.TaskModeDryRun {
+            return ResultType{}, nil
+        }
+
+        // 2. Run mode: Perform actual log fetching and time-consuming analysis or calculation
+        logs := coretask.GetTaskResult(ctx, SourceLogsTaskID.Ref())
+        result, err := doHeavyAnalysis(ctx, logs, progress)
+        if err != nil {
+            return ResultType{}, err
+        }
+        return result, nil
+    },
+)
+```
+
+By consistently applying this "early return by mode" pattern across all tasks, KHI maintains responsive and fast interactions on the "New Inspection" screen even when configuring complex log analysis task graphs.
+
+## 7. Task Testing
+
+You can test individual tasks and task graphs independently using the testing utilities provided by KHI.
+This section describes testing using the `tasktest` package.
+
+### 7.1 `tasktest.RunTask`
+
+To verify the behavior of a single task simply, you can call `tasktest.RunTask`.
+
+```go
+func TestIntGeneratorTask(t *testing.T) {
+    res, err := tasktest.RunTask(t.Context(), IntGeneratorTask, map[taskid.UntypedTaskImplementationID]any{})
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if res != 1 {
+        t.Errorf("res mismatch (-want +got):\n- %v\n+ %v", 1, res)
+    }
+}
+```
+
+The third argument allows you to pass a map that mocks return values from dependency tasks.
+For tasks without dependencies, pass an empty map.
+
+### 7.2 `tasktest.RunTaskWithDependency`
+
+When you want to verify the execution of a sub-graph including its dependencies rather than mocking them, use `tasktest.RunTaskWithDependency`.
+This automatically builds, topologically sorts, and executes a mini-task graph containing the dependency tasks.
+
+```go
+func TestDoubleIntTaskWithDependency(t *testing.T) {
+    res, err := tasktest.RunTaskWithDependency(t.Context(), DoubleIntTask, []coretask.UntypedTask{
+        IntGeneratorTask,
+    })
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if res != 2 {
+        t.Errorf("res mismatch (-want +got):\n- %v\n+ %v", 2, res)
+    }
+}
+```
+
+---
+
+[< Back to Index](../khi-task-system-concept.md) | [Next: Log Processing Cookbook >](./02-log-processing-cookbook.md)

--- a/docs/en/task-system/02-log-processing-cookbook.md
+++ b/docs/en/task-system/02-log-processing-cookbook.md
@@ -4,7 +4,7 @@
 
 ---
 
-This document explains the overall log processing pipeline in KHI and provides **practical cookbooks for 6 high-level task utilities** that developers use to implement new log parsers and timeline mappers.
+This document explains the overall log processing pipeline in KHI and provides **practical cookbooks for 5 high-level task utilities** that developers use to implement new log parsers and timeline mappers.
 
 ## 1. Overview of the Log Processing Pipeline
 
@@ -68,10 +68,10 @@ var MyFieldSetReadTask = inspectiontaskbase.NewFieldSetReadTask(
 )
 ```
 
-In tasks that use this utility, you can read the specific field set from a log using `log.GetFieldSet(l, MyFieldSetReadTaskID)`.
+In tasks that use this utility, you can read the specific field set from a log using `log.GetFieldSet(l, &MyFieldSet{})`.
 
 ```go
-fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+fieldSet := log.GetFieldSet(l, &MyFieldSet{})
 ```
 
 > [!TIP]
@@ -90,7 +90,7 @@ var MyGrouperTask = inspectiontaskbase.NewLogGrouperTask(
     SourceLogsTaskID.Ref(),
     func(ctx context.Context, l *log.Log) (string, error) {
         // Return a string as the grouping key from log l
-        fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+        fieldSet := log.GetFieldSet(l, &MyFieldSet{})
         return fieldSet.foo, nil
     },
 )
@@ -110,7 +110,7 @@ var MyFilterTask = inspectiontaskbase.NewLogFilterTask(
     SourceLogsTaskID.Ref(),
     func(ctx context.Context, l *log.Log) (bool, error) {
         // Keep logs that return true, and filter out logs that return false
-        fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+        fieldSet := log.GetFieldSet(l, &MyFieldSet{})
         return fieldSet.bar > 0, nil
     },
 )
@@ -193,18 +193,33 @@ func (m *MyMapper) Dependencies() []taskid.UntypedTaskReference {
 }
 ```
 
-### 6.2 Building Timeline Paths with Tree Structures
+### 6.2 Creating and Using Timeline Path Helper Utilities
 
-In the current timeline API, legacy string paths that simply concatenate resource names with `#` or `/` are deprecated. Instead, use **`*khifilev6.TimelinePath`**, which clearly expresses resource hierarchies (tree structures) with types, to add and resolve events.
+In current KHI implementations, mappers do not construct raw string paths directly. Instead, they use **`*khifilev6.TimelinePath`**, which clearly expresses resource hierarchies (tree structures) with types, to add and resolve events.
+Furthermore, KHI uses a common implementation pattern where you create a **timeline path helper utility** that encapsulates joining child segments to parent paths, and reuses objects through `TimelinePathPool`.
+
+#### 1. Example of Creating a Timeline Path Helper (defined in `contract` package, etc.)
+
+```go
+// Example of a standard TimelinePath helper function in KHI
+func MustK8sPodTimeline(ctx context.Context, clusterName string, namespace string, podName string) *khifilev6.TimelinePath {
+    // 1. Get or construct the parent cluster TimelinePath
+    clusterPath := MustK8sClusterTimeline(ctx, clusterName)
+    // 2. Use TimelinePathPool to safely join child segments and avoid duplicate allocations
+    pathPool := khictx.MustGetValue(ctx, inspectioncore_contract.TimelinePathPool)
+    return pathPool.MustGet(clusterPath, namespace, podName)
+}
+```
+
+#### 2. Using the Timeline Path Helper from a Mapper
 
 ```go
 // Process messages and add timeline events
 func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
     cs := khifilev6.NewTimelineChangeSet()
 
-    // Use a path pool to avoid creating duplicate path objects and optimize performance
-    pathPool := khictx.MustGetValue(ctx, inspectioncore_contract.TimelinePathPool)
-    podPath := pathPool.Get("test-cluster", "default", "my-pod")
+    // Call your timeline path helper utility to safely get the path
+    podPath := commonlogk8saudit_contract.MustK8sPodTimeline(ctx, "test-cluster", "default", "my-pod")
 
     // Add event
     cs.AddEvent(podPath)
@@ -217,7 +232,7 @@ func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData M
 var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
     MyMapperTaskID,
     &MyMapper{},
-    inspectioncore_contract.FeatureTaskLabel("my-mapper", /* other parameters */),
+    inspectioncore_contract.FeatureTaskLabel("my-feature", "Feature label", "Detailed description of the feature", true, "gcp-gke"),
 )
 ```
 

--- a/docs/en/task-system/02-log-processing-cookbook.md
+++ b/docs/en/task-system/02-log-processing-cookbook.md
@@ -1,0 +1,248 @@
+# Log Processing Task Implementation Patterns (Cookbook)
+
+[< Previous: Syntax and Modes](./01-syntax-and-modes.md) | [Back to Index](../khi-task-system-concept.md) | [Next: Advanced Patterns >](./03-advanced-and-form-tasks.md)
+
+---
+
+This document explains the overall log processing pipeline in KHI and provides **practical cookbooks for 6 high-level task utilities** that developers use to implement new log parsers and timeline mappers.
+
+## 1. Overview of the Log Processing Pipeline
+
+KHI uses its robust task system to perform log processing. This architecture makes KHI highly extensible (you can add new features just by creating new tasks) and allows it to fully leverage Go's concurrency.
+However, because log processing shares many common patterns, you should implement log processing tasks using the high-level task creation utilities provided by KHI.
+
+KHI provides the following high-level task creation utilities to cover basic log processing use cases:
+
+- **`FieldSetReadTask`** : Stores structured log fields into typed structs.
+- **`LogGrouperTask`** : Groups logs by specific fields.
+- **`LogFilterTask`** : Filters logs based on conditions.
+- **`LogIngesterTask`** : Ingests logs into the final history data.
+- **`LogToTimelineMapperTask`** : Maps ingested logs to timeline events displayed on the KHI UI.
+
+The following is an example dependency graph showing how these 5 task types work together to parse Kubernetes node audit logs fetched from Cloud Logging and render them on the UI timeline:
+
+```mermaid
+flowchart TD
+    Fetch["Log Collection/Query Task<br>(Cloud Logging, etc.)"]
+    Ingester["LogIngesterTask<br>(Build log objects and inject types)"]
+    FieldSet["FieldSetReadTask<br>(Read specific sets of fields)"]
+    Filter["LogFilterTask<br>(Filter out unwanted logs)"]
+    Grouper["LogGrouperTask<br>(Group by Pod name or thread)"]
+    Mapper["LogToTimelineMapperTask<br>(Map to timeline events and paths)"]
+
+    Fetch --> Ingester
+    Ingester --> FieldSet
+    FieldSet --> Filter
+    Filter --> Grouper
+    Grouper --> Mapper
+```
+
+When developers add support for a new log type, they declare tasks along this pipeline and connect them to the task graph.
+You create all of these using utility functions in the `pkg/core/inspection/taskbase` package (such as `NewFieldSetReadTask`).
+
+---
+
+## 2. Reading Field Sets (`FieldSetReadTask`)
+
+Logs in KHI are unstructured initially, so you should use `FieldSetReadTask` to read specific fields from logs.
+This unmarshals and stores a specific set of fields from a log into a predefined Go struct type.
+
+```go
+// 1. Define a struct for the fields you want to read
+type MyFieldSet struct {
+    foo string
+    bar int
+}
+
+// 2. Define a task that attaches the field set to log structures
+var MyFieldSetReadTask = inspectiontaskbase.NewFieldSetReadTask(
+    MyFieldSetReadTaskID, // The ID of this task itself
+    SourceLogsTaskID.Ref(), // The target log list
+    func(ctx context.Context, l *log.Log) (*MyFieldSet, error) {
+        // ... (Logic to extract values from the log body) ...
+        return &MyFieldSet{
+            foo: "foo",
+            bar: 1,
+        }, nil
+    },
+)
+```
+
+In tasks that use this utility, you can read the specific field set from a log using `log.GetFieldSet(l, MyFieldSetReadTaskID)`.
+
+```go
+fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+```
+
+> [!TIP]
+> For details on why we attach information to log objects instead of returning values directly from tasks, see **"Log Immutability and Concurrent Access"** in the architecture documentation.
+
+---
+
+## 3. Grouping Logs (`LogGrouperTask`)
+
+When an individual log message is not enough to identify a cause, you need to group related logs across time (e.g., a sequence of events from Pod creation to termination).
+`LogGrouperTask` groups logs based on a specific key:
+
+```go
+var MyGrouperTask = inspectiontaskbase.NewLogGrouperTask(
+    MyGrouperTaskID,
+    SourceLogsTaskID.Ref(),
+    func(ctx context.Context, l *log.Log) (string, error) {
+        // Return a string as the grouping key from log l
+        fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+        return fieldSet.foo, nil
+    },
+)
+```
+
+Subsequent tasks can use `log.GetGroup(l, MyGrouperTaskID)` to get the group name (group key) that a target log belongs to.
+
+---
+
+## 4. Filtering Logs (`LogFilterTask`)
+
+Use `LogFilterTask` to filter out noise logs (such as routine health check logs) in advance that are not needed for visualization or analysis.
+
+```go
+var MyFilterTask = inspectiontaskbase.NewLogFilterTask(
+    MyFilterTaskID,
+    SourceLogsTaskID.Ref(),
+    func(ctx context.Context, l *log.Log) (bool, error) {
+        // Keep logs that return true, and filter out logs that return false
+        fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+        return fieldSet.bar > 0, nil
+    },
+)
+```
+
+---
+
+## 5. Ingesting Logs (`LogIngesterTask`)
+
+`LogIngesterTask` is an ingestion task that initializes and appends raw log strings collected from cloud APIs or local files into common `*log.Log` objects in KHI, and executes parser initialization logic for each log type (such as generating summaries and injecting required field sets).
+
+### 1. Declaring the `LogIngester` Interface
+
+When defining an ingestion task, first implement a struct that satisfies the `inspectiontaskbase.LogIngester` interface:
+
+```go
+type MyLogIngester struct{}
+
+// RawLogTask returns the raw log source or parent task reference ID
+func (i *MyLogIngester) RawLogTask() taskid.UntypedTaskReference {
+    return SourceLogsTaskID.Ref()
+}
+
+// Dependencies returns the list of dependencies required by the parser
+func (i *MyLogIngester) Dependencies() []taskid.UntypedTaskReference {
+    return []taskid.UntypedTaskReference{}
+}
+
+// ProcessLog implements initial processing or transformation logic for each log
+func (i *MyLogIngester) ProcessLog(ctx context.Context, l *log.Log) error {
+    // Summarize log messages and initialize basic fields
+    l.Summary = "Parsed Log Summary"
+    return nil
+}
+
+var _ inspectiontaskbase.LogIngester = (*MyLogIngester)(nil)
+```
+
+### 2. Building the Task Instance
+
+Pass the address of your ingester struct to `inspectiontaskbase.NewLogIngesterTask` to declare the task instance:
+
+```go
+var MyLogIngesterTask = inspectiontaskbase.NewLogIngesterTask(
+    MyLogIngesterTaskID,
+    &MyLogIngester{},
+)
+```
+
+---
+
+## 6. Mapping to Timelines (`LogToTimelineMapperTask`)
+
+As the final step in log processing, `LogToTimelineMapperTask` maps `*log.Log` objects after filtering and grouping to resource trees and chronological timeline events (event bars, severity, detailed messages) rendered on the KHI UI.
+
+### 6.1 Implementing the `LogToTimelineMapper[T]` Interface
+
+To create a mapper task, declare a struct that satisfies the `inspectiontaskbase.LogToTimelineMapper[T]` interface.
+In most cases, embed **`inspectiontaskbase.SinglePassMapperBase[T]`** to eliminate boilerplate and make it easy to write custom sequential processing, overriding only required methods.
+
+```go
+type MyGroupData struct {
+    Count int
+}
+
+type MyMapper struct {
+    inspectiontaskbase.SinglePassMapperBase[MyGroupData]
+}
+
+func (m *MyMapper) GroupingTask() taskid.UntypedTaskReference {
+    return MyGrouperTaskID.Ref()
+}
+
+func (m *MyMapper) LogTask() taskid.UntypedTaskReference {
+    return SourceLogsTaskID.Ref()
+}
+
+func (m *MyMapper) Dependencies() []taskid.UntypedTaskReference {
+    return []taskid.UntypedTaskReference{MyFieldSetReadTaskID.Ref()}
+}
+```
+
+### 6.2 Building Timeline Paths with Tree Structures
+
+In the current timeline API, legacy string paths that simply concatenate resource names with `#` or `/` are deprecated. Instead, use **`*khifilev6.TimelinePath`**, which clearly expresses resource hierarchies (tree structures) with types, to add and resolve events.
+
+```go
+// Process messages and add timeline events
+func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
+    cs := khifilev6.NewTimelineChangeSet()
+
+    // Use a path pool to avoid creating duplicate path objects and optimize performance
+    pathPool := khictx.MustGetValue(ctx, inspectioncore_contract.TimelinePathPool)
+    podPath := pathPool.Get("test-cluster", "default", "my-pod")
+
+    // Add event
+    cs.AddEvent(podPath)
+
+    // Pass updated state to the next log processing step in the group
+    return cs, MyGroupData{Count: prevData.Count + 1}, nil
+}
+
+// Initialize as a task
+var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
+    MyMapperTaskID,
+    &MyMapper{},
+    inspectioncore_contract.FeatureTaskLabel("my-mapper", /* other parameters */),
+)
+```
+
+### 6.3 Unit Testing Mappers (`testchangeset.AssertTimeline`)
+
+When testing mappers, use `testchangeset.AssertTimeline(t, cs)` to declaratively verify the contents of the generated `TimelineChangeSet`.
+Do not use string paths or deprecated APIs; create and assert expected `*khifilev6.TimelinePath` objects.
+
+```go
+func TestMyMapper_ProcessLogByGroup(t *testing.T) {
+    l := log.NewLogWithFieldSetsForTest(&log.CommonFieldSet{Timestamp: time.Now()}, /* ... */)
+    mapper := &MyMapper{}
+
+    cs, _, err := mapper.ProcessLogByGroup(t.Context(), l, MyGroupData{})
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+
+    wantPodPath := commonlogk8saudit_contract.MustK8sPodTimeline(t.Context(), "test-cluster", "default", "my-pod")
+    testchangeset.AssertTimeline(t, cs).
+        HasEvent(wantPodPath).
+        HasLogSeverity(enum.SeverityInfo)
+}
+```
+
+---
+
+[< Previous: Syntax and Modes](./01-syntax-and-modes.md) | [Back to Index](../khi-task-system-concept.md) | [Next: Advanced Patterns >](./03-advanced-and-form-tasks.md)

--- a/docs/en/task-system/03-advanced-and-form-tasks.md
+++ b/docs/en/task-system/03-advanced-and-form-tasks.md
@@ -1,0 +1,408 @@
+# Advanced Task Patterns and Utilities
+
+[< Previous: Log Processing Cookbook](./02-log-processing-cookbook.md) | [Back to Index](../khi-task-system-concept.md)
+
+---
+
+This document explains the specifications and utilities used to build advanced analysis pipelines and UI integrations in KHI, including task registration, label selection, resource discovery, input forms, progress reporting, and caching strategies.
+
+## 1. Registering Tasks to the Inspection Task Server
+
+KHI build scripts automatically configure the system to call `Register()` during initialization if a `registration.go` file exists under `task/inspection/<package-name>/impl`.
+To define a package that adds new tasks, register your tasks and Inspection Types inside this `Register()` function.
+
+```go
+// Register registers all googlecloudlogserialport inspection tasks to the registry.
+func Register(registry coreinspection.InspectionTaskRegistry) error {
+    err := registry.AddInspectionType(ossclusterk8s_contract.OSSKubernetesLogFilesInspectionType)
+    if err != nil {
+        return err
+    }
+
+    return coretask.RegisterTasks(registry,
+        InputAuditLogFilesTask,
+        InputNodeLogFilesTask,
+        SerialPortLogIngesterTask,
+    )
+}
+```
+
+## 2. Inspection Task Labels
+
+On the "New Inspection" screen in KHI, the system dynamically determines which tasks to include and run in the graph based on the selected environment and log types. To control this behavior, you can attach special labels to inspection tasks.
+
+### 2.1 Filtering with General Label Selectors (`LabelSelector`)
+
+In current KHI versions, you can attach arbitrary key-value metadata labels to tasks and filter them flexibly using **`LabelSelector`**, which evaluates boolean logic expressions (AND, OR, NOT, etc.) to enable tasks only in specific environments or modes.
+
+```go
+// Set task labels using the general LabelValue option
+var AdvancedTask = task.NewTask(AdvancedTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (any, error) {
+    return nil, nil
+},
+    coretask.LabelValue("environment", "gcp"),
+    coretask.LabelValue("feature-stage", "beta"),
+)
+```
+
+During server initialization or inspection configuration, KHI evaluates expressions like the following to select tasks:
+
+```go
+selector, _ := labelselector.Parse("environment=gcp && !feature-stage=deprecated")
+compatibleTasks := taskSet.Select(selector)
+```
+
+### 2.2 Legacy Inspection Type Labels (`InspectionTypeLabel`)
+
+For backward compatibility, you can still use traditional `InspectionTypeLabel` declarations.
+This enables the task only for the Inspection Types listed in the label (e.g., GCP Cloud Logging, local log files, etc.).
+
+```go
+var MyTask = task.NewTask(MyTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (any, error) {
+    return nil, nil
+}, inspectioncore_contract.InspectionTypeLabel(
+    "example.khi.google.com/inspection-type-1",
+    "example.khi.google.com/inspection-type-2",
+))
+```
+
+### 2.3 FeatureTask Labels
+
+The FeatureTask label is a special label that exposes a task as a toggleable feature on KHI's "New Inspection" screen.
+By specifying this label on main feature tasks such as mappers, you allow users to enable or disable the feature.
+
+```go
+inspectioncore_contract.FeatureTaskLabel("my-feature", "Feature label", "Detailed description of the feature", true, 0)
+```
+
+## 3. Task Utilities for Discovering Information from Logs (`Inventory` and `Discovery` Tasks)
+
+### 3.1 Why the Inventory-Discovery Pattern is Needed (Motivation)
+
+A major feature of KHI is that users can freely enable or disable individual features (parser tasks) on the "New Inspection" screen.
+For example, the relationship between a container ID and a Pod name **might be discovered from node logs, or it might be discovered from audit logs**.
+If a subsequent mapper task directly depends on a specific parser task that extracts container IDs from node logs, **that parser task is forcibly included in the task graph and executed during dependency resolution even if the user disabled node log parsing**.
+
+To support this feature-toggle independence and loosely coupled information integration from multiple sources, KHI uses the **`Inventory`-`Discovery` task pattern**.
+
+```mermaid
+flowchart TD
+    subgraph Discovery [Independent Discovery tasks per log source]
+        D1[NodeLog ContainerID Discovery]
+        D2[AuditLog ContainerID Discovery]
+    end
+    subgraph Inventory [Inventory task aggregating only enabled Discovery tasks]
+        Inv[ContainerID Inventory Task]
+    end
+    subgraph Consumer [Subsequent consumer tasks]
+        M[LogToTimelineMapper]
+    end
+
+    D1 -.->|Provide info| Inv
+    D2 -.->|Provide info| Inv
+    Inv -->|Provide consolidated PatternFinder| M
+```
+
+Instead of depending directly on a specific parser, an **Inventory task** dynamically and transparently **aggregates results only from Discovery tasks that are currently enabled (available)** in the inspection environment, and provides the merged value to subsequent tasks.
+This allows KHI to fully leverage information discovered from other enabled log sources (such as audit logs) without breaking graph resolution when specific log parsing features are disabled.
+
+### 3.2 Creating Discovery Tasks and Integrating with Inventory Tasks
+
+In KHI, use `inspectiontaskbase.NewInventoryTaskBuilder` to build **two or more independent `DiscoveryTask`s** corresponding to each log source, combined with a **single `InventoryTask`** that integrates them.
+
+1. **`DiscoveryTask` is included in the graph only when requested by another task**:
+   Each discovery task created by `.DiscoveryTask(...)` on the builder automatically receives `coretask.NewSubsequentTaskRefsTaskLabel`. As a result, **the discovery task itself is never included in the task graph unless requested as a dependency by a parser or feature task that uses it** (if the corresponding parser is disabled, the discovery task is excluded from the graph).
+2. **Optional integration of enabled results by `InventoryTask`**:
+   The inventory task created by `.InventoryTask(strategy)` on the builder uses `coretask.GetTaskResultOptional` to collect and merge **only the results of Discovery tasks that were actually included and executed in the graph**.
+
+#### Example Code: Two Discovery Tasks (Node Log and Audit Log) and an Integrated Inventory Task
+
+```go
+// 1. Initialize the Inventory builder
+var containerInventoryBuilder = inspectiontaskbase.NewInventoryTaskBuilder(ContainerIDInventoryTaskID)
+
+// 2-A. Discovery task for container IDs from node logs (included in the graph only when depended on by node log parsers, etc.)
+var NodeLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
+    NodeLogContainerIDDiscoveryTaskID,
+    []taskid.UntypedTaskReference{NodeLogParserTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*ContainerIdentity, error) {
+        logs := coretask.GetTaskResult(ctx, NodeLogParserTaskID.Ref())
+        return extractContainersFromNodeLogs(logs), nil
+    },
+)
+
+// 2-B. Discovery task for container IDs from audit logs (included in the graph only when depended on by audit log parsers, etc.)
+var AuditLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
+    AuditLogContainerIDDiscoveryTaskID,
+    []taskid.UntypedTaskReference{AuditLogParserTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*ContainerIdentity, error) {
+        logs := coretask.GetTaskResult(ctx, AuditLogParserTaskID.Ref())
+        return extractContainersFromAuditLogs(logs), nil
+    },
+)
+
+// 3. Merge strategy that deduplicates and combines results from multiple sources (implementing InventoryMergerStrategy)
+type containerIDMergeStrategy struct{}
+
+func (c *containerIDMergeStrategy) Merge(results []commonlogk8saudit_contract.ContainerIDToContainerIdentity) (commonlogk8saudit_contract.ContainerIDToContainerIdentity, error) {
+    result := map[string]*commonlogk8saudit_contract.ContainerIdentity{}
+    for _, r := range results {
+        for cid, s := range r {
+            if current, ok := result[cid]; ok {
+                // Merge and complement information if the same container ID already exists
+                result[cid] = current.Merge(s)
+            } else {
+                result[cid] = s
+            }
+        }
+    }
+    return result, nil
+}
+
+var _ inspectiontaskbase.InventoryMergerStrategy[commonlogk8saudit_contract.ContainerIDToContainerIdentity] = (*containerIDMergeStrategy)(nil)
+
+// 4. Inventory task that aggregates and merges results only from enabled Discovery tasks
+var ContainerIDInventoryTask = containerInventoryBuilder.InventoryTask(&containerIDMergeStrategy{})
+```
+
+By delegating the choice to use discovery tasks and include them in the graph to individual log parsers, KHI achieves a resource inventory that operates safely and flexibly even when users disable certain log parsing features.
+
+### 3.3 Building Searchers with PatternFinder to Reduce Complexity
+
+If subsequent parsers and mappers repeatedly search raw lists aggregated by an `InventoryTask` in a loop, the computational complexity becomes `O(N * M)`, which takes an enormous amount of time.
+To avoid this, KHI converts the aggregated inventory into high-speed search automatons (or prefix trees) based on the Aho-Corasick algorithm or binary search, called **`PatternFinder`**, using **`PatternFinderTask` / `DiscoveryTask`**.
+
+Common Discovery / PatternFinder utilities:
+
+- **`NodeNameDiscoveryTask`**: Aggregates mapping tables for node names, cluster information, and IP addresses.
+- **`ResourceUIDDiscoveryTask` / `ResourceUIDPatternFinderTask`**: Records mappings between Kubernetes object UIDs (`metadata.uid`) and resource names or namespaces, enabling high-speed reverse lookups from audit logs that contain only UIDs.
+- **`ContainerIDDiscoveryTask` / `ContainerIDPatternFinderTask`**: Instantly resolves Pod names and namespaces from long hashes (`6123c6aac...`) or prefixes output by container runtimes.
+- **`IPLeaseHistoryDiscoveryTask`**: Tracks IP address allocation history over time to identify Pods and Nodes from an IP at a specific timestamp.
+
+#### Using PatternFinders in Mapper Tasks
+
+By adding the reference ID of a Discovery/PatternFinder task to your mapper task's `Dependencies()`, you can retrieve the searcher inside `ProcessLogByGroup` using `coretask.GetTaskResult(ctx, ...)` and perform high-speed O(1) to O(log N) association lookups using functions like `patternfinder.FindAllWithStarterRunes(...)`.
+
+```go
+func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
+    // Get the container ID searcher
+    containerFinder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ContainerIDPatternFinderTaskID.Ref())
+
+    originalMsg := l.Message // Message body
+    // Scan high-speed for container ID patterns starting with alphabet or digit runes
+    results := patternfinder.FindAllWithStarterRunes(originalMsg, containerFinder, false, '"')
+
+    cs := khifilev6.NewTimelineChangeSet()
+    for _, res := range results {
+        // Add Pod timeline event based on the discovered container information
+        podPath := commonlogk8saudit_contract.MustK8sPodTimeline(ctx, clusterName, res.Value.PodNamespace, res.Value.PodName)
+        cs.AddEvent(podPath)
+    }
+    return cs, prevData, nil
+}
+```
+
+## 4. Task Forms and User Input Fields (`formtask`)
+
+To allow users to enter or select parameters (such as project IDs, locations, cluster names, time ranges, or log files) in KHI's "New Inspection" dialog, implement tasks using the declarative form task builder package (`github.com/GoogleCloudPlatform/khi/pkg/core/inspection/formtask`).
+
+### 4.1 Types of Form Builders
+
+Choose from the following 3 builder types depending on the input format:
+
+- **`formtask.NewTextFormTaskBuilder(...)`**: Builds form tasks for string or text input (supporting autocomplete and regular expression validation).
+- **`formtask.NewSetFormTaskBuilder(...)`**: Builds form tasks that let users select single or multiple values from options, such as dropdowns or checklists.
+- **`formtask.NewFileFormTaskBuilder(...)`**: Builds form tasks that accept log file uploads or file path selections from the user's local environment.
+
+### 4.2 Building Rich Input Forms and Autocomplete Integrations
+
+Form builders provide various methods to support comfortable user input, such as UI validation and dynamic autocomplete suggestions:
+
+- **`WithDescription(desc)`**: Sets the help description text displayed in the UI input field.
+- **`WithDependencies(...)`**: Declares dependency tasks required to calculate default values or autocomplete suggestions.
+- **`WithDefaultValueFunc(fn)`**: Dynamically calculates default values based on input history from previous inspection runs or dependency task results.
+- **`WithSuggestionsFunc(fn)`**: Dynamically sorts and presents autocomplete suggestion lists from autocomplete task results as the user types (`common.SortForAutocomplete` is standard).
+- **`WithValidator(fn)`**: Performs required field checks or regular expression checks, displaying error messages in the UI and blocking execution when input is invalid.
+
+#### Example Code: Location Input Task with Autocomplete and Validation
+
+The following is a declarative task implementation example used in the actual `InputLocationsTask`, incorporating autocomplete integration and validation (`Validator`):
+
+```go
+var InputLocationsTask = formtask.NewTextFormTaskBuilder(
+    googlecloudcommon_contract.InputLocationsTaskID,
+    googlecloudcommon_contract.PriorityForResourceIdentifierGroup+3000,
+    "Location",
+).
+    WithDependencies([]taskid.UntypedTaskReference{
+        googlecloudcommon_contract.AutocompleteLocationTaskID.Ref(),
+    }).
+    WithDescription("The location (region) to specify where the resource exists").
+    WithDefaultValueFunc(func(ctx context.Context, previousValues []string) (string, error) {
+        locations := coretask.GetTaskResult(ctx, googlecloudcommon_contract.AutocompleteLocationTaskID.Ref())
+        if len(previousValues) > 0 && slices.Contains(locations.Values, previousValues[0]) {
+            return previousValues[0], nil
+        }
+        if len(locations.Values) == 0 {
+            return "", nil
+        }
+        return locations.Values[0], nil
+    }).
+    WithSuggestionsFunc(func(ctx context.Context, value string, previousValues []string) ([]string, error) {
+        regions := coretask.GetTaskResult(ctx, googlecloudcommon_contract.AutocompleteLocationTaskID.Ref())
+        return common.SortForAutocomplete(value, regions.Values), nil
+    }).
+    WithValidator(func(ctx context.Context, value string) (string, error) {
+        if value == "" {
+            return "location is required", nil
+        }
+        return "", nil
+    }).
+    Build()
+```
+
+### 4.3 Reading Input Values from Subsequent Tasks
+
+Consumer tasks (such as log query tasks or resource identification tasks) that add the created input form task ID to their dependencies (`Dependencies()`) can safely read user-confirmed input values (`string`, etc.) with proper types by calling `coretask.GetTaskResult`:
+
+```go
+var ClusterIdentityTask = inspectiontaskbase.NewInspectionTask(
+    googlecloudk8scommon_contract.ClusterIdentityTaskID,
+    []taskid.UntypedTaskReference{
+        googlecloudcommon_contract.InputLocationsTaskID.Ref(),
+        googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(),
+    },
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) (GoogleCloudClusterIdentity, error) {
+        // Get the entered location string
+        location := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputLocationsTaskID.Ref())
+        clusterName := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref())
+
+        return GoogleCloudClusterIdentity{
+            Location:    location,
+            ClusterName: clusterName,
+        }, nil
+    },
+)
+```
+
+## 5. Low-Level Task Utilities
+
+### 5.1 Dynamic Progress Reporting (`NewProgressReportableInspectionTask`)
+
+When you want to dynamically report task progress to the frontend, such as during log fetching or large file parsing, create your task using `NewProgressReportableInspectionTask`.
+This task receives `TaskProgressMetadata` in its logic and can notify the frontend of specific completion percentages or indeterminate states as execution proceeds.
+
+#### 1. Example of Periodically Updating Quantitative Progress (`progressutil.NewProgressUpdator`)
+
+When the total work amount (item count or byte size) is known, use `progressutil.NewProgressUpdator` to periodically update the progress ratio and status message at regular timer intervals (e.g., every second):
+
+```go
+var HeavyProcessingTask = inspectiontaskbase.NewProgressReportableInspectionTask(
+    HeavyProcessingTaskID,
+    []taskid.UntypedTaskReference{SourceLogsTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
+        if taskMode != inspectioncore_contract.TaskModeRun {
+            return ResultType{}, nil
+        }
+
+        logs := coretask.GetTaskResult(ctx, SourceLogsTaskID.Ref())
+        total := len(logs)
+        processed := 0
+
+        // Create a ProgressUpdator that updates progress every second
+        updater := progressutil.NewProgressUpdator(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
+            tp.Percentage = float32(processed) / float32(total)
+            tp.Message = fmt.Sprintf("Processed %d/%d logs", processed, total)
+        })
+
+        updater.Start(ctx)
+        defer updater.Done()
+
+        for _, l := range logs {
+            // Execute heavy analysis or processing...
+            processed++
+        }
+
+        return result, nil
+    },
+)
+```
+
+#### 2. Reporting Indeterminate Progress When Total Work Amount is Unknown (`MarkIndeterminate()`)
+
+When the total work amount before task completion cannot be known in advance, such as when processing dynamic items from a channel, call `progress.MarkIndeterminate()` to mark the frontend progress bar as indeterminate:
+
+```go
+var UnknownLengthTask = inspectiontaskbase.NewProgressReportableInspectionTask(
+    UnknownLengthTaskID,
+    []taskid.UntypedTaskReference{SomeDependencyTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
+        if taskMode != inspectioncore_contract.TaskModeRun {
+            return ResultType{}, nil
+        }
+
+        // Declare indeterminate progress because the total amount is unknown
+        progress.MarkIndeterminate()
+
+        // Process items discovered dynamically...
+        for item := range dynamicItemsChannel {
+            process(item)
+        }
+
+        return result, nil
+    },
+)
+```
+
+### 5.2 Caching Task Results (`NewGlobalCachedTask` and `NewInspectionCachedTask`)
+
+For high-cost tasks where results depend only on input parameters, such as heavy computations or external API calls, you can create cache-enabled tasks that cache and reuse results.
+KHI provides the following two creation functions depending on the cache lifetime (scope):
+
+- **`inspectiontaskbase.NewGlobalCachedTask[T]`**: Creates a task cached permanently across the entire application (`GlobalSharedMap`). It reuses results across different inspections as long as the inputs are identical.
+- **`inspectiontaskbase.NewInspectionCachedTask[T]`**: Creates a task cached only within the same inspection run (`InspectionSharedMap`). For example, it reuses results during DryRun updates when input forms change in the "New Inspection" dialog, or when re-querying within the same inspection.
+
+Both functions pass a **`CacheableTaskResult[T]`** to your task logic containing the previous calculation result and dependency digest, allowing the task to compare the digest calculated from current parameters against the previous digest (`DependencyDigest`).
+
+#### Example Code
+
+The following is a complete implementation example of `NewInspectionCachedTask` that returns the previous cached value when input parameter digests remain unchanged:
+
+```go
+var CachedHeavyTask = inspectiontaskbase.NewInspectionCachedTask(
+    CachedHeavyTaskID,
+    []taskid.UntypedTaskReference{InputParamsTaskID.Ref()},
+    func(ctx context.Context, prevResult inspectiontaskbase.CacheableTaskResult[ResultType]) (inspectiontaskbase.CacheableTaskResult[ResultType], error) {
+        params := coretask.GetTaskResult(ctx, InputParamsTaskID.Ref())
+        // Calculate the current digest from input parameters
+        digest := calculateDigest(params)
+
+        // If the digest matches the previous run, return the cached value immediately without recomputing
+        if prevResult.DependencyDigest == digest {
+            return prevResult, nil
+        }
+
+        // Recompute if this is the first run or the input digest changed
+        newValue := doHeavyCalculation(params)
+        return inspectiontaskbase.CacheableTaskResult[ResultType]{
+            Value:            newValue,
+            DependencyDigest: digest,
+        }, nil
+    },
+)
+```
+
+> [!TIP]
+> **Releasing Resources When an Inspection Ends**
+> If you want to clean up cached data or resources created by `NewInspectionCachedTask` when the inspection is destroyed, you can tie into the inspection lifecycle using `context.AfterFunc` as follows:
+>
+> ```go
+> inspectionContext := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionContext)
+> context.AfterFunc(inspectionContext, func() {
+>     // Release resources such as closing sockets or deleting temporary files
+> })
+> ```
+
+---
+
+[< Previous: Log Processing Cookbook](./02-log-processing-cookbook.md) | [Back to Index](../khi-task-system-concept.md)

--- a/docs/en/task-system/03-advanced-and-form-tasks.md
+++ b/docs/en/task-system/03-advanced-and-form-tasks.md
@@ -72,7 +72,7 @@ The FeatureTask label is a special label that exposes a task as a toggleable fea
 By specifying this label on main feature tasks such as mappers, you allow users to enable or disable the feature.
 
 ```go
-inspectioncore_contract.FeatureTaskLabel("my-feature", "Feature label", "Detailed description of the feature", true, 0)
+inspectioncore_contract.FeatureTaskLabel("my-feature", "Feature label", "Detailed description of the feature", true, "gcp-gke")
 ```
 
 ## 3. Task Utilities for Discovering Information from Logs (`Inventory` and `Discovery` Tasks)
@@ -125,7 +125,7 @@ var containerInventoryBuilder = inspectiontaskbase.NewInventoryTaskBuilder(Conta
 var NodeLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
     NodeLogContainerIDDiscoveryTaskID,
     []taskid.UntypedTaskReference{NodeLogParserTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*ContainerIdentity, error) {
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (commonlogk8saudit_contract.ContainerIDToContainerIdentity, error) {
         logs := coretask.GetTaskResult(ctx, NodeLogParserTaskID.Ref())
         return extractContainersFromNodeLogs(logs), nil
     },
@@ -135,7 +135,7 @@ var NodeLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
 var AuditLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
     AuditLogContainerIDDiscoveryTaskID,
     []taskid.UntypedTaskReference{AuditLogParserTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*ContainerIdentity, error) {
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (commonlogk8saudit_contract.ContainerIDToContainerIdentity, error) {
         logs := coretask.GetTaskResult(ctx, AuditLogParserTaskID.Ref())
         return extractContainersFromAuditLogs(logs), nil
     },
@@ -292,9 +292,9 @@ var ClusterIdentityTask = inspectiontaskbase.NewInspectionTask(
 When you want to dynamically report task progress to the frontend, such as during log fetching or large file parsing, create your task using `NewProgressReportableInspectionTask`.
 This task receives `TaskProgressMetadata` in its logic and can notify the frontend of specific completion percentages or indeterminate states as execution proceeds.
 
-#### 1. Example of Periodically Updating Quantitative Progress (`progressutil.NewProgressUpdator`)
+#### 1. Example of Periodically Updating Quantitative Progress (`progressutil.NewProgressUpdater`)
 
-When the total work amount (item count or byte size) is known, use `progressutil.NewProgressUpdator` to periodically update the progress ratio and status message at regular timer intervals (e.g., every second):
+When the total work amount (item count or byte size) is known, use `progressutil.NewProgressUpdater` to periodically update the progress ratio and status message at regular timer intervals (e.g., every second):
 
 ```go
 var HeavyProcessingTask = inspectiontaskbase.NewProgressReportableInspectionTask(
@@ -309,8 +309,8 @@ var HeavyProcessingTask = inspectiontaskbase.NewProgressReportableInspectionTask
         total := len(logs)
         processed := 0
 
-        // Create a ProgressUpdator that updates progress every second
-        updater := progressutil.NewProgressUpdator(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
+        // Create a ProgressUpdater that updates progress every second
+        updater := progressutil.NewProgressUpdater(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
             tp.Percentage = float32(processed) / float32(total)
             tp.Message = fmt.Sprintf("Processed %d/%d logs", processed, total)
         })

--- a/docs/ja/architecture/khi-backend-serializer.md
+++ b/docs/ja/architecture/khi-backend-serializer.md
@@ -14,21 +14,18 @@ flowchart TD
     subgraph AccumulatorLayer ["Accumulator layer"]
         TimelineAccumulator
         LogAccumulator
-        TimelineStyleAccumulator
+        MetadataAccumulator
         OtherAccumulators["他の Accumulator"]
     end
-
-    Register["Register()"]
 
     %% 入力からAccumulatorへの流れ
     TimelineMapper -->|TimelineChangeSet| TimelineAccumulator
     LogIngestor -->|LogChangeSet| LogAccumulator
-    Register --> TimelineStyleAccumulator
 
     %% Accumulatorからプール/ジェネレータへの流れ
     TimelineAccumulator --> IDGenerator
     LogAccumulator --> IDGenerator
-    TimelineStyleAccumulator --> IDGenerator
+    MetadataAccumulator --> IDGenerator
     OtherAccumulators --> IDGenerator
 
     TimelineAccumulator --> InternPool
@@ -37,7 +34,7 @@ flowchart TD
 
     TimelineAccumulator --> FileBuilder
     LogAccumulator --> FileBuilder
-    TimelineStyleAccumulator --> FileBuilder
+    MetadataAccumulator --> FileBuilder
     IDGenerator --> FileBuilder
     InternPool --> FileBuilder
     OtherAccumulators --> FileBuilder
@@ -46,8 +43,8 @@ flowchart TD
     ChunkGenerator -.-> FinalFile[(".khi file")]
 ```
 
-- **Tasks**: 各タスクが解析した要素やログを Accumulator 層に追加します。TimelineStyle は起動時から変化がないため、初期化時に Register 関数内で各種スタイルを追記します。
-- **Accumulator Layer**: ID を生成し、重複排除処理や Proto 型への変換を行います。
+- **Tasks**: 各タスクが解析した要素やログを Accumulator 層に追加します。
+- **Accumulator Layer**: ID を生成し、重複排除処理や Proto 型への変換を行います (`LogAccumulator`, `TimelineAccumulator`, `MetadataAccumulator` 等)。タイムラインスタイルなどは初期化時に別途レジストリから構築されます。
 - **IDGenerator / InternPool**: ID の割り当て、文字列のインターン化、および構造化データのフラット化を一元的に行います。 Accumulator 側から呼び出されます。
 - **FileBuilder / ChunkGenerator**: 集約されたデータとプール群を元に Protobuf の各チャンクバイナリを構築し、最終的な `.khi` ファイルへ書き出します。
 

--- a/docs/ja/architecture/khi-frontend-parser.md
+++ b/docs/ja/architecture/khi-frontend-parser.md
@@ -45,18 +45,18 @@ flowchart TD
 
 ネストしたファクトリに依存するのではなく、ファイルバージョンごとに `ParserBlueprint` を登録し、チャンクタイプとそれを処理するアセンブラーをマッピングします。
 
-### 1.1 DataAssembler
+### 1.1 IDataAssembler
 
-ParserBlueprintはproto型ごとにDataAssemblerインターフェースを実装を登録しています。まず各DataAssemblerは新しいProtoがデコードされるごとにingestでデータが追加され、最終的にassembleIntoがInspectionDataとともに呼ばれるのでDTOに変換した値をInspectionDataに付加します。
+ParserBlueprint は proto 型ごとに IDataAssembler インターフェース実装を登録しています。まず各 IDataAssembler は新しい Proto がデコードされるごとに ingest でデータが追加され、最終的に assembleInto が InspectionDataBuilder とともに呼ばれ、DTO から変換した値をビルダーのドメインストアに統合します。
 
 ```typescript
 // デコードされたProtobufを収集し、最終モデルを構築する状態を持つアセンブラー
-interface DataAssembler<TProto> {
+interface IDataAssembler<TProto = unknown> {
     // デコードされたチャンクを受け取ります。チャンク分割により複数回呼ばれる可能性があります。
     ingest(proto: TProto): void;
     
-    // 収集したデータを最終的な InspectionData へ統合します。
-    assembleInto(model: InspectionData): void;
+    // 収集したデータを InspectionDataBuilder を通じて最終的なモデルへ統合します。
+    assembleInto(builder: InspectionDataBuilder): void;
 }
 ```
 
@@ -66,14 +66,16 @@ interface DataAssembler<TProto> {
 
 ```typescript
 // 特定のチャンクタイプの処理方法の定義
-interface ChunkDefinition<TProto = any> {
-    typeId: number;
+interface ChunkDefinition<TProto = unknown> {
+    readonly typeId: number;
+    // 進捗表示等で利用する人間が読みやすいラベル文字列
+    readonly label: string;
     // 生のバイト配列をProtobufオブジェクトへデコードする純粋関数
-    decode: (bytes: Uint8Array) => TProto; 
+    readonly decode: (bytes: Uint8Array) => TProto; 
     // 状態を持つアセンブラーのファクトリメソッド
-    createAssembler: () => DataAssembler<TProto>;
+    readonly createAssembler: () => IDataAssembler<TProto>;
     // 依存関係解決のための実行優先度。数値が低いほど先に assembleInto が呼ばれます。
-    priority: number; 
+    readonly priority: number; 
 }
 
 // バージョン固有のチャンク定義のレジストリ

--- a/docs/ja/khi-task-system-concept.md
+++ b/docs/ja/khi-task-system-concept.md
@@ -25,7 +25,7 @@ flowchart LR
 1. **[タスクシステムの基本文法と実行モード](./task-system/01-syntax-and-modes.md)**
    - DAG の基本形式、タスクの型 (`Task[T]`) の宣言、依存関係からの値の取得 (`GetTaskResult`)、構造化ログ (`slog`)、パッケージ構成と命名規約 (`_contract`/`_impl`)、**インスペクション実行モード (`Run` と `DryRun`)**、**単体テスト (`tasktest`)** を収録しています。
 2. **[ログ解析のためのタスク実装パターン (実践ガイド)](./task-system/02-log-processing-cookbook.md)**
-   - ログ解析パイプラインの全体像と、**6 種類の主要タスク作成ユーティリティ (`FieldSetReadTask`, `LogGrouperTask`, `LogFilterTask`, `LogIngesterTask`, `LogToTimelineMapperTask`)** の実践レシピ、および最新の `*khifilev6.TimelinePath` と `testchangeset.AssertTimeline` を用いたタイムライン変換を収録しています。
+   - ログ解析パイプラインの全体像と、**5 種類の主要タスク作成ユーティリティ (`FieldSetReadTask`, `LogGrouperTask`, `LogFilterTask`, `LogIngesterTask`, `LogToTimelineMapperTask`)** の実践レシピ、および最新の `*khifilev6.TimelinePath` と `testchangeset.AssertTimeline` を用いたタイムライン変換を収録しています。
 3. **[高度なタスクパターンとユーティリティ](./task-system/03-advanced-and-form-tasks.md)**
    - インスペクションサーバーへの自動登録 (`Register`)、ラベルセレクタ (`LabelSelector`, `FeatureTask`)、複数ログソースから名前解決を行う **`Inventory` - `Discovery` タスクパターン (`InventoryTaskBuilder` と戦略)**、UI にリッチな入力欄を提示する **フォームタスク (`formtask` / オートコンプリート)**、および **進捗報告 / キャッシュ制御 (`NewGlobalCachedTask`, `NewInspectionCachedTask`)** を収録しています。
 

--- a/docs/ja/khi-task-system-concept.md
+++ b/docs/ja/khi-task-system-concept.md
@@ -1,940 +1,113 @@
-# KHI Task システムの概念
+# KHI タスクシステム概念ドキュメント (総合案内)
 
-## ログ可視化システムの複雑性
+Kubernetes History Inspector (KHI) は、膨大かつ多様なコンテナ・クラウドログからタイムラインベースの履歴ファイルを自動構築するために、非常に強力で柔軟な **有向非巡回グラフ (DAG) ベースのタスクシステム** を採用しています。
 
-KHI の拡張方法について議論する前に、ログ可視化システムに本質的に存在する複雑性について説明しましょう。
-KHI は大量のログを入力として受け取り、各ログをタイムライン上の 1 つ以上の「イベント」や「リビジョン」と関連付けます。
-一見すると、ログを入力として受け取り、タイムライン上の位置の配列を出力する単純な関数のように見えるかもしれません。
+本ドキュメント群では、KHI のアーキテクチャの核心であるタスクシステムの基本概念から、開発者がプラグインやログパーサーを実装するための実践文法・クックブックまでを解説します。
 
-しかし実際には、他のログを調べなければ関連付けができないログが存在します。
+---
 
-- PATCH リクエストから生成されたリソースの「リビジョン」は、それ以前のリクエストを解析してリソースの状態を復元しなければ、その時点では再構築できません。
-- Containerd ログに含まれるコンテナ ID は、Pod サンドボックス作成時に一度だけ出力される Pod 名と関連付けるログを調べなければ、特定の Pod にリンクできません。
-- 様々なログに現れる IP は、タイミングによって異なるリソースに関連付けられる可能性があり、リソース名と IP の関連付けを確認するログを解析しなければ、IP しか含まないログをリソースにリンクすることはできません。
+## タスクシステムガイド 目次
 
-大量のログを有意味な形でリソースにリンクすることは、ログをグループに分け、決められた順序で解析し、リソースにリンクするという綿密な操作を必要とします。
-これらの複雑な依存関係を効率的に処理するために、KHI は「ユーザー入力用の入力フィールド生成」「ログクエリ生成」「ログ収集」「各種パーサーの実行」を含む独自の DAG (Directed Acyclic Graph: 有向非巡回グラフ) で記述されたシステムを実装しています。
+学習段階や開発目的に合わせて、以下の各専門ドキュメントを参照してください:
 
 ```mermaid
-flowchart TD
-    A[Containerd logs] --> B[filter logs containing <br> Container ID and Pod Name]
-    A --> C[The other Logs <br> with Container ID only]
-    B --> D[Record Container ID <br> and Pod Name]
-    D --> C
-    C --> E[Associate Logs to Pods]
-    D --> F[Timeline associations]
-    E --> F
+flowchart LR
+    Portal["総合案内 (本ドキュメント)<br>• なぜ DAG か<br>• UI フローとタスクグラフ"]
+    P1["1. 基本文法と実行モード<br>• Task[T] と依存関係<br>• Run/DryRun モード<br>• 単体テスト"]
+    P2["2. ログ解析実践ガイド<br>• 6 大タスク実装クックブック<br>• タイムライン API・アサーション"]
+    P3["3. 高度なタスクパターン<br>• Inventory - Discovery パターン<br>• 入力フォーム (formtask)<br>• キャッシュと進捗報告"]
 
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
-    classDef highlight fill:#d4f4fa,stroke:#333,stroke-width:1px;
-    class A,F highlight;
+    Portal --> P1
+    P1 --> P2
+    P2 --> P3
 ```
 
-> 例: containerd ログを解析して Pod 名に関連付ける DAG のサブグラフ
+1. **[タスクシステムの基本文法と実行モード](./task-system/01-syntax-and-modes.md)**
+   - DAG の基本形式、タスクの型 (`Task[T]`) の宣言、依存関係からの値の取得 (`GetTaskResult`)、構造化ログ (`slog`)、パッケージ構成と命名規約 (`_contract`/`_impl`)、**インスペクション実行モード (`Run` と `DryRun`)**、**単体テスト (`tasktest`)** を収録しています。
+2. **[ログ解析のためのタスク実装パターン (実践ガイド)](./task-system/02-log-processing-cookbook.md)**
+   - ログ解析パイプラインの全体像と、**6 種類の主要タスク作成ユーティリティ (`FieldSetReadTask`, `LogGrouperTask`, `LogFilterTask`, `LogIngesterTask`, `LogToTimelineMapperTask`)** の実践レシピ、および最新の `*khifilev6.TimelinePath` と `testchangeset.AssertTimeline` を用いたタイムライン変換を収録しています。
+3. **[高度なタスクパターンとユーティリティ](./task-system/03-advanced-and-form-tasks.md)**
+   - インスペクションサーバーへの自動登録 (`Register`)、ラベルセレクタ (`LabelSelector`, `FeatureTask`)、複数ログソースから名前解決を行う **`Inventory` - `Discovery` タスクパターン (`InventoryTaskBuilder` と戦略)**、UI にリッチな入力欄を提示する **フォームタスク (`formtask` / オートコンプリート)**、および **進捗報告 / キャッシュ制御 (`NewGlobalCachedTask`, `NewInspectionCachedTask`)** を収録しています。
 
-KHI の拡張方法を学ぶには、この DAG システムを理解する必要があります。
+---
 
-## DAG で使用される基本的な形式
+## 1. KHI タスクシステムの基本概念
 
-DAG (Directed Acyclic Graph: 有向非巡回グラフ) は、サイクルを持たずに一方向に流れるグラフです。KHI の文脈では、これはタスクが依存関係に基づいて特定の順序で実行されるワークフローを表します。グラフ内の各ノードはタスクであり、エッジはタスク間の依存関係を表します。
+### 1.1 ログ可視化システムの複雑性
 
-### タスクの型
+Kubernetes クラスターにおける問題を診断するにあたって、多くの異なるシステムから様々な種類のログを収集する必要があります（例: Kubernetes Control Plane ログ、クラスター内のノードログ、Kubelet ログ、コンテナランタイムログ、ホストカーネルログなど）。
 
-KHI で使用される DAG タスクシステムでは、各タスクは `task.Task[T]` インターフェースを実装するように作成されます。
-(詳細な実装については `pkg/core/task/task.go` を参照してください。)
+単一のログだけでは、そこで発生した事態の全貌を説明できません。特定された問題から実際の根本原因へと到達するには、複数の異なるシステムから出力されたログの間に存在する関係性を総合して結び付ける必要があります。
+これにより、ログ解析・可視化ツールは以下の課題に直面します:
 
-このインターフェースは、概略として以下のような型として定義されています:
-(実際には、TaskResult 型を気にする必要がない要素は `UntypedTask` インターフェースで実装されており、任意の `task.Task[T]` を一様に扱うために少し複雑な型定義がありますが、一般的理解には以下のフィールドで十分です。)
+- **非同期性と順序の不確実性**: 分散システムのログは時刻の完全な順序性を保証しません。
+- **データ依存関係の複雑化**: あるログを解釈するために、別のログから抽出されたメタデータ（例: コンテナ ID と Pod 名の対応表）が必要になります。
+- **プラグインとカスタマイズの要求**: すべてのユーザーが同じ環境や同じログ種別を使用しているわけではありません（例: オンプレミス vs クラウド管理クラスタ）。
 
-```go
-type Task[TaskResult any] interface {
-    // ID returns the unique identifier of the task.
-    ID() taskid.TaskImplementationID[TaskResult]
+これらの課題に対し、逐次的なスクリプトや静的な手続き処理ではなく、データフロー間の依存関係を明確に宣言する **DAG (Directed Acyclic Graph: 有向非巡回グラフ)** タスクシステムを採用することで、KHI は並行処理による高いパフォーマンスと疎結合なプラグイン設計を両立しています。
 
-    // Labels returns the labels associated with the task. KHI uses this value for various purposes (e.g. document generation, filtering tasks by cluster types, ...etc)
-    Labels() *typedmap.ReadonlyTypedMap
+### 1.2 KHI における UI フローとタスクグラフの関係
 
-    // Dependencies returns the IDs of tasks that need to be done before this task.
-    Dependencies() []taskid.UntypedTaskReference
-
-    // Run is the actual function called to run this task.
-    Run(ctx context.Context) (TaskResult, error)
-}
-```
-
-通常、このインターフェースを直接実装する必要はありません。`task.NewTask` 関数を使用してタスクを作成できます。
-例として、固定の整数値を生成する `IntGeneratorTask` と、前のタスクからの値を 2 倍にする `DoubleIntTask` があるとします。
-
-```go
-var IntGeneratorTaskID = taskid.NewDefaultImplementationID[int]("example.khi.google.com/int-generator")
-var DoubleIntTaskID = taskid.NewDefaultImplementationID[int]("example.khi.google.com/double-int")
-
-var IntGeneratorTask = task.NewTask(IntGeneratorTaskID,[]taskid.UntypedTaskReference{}, func(ctx context.Context) (int, error){
-    return 1, nil
-})
-
-var DoubleIntTask = task.NewTask(DoubleIntTaskID,[]taskid.UntypedTaskReference{IntGeneratorTaskID.Ref()}, func(ctx context.Context, reference taskid.TaskReference[int]) (int, error){
-    intGeneratorResult := task.GetTaskResult(ctx, IntGeneratorTaskID.Ref())
-    return intGeneratorResult * 2, nil
-})
-```
-
-```mermaid
-flowchart TD
-    A[IntGeneratorTask] -->|returns 1| B[DoubleIntTask]
-    B -->|multiplies by 2| C[result: 2]
-
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
-    classDef task fill:#d4f4fa,stroke:#333,stroke-width:1px;
-    classDef result fill:#e1f5e1,stroke:#333,stroke-width:1px;
-    class A,B task;
-    class C result;
-```
-
-#### タスク ID とタスク参照
-
-KHI では、各タスクは `taskid.TaskImplementationID[T]` 型の一意の ID を持ちます。
-通常、これは `taskid.NewDefaultImplementationID[T](id string)` を呼び出して生成されます。
-
-型パラメータは、この ID を使用するタスクが返す型です。`taskid.TaskImplementationID[T]` 型はタスクを定義する人が作成する必要がありますが、
-そのタスクを参照する人は `taskid.TaskReference[T]` を使用する必要があります。
-
-これはタスクの依存関係リストを指定するため、また依存する前のタスクから値を取得する `GetTaskResult[T](ctx context.Context, reference taskid.TaskReference[T])` でも使用されます。
-
-多くの場合、`TaskReference[T]` は `Ref()` を通じて `TaskImplementationID[T]` から取得されます。
-しかし、KHI のタスクシステムには、ID 自体に入力を抽象化するメカニズムがあります。
-例えば、「Cloud Logging から収集されたログ」または「ファイルからアップロードされたログ」を「特定のパーサー」で処理するタスクグラフを作成したいとします。
-
-```go
-var LogsInputTaskReference = taskid.NewTaskReference[[]Log]("example.khi.google.com/log-input")
-var LogsInputFromCloudLoggingTaskID = taskid.NewImplementationID(LogsInputTaskReference, "cloud-logging")
-var LogsInputFromFileTaskID = taskid.NewImplementationID(LogsInputTaskReference, "file")
-
-var LogParserTaskID = taskid.NewDefaultImplementationID[[]ParsedLog]("example.khi.google.com/log-parser")
-
-var LogsInputFromCloudLoggingTask = task.NewTask(LogsInputFromCloudLoggingTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) ([]Log, error) {
- // Get logs from Cloud Logging
- return logs, nil
-})
-
-var LogsInputFromFileTask = task.NewTask(LogsInputFromFileTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) ([]Log, error) {
- // Get logs from file
- return logs, nil
-})
-
-var LogParserTask = task.NewTask(LogParserTaskID, []taskid.UntypedTaskReference{LogsInputTaskReference}, func(ctx context.Context) ([]ParsedLog, error) {
- logs := task.GetTaskResult(ctx, LogsInputTaskReference)
- // Parse logs
- return parsedLogs, nil
-})
-```
-
-```mermaid
-flowchart TD
-    A[LogsInputFromCloudLogging] -.->|logs from Cloud Logging| E[LogParserTask]
-    B[LogsInputFromFile] -.->|logs from file| E
-
-    E(LogsInputTaskReference)-->|logs from something|C[LogParserTask]
-    C --> D[Parsed logs]
-
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
-    classDef task fill:#d4f4fa,stroke:#333,stroke-width:1px;
-    classDef abst fill:#f4c4ca,stroke:#333,stroke-width:1px;
-    classDef result fill:#e1f5e1,stroke:#333,stroke-width:1px;
-    class A,B,C task;
-    class D result;
-    class E abst;
-```
-
-TaskReference はタスクの特定の具体的な実装を指定しないため、タスクグラフに含まれるタスクを並べ替えるだけで、DAG グラフの一部を再利用できます。
-
-### タスク内部からの値の取得
-
-#### 前のタスクからの結果の取得
-
-依存するタスクが出力する値は、タスクに渡されたコンテキストと TaskReference を使用して `task.GetTaskResult` 関数で取得できます。
-コンテキストは、タスク関数自体に渡された正確なコンテキスト値である必要があります。
-
-```go
-taskResult := coretask.GetTaskResult(ctx, SomeTaskID.Ref())
-// The taskResult type is T when SomeTaskID is taskid.TaskImplementationID[T]
-```
-
-#### タスクグラフ外部からの値の取得
-
-KHI では、値はコンテキストに含めることでタスクグラフに渡されます。
-また、コンテキストで提供される値を型安全に扱うために、`khictx` パッケージで定義された関数を使用します。
-
-```go
-contextValueID := typedmap.NewTypedKey[string]("a-string-value") // This is a key associating string value.
-theValue := typedmap.GetOrDefault(ctx, contextValueID, "default-value")
-```
-
-### タスク内でのログ出力
-
-KHI はログ出力に `log/slog` パッケージを使用します。KHI のログハンドラは、タスクコンテキストから情報を抽出することで自動的にログをタスク名に関連付け、各ログエントリを生成したタスクを明確にします。このため、タスク内でログを出力する場合は、コンテキスト非対応のものよりも、`slog.InfoContext`、`slog.WarnContext`、`slog.ErrorContext` などのコンテキスト対応のログメソッドを常に使用する必要があります。
-
-例:
-
-```go
-task.NewTask(TaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (Result, error) {
-    // Good: Using context-aware logging
-    slog.InfoContext(ctx, "Processing started")
-
-    // Bad: Using non context-aware logging
-    // slog.Info("Processing started")
-    // fmt.Printf("Processing started")
-
-    // ... task implementation ...
-    return result, nil
-})
-```
-
-### タスクのパッケージ構造
-
-タスクは多くの場合、パッケージレベルのグローバル変数として定義されます。しかし、同じパッケージ内のグローバル変数の初期化順序は Go 言語によって保証されていません。[参照: The Go Programming Language Specification](https://go.dev/ref/spec#Package_initialization) これにより、タスクがまだ `nil` である別の `TaskID` への参照で初期化されるエラーが発生する可能性があります。
-
-この問題を確実に解決するために、タスクの **"contract"** (タスク ID とそれらが使用する型を含む) と **"implementation"** を別々のパッケージに分離します。実装パッケージはコントラクトパッケージをインポートするため、Go は実装の前にコントラクト (およびその `TaskID`) が完全に初期化されることを保証します。
-
-以下の標準構造を使用します。例えば、`foo` という機能の場合:
-
-```plaintext
-pkg/task/inspection/foo/
-├── contract/
-│   └── taskid.go          // package foocontract
-├── impl/
-│   └── parsertask.go   // package fooimpl
-└── registration.go     // package foo
-```
-
-各コンポーネントの役割
-
-- `contract/` (package foocontract)
-
-  TaskID 変数を含み、TaskID の型パラメータとして使用される結果型を定義します。コントラクトパッケージには、タスクラベルキーやその型パラメータで使用される型も含まれる場合があります。
-  コントラクトパッケージは実装パッケージに依存してはいけません。
-
-- `impl/` (package fooimpl)
-
-  このパッケージには、タスクの実際の実装ロジックが含まれます。
-  TaskID を安全に参照するためにコントラクトパッケージをインポートします。
-
-- `registration.go` (package foo)
-
-  通常、(fooimpl パッケージからの) タスクインスタンスを中央タスクレジストリに登録する関数が含まれます。この関数は、上位層のパッケージまたは `cmd/kubernetes-history-inspector/` 内のファイルの初期化ステップから呼び出されます。
-
-### タスクのテスト
-
-タスクをテストするには、以下の 2 つのヘルパー関数のいずれかを使用します:
-
-- `tasktest.RunTask`: 特定のタスクを呼び出し、結果の値とエラーを受け取るために使用します
-- `tasktest.RunTaskWithDependency`: 指定されたタスクリストで依存関係を解決し、特定のタスクを実行して、結果の値とエラーを受け取るために使用します
-
-#### tasktest.RunTask
-
-特定の入力でタスクを実行し、その結果をテストしたいだけの場合は、`tasktest.RunTask` を使用してください。
-
-```go
-
-var ReturnSomeNumberReference = taskid.NewTaskReference[int]("example.khi.google.com/some-number")
-var DoubleNumberTaskID = taskid.NewDefaultImplementationID[int]("example.khi.google.com/double-number")
-
-var DoubleNumberTask = task.NewTask(DoubleNumberTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (int, error) {
-    number := task.GetTaskResult(ctx, ReturnSomeNumberReference)
- return number * 2, nil
-})
-
-func TestRunTask(t *testing.T) {
- result,err := tasktest.RunTask(context.Background(), DoubleNumberTaskID, tasktest.NewTaskDependencyValuePair(ReturnSomeNumberReference, 5))
- if err != nil {
-  t.Fatalf("failed to run task: %v", err)
- }
- if result != 10 {
-  t.Fatalf("unexpected result: %v", result)
- }
-}
-```
-
-#### tasktest.RunTaskWithDependency
-
-場合によっては、タスクの入力となるテストケースを作成するのが難しく、実際に依存タスクも実行したいことがあります。
-
-```go
-var SimpleInputTaskReference = taskid.NewTaskReference[int]("example.khi.google.com/simple-input")
-var ComplexOutputTaskID = taskid.NewDefaultImplementationID[ComplexOutput]("example.khi.google.com/complex-output")
-var TestingTargetTaskID = taskid.NewDefaultImplementationID[int]("example.khi.google.com/testing-target")
-
-var ComplexOutputTask = task.NewTask(ComplexOutputTaskID, []taskid.UntypedTaskReference{SimpleInputTaskReference}, func(ctx context.Context) ([]int, error) {
- input := task.GetTaskResult(ctx, SimpleInputTaskReference)
-    // Do the complex processing
- return complex,nil
-})
-
-var TestingTargetTask = task.NewTask(TestingTargetTaskID, []taskid.UntypedTaskReference{ComplexOutputTaskID.Ref()}, func(ctx context.Context) (int, error) {
- complexOutput := task.GetTaskResult(ctx, ComplexOutputTaskID.Ref())
-    // Consume the complex output and produce a comperable output
-    return testOutput, nil
-})
-
-func TestRunTaskWithDependency(t *testing.T) {
- result, err := tasktest.RunTaskWithDependency(context.Background(), TestingTargetTaskID,[]coretask.UntypedTask{ComplexOutputTask,tasktest.StubTaskFromReferenceID(SimpleInputTaskReference, 5, nil)})
- if err != nil {
-  t.Fatalf("failed to run task: %v", err)
- }
- if result != EXPECTED_VALUE {
-  t.Fatalf("unexpected result: %v", result)
- }
-}
-```
-
-上記の例では、`SimpleInputTaskReference` として固定値 5 を返すテストタスクを作成し、このスタブタスクを依存関係として渡しています。
-
-`RunTaskWithDependency` を使用すると、`task_test.StubTaskFromReferenceID` によって生成されたスタブタスクが実行され、次に ComplexOutputTask が実際に実行され、最後に TestingTargetTask が実行されて実行結果を取得・比較します。
-
-## タスクグラフの解決と実行
-
-### タスクグラフの依存関係と順序の解決
-
-KHI を拡張する場合、通常はタスクグラフの実行について気にする必要はありません。しかし、KHI がどのようにタスクグラフを実行するかを理解しておくと、後の説明がわかりやすくなります。
-KHI では、複数のタスクがグループ化され、`TaskSet` 型として一緒に実行されます。
-
-```go
-taskSet := task.NewTaskSet([]task.UntypedTask{
-    Task1,
-    Task2,
-    Task3
-})
-```
-
-通常、`TaskSet` は直接実行できません。トポロジカルソートで処理し、必要な依存タスクを追加して、実行可能なグラフを構築する必要があります。
-
-```go
-dependencyTaskSet := task.NewTaskSet([]task.UntypedTask{
-    DependencyTask1,
-    DependencyTask2,
-    DependencyTask3
-})
-taskSet := task.NewTaskSet([]task.UntypedTask{
-    Task1,
-    Task2
-})
-
-resolvedTaskSet, err := taskSet.ResolveTask(dependencyTaskSet)
-```
-
-`TaskSet` 型の `ResolveTask` メソッドは、含まれているタスクを実行可能な順序にソートします。これらのタスクに不足している依存関係がある場合、引数として渡された別の `TaskSet` から必要なタスクのみを含めます。タスクに循環参照がある場合、または提供された `TaskSet` が必要な依存関係を満たしていない場合、`ResolveTask` はエラーを返します。
-
-これらのタスクが以下のような依存関係を持っていると仮定しましょう:
-
-```mermaid
-flowchart TD
-    Task1 --> DependencyTask1
-    Task1 --> DependencyTask2
-    Task2 --> DependencyTask1
-
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;
-```
-
-この場合、`DependencyTask1` と `DependencyTask2` の間には依存関係がないため、これらは最初に実行され、並行して実行できます。`DependencyTask1` が完了すると `Task2` が実行され、`DependencyTask2` が完了すると `Task1` が実行されるようなグラフ構造が形成されます。
-`DependencyTask3` は `Task1` または `Task2` のいずれからも参照されていないため、`resolvedTaskSet` には含まれません。
-
-### タスクグラフの実行
-
-依存関係と実行順序が解決された `TaskSet` は、`TaskRunner` インターフェースを実装する型によって実行できます。
-現在、`LocalRunner` のみが実装されているため、解決された `TaskSet` を以下のように実行できます:
-
-```go
-taskRunner := task.NewLocalRunner(resolvedTaskSet)
-
-err := taskRunner.Run(context.Background())
-
-<- taskRunner.Wait()
-
-result, err := taskRunner.Result()
-```
-
-上記のように、タスクを実行し、完了を待ち、結果を取得できます。
-結果は各タスクの出力を含む `typedmap` として返されますが、特定のタスクの結果が必要な場合は、`task.GetTaskResultFromLocalRunner` を使用します。
-
-```go
-taskRunner := task.NewLocalRunner(resolvedTaskSet)
-
-err := taskRunner.Run(context.Background())
-
-<- taskRunner.Wait()
-
-_, err := taskRunner.Result() // make sure the task graph ended without error
-
-result := task.GetTaskResultFromLocalRunner(taskRunner, TaskID)
-```
-
-## インスペクションタスク
-
-ここまでに説明したタスクメカニズムは、KHI のログ分析目的のみに依存するものではありません。
-しかし、KHI は、KHI 専用にこのシステム上に実装されたログ処理タスクグラフメカニズムを通じて拡張性を維持しながら、さまざまな種類のログを分析します。
-
-### KHI における UI フローとタスクグラフの関係
-
-KHI を使用する場合、ユーザーは以下のようなワークフローに従います:
+KHI では、インスペクション環境の初期化からユーザーによる画面操作、そして分析実行に至るまで、タスクシステムがシステム全体の「状態」と「実行フロー」を動的に制御します。
 
 ![ユーザーに表示されるインスペクションフローでタスク構造がどのように使用されるかを示す図](../en/images/inspection-task-structure.png)
 
-実際のログ処理に使用される様々なタスクは、KHI の初期化中に `InspectionServer` に登録されます。
-ユーザーが `New Inspection` ボタンをクリックすると、まず `Inspection Type` を選択する必要があります。すると KHI は、登録されたタスクをフィルタリングし、選択された `Inspection Type` で動作可能なタスクのみを含めます。これには、ユーザーが有効化または無効化できるタスクだけでなく、それらの依存関係で使用されるすべてのタスクも含まれます。
-次に、ユーザーはログの種類を選択します。これは KHI 内部では Feature タスクと呼ばれる特別なタスクのリストとして表現されます。KHI は Feature タスクであり、かつ選択された Inspection Type で利用可能なタスクのみを表示し、ユーザーが各タスクを含めるかどうかを選択できるようにします。
-
-ユーザーによって選択されたタスクを実行するために、KHI はまず、Inspection Type によってフィルタリングされた利用可能なタスク全体の部分タスク集合を使用して依存関係を解決し、トポロジカルソートを実行してタスクグラフを構築します。
-ログ分析のためのタスクグラフを実行する際、KHI はコンテキストを通じて `Metadata` と呼ばれる JSON シリアライズ可能な値を渡します。この `Metadata` は、タスク実行中の任意の時点で実行外部からアクセスできます。
-例えば、タスクが時間のかかる処理を実行している場合、この `Metadata` に格納されている Progress メタデータを編集できます。フロントエンドがタスクリストを取得すると、この `Metadata` が読み取られ、進捗状況がフロントエンドに表示されます。
-フォーム編集についても同様です。フォーム編集中に Dryrun モードで実行される各タスクは、フロントエンドがフォームを表示するために必要な情報を `Metadata` に埋め込みます。フロントエンドはこの情報を取得して実際のフロントエンドをレンダリングします。
-
-### インスペクションタスクサーバーへのタスク登録
-
-KHI のビルドスクリプトは自動で初期化時に`task/inspection/<パッケージ名>/impl`以下に`registration.go`が存在する場合に`Register()`を呼び出すよう構成します。
-新しいタスクを追加するパッケージを定義するには、この`Register()`関数の中で、タスクや Inspection Type を登録する必要があります。
-
-example:
-
-```go
-// Register registers all googlecloudlogserialport inspection tasks to the registry.
-func Register(registry coreinspection.InspectionTaskRegistry) error {
- err := registry.AddInspectionType(ossclusterk8s_contract.OSSKubernetesLogFilesInspectionType)
- if err != nil {
-  return err
- }
-
- return coretask.RegisterTasks(registry,
-  InputAuditLogFilesTask,
-  AuditLogFileReaderTask,
-  EventAuditLogFilterTask,
-  NonEventAuditLogFilterTask,
-  OSSK8sEventLogParserTask,
-  OSSK8sAuditLogFieldExtractorTask,
-  OSSK8sAuditLogParserTailTask,
- )
-}
-```
-
-### インスペクションタスクのラベル
-
-先ほどタスクについて議論した際、ラベルについては深く触れませんでしたが、KHI の各タスクはラベルのマップを持っています。
-KHI はこの機能を利用して、KHI に登録されているすべてのタスクのセットから特定のタスクセットを選択します。
-
-#### インスペクションタイプの制限 (LabelSelector / InspectionTypeラベル)
-
-タスクを実行可能なインスペクションタイプに制限するには、新しく導入された **LabelSelector（推奨）** を使用する方法と、従来の **InspectionType ラベル（レガシー）** を使用する方法の2つがあります。
-
-KHIはまず LabelSelector による判定を試み、それが設定されていない場合に従来の InspectionType 配列による判定（IDの完全一致リスト）へフォールバックします。どちらも設定されていない場合は、すべてのインスペクションタイプで有効なグローバルタスクとして解釈されます。
-
-##### 1. LabelSelector による判定 (推奨)
-
-`LabelSelector` はマップ（`map[string]string`）形式で条件を指定し、指定したすべてのラベルを現在のインスペクションタイプが **含んでいる（包含している）** 場合にタスクを有効化します。インスペクションタイプ側がセレクターにない追加のラベルを持っていても一致と判定されます（インスペクションタイプのラベルがセレクターのスーパーセットである必要があります）。
-
-これにより、特定のプラットフォーム全体（例: `platform: gke`）などで柔軟にタスクを有効化できます。
-
-```go
-var MyTask = task.NewTask(MyTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (any, error) {
-    return nil, nil
-}, inspectioncore_contract.InspectionTypeLabelSelector(map[string]string{
-    "platform": "gke",
-})) // platform: gke ラベルを持つインスペクションタイプでのみ動作
-```
-
-##### 2. InspectionType ラベルによる判定 (レガシー)
-
-タスクに適用される InspectionType ラベルは `[]string` 型の値を持ちます。これらは InspectionType ID の配列であり、以下の基準に基づいてタスクが有効かどうかを決定します。
-
-- タスクがラベルを持っていない（任意の InspectionType で使用できるグローバルタスクとして解釈される）
-- タスクが InspectionType ID のリストの中に、ユーザーが選択した InspectionType の ID を含んでいる
-
-```go
-var IntGeneratorTask = task.NewTask(IntGeneratorTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (int, error) {
-    return 1, nil
-}, inspectioncore_contract.InspectionTypeLabel("gcp-gke", "gcp-gdcv-for-baremetal")) // 指定されたIDと完全一致する場合のみ
-```
-
-#### FeatureTask ラベル
-
-KHI では、ユーザーが有効化または無効化できるタスクを Feature タスクと呼びます。これらも単なる通常のタスクですが、特定のラベルが付与されています。
-Feature タスクは UI でユーザーによって選択される必要があるため、タイトルや説明などの追加ラベルが付与されます。これらは `task.FeatureTaskLabel` 関数を使用して一度に割り当てることができます。
-
-```go
-
-var ContainerdLogFeatureTaskID = taskid.NewDefaultImplementationID[[]Log]("example.khi.google.com/containerd-log-feature")
-
-var ContainerdLogFeatureTask = task.NewTask(ContainerdLogFeatureTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) ([]Log, error) {
- // Get logs from containerd
- return logs, nil
-}, inspectioncore_contract.FeatureTaskLabel("title","description",/*Log type*/,/*is default feature or not */, "gcp-gke","gcp-gdcv-for-baremetal"))
-
-```
-
-新しいパーサーを実装する場合、この `FeatureTaskLabel` 関数によって生成されたラベルを持つタスクを登録することがよくあります。
-FeatureTaskLabel では、最後に必須の可変長引数として InspectionType を指定する必要があることに注意してください。
-
-### タスクモード
-
-KHI はインスペクション用のタスクを `run` または `dryrun` モードで実行します。グラフが構築されると、KHI はユーザーがフォーム値を編集中に定期的にタスクグラフを `dryrun` モードで実行します。`run` モードでのみ実行されるタスクは、`dryrun` モードの場合に処理をスキップするために、コンテキスト値からこのタスクモードを読み取る必要があります。
-
-```go
-taskMode := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionTaskMode)
-// taskMode should be inspectioncore_contract.TaskModeDryRun or inspectioncore_contract.TaskModeRun
-```
-
-ユーザーは通常、`task.NewTask` のラッパーである `inspection_task.NewInspectionTask()` を使用する場合、コンテキストからタスクモードを取得する必要はありません。
-
-```go
-var Task = inspection_task.NewInspectionTask(TestTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context, taskMode inspection_task_interface.TaskMode) (Result, error) {
- if taskMode == inspection_task_interface.TaskModeDryRun { // Skip the task processing when the mode is dryrun.
-  return nil, nil
- }
- // ...
-})
-```
-
-### タスクメタデータ
-
-KHI の各タスクは、タスクの結果だけでなく、さまざまな追加情報を出力できます。
-例えば、ログ収集に使用されたクエリや、タスクによって出力されたログなどが含まれる場合があります。
-
-KHI では、タスクの主な出力ではないデータは Metadata と呼ばれる単一のマップで管理されます。タスクグラフが実行されると、最初に空のマップが渡され、各タスクが必要に応じて値を追加します。
-Metadata はタスクの実行中でも読み取ることができます。これは重要です。なぜなら、例えばプログレスバーの値はタスクによって継続的に書き込まれ、実行中でもタスクメタデータとして取得できる必要があるからです。
-
-メタデータマップを取得するには、以下のように `khictx` を使用してコンテキストから取得できます:
-
-```go
-metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
-```
-
-通常の拡張を行う開発者は、メタデータの存在を意識する必要はありません。通常、これらはさまざまなユーティリティによってラップされており、値は自動的に設定されます。
-
-#### 入力フィールド
-
-Metadata の主要な用途の 1 つは、ログフィルタを作成する際のフォームです。
-各タスクはフォームに必要なメタデータをフォームメタデータに書き込み、フロントエンドはそれを受け取ってフォームをレンダリングします。
-
-ただし、ユーザーがメタデータの扱いの詳細を理解する必要はありません。例えば、テキストフォームの場合は `formtask.NewTextFormTaskBuilder` を使用します。
-
-以下は、Duration 値を入力するためのフォームタスクの実践的な例です。フォームもタスクであるため、前提タスクを持つことができます。
-
-```go
-var InputDurationTask = formtask.NewTextFormTaskBuilder(InputDurationTaskID, PriorityForQueryTimeGroup+4000, "Duration").
- WithDependencies([]taskid.UntypedTaskReference{
-  InspectionTimeTaskID,
-  InputEndTimeTaskID,
-  TimeZoneShiftInputTaskID,
- }).
- WithDescription("The duration of time range to gather logs. Supported time units are `h`,`m` or `s`. (Example: `3h30m`)").
- WithDefaultValueFunc(func(ctx context.Context, previousValues []string) (string, error) {
-  if len(previousValues) > 0 {
-   return previousValues[0], nil
-  } else {
-   return "1h", nil
-  }
- }).
- WithHintFunc(func(ctx context.Context, value string, convertedValue any) (string, form_metadata.ParameterHintType, error) {
-  inspectionTime := task.GetTaskResult(ctx, InspectionTimeTaskID.Ref())
-  endTime := task.GetTaskResult(ctx, InputEndTimeTaskID.Ref())
-  timezoneShift := task.GetTaskResult(ctx, TimeZoneShiftInputTaskID.Ref())
-
-  duration := convertedValue.(time.Duration)
-  startTime := endTime.Add(-duration)
-  startToNow := inspectionTime.Sub(startTime)
-  hintString := ""
-  if startToNow > time.Hour*24*30 {
-   hintString += "Specified time range starts from over than 30 days ago, maybe some logs are missing and the generated result could be incomplete.\n"
-  }
-  if duration > time.Hour*3 {
-   hintString += "This duration can be too long for big clusters and lead OOM. Please retry with shorter duration when your machine crashed.\n"
-  }
-  hintString += fmt.Sprintf("Query range:\n%s\n", toTimeDurationWithTimezone(startTime, endTime, timezoneShift, true))
-  hintString += fmt.Sprintf("(UTC: %s)\n", toTimeDurationWithTimezone(startTime, endTime, time.UTC, false))
-  hintString += fmt.Sprintf("(PDT: %s)", toTimeDurationWithTimezone(startTime, endTime, time.FixedZone("PDT", -7*3600), false))
-  return hintString, form_metadata.Info, nil
- }).
- WithSuggestionsConstant([]string{"1m", "10m", "1h", "3h", "12h", "24h"}).
- WithValidator(func(ctx context.Context, value string) (string, error) {
-  d, err := time.ParseDuration(value)
-  if err != nil {
-   return err.Error(), nil
-  }
-  if d <= 0 {
-   return "duration must be positive", nil
-  }
-  return "", nil
- }).
- WithConverter(func(ctx context.Context, value string) (time.Duration, error) {
-  d, err := time.ParseDuration(value)
-  if err != nil {
-   return 0, err
-  }
-  return d, nil
- }).
- Build()
-```
-
-これらのフォームフィールド設定はフォームメタデータに格納されます。
-
-```go
-metadata := khictx.MustGetValue(ctx, inspection_task_contextkey.InspectionRunMetadata)
-formFields, found := typedmap.Get(metadata, form_metadata.FormFieldSetMetadataKey)
-```
-
-## ログを解析するためのタスクユーティリティ
-
-KHI はその堅牢なタスクシステムを使用してログ解析を実行します。このアーキテクチャは KHI を非常に拡張性の高いものにし（新しいタスクを作成するだけで新しい機能を追加できます）、Go の並行処理機能をフル活用することを可能にします。しかし、ログ解析には多くの共通パターンがあるため、ログ解析タスクは KHI が提供する高レベルなタスク作成ユーティリティを使用して実装すべきです。
-
-KHI は、基本的なログ解析のユースケースをカバーするために、以下の高レベルタスク作成ユーティリティを提供しています:
-
-- FieldSetReadTask : 構造化ログのフィールドを型付き構造体に格納します。
-- LogGrouperTask : 特定のフィールドでログをグループ化します。
-- LogFilterTask : 条件に基づいてログをフィルタリングします。
-- LogIngesterTask : ログを最終的な履歴データに取り込みます。
-- LogToTimelineMapperTask : 取り込まれたログをタイムラインにマッピングします。
-
-これらのタスクは通常、以下の図のように接続されます:
-
 ```mermaid
-flowchart TD
-    QueryTask --> FieldSetReadTask
-    FieldSetReadTask --> LogFilterTask
-    LogFilterTask --> LogGrouperTask
-    LogFilterTask --> LogIngesterTask
-    LogIngesterTask --> LogToTimelineMapperTask
-    LogGrouperTask --> LogToTimelineMapperTask
+sequenceDiagram
+    autonumber
+    actor U as ユーザー (UI)
+    participant S as InspectionServer
+    participant R as InspectionTaskRunner
+    participant G as 実行用タスクグラフ
+
+    Note over S,R: 1. プラットフォーム・ログ種別によるプール絞り込み
+    U->>S: New Inspection ダイアログを開き<br>Inspection Type を選択
+    S->>S: LabelSelector でタスク群をフィルタ (availableTasks)
+    S->>U: FeatureTask のトグル機能リストを提示
+
+    Note over U,G: 2. 入力フォームおよび機能選択 (DryRun モード)
+    U->>R: パラメータ入力・変更 / オートコンプリート要求
+    R->>G: DryRun モードで軽量グラフ実行
+    G->>R: Metadata にフォーム定義や候補リストを書き出し
+    R->>U: 入力フォーム・候補一覧を描画
+
+    Note over U,G: 3. 分析実行とメタデータ通信 (Run モード)
+    U->>R: Start Inspection ボタンを押下
+    R->>S: 選択された FeatureTask の依存関係を再帰解決
+    S->>G: トポロジカルソートし最終実行グラフを構築
+    R->>G: Run モードでタスクグラフを並行実行
+    G->>R: Metadata 経由で進捗率 (Progress) を通知
+    R->>U: リアルタイムなプログレスバー表示
+    G->>U: 最終的な履歴ファイル (KHI ファイル) を生成
 ```
 
-KHI はログをリソースに関連付ける前に、まずログを取り込む必要があることに注意してください。
+#### 1. プラットフォームと機能選択によるタスクグラフ構築（ビルドフェーズ）
 
-### FieldSetReadTask
+1. **プラットフォーム・ログ種別による全体プールの絞り込み**:
+   実際のログ処理に使用されるタスク群は、初期化時に `InspectionServer` のルートタスクセットへ登録されます。
+   ユーザーが「New Inspection」ボタンをクリックし、最初のドロップダウンで **Inspection Type** を選択すると、KHI は登録されたすべてのタスクの中からラベルセレクタ式を評価し、選択されたインスペクション環境に適合するタスクのみをフィルタリングします (`availableTasks`)。
+2. **FeatureTask ラベルに基づく機能選択 UI の提示**:
+   次に、KHI は絞り込まれた `availableTasks` の中から **`FeatureTask`** ラベル（機能フラグ）を持つタスクを抽出して画面に提示します。
+   ユーザーはこれらをチェックボックス等で切り替えることで、どのログ解析機能を今回のインスペクションに含めるかを選択できます。
+3. **依存タスクの再帰解決とタスクグラフの構築**:
+   ユーザーが選択した `FeatureTask` を起点として、それらの処理に必要となるすべての依存タスク（ログ収集タスク、パーサー、インベンター等）が利用可能タスク群の中から再帰的に解決され、トポロジカルソートを実行して最終的な実行用タスクグラフとして構築されます。
 
-解析における一般的かつ重要なステップは、単一のログエントリから特定のフィールドを読み取ることです。この操作は通常他のログから独立しているため、並行して実行できます。モノリシックなパーサーにフィールドを順次読み取らせるのではなく、KHI は `FieldSetReadTask` を使用してそれらを同時に処理します。このタスクは各ログから事前定義されたフィールドを並行して読み取り、強く型付けされた結果 (FieldSet と呼ばれます) を対応するログオブジェクトに付加します。
+#### 2. タスク実行時の UI 通信とメタデータ共有（ランタイムフェーズ）
 
-例えば、特定のデータを抽出するために `FieldSet` 型とその対応するリーダーを定義できます:
+タスクグラフが構成された後、KHI はコンテキストを通じて **`Metadata`** と呼ばれる JSON シリアライズ可能な共有データストアを各タスクに渡します。
+この `Metadata` はタスク実行中および完了後にサーバー外部やフロントエンド（UI）からアクセスでき、主に以下の目的で使用されます:
 
-```go
-// Define a struct for the data you want to extract.
-type PodInfoFieldSet struct {
-    PodName      string
-    ContainerID  string
-}
-func (fs *PodInfoFieldSet) Kind() string { return "PodInfo" }
+- **進捗状況のリアルタイム表示**:
+  時間のかかるログ取得や重い解析処理を行うタスクは、実行中に `Metadata` 内の進捗情報 (`Progress`) を継続的に更新します。フロントエンドが定期的にタスクステータスを取得すると、この値が読み取られてプログレスバー等に反映されます。
+- **動的な入力フォームや候補一覧のレンダリング**:
+  「New Inspection」画面のフォーム操作時（`DryRun` モード時）には、パラメータ入力タスクやオートコンプリート候補取得タスクが、画面表示に必要なフィールド定義や候補リストを `Metadata` に書き込みます。フロントエンドはこの情報を取り出してインタラクティブな入力フォームを描画します。
 
-// Create a reader that implements the log.FieldSetReader interface.
-type PodInfoReader struct{}
-func (r *PodInfoReader) FieldSetKind() string { return "PodInfo" }
-func (r *PodInfoReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
-    // Logic to read from the log's structured data.
-    return &PodInfoFieldSet{
-        PodName:      reader.ReadStringOrDefault("podName", ""),
-        ContainerID:  reader.ReadStringOrDefault("containerID", ""),
-    }, nil
-}
+---
 
-// In your task graph, create a FieldSetReadTask.
-var ReadPodInfoTask = inspectiontaskbase.NewFieldSetReadTask(
-    ReadPodInfoTaskID,
-    SourceLogsTaskID.Ref(), // Depends on a task that returns []*log.Log, likely from a Query.
-    []log.FieldSetReader{&PodInfoReader{}},
-)
-```
+## 2. 次のステップ
 
-グラフ内の後続のタスクは、各ログオブジェクトから解析済みの `PodInfoFieldSet` にアクセスできるようになり、高価な解析ステップが一度だけ並行して行われることが保証されます。
+ここから先のタスクの実装文法やコードサンプルについては、以下の専門ガイドへと進んでください:
 
-後続のタスクでは以下の様にしてログのインスタンスから FieldSet 構造体を読み取れます。
-
-```go
-func FieldSetConsumer(l *log.Log){
-  p := log.MustGetFieldSet(l, &PodInfoFieldSet{})
-}
-```
-
-単一のフィールドセットに対して複数のフィールドセットリーダーを定義できます。フィールドセットはリーダーによる実際のフィールドへのアクセス方法を抽象化しますが、実際のリーダーはクラスタータイプに応じて FieldSetReadTask として注入できます。例えば、OSS kube-apiserver 監査ログと GKE kubernetes 監査ログは同じフィールドセットに依存しますが、一部のフィールド名が GKE で独自であるため、リーダーは異なります。
-
-### NewLogGrouperTask
-
-ログ解析はしばしば時系列に従う必要がありますが、異なるリソース (例: 2 つの異なる Pod) に対する操作は通常独立しており、並行して処理できます。これを可能にするために、リソース名や ID などの特定のフィールドに基づいてログをグループ化する `NewLogGrouperTask` が使用されます。
-
-```go
-// This task takes a list of logs and a grouper function.
-var GroupLogsByPodTask = inspectiontaskbase.NewLogGrouperTask(
-    GroupLogsByPodTaskID,
-    SourceLogsTaskID.Ref(), // Depends on the source logs
-    func(ctx context.Context, l *log.Log) string {
-        // Group by Pod name. Assumes FieldSetReadTask has already run.
-        if podInfo, ok := log.GetFieldSet(l, &PodInfoFieldSet{}); ok {
-            return podInfo.PodName
-        }
-  return "unknown-pod"
-    },
-)
-```
-
-これにより、下流のタスクは各 Pod のログを並行して処理できるため、パフォーマンスが大幅に向上します。
-
-### NewLogFilterTask
-
-多くの場合、パーサーはログのサブセットに対してのみ操作を行う必要があります。`NewLogFilterTask` は、述語関数に基づいてログリストをフィルタリングする簡単な方法を提供します。これは、以降のより高価な処理タスクの範囲を絞り込むのに役立ちます。
-
-```go
-// This task takes a list of logs and a filter function.
-var FilterPodLogsTask = inspectiontaskbase.NewLogFilterTask(
-    FilterPodLogsTaskID,
-    SourceLogsTaskID.Ref(), // Depends on the source logs
-    func(ctx context.Context, l *log.Log) bool {
-        // Keep only logs related to Pods. Assumes FieldSetReadTask has run.
-        if podInfo, ok := log.GetFieldSet(l, &PodInfoFieldSet{}); ok {
-            return podInfo.PodName != ""
-        }
-        return false
-    },
-)
-```
-
-### NewLogIngesterTask
-
-`LogIngesterTask` は、ログから抽出された他のデータを追加する前に、ログを KHI ファイルに取り込む責任があります。
-
-> [!IMPORTANT] > `LogIngesterTask` によって処理されたログのみが最終的な KHI ファイルに書き込まれます。クエリされたログの一部を最終結果から除外したい場合は、`LogIngesterTask` に渡す前に**必ず**フィルタリングする必要があります。この目的には `NewLogFilterTask` を使用してください。
->
-> ログにリンクされた結果データを生成するタスク (例: `LogToTimelineMapperTask`) は、`LogIngesterTask` によって処理されていないログの情報を保存できません。ターゲットのログが最初に取り込まれていることを確認してください。
-
-```go
-var IngestLogsTask = inspectiontaskbase.NewLogIngesterTask(
-    IngestLogsTaskID,
-    SourceLogsTaskID.Ref(), // taskid.TaskReference[[]log.Log]
-)
-```
-
-### NewLogToTimelineMapperTask
-
-`LogToTimelineMapperTask` はログを複数のリソースに関連付けたり、ログサマリーを上書きしたりします。
-
-履歴を変更するには、`ProcessLogByGroup` から返される `TimelineChangeSet` オブジェクトを使用します。
-
-このタスクは、実行された書き込みのサマリー（どのタイムラインパスにイベント、リビジョン、またはエイリアスが追加されたか）を含む `TimelineMapperResult` を返します。後続のタスクはこの結果を参照して特定のタイムラインが構築されたかどうかを判定し、特定のタイムラインへの書き込みがない場合に別のログソースから代替のタイムラインを生成する、といった制御を行うことができます。
-
-#### `TimelineChangeSet` の操作
-
-- **`AddEvent(resourcePath)`**: タイムラインに特定の時点のイベントを追加します。
-- **`AddRevision(resourcePath, revision)`**: 特定の時間における状態を追加します。
-- **`AddResourceAlias(source, dest)`**: リソースをリンクします (例: Pod -> Owner)。
-- **`SetLogSummary(summary)` / `SetLogSeverity(severity)`**: ログメタデータを上書きします。
-
-### リソースとのログ関連付けのマッピング
-
-これはリソースごとにログをグループ化した後にログを処理し、`ProcessLogByGroup` の `prevGroupData` 引数を使用して、同じグループ内のログ間で状態を維持することを可能にします。
-
-```go
-// Define a custom struct to hold state between logs in the same group.
-type MyGroupData struct {
-    Count int
-}
-
-type MyMapper struct {}
-
-// Implement LogToTimelineMapper interface
-func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
-    cs := khifilev6.NewTimelineChangeSet()
-    // Modify history via TimelineChangeSet
-    cs.SetLogSeverity(enum.SeverityInfo)
-
-    // Add an event to a resource timeline
-    cs.AddEvent(resourcepath.NameLayerGeneralItem("v1", "Pod", "default", "my-pod"))
-
-    // Pass updated state to the next log in the group
-    return cs, MyGroupData{Count: prevData.Count + 1}, nil
-}
-
-// ... Implement other interface methods (Dependencies, LogIngesterTask, GroupedLogTask, PassCount, PreProcessLogByGroup) ...
-
-var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
-    MyMapperTaskID,
-    &MyMapper{},
-    inspectioncore_contract.FeatureTaskLabel("my-mapper",/*rest of the other parameters*/)  // LogToTimelineMapper is usually labeled with FeatureTaskLabel.
-)
-```
-
-#### ChangeSet 結果のテスト
-
-シンプルなユニットテストで `testchangeset.ChangeSetAsserter` を使用してマッパーロジックをテストすべきです。これにより、`ChangeSet` の変更を宣言的に検証できます。
-
-```go
-func TestMyMapper_ProcessLogByGroup(t *testing.T) {
-    // 1. Setup Inputs
-    l := log.NewLogWithFieldSetsForTest(&log.CommonFieldSet{Timestamp: time.Now()}, /* ... */)
-    cs := history.NewChangeSet(l)
-    mapper := &MyMapper{}
-
-    // 2. Run Logic
-    _, err := mapper.ProcessLogByGroup(t.Context(), l, cs, nil, MyGroupData{})
-    if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-
-    // 3. Verify using ChangeSetAsserter
-    asserters := []testchangeset.ChangeSetAsserter{
-        &testchangeset.HasEvent{
-            ResourcePath: "v1#Pod#default#my-pod",
-        },
-        &testchangeset.HasLogSeverity{
-            WantLogSummary: "expected summary",
-        },
-    }
-
-    for _, a := range asserters {
-        a.Assert(t, cs)
-    }
-}
-```
-
-## ログから情報を発見するためのタスクユーティリティ
-
-ログパーサーは、ログをリソースに関連付けるために、(`時刻 T に "x.y.z.w" を取得したのは誰か`、`コンテナ ID "6123c..." に関連付けられている Pod はどれか` など) の情報を必要とすることがよくあります。この情報は複数のログソースから得られる可能性がありますが、ユーザーは KHI でどのログを処理するかを切り替えることができます。
-
-KHI は、複数のソースから情報を収集するための `Discovery-Inventory` パターンタスクユーティリティを提供します。
-
-### Inventory Task
-
-`InventoryTask` フレームワークは、複数のオプションのログソースからの情報を単一の統合されたビューに集約する問題を解決します。これにより、データ消費者（最終的なマッピング、例えば ContainerID から Pod へのマッピングが必要なだけの人）とデータプロバイダー（特定のログパーサー）が分離されます。
-
-#### 使用法
-
-1. **Builder を定義する**: 統合されたインベントリ用の一意の ID を持つ `InventoryTaskBuilder` を作成します。
-2. **Discovery Task を作成する**: ビルダーの `DiscoveryTask` メソッドを使用して、さまざまなソースから部分的なインベントリデータを抽出するタスクを作成します。
-3. **Inventory Task を作成する**: ビルダーの `InventoryTask` メソッドを使用して、マージ戦略を使用してすべての発見結果を集約する最終タスクを作成します。
-
-#### 例: コンテナ ID インベントリ
-
-```go
-// 1. Define the Builder
-var ContainerIDInventoryBuilder = inspectiontaskbase.NewInventoryTaskBuilder[ContainerIDToContainerIdentity](ContainerIDInventoryTaskID)
-
-// 2. Define Discovery Tasks (e.g., from Audit Logs)
-// This task discovers container ID to container identity mappings from manifests.
-// Discovery tasks must depend on a task labeled with `FeatureTaskLabel`. This ensures the discovery task is activated only when the corresponding feature is selected by the user.
-var ContainerIDDiscoveryTask = ContainerIDInventoryBuilder.DiscoveryTask(
-    ContainerIDDiscoveryTaskID,
-    []taskid.UntypedTaskReference{ManifestGeneratorTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ContainerIDToContainerIdentity, error) {
-        if taskMode != inspectioncore.InspectionTaskModeRun {
-            return nil, nil
-        }
-        // ... extract container IDs and their identities from manifests ...
-        // For example:
-        manifests := coretask.GetTaskResult(ctx, ManifestGeneratorTaskID.Ref())
-        partialResult := make(ContainerIDToContainerIdentity)
-        for _, manifest := range manifests {
-            if containerID, identity := extractContainerInfo(manifest); containerID != "" {
-                partialResult[containerID] = identity
-            }
-        }
-        return partialResult, nil
-    },
-)
-
-// 3. Define the Inventory Task with a Merger Strategy
-// The merger strategy defines how to combine results from multiple discovery tasks.
-type ContainerIDMergeStrategy struct{}
-
-// Merge combines two ContainerIDToContainerIdentity maps.
-func (s *ContainerIDMergeStrategy) Merge(identities []ContainerIDToContainerIdentity) ContainerIDToContainerIdentity {
-    // logic to merge given identities from DiscoveryTask into a single identity instance
-}
-
-var ContainerIDInventoryTask = ContainerIDInventoryBuilder.InventoryTask(&ContainerIDMergeStrategy{})
-```
-
-## 低レベルタスクユーティリティ
-
-高レベルのタスクユーティリティではニーズを満たせない場合、ベースからタスクを定義するためのいくつかの低レベルユーティリティがあります。
-
-### NewProgressReportableInspectionTask
-
-タスクが短時間で完了する場合でも、低レベルのタスクを定義する際は `NewProgressReportableInspectionTask` を使用すべきです。
-これは `progress` 引数を提供し、タスクがユーザーにステータスを報告できるようにします。
-
-```go
-var HeavyProcessingTask = inspectiontaskbase.NewProgressReportableInspectionTask(
-    HeavyProcessingTaskID,
-    []taskid.UntypedTaskReference{SourceLogsTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
-        if taskMode != inspectioncore_contract.TaskModeRun {
-            return ResultType{}, nil
-        }
-
-        logs := coretask.GetTaskResult(ctx, SourceLogsTaskID.Ref())
-        total := len(logs)
-        processed := 0
-
-  // Create a ProgressUpdater that updates the progress metadata every second.
-        updater := progressutil.NewProgressUpdater(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
-            tp.Percentage = float32(processed) / float32(total)
-            tp.Message = fmt.Sprintf("Processed %d/%d logs", processed, total)
-        })
-
-        updater.Start(ctx)
-        defer updater.Done()
-
-        for _, l := range logs {
-            // Do heavy processing...
-            processed++
-        }
-
-        return result, nil
-    },
-)
-```
-
-#### 不定の進捗報告
-
-作業の総量が不明な場合は、`MarkIndeterminate()` を使用して現在のタスクの進捗を不定としてマークできます。
-
-```go
-var UnknownLengthTask = inspectiontaskbase.NewProgressReportableInspectionTask(
-    UnknownLengthTaskID,
-    []taskid.UntypedTaskReference{SomeDependencyTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
-        if taskMode != inspectioncore_contract.TaskModeRun {
-            return ResultType{}, nil
-        }
-
-        progress.MarkIndeterminate()
-
-        // Do work where items are discovered dynamically...
-        for item := range dynamicItemsChannel {
-            process(item)
-        }
-
-        return result, nil
-    },
-)
-```
-
-### タスク結果のキャッシュ
-
-計算量が多く、結果が入力のみに依存するタスクの場合は、`NewCachedTask` を使用できます。このタスクは結果を共有メタデータマップにキャッシュし、入力ダイジェストが変更されていない場合、以降の実行（例：「ドライラン」実行の更新中）で再利用します。
-
-```go
-var CachedHeavyTask = inspectiontaskbase.NewCachedTask(
-    CachedHeavyTaskID,
-    []taskid.UntypedTaskReference{InputParamsTaskID.Ref()},
-    func(ctx context.Context, prevResult inspectiontaskbase.CacheableTaskResult[ResultType]) (inspectiontaskbase.CacheableTaskResult[ResultType], error) {
-        params := coretask.GetTaskResult(ctx, InputParamsTaskID.Ref())
-        // Calculate a digest from the input parameters.
-        digest := calculateDigest(params)
-
-        // If the digest matches the previous run, return the cached value.
-        if prevResult.DependencyDigest == digest {
-            return prevResult, nil
-        }
-
-        // Re-calculate if digest changed or it's the first run.
-        newValue := doHeavyCalculation(params)
-        return inspectiontaskbase.CacheableTaskResult[ResultType]{
-            Value:            newValue,
-            DependencyDigest: digest,
-        }, nil
-    },
-)
-```
+- **[1. タスクシステムの基本文法と実行モード](./task-system/01-syntax-and-modes.md)** — タスク (`Task[T]`) の構文、`Run`/`DryRun` モード、単体テスト
+- **[2. ログ解析のためのタスク実装パターン (実践ガイド)](./task-system/02-log-processing-cookbook.md)** — ログ解析パイプラインと 6 大タスクのクックブック
+- **[3. 高度なタスクパターンとユーティリティ](./task-system/03-advanced-and-form-tasks.md)** — 自動登録、ラベル、インベントリ・ディスカバリ、入力フォーム (`formtask`)

--- a/docs/ja/task-system/01-syntax-and-modes.md
+++ b/docs/ja/task-system/01-syntax-and-modes.md
@@ -1,0 +1,179 @@
+# KHI タスクシステムの基本文法と実行モード
+
+[< インデックスへ戻る](../khi-task-system-concept.md) | [次へ: ログ解析のためのタスク実装パターン >](./02-log-processing-cookbook.md)
+
+---
+
+本ドキュメントでは、KHI のタスクアーキテクチャを理解し開発するために必須となる**タスクシステムの基本文法、実行ライフサイクルモード（`Run` と `DryRun`）、およびテスト手法**について解説します。
+
+## 1. DAG で使用される基本的な形式
+
+DAG (Directed Acyclic Graph: 有向非巡回グラフ) は、サイクルを持たずに一方向に流れるグラフです。KHI の文脈では、これはタスクが依存関係に基づいて特定の順序で実行されるワークフローを表します。グラフ内の各ノードはタスクであり、エッジはタスク間の依存関係を表します。
+
+## 2. タスクの型 (`Task[T]`)
+
+KHI のすべてのタスクには、その出力に関連付けられた「型」があります。これらは Go のジェネリクス型を使用して記述され、コンパイル時に検証されます。
+以下は `int` 値を返すタスクを宣言する例です:
+
+```go
+var IntGeneratorTask = task.NewTask(
+    IntGeneratorTaskID,
+    []taskid.UntypedTaskReference{},
+    func(ctx context.Context) (int, error) {
+        return 1, nil
+    },
+)
+```
+
+この例では、以下の重要な要素を宣言しています:
+
+1. **`IntGeneratorTask` 型**: Go コンパイラはジェネリクス推論によりこのタスクの型を `task.Task[int]` と推論します。
+2. **第一引数 (`IntGeneratorTaskID`)**: タスクグラフにおけるそのタスク実装の ID を示します。これは `taskid.TaskImplementationID[int]` 型である必要があります。この ID を使用して、他のタスクからそのタスクへの参照を取得できます。
+3. **第二引数 (`[]taskid.UntypedTaskReference`)**: このタスクが依存するタスク参照のリストです。タスクグラフの順序付けや、タスクグラフ内の他のタスクから値を読み取る際に使用します。
+4. **第三引数 (実行関数)**: この関数の戻り値はタスクの型パラメータ（この場合は `int`）に準拠している必要があり、かつ戻り値の第二引数として常にエラーを返す必要があります。
+
+## 3. タスク内部からの値の取得
+
+タスクから値を読み取るには、読み取り先のタスクへのタスク参照を依存関係リストに含める必要があります。
+これにより、タスク実行関数から `coretask.GetTaskResult(ctx, dependencyTaskRef)` を使用して依存タスクからの戻り値を安全に取得できます:
+
+```go
+var DoubleIntTask = task.NewTask(
+    DoubleIntTaskID,
+    []taskid.UntypedTaskReference{IntGeneratorTaskID.Ref()}, // 依存するタスク参照を指定
+    func(ctx context.Context) (int, error) {
+        // コンテキストと参照IDを渡して戻り値を取得
+        value := coretask.GetTaskResult(ctx, IntGeneratorTaskID.Ref())
+        return value * 2, nil
+    },
+)
+```
+
+> [!IMPORTANT]
+> **未宣言の依存関係へのアクセス禁止**
+> 依存関係リストに宣言していないタスクに対して `coretask.GetTaskResult` を呼び出すと、実行時パニック (`panic`) が発生します。必ず第二引数の依存関係リストにアクセス対象のタスク参照を含めてください。
+
+## 4. タスク内でのログ出力 (`slog`)
+
+タスクのデバッグやエラー解析を行う際は、標準の `fmt.Println` ではなく、コンテキスト付きの構造化ロガーである `slog` (例: `slog.InfoContext`, `slog.ErrorContext` など) を使用してログを出力します。
+
+```go
+slog.InfoContext(ctx, "processing int value", "intValue", value)
+```
+
+これにより、ログメッセージにインスペクションのトレース ID や実行時コンテキスト情報が自動的に付与され、Cloud Logging やローカルデバッグログからの追跡が容易になります。
+
+## 5. タスクのパッケージ構造とパッケージ名規約
+
+KHI のすべての検査タスクは、**単一機能ごとに専用のパッケージとして分離する** アーキテクチャ原則を採用しています。
+各タスクは `pkg/task/inspection/<パッケージ名>/` 配下の固有のフォルダー内に定義し、さらにその配下で以下の 2 つのディレクトリへと明確に分離する必要があります:
+
+```text
+pkg/task/inspection/<パッケージ名>/
+├── contract/  # 公開インターフェース・タスク ID・型定義のみを置く (実処理は書かない)
+└── impl/      # 実際のタスク定義やログ処理ロジック (実装) を置く
+```
+
+### 1. `contract` フォルダーの責務
+
+- その機能が他のタスクへと公開する **タスク ID**、**インターフェース**、および **公開データ構造（構造体や列挙型など）** のみを定義します。
+- **実処理を含む関数やタスク実装自体（`task.NewTask(...)`）を記述してはなりません。**
+- 他のあらゆるタスクパッケージからインポート可能な唯一の公開レイヤーです。
+
+### 2. `impl` フォルダーの責務
+
+- `contract` で定義されたタスク ID に紐づく実際のタスク（`var SomeTask = task.NewTask(...)` 等）や、パーサー・マッパーロジックの実装コードを記述します。
+- `init()` や初期化関数 (`Register(...)` 等) を配置します。
+- **他の機能パッケージの `impl` をインポートすることは禁止されています。** 別の機能に依存する場合は、必ずその機能の `contract` のみをインポートし、タスク依存関係としてタスクグラフ上で連携してください。
+
+### 3. パッケージ名 (`package` 宣言) の命名規約
+
+Go では、単に `contract` や `impl` というパッケージ名で宣言すると、異なる機能間でインポート時の識別名が衝突したりコード上で出処が分かりにくくなります。
+そのため、`contract` ディレクトリおよび `impl` ディレクトリ内の Go ソースファイルでは、**親の機能パッケージ名に `_contract` または `_impl` のサフィックスを結合したパッケージ名で宣言する** 規約を採用しています:
+
+- **`contract/` 配下のファイル**: `package <機能名>_contract` (例: `package example_contract`)
+- **`impl/` 配下のファイル**: `package <機能名>_impl` (例: `package example_impl`)
+
+他のタスクから型や ID を参照する際は、必ずこの `<機能名>_contract` パッケージのみをインポートしてください。
+
+## 6. インスペクションタスクの実行モード (`Run` と `DryRun`)
+
+KHI のインスペクションタスクは、実行されるシチュエーションに応じて **`Run` モード** と **`DryRun` モード** のいずれかで呼び出されます。これはタスクグラフ実行における根本的なライフサイクル機能であり、重い解析処理と UI の軽量なインタラクションを明確に分離するために設計されています。
+
+- **`Run` モード (`TaskModeRun`)**: ユーザーが「Start Inspection」ボタンをクリックして分析を開始した際に選択される通常実行モードです。実際のログクエリ、構文解析、履歴ファイル（KHI ファイル）の生成・シリアライズを実行します。
+- **`DryRun` モード (`TaskModeDryRun`)**: ユーザーが「New Inspection」画面で入力パラメータを変更したり、フォーム項目やオートコンプリート候補を動的に取得する際に実行される軽量なモードです。UI の応答性を維持するため、時間のかかるログ取得や解析処理はこのモードではスキップされます。
+
+### 実行モードを判定する具体的なコード例
+
+すべてのインスペクションタスク（または低レベルタスクユーティリティ）は、引数として渡される `inspectioncore_contract.InspectionTaskModeType` (`taskMode`) を評価し、現在の実行モードに応じて処理を切り替える実装にします。
+以下は、`DryRun` 時には重い処理を行わずに軽量な空結果や必要な UI メタデータのみを返し、`Run` モード時にのみ実際の解析処理を実行する標準的な Go 実装例です:
+
+```go
+var ExampleInspectionTask = inspectiontaskbase.NewProgressReportableInspectionTask(
+    ExampleInspectionTaskID,
+    []taskid.UntypedTaskReference{SourceLogsTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
+        // 1. DryRun モードの判定: フォーム設定用や軽量実行時は、重いログ取得や解析をスキップして即座に返す
+        if taskMode == inspectioncore_contract.TaskModeDryRun {
+            return ResultType{}, nil
+        }
+
+        // 2. Run モード時: 実際のログ取得および時間のかかる解析・計算処理を実行する
+        logs := coretask.GetTaskResult(ctx, SourceLogsTaskID.Ref())
+        result, err := doHeavyAnalysis(ctx, logs, progress)
+        if err != nil {
+            return ResultType{}, err
+        }
+        return result, nil
+    },
+)
+```
+
+この「モードによる早期リターン（Early Return）」パターンをすべてのタスクで一貫して適用することにより、KHI は複雑なログ分析タスクグラフを構成している場合でも、「New Inspection」画面での快適かつ高速なインタラクションを実現しています。
+
+## 7. タスクのテスト
+
+作成された個々のタスクやタスクグラフは、KHI が提供するテストユーティリティを使用して独立してテストできます。
+ここでは `tasktest` パッケージを利用したテストについて説明します。
+
+### 7.1 `tasktest.RunTask`
+
+最もシンプルに単一タスクの振る舞いを検証する場合、`tasktest.RunTask` を呼び出すことができます。
+
+```go
+func TestIntGeneratorTask(t *testing.T) {
+    res, err := tasktest.RunTask(t.Context(), IntGeneratorTask, map[taskid.UntypedTaskImplementationID]any{})
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if res != 1 {
+        t.Errorf("res mismatch (-want +got):\n- %v\n+ %v", 1, res)
+    }
+}
+```
+
+第三引数には、依存タスクからの戻り値をモックアップするマップを渡すことができます。
+依存関係を持たないタスクの場合は、空のマップを指定します。
+
+### 7.2 `tasktest.RunTaskWithDependency`
+
+依存関係をモックするのではなく、依存先を含むグラフ全体の実行を検証したい場合は、`tasktest.RunTaskWithDependency` を使用します。
+これにより、依存タスクを含むミニタスクグラフが自動で組み立てられ、トポロジカルソート・実行されます。
+
+```go
+func TestDoubleIntTaskWithDependency(t *testing.T) {
+    res, err := tasktest.RunTaskWithDependency(t.Context(), DoubleIntTask, []coretask.UntypedTask{
+        IntGeneratorTask,
+    })
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if res != 2 {
+        t.Errorf("res mismatch (-want +got):\n- %v\n+ %v", 2, res)
+    }
+}
+```
+
+---
+
+[< インデックスへ戻る](../khi-task-system-concept.md) | [次へ: ログ解析のためのタスク実装パターン >](./02-log-processing-cookbook.md)

--- a/docs/ja/task-system/02-log-processing-cookbook.md
+++ b/docs/ja/task-system/02-log-processing-cookbook.md
@@ -4,7 +4,7 @@
 
 ---
 
-本ドキュメントでは、KHI におけるログ解析の全体パイプラインと、開発者が新しいログのパースやタイムライン変換を実装するために使用する **6 種類の高レベルタスク作成ユーティリティの実践的なクックブック** を提供します。
+本ドキュメントでは、KHI におけるログ解析の全体パイプラインと、開発者が新しいログのパースやタイムライン変換を実装するために使用する **5 種類の高レベルタスク作成ユーティリティの実践的なクックブック** を提供します。
 
 ## 1. ログ解析パイプラインの全体像
 
@@ -68,10 +68,10 @@ var MyFieldSetReadTask = inspectiontaskbase.NewFieldSetReadTask(
 )
 ```
 
-このユーティリティを使用するタスクでは、`log.GetFieldSet(l, MyFieldSetReadTaskID)` を使用してログから特定のフィールドセットを読み取ることができます。
+このユーティリティを使用するタスクでは、`log.GetFieldSet(l, &MyFieldSet{})` を使用してログから特定のフィールドセットを読み取ることができます。
 
 ```go
-fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+fieldSet := log.GetFieldSet(l, &MyFieldSet{})
 ```
 
 > [!TIP]
@@ -90,7 +90,7 @@ var MyGrouperTask = inspectiontaskbase.NewLogGrouperTask(
     SourceLogsTaskID.Ref(),
     func(ctx context.Context, l *log.Log) (string, error) {
         // ログ l からグループ化キーとなる文字列を返す
-        fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+        fieldSet := log.GetFieldSet(l, &MyFieldSet{})
         return fieldSet.foo, nil
     },
 )
@@ -110,7 +110,7 @@ var MyFilterTask = inspectiontaskbase.NewLogFilterTask(
     SourceLogsTaskID.Ref(),
     func(ctx context.Context, l *log.Log) (bool, error) {
         // true を返したログのみが維持され、false を返したログは除外されます
-        fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+        fieldSet := log.GetFieldSet(l, &MyFieldSet{})
         return fieldSet.bar > 0, nil
     },
 )
@@ -193,18 +193,33 @@ func (m *MyMapper) Dependencies() []taskid.UntypedTaskReference {
 }
 ```
 
-### 6.2 ツリー構造を保持したタイムラインパスの構築
+### 6.2 タイムラインパス生成ユーティリティの作成と利用
 
-現在のタイムライン API では、リソース名や文字列を `#` や `/` で単純連結するレガシーな文字列パスは廃止され、リソースの階層関係（ツリー構造）を明確に型で表現する **`*khifilev6.TimelinePath`** を用いてイベントを追加・解決します。
+現在の KHI 実装では、マッパー内で生の文字列からパスを直接構築するのではなく、リソースの階層関係（ツリー構造）を明確に型で表現する **`*khifilev6.TimelinePath`** を用いてイベントを追加・解決します。
+さらに、同一の親パスから子セグメントへ結合する処理をカプセル化した**タイムラインパス生成ユーティリティ（ヘルパー関数）**を作成し、`TimelinePathPool` を通じてオブジェクト再利用を行う一般的な実装パターンを採用しています。
+
+#### 1. タイムラインパス生成ヘルパーの作成例 (`contract` パッケージ等に定義)
+
+```go
+// KHI における標準的な TimelinePath ヘルパー関数の作成例
+func MustK8sPodTimeline(ctx context.Context, clusterName string, namespace string, podName string) *khifilev6.TimelinePath {
+    // 1. 親階層となるクラスタの TimelinePath を取得・構築
+    clusterPath := MustK8sClusterTimeline(ctx, clusterName)
+    // 2. TimelinePathPool を使用して子セグメントを安全に結合し、重複生成を抑止
+    pathPool := khictx.MustGetValue(ctx, inspectioncore_contract.TimelinePathPool)
+    return pathPool.MustGet(clusterPath, namespace, podName)
+}
+```
+
+#### 2. マッパーからのタイムラインパスヘルパーの利用
 
 ```go
 // メッセージを処理し、タイムラインイベントを追加するロジック
 func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
     cs := khifilev6.NewTimelineChangeSet()
 
-    // パスプールの使用により同一パスのオブジェクト生成を抑止し最適化
-    pathPool := khictx.MustGetValue(ctx, inspectioncore_contract.TimelinePathPool)
-    podPath := pathPool.Get("test-cluster", "default", "my-pod")
+    // 作成したタイムラインパス生成ヘルパーを呼び出してパスを安全に取得
+    podPath := commonlogk8saudit_contract.MustK8sPodTimeline(ctx, "test-cluster", "default", "my-pod")
 
     // イベント追加
     cs.AddEvent(podPath)
@@ -217,7 +232,7 @@ func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData M
 var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
     MyMapperTaskID,
     &MyMapper{},
-    inspectioncore_contract.FeatureTaskLabel("my-mapper", /* その他パラメータ */),
+    inspectioncore_contract.FeatureTaskLabel("my-feature", "Feature label", "Detailed description of the feature", true, "gcp-gke"),
 )
 ```
 

--- a/docs/ja/task-system/02-log-processing-cookbook.md
+++ b/docs/ja/task-system/02-log-processing-cookbook.md
@@ -1,0 +1,248 @@
+# ログ解析のためのタスク実装パターン (実践ガイド)
+
+[< 前へ: 基本文法と実行モード](./01-syntax-and-modes.md) | [インデックスへ戻る](../khi-task-system-concept.md) | [次へ: 高度なタスクパターン >](./03-advanced-and-form-tasks.md)
+
+---
+
+本ドキュメントでは、KHI におけるログ解析の全体パイプラインと、開発者が新しいログのパースやタイムライン変換を実装するために使用する **6 種類の高レベルタスク作成ユーティリティの実践的なクックブック** を提供します。
+
+## 1. ログ解析パイプラインの全体像
+
+KHI はその堅牢なタスクシステムを使用してログ解析を実行します。このアーキテクチャは KHI を非常に拡張性の高いものにし（新しいタスクを作成するだけで新しい機能を追加できます）、Go の並行処理機能をフル活用することを可能にします。
+しかし、ログ解析には多くの共通パターンがあるため、ログ解析タスクは KHI が提供する高レベルなタスク作成ユーティリティを使用して実装すべきです。
+
+KHI は、基本的なログ解析のユースケースをカバーするために、以下の高レベルタスク作成ユーティリティを提供しています:
+
+- **`FieldSetReadTask`** : 構造化ログのフィールドを型付き構造体に格納します。
+- **`LogGrouperTask`** : 特定のフィールドでログをグループ化します。
+- **`LogFilterTask`** : 条件に基づいてログをフィルタリングします。
+- **`LogIngesterTask`** : ログを最終的な履歴データに取り込みます。
+- **`LogToTimelineMapperTask`** : 取り込まれたログを KHI の UI 上で表示するタイムラインのイベントへとマッピングします。
+
+以下は、これら 5 種類のタスクを組み合わせて、Cloud Logging から取得した Kubernetes ノードの監査ログを解析し、UI タイムラインへと描画するまでのパイプライン全体の依存グラフ例です:
+
+```mermaid
+flowchart TD
+    Fetch["ログ収集・クエリタスク<br>(Cloud Logging 等)"]
+    Ingester["LogIngesterTask<br>(ログ構造体の構築と型付け)"]
+    FieldSet["FieldSetReadTask<br>(特定フィールド群の読み出し)"]
+    Filter["LogFilterTask<br>(不要ログの除外)"]
+    Grouper["LogGrouperTask<br>(Pod名やスレッドごとのグループ化)"]
+    Mapper["LogToTimelineMapperTask<br>(タイムラインイベント・リソースパス変換)"]
+
+    Fetch --> Ingester
+    Ingester --> FieldSet
+    FieldSet --> Filter
+    Filter --> Grouper
+    Grouper --> Mapper
+```
+
+開発者が新しいログ種別をサポートする際は、このパイプラインに沿って各タスクを宣言し、タスクグラフに結合します。
+これらはすべて `pkg/core/inspection/taskbase` パッケージのユーティリティ関数（`NewFieldSetReadTask` 等）から生成します。
+
+---
+
+## 2. フィールドセットの読み出し (`FieldSetReadTask`)
+
+KHI のログは初期状態では構造化されていない形式であり、ログの各フィールドを読み取るには `FieldSetReadTask` を使用すべきです。
+これは、ログ内の特定の一連のフィールドを、定義済みの Go の構造体型にアンマーシャル・型付けして格納します。
+
+```go
+// 1. 読み取りたいフィールドに対応する構造体を定義
+type MyFieldSet struct {
+    foo string
+    bar int
+}
+
+// 2. フィールドセットをログ構造体に結合するタスクの定義
+var MyFieldSetReadTask = inspectiontaskbase.NewFieldSetReadTask(
+    MyFieldSetReadTaskID, // このタスク自身の ID
+    SourceLogsTaskID.Ref(), // 対象となるログのリスト
+    func(ctx context.Context, l *log.Log) (*MyFieldSet, error) {
+        // ... (ログ本文から値を抽出するロジック) ...
+        return &MyFieldSet{
+            foo: "foo",
+            bar: 1,
+        }, nil
+    },
+)
+```
+
+このユーティリティを使用するタスクでは、`log.GetFieldSet(l, MyFieldSetReadTaskID)` を使用してログから特定のフィールドセットを読み取ることができます。
+
+```go
+fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+```
+
+> [!TIP]
+> タスクから直接値を返すのではなくログそのものに情報を添付して受け渡す理由の詳細は、アーキテクチャドキュメントの **「ログの不変性と並行アクセス」** を参照してください。
+
+---
+
+## 3. ログのグループ化 (`LogGrouperTask`)
+
+個別のログメッセージだけでは原因を特定できない場合、関連する複数のログを時系列でグループ化して処理する必要があります（例: Kubernetes の Pod の起動から終了までの一連のイベント群など）。
+`LogGrouperTask` は、特定のキーに基づいてログをグルーピングします:
+
+```go
+var MyGrouperTask = inspectiontaskbase.NewLogGrouperTask(
+    MyGrouperTaskID,
+    SourceLogsTaskID.Ref(),
+    func(ctx context.Context, l *log.Log) (string, error) {
+        // ログ l からグループ化キーとなる文字列を返す
+        fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+        return fieldSet.foo, nil
+    },
+)
+```
+
+後続のタスクは `log.GetGroup(l, MyGrouperTaskID)` を使用して、対象ログが属するグループ名（グループキー）を取得できます。
+
+---
+
+## 4. ログのフィルタリング (`LogFilterTask`)
+
+膨大なログの中から、可視化や解析に不要なノイズログ（ヘルスチェックの正常ログなど）を事前に除外するには `LogFilterTask` を使用します。
+
+```go
+var MyFilterTask = inspectiontaskbase.NewLogFilterTask(
+    MyFilterTaskID,
+    SourceLogsTaskID.Ref(),
+    func(ctx context.Context, l *log.Log) (bool, error) {
+        // true を返したログのみが維持され、false を返したログは除外されます
+        fieldSet := log.GetFieldSet(l, MyFieldSetReadTaskID)
+        return fieldSet.bar > 0, nil
+    },
+)
+```
+
+---
+
+## 5. ログの取り込み (`LogIngesterTask`)
+
+`LogIngesterTask` は、クラウド API やローカルファイルなどから収集した生のログ文字列を KHI が扱える共通の `*log.Log` オブジェクトへと初期化・追加し、さらにログ種別ごとのパーサーや初期化処理（サマリー生成、必須フィールドセットの注入など）を実行するための取り込みタスクです。
+
+### 1. `LogIngester` インターフェースの宣言
+
+取り込みを行うタスクを定義する際は、まず `inspectiontaskbase.LogIngester` インターフェースを満たす構造体を実装します:
+
+```go
+type MyLogIngester struct{}
+
+// ログソースとなる生ログまたは親タスクの参照IDを返します
+func (i *MyLogIngester) RawLogTask() taskid.UntypedTaskReference {
+    return SourceLogsTaskID.Ref()
+}
+
+// パーサーが必要とする依存関係のリストを返します
+func (i *MyLogIngester) Dependencies() []taskid.UntypedTaskReference {
+    return []taskid.UntypedTaskReference{}
+}
+
+// 個々のログに対して実行する初期処理や変換ロジックを実装します
+func (i *MyLogIngester) ProcessLog(ctx context.Context, l *log.Log) error {
+    // ログメッセージの要約や基礎フィールドの初期化
+    l.Summary = "Parsed Log Summary"
+    return nil
+}
+
+var _ inspectiontaskbase.LogIngester = (*MyLogIngester)(nil)
+```
+
+### 2. タスクインスタンスの構築
+
+実装したインジェスター構造体のアドレスを `inspectiontaskbase.NewLogIngesterTask` に渡してタスクインスタンスを宣言します:
+
+```go
+var MyLogIngesterTask = inspectiontaskbase.NewLogIngesterTask(
+    MyLogIngesterTaskID,
+    &MyLogIngester{},
+)
+```
+
+---
+
+## 6. タイムラインへのマッピング (`LogToTimelineMapperTask`)
+
+ログ解析の最終工程として、フィルタリングやグループ化を経た `*log.Log` オブジェクトから、KHI の UI 上に描画するリソースツリーおよび時系列タイムラインイベント（イベントバー、重要度、詳細メッセージ）へとマッピングするタスクが `LogToTimelineMapperTask` です。
+
+### 6.1 `LogToTimelineMapper[T]` インターフェースの実装
+
+マッパータスクを作成するには、`inspectiontaskbase.LogToTimelineMapper[T]` インターフェースを満たす構造体を宣言します。
+通常は、独自の順次処理を記述しやすいように **`inspectiontaskbase.SinglePassMapperBase[T]`** を埋め込んで定型コードを省略し、必要なメソッドのみをオーバーライドします。
+
+```go
+type MyGroupData struct {
+    Count int
+}
+
+type MyMapper struct {
+    inspectiontaskbase.SinglePassMapperBase[MyGroupData]
+}
+
+func (m *MyMapper) GroupingTask() taskid.UntypedTaskReference {
+    return MyGrouperTaskID.Ref()
+}
+
+func (m *MyMapper) LogTask() taskid.UntypedTaskReference {
+    return SourceLogsTaskID.Ref()
+}
+
+func (m *MyMapper) Dependencies() []taskid.UntypedTaskReference {
+    return []taskid.UntypedTaskReference{MyFieldSetReadTaskID.Ref()}
+}
+```
+
+### 6.2 ツリー構造を保持したタイムラインパスの構築
+
+現在のタイムライン API では、リソース名や文字列を `#` や `/` で単純連結するレガシーな文字列パスは廃止され、リソースの階層関係（ツリー構造）を明確に型で表現する **`*khifilev6.TimelinePath`** を用いてイベントを追加・解決します。
+
+```go
+// メッセージを処理し、タイムラインイベントを追加するロジック
+func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
+    cs := khifilev6.NewTimelineChangeSet()
+
+    // パスプールの使用により同一パスのオブジェクト生成を抑止し最適化
+    pathPool := khictx.MustGetValue(ctx, inspectioncore_contract.TimelinePathPool)
+    podPath := pathPool.Get("test-cluster", "default", "my-pod")
+
+    // イベント追加
+    cs.AddEvent(podPath)
+
+    // 更新した状態をグループ内の次のログ処理へと受け渡す
+    return cs, MyGroupData{Count: prevData.Count + 1}, nil
+}
+
+// タスクとして初期化
+var MyMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
+    MyMapperTaskID,
+    &MyMapper{},
+    inspectioncore_contract.FeatureTaskLabel("my-mapper", /* その他パラメータ */),
+)
+```
+
+### 6.3 マッパーのユニットテスト (`testchangeset.AssertTimeline`)
+
+マッパーのテストでは、`testchangeset.AssertTimeline(t, cs)` を使用して、生成された `TimelineChangeSet` の内容を宣言的に検証します。
+文字列パスや非推奨の API は使用せず、期待される `*khifilev6.TimelinePath` を作成して検証します。
+
+```go
+func TestMyMapper_ProcessLogByGroup(t *testing.T) {
+    l := log.NewLogWithFieldSetsForTest(&log.CommonFieldSet{Timestamp: time.Now()}, /* ... */)
+    mapper := &MyMapper{}
+
+    cs, _, err := mapper.ProcessLogByGroup(t.Context(), l, MyGroupData{})
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+
+    wantPodPath := commonlogk8saudit_contract.MustK8sPodTimeline(t.Context(), "test-cluster", "default", "my-pod")
+    testchangeset.AssertTimeline(t, cs).
+        HasEvent(wantPodPath).
+        HasLogSeverity(enum.SeverityInfo)
+}
+```
+
+---
+
+[< 前へ: 基本文法と実行モード](./01-syntax-and-modes.md) | [インデックスへ戻る](../khi-task-system-concept.md) | [次へ: 高度なタスクパターン >](./03-advanced-and-form-tasks.md)

--- a/docs/ja/task-system/03-advanced-and-form-tasks.md
+++ b/docs/ja/task-system/03-advanced-and-form-tasks.md
@@ -1,0 +1,408 @@
+# 高度なタスクパターンとユーティリティ
+
+[< 前へ: ログ解析のためのタスク実装パターン](./02-log-processing-cookbook.md) | [インデックスへ戻る](../khi-task-system-concept.md)
+
+---
+
+本ドキュメントでは、KHI のタスクシステムを用いてより高度な解析パイプラインや UI 連携（登録、ラベル選択、リソースディスカバリ、入力フォーム、進捗報告、キャッシュ戦略）を構築するための仕様とユーティリティについて解説します。
+
+## 1. インスペクションタスクサーバーへのタスク登録
+
+KHI のビルドスクリプトは、自動で初期化時に `task/inspection/<パッケージ名>/impl` 以下に `registration.go` が存在する場合に `Register()` を呼び出すよう構成します。
+新しいタスクを追加するパッケージを定義するには、この `Register()` 関数の中で、タスクや Inspection Type を登録する必要があります。
+
+```go
+// Register registers all googlecloudlogserialport inspection tasks to the registry.
+func Register(registry coreinspection.InspectionTaskRegistry) error {
+    err := registry.AddInspectionType(ossclusterk8s_contract.OSSKubernetesLogFilesInspectionType)
+    if err != nil {
+        return err
+    }
+
+    return coretask.RegisterTasks(registry,
+        InputAuditLogFilesTask,
+        InputNodeLogFilesTask,
+        SerialPortLogIngesterTask,
+    )
+}
+```
+
+## 2. インスペクションタスクのラベル
+
+KHI の「New Inspection」画面では、選択された環境やログ種別に応じて、どのタスクをグラフに含めて実行するかが動的に決定されます。これらを制御するために、インスペクションタスクには特別なラベルを付与できます。
+
+### 2.1 汎用ラベルセレクタによるフィルタリング (`LabelSelector`)
+
+現在の KHI では、タスクに対して任意のキー・バリュー形式のメタデータラベルを付与し、それらをブール論理 (AND / OR / NOT 等) の式で表現した **`LabelSelector`** によって、特定の環境やモードでのみ有効化する柔軟なタスク絞り込みを行います。
+
+```go
+// 汎用の LabelValue オプションを利用したタスクラベル設定
+var AdvancedTask = task.NewTask(AdvancedTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (any, error) {
+    return nil, nil
+},
+    coretask.LabelValue("environment", "gcp"),
+    coretask.LabelValue("feature-stage", "beta"),
+)
+```
+
+これに対して、サーバー初期化時やインスペクション構成時に以下のような式を評価してタスクを抽出します:
+
+```go
+selector, _ := labelselector.Parse("environment=gcp && !feature-stage=deprecated")
+compatibleTasks := taskSet.Select(selector)
+```
+
+### 2.2 レガシー Inspection Type ラベル (`InspectionTypeLabel`)
+
+互換性のため、従来の `InspectionTypeLabel` も引き続き利用可能です。
+このラベルにリストされている Inspection Type (例: GCP Cloud Logging, ローカルログファイル等) でのみタスクを有効化します。
+
+```go
+var MyTask = task.NewTask(MyTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (any, error) {
+    return nil, nil
+}, inspectioncore_contract.InspectionTypeLabel(
+    "example.khi.google.com/inspection-type-1",
+    "example.khi.google.com/inspection-type-2",
+))
+```
+
+### 2.3 FeatureTask ラベル
+
+FeatureTask ラベルは、そのタスクを KHI の「New Inspection」画面におけるトグル可能な機能として公開するための特別なラベルです。
+マッパータスクなどの主機能となるタスクに指定することで、ユーザーは機能の有効/無効を選択できます。
+
+```go
+inspectioncore_contract.FeatureTaskLabel("my-feature", "機能ラベル", "機能詳細の説明文", true, 0)
+```
+
+## 3. ログから情報を発見するためのタスクユーティリティ (`Inventory` と `Discovery` タスク)
+
+### 3.1 なぜ Inventory - Discovery パターンが必要なのか（モチベーション）
+
+KHI の大きな特徴は、ユーザーが「New Inspection」画面で任意の機能（パーサータスク）の有効・無効を自由に切り替えられる点にあります。
+例えば、「コンテナ ID と Pod 名の対応関係」は、**ノードログから発見できる場合もあれば、監査ログから発見できる場合もあります**。
+もし、後続のマッパータスクが「ノードログからコンテナ ID を解析する特定のパーサータスク」へ直接依存する設計にしてしまうと、**ユーザーがノードログのパースを無効化していても、依存関係解決の際にそのパーサータスクが強制的にタスクグラフへと含まれ、実行されてしまう問題**が発生します。
+
+この「機能有効化／無効化の独立性」と「複数の情報源からの疎結合な情報統合」を両立させるために導入されているのが、**`Inventory` - `Discovery` タスクパターン**です。
+
+```mermaid
+flowchart TD
+    subgraph Discovery [各ログソースごとの独立した Discovery タスク]
+        D1[NodeLog ContainerID Discovery]
+        D2[AuditLog ContainerID Discovery]
+    end
+    subgraph Inventory [有効な Discovery のみを集約する Inventory タスク]
+        Inv[ContainerID Inventory Task]
+    end
+    subgraph Consumer [後続のコンシューマタスク]
+        M[LogToTimelineMapper]
+    end
+
+    D1 -.->|情報提供| Inv
+    D2 -.->|情報提供| Inv
+    Inv -->|統合された PatternFinder を提供| M
+```
+
+**Inventory タスク**は、特定のパーサーに直接依存するのではなく、そのインスペクション環境において**現在有効になっている（利用可能な）Discovery タスクの結果のみを透過的に収集・統合**し、後続タスクに値を提供します。
+これにより、特定のログパース機能が無効化されていてもグラフ解決を壊すことなく、有効な他のログソース（監査ログなど）から発見された情報だけを最大限活用することが可能になります。
+
+### 3.2 Discovery タスクの作成と Inventory タスクによる統合
+
+KHI では、`inspectiontaskbase.NewInventoryTaskBuilder` を使用して、情報収集元の各ログソースに対応する **2 つ以上の個別の `DiscoveryTask`** と、それらを統合する **単一の `InventoryTask`** を組み合わせて構築します。
+
+1. **`DiscoveryTask` は別のタスクにリクエストされた場合のみグラフに含まれる**:
+   ビルダの `.DiscoveryTask(...)` で生成された各ディスカバリタスクには、`coretask.NewSubsequentTaskRefsTaskLabel` が自動で付与されます。これにより、**ディスカバリタスク自体は、それを使用するパーサーや機能タスクから依存関係としてリクエストされない限り、タスクグラフにいっさい含まれません**（該当パーサーが無効ならグラフから除外されます）。
+2. **`InventoryTask` による有効な結果のオプショナル統合**:
+   ビルダの `.InventoryTask(strategy)` で生成されたインベントリタスクは、`coretask.GetTaskResultOptional` を用いて、**グラフに実際に含まれて実行された Discovery タスクの結果のみ** を回収・マージします。
+
+#### 実装サンプル: ノードログと監査ログの 2 つの Discovery タスクと統合 Inventory タスク
+
+```go
+// 1. Inventory ビルダを初期化
+var containerInventoryBuilder = inspectiontaskbase.NewInventoryTaskBuilder(ContainerIDInventoryTaskID)
+
+// 2-A. ノードログからのコンテナID発見タスク (ノードログパーサー等から依存された場合のみグラフに含まれる)
+var NodeLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
+    NodeLogContainerIDDiscoveryTaskID,
+    []taskid.UntypedTaskReference{NodeLogParserTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*ContainerIdentity, error) {
+        logs := coretask.GetTaskResult(ctx, NodeLogParserTaskID.Ref())
+        return extractContainersFromNodeLogs(logs), nil
+    },
+)
+
+// 2-B. 監査ログからのコンテナID発見タスク (監査ログパーサー等から依存された場合のみグラフに含まれる)
+var AuditLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
+    AuditLogContainerIDDiscoveryTaskID,
+    []taskid.UntypedTaskReference{AuditLogParserTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*ContainerIdentity, error) {
+        logs := coretask.GetTaskResult(ctx, AuditLogParserTaskID.Ref())
+        return extractContainersFromAuditLogs(logs), nil
+    },
+)
+
+// 3. 複数ソースからの結果を重複排除・結合するマージ戦略 (InventoryMergerStrategy の実装)
+type containerIDMergeStrategy struct{}
+
+func (c *containerIDMergeStrategy) Merge(results []commonlogk8saudit_contract.ContainerIDToContainerIdentity) (commonlogk8saudit_contract.ContainerIDToContainerIdentity, error) {
+    result := map[string]*commonlogk8saudit_contract.ContainerIdentity{}
+    for _, r := range results {
+        for cid, s := range r {
+            if current, ok := result[cid]; ok {
+                // 同一のコンテナ ID が既に存在する場合は情報を結合・補完
+                result[cid] = current.Merge(s)
+            } else {
+                result[cid] = s
+            }
+        }
+    }
+    return result, nil
+}
+
+var _ inspectiontaskbase.InventoryMergerStrategy[commonlogk8saudit_contract.ContainerIDToContainerIdentity] = (*containerIDMergeStrategy)(nil)
+
+// 4. 有効になっている Discovery タスクの結果のみを集計・マージする Inventory タスク
+var ContainerIDInventoryTask = containerInventoryBuilder.InventoryTask(&containerIDMergeStrategy{})
+```
+
+このように、Discovery タスクの利用要否とタスクグラフへの包含を個々のログパーサー側に委ねることで、「ユーザーが一部のログパース機能をオフにしていても安全かつ柔軟に動作するリソースインベントリ」を実現しています。
+
+### 3.3 PatternFinder による検索器の生成と計算量削減
+
+`InventoryTask` で集約された raw リストを、後続の複数のパーサーやマッパーから毎回ループ探索すると計算量が `O(N * M)` となり膨大な時間がかかります。
+これを避けるため、KHI では収集されたインベントリを **`PatternFinder`** と呼ばれる Aho-Corasick アルゴリズムや二分探索をベースにした高速検索オートマトン（またはプレフィックスツリー）へと変換する **`PatternFinderTask` / `DiscoveryTask`** を構成します。
+
+代表的な Discovery / PatternFinder ユーティリティ:
+
+- **`NodeNameDiscoveryTask`**: ノード名とクラスタ情報、IP アドレスの対応表を集約。
+- **`ResourceUIDDiscoveryTask` / `ResourceUIDPatternFinderTask`**: Kubernetes オブジェクトの UID (`metadata.uid`) とリソース名・Namespace の対応を記録し、UID しか持たない監査ログからの高速逆引きを実現。
+- **`ContainerIDDiscoveryTask` / `ContainerIDPatternFinderTask`**: コンテナランタイムが出力した長いハッシュ (`6123c6aac...`) やプレフィックスから、Pod 名・Namespace を即座に解決。
+- **`IPLeaseHistoryDiscoveryTask`**: 時系列で変動する IP アドレスの割り当て履歴を追跡し、特定の時刻における IP から Pod や Node を特定。
+
+#### マッパータスクからの利用法
+
+これら Discovery/PatternFinder タスクの参照 ID をマッパータスクの `Dependencies()` に追加することで、マッパーの `ProcessLogByGroup` 内から `coretask.GetTaskResult(ctx, ...)` で検索器を取得し、以下のように `patternfinder.FindAllWithStarterRunes(...)` 等を用いて O(1)〜O(log N) の高速な関連付け解決を実行できます。
+
+```go
+func (m *MyMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, prevData MyGroupData) (*khifilev6.TimelineChangeSet, MyGroupData, error) {
+    // コンテナID検索器の取得
+    containerFinder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ContainerIDPatternFinderTaskID.Ref())
+
+    originalMsg := l.Message // メッセージ本文
+    // アルファベット/数字で始まるコンテナIDパターンを高速に走査
+    results := patternfinder.FindAllWithStarterRunes(originalMsg, containerFinder, false, '"')
+
+    cs := khifilev6.NewTimelineChangeSet()
+    for _, res := range results {
+        // 発見されたコンテナ情報をもとに Pod のタイムラインイベントを追加
+        podPath := commonlogk8saudit_contract.MustK8sPodTimeline(ctx, clusterName, res.Value.PodNamespace, res.Value.PodName)
+        cs.AddEvent(podPath)
+    }
+    return cs, prevData, nil
+}
+```
+
+## 4. タスクフォームとユーザー入力フィールド (`formtask`)
+
+KHI の「New Inspection」ダイアログでユーザーからパラメータ（プロジェクト ID、ロケーション、クラスタ名、期間、ログファイル等）を入力・選択させるために、タスクは宣言的なフォームタスクビルダパッケージ (`github.com/GoogleCloudPlatform/khi/pkg/core/inspection/formtask`) を使用して実装されます。
+
+### 4.1 フォームビルダの種類
+
+入力形式に応じて、以下の 3 種類のビルダを使い分けます:
+
+- **`formtask.NewTextFormTaskBuilder(...)`**: 文字列やテキスト入力用（オートコンプリートや正規表現バリデーション対応）のフォームタスクを構築します。
+- **`formtask.NewSetFormTaskBuilder(...)`**: ドロップダウンやチェックリストなど、選択肢から単一または複数の値を選択させるフォームタスクを構築します。
+- **`formtask.NewFileFormTaskBuilder(...)`**: ユーザーのローカル環境からのログファイルアップロードやファイルパス選択を受け取るフォームタスクを構築します。
+
+### 4.2 リッチな入力フォームの構築とオートコンプリート連携
+
+ビルダには、UI 上でのバリデーションや動的なオートコンプリート候補の提示など、快適な入力をサポートするための多様なメソッドが用意されています:
+
+- **`WithDescription(desc)`**: UI の入力欄に表示するヘルプ説明文を設定します。
+- **`WithDependencies(...)`**: デフォルト値の算出やオートコンプリートに必要な依存タスクを宣言します。
+- **`WithDefaultValueFunc(fn)`**: 前回のインスペクション実行時の入力履歴や依存タスク結果をもとに、動的にデフォルト値を算出します。
+- **`WithSuggestionsFunc(fn)`**: ユーザーが入力中の文字列に合わせて、オートコンプリートタスクの結果から動的に候補リストを並べ替えて提示します (`common.SortForAutocomplete` の利用が標準的です)。
+- **`WithValidator(fn)`**: 必須入力チェックや正規表現チェックなどを行い、不正な入力に対してエラーメッセージを表示して実行をブロックします。
+
+#### 実装サンプル: オートコンプリートとバリデーションを備えたロケーション入力タスク
+
+以下は、実際の `InputLocationsTask` に用いられている、オートコンプリート連携および妥当性検証 (`Validator`) を組み込んだ宣言的タスク実装例です:
+
+```go
+var InputLocationsTask = formtask.NewTextFormTaskBuilder(
+    googlecloudcommon_contract.InputLocationsTaskID,
+    googlecloudcommon_contract.PriorityForResourceIdentifierGroup+3000,
+    "Location",
+).
+    WithDependencies([]taskid.UntypedTaskReference{
+        googlecloudcommon_contract.AutocompleteLocationTaskID.Ref(),
+    }).
+    WithDescription("The location (region) to specify where the resource exists").
+    WithDefaultValueFunc(func(ctx context.Context, previousValues []string) (string, error) {
+        locations := coretask.GetTaskResult(ctx, googlecloudcommon_contract.AutocompleteLocationTaskID.Ref())
+        if len(previousValues) > 0 && slices.Contains(locations.Values, previousValues[0]) {
+            return previousValues[0], nil
+        }
+        if len(locations.Values) == 0 {
+            return "", nil
+        }
+        return locations.Values[0], nil
+    }).
+    WithSuggestionsFunc(func(ctx context.Context, value string, previousValues []string) ([]string, error) {
+        regions := coretask.GetTaskResult(ctx, googlecloudcommon_contract.AutocompleteLocationTaskID.Ref())
+        return common.SortForAutocomplete(value, regions.Values), nil
+    }).
+    WithValidator(func(ctx context.Context, value string) (string, error) {
+        if value == "" {
+            return "location is required", nil
+        }
+        return "", nil
+    }).
+    Build()
+```
+
+### 4.3 後続タスクからの入力値の取得方法
+
+このように作成された入力フォームタスク ID を依存関係 (`Dependencies()`) に追加したコンシューマタスク側（ログクエリタスクやリソース特定タスクなど）は、以下のように `coretask.GetTaskResult` を呼び出すことで、ユーザーが画面で確定した入力値（`string` 等）を型安全に取得できます:
+
+```go
+var ClusterIdentityTask = inspectiontaskbase.NewInspectionTask(
+    googlecloudk8scommon_contract.ClusterIdentityTaskID,
+    []taskid.UntypedTaskReference{
+        googlecloudcommon_contract.InputLocationsTaskID.Ref(),
+        googlecloudk8scommon_contract.InputClusterNameTaskID.Ref(),
+    },
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) (GoogleCloudClusterIdentity, error) {
+        // 入力されたロケーション文字列を取得
+        location := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputLocationsTaskID.Ref())
+        clusterName := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputClusterNameTaskID.Ref())
+
+        return GoogleCloudClusterIdentity{
+            Location:    location,
+            ClusterName: clusterName,
+        }, nil
+    },
+)
+```
+
+## 5. 低レベルタスクユーティリティ
+
+### 5.1 動的な進捗報告 (`NewProgressReportableInspectionTask`)
+
+ログフェッチや大容量ファイルの解析など、タスクの進捗状況を動的にフロントエンドへ報告したい場合は、`NewProgressReportableInspectionTask` を使用してタスクを作成します。
+このタスクはロジック内に `TaskProgressMetadata` を受け取り、実行の進み具合に応じて具体的なパーセンテージや不定状態をフロントエンドへ通知できます。
+
+#### 1. 定量的な進捗を定期更新する例 (`progressutil.NewProgressUpdator`)
+
+処理総量（件数やバイト数）が既知である場合、`progressutil.NewProgressUpdator` を利用してタイマー間隔（例: 1秒ごと）で進行度とステータスメッセージを定期反映させる実装が標準的です:
+
+```go
+var HeavyProcessingTask = inspectiontaskbase.NewProgressReportableInspectionTask(
+    HeavyProcessingTaskID,
+    []taskid.UntypedTaskReference{SourceLogsTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
+        if taskMode != inspectioncore_contract.TaskModeRun {
+            return ResultType{}, nil
+        }
+
+        logs := coretask.GetTaskResult(ctx, SourceLogsTaskID.Ref())
+        total := len(logs)
+        processed := 0
+
+        // 1秒ごとに progress を更新する ProgressUpdator を生成
+        updater := progressutil.NewProgressUpdator(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
+            tp.Percentage = float32(processed) / float32(total)
+            tp.Message = fmt.Sprintf("Processed %d/%d logs", processed, total)
+        })
+
+        updater.Start(ctx)
+        defer updater.Done()
+
+        for _, l := range logs {
+            // 重い解析・処理の実行...
+            processed++
+        }
+
+        return result, nil
+    },
+)
+```
+
+#### 2. 処理総量が不明な際の不定進捗の報告 (`MarkIndeterminate()`)
+
+チャンネルからの動的処理など、タスク完了までの処理総量が事前に判明しない場合は、`progress.MarkIndeterminate()` を呼び出すことで、フロントエンドのプログレスバーを不定モード（インデターミネイト表示）としてマークできます:
+
+```go
+var UnknownLengthTask = inspectiontaskbase.NewProgressReportableInspectionTask(
+    UnknownLengthTaskID,
+    []taskid.UntypedTaskReference{SomeDependencyTaskID.Ref()},
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (ResultType, error) {
+        if taskMode != inspectioncore_contract.TaskModeRun {
+            return ResultType{}, nil
+        }
+
+        // 総量が判別できないため不定進捗として宣言
+        progress.MarkIndeterminate()
+
+        // 動的に発見されるアイテム等の処理...
+        for item := range dynamicItemsChannel {
+            process(item)
+        }
+
+        return result, nil
+    },
+)
+```
+
+### 5.2 タスク結果のキャッシュ (`NewGlobalCachedTask` と `NewInspectionCachedTask`)
+
+計算量が多い計算や外部 API 呼び出しなど、結果が入力パラメータのみに依存する高コストなタスクの場合は、タスク結果をキャッシュして再利用するキャッシュ対応タスクを作成できます。
+KHI では、キャッシュの生存期間（スコープ）に応じて以下の 2 つの作成関数を用意しています:
+
+- **`inspectiontaskbase.NewGlobalCachedTask[T]`**: アプリケーション全体 (`GlobalSharedMap`) を通じて永続的にキャッシュされるタスクを作成します。異なるインスペクション間でも同じ入力であれば結果を再利用できます。
+- **`inspectiontaskbase.NewInspectionCachedTask[T]`**: 同一のインスペクション実行内 (`InspectionSharedMap`) のみでキャッシュされるタスクを作成します。例えば、「New Inspection」ダイアログでの入力フォーム変更に伴う Dryrun 更新時や、同じインスペクションでの再クエリ時に結果を再利用します。
+
+いずれの関数も、タスクロジックに対して前回の計算結果と依存ダイジェストを保持する **`CacheableTaskResult[T]`** を渡し、タスクが「現在のパラメータから算出されたダイジェスト」と「前回のダイジェスト (`DependencyDigest`)」を比較できるように設計されています。
+
+#### 実装サンプル
+
+以下は、入力パラメータのダイジェストが変更されていない場合に前回のキャッシュ値を返す `NewInspectionCachedTask` の完全実装例です:
+
+```go
+var CachedHeavyTask = inspectiontaskbase.NewInspectionCachedTask(
+    CachedHeavyTaskID,
+    []taskid.UntypedTaskReference{InputParamsTaskID.Ref()},
+    func(ctx context.Context, prevResult inspectiontaskbase.CacheableTaskResult[ResultType]) (inspectiontaskbase.CacheableTaskResult[ResultType], error) {
+        params := coretask.GetTaskResult(ctx, InputParamsTaskID.Ref())
+        // 入力パラメータから現在のダイジェスト値を算出
+        digest := calculateDigest(params)
+
+        // 前回の実行結果のダイジェストと一致すれば、再計算せずキャッシュを即座に返す
+        if prevResult.DependencyDigest == digest {
+            return prevResult, nil
+        }
+
+        // 初回実行、または入力が変わってダイジェストが変化した場合は再計算を行う
+        newValue := doHeavyCalculation(params)
+        return inspectiontaskbase.CacheableTaskResult[ResultType]{
+            Value:            newValue,
+            DependencyDigest: digest,
+        }, nil
+    },
+)
+```
+
+> [!TIP]
+> **インスペクション終了時のリソース解放**
+> `NewInspectionCachedTask` で生成されたキャッシュデータや割り当てたリソースをインスペクションの破棄時にクリーンアップしたい場合は、以下のように `context.AfterFunc` を使用してライフサイクルを紐付けることができます:
+>
+> ```go
+> inspectionContext := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionContext)
+> context.AfterFunc(inspectionContext, func() {
+>     // ソケットのクローズやテンポラリファイルの削除などの解放処理
+> })
+> ```
+
+---
+
+[< 前へ: ログ解析のためのタスク実装パターン](./02-log-processing-cookbook.md) | [インデックスへ戻る](../khi-task-system-concept.md)

--- a/docs/ja/task-system/03-advanced-and-form-tasks.md
+++ b/docs/ja/task-system/03-advanced-and-form-tasks.md
@@ -72,7 +72,7 @@ FeatureTask ラベルは、そのタスクを KHI の「New Inspection」画面�
 マッパータスクなどの主機能となるタスクに指定することで、ユーザーは機能の有効/無効を選択できます。
 
 ```go
-inspectioncore_contract.FeatureTaskLabel("my-feature", "機能ラベル", "機能詳細の説明文", true, 0)
+inspectioncore_contract.FeatureTaskLabel("my-feature", "機能ラベル", "機能詳細の説明文", true, "gcp-gke")
 ```
 
 ## 3. ログから情報を発見するためのタスクユーティリティ (`Inventory` と `Discovery` タスク)
@@ -125,7 +125,7 @@ var containerInventoryBuilder = inspectiontaskbase.NewInventoryTaskBuilder(Conta
 var NodeLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
     NodeLogContainerIDDiscoveryTaskID,
     []taskid.UntypedTaskReference{NodeLogParserTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*ContainerIdentity, error) {
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (commonlogk8saudit_contract.ContainerIDToContainerIdentity, error) {
         logs := coretask.GetTaskResult(ctx, NodeLogParserTaskID.Ref())
         return extractContainersFromNodeLogs(logs), nil
     },
@@ -135,7 +135,7 @@ var NodeLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
 var AuditLogContainerIDDiscoveryTask = containerInventoryBuilder.DiscoveryTask(
     AuditLogContainerIDDiscoveryTaskID,
     []taskid.UntypedTaskReference{AuditLogParserTaskID.Ref()},
-    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*ContainerIdentity, error) {
+    func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (commonlogk8saudit_contract.ContainerIDToContainerIdentity, error) {
         logs := coretask.GetTaskResult(ctx, AuditLogParserTaskID.Ref())
         return extractContainersFromAuditLogs(logs), nil
     },
@@ -292,9 +292,9 @@ var ClusterIdentityTask = inspectiontaskbase.NewInspectionTask(
 ログフェッチや大容量ファイルの解析など、タスクの進捗状況を動的にフロントエンドへ報告したい場合は、`NewProgressReportableInspectionTask` を使用してタスクを作成します。
 このタスクはロジック内に `TaskProgressMetadata` を受け取り、実行の進み具合に応じて具体的なパーセンテージや不定状態をフロントエンドへ通知できます。
 
-#### 1. 定量的な進捗を定期更新する例 (`progressutil.NewProgressUpdator`)
+#### 1. 定量的な進捗を定期更新する例 (`progressutil.NewProgressUpdater`)
 
-処理総量（件数やバイト数）が既知である場合、`progressutil.NewProgressUpdator` を利用してタイマー間隔（例: 1秒ごと）で進行度とステータスメッセージを定期反映させる実装が標準的です:
+処理総量（件数やバイト数）が既知である場合、`progressutil.NewProgressUpdater` を利用してタイマー間隔（例: 1秒ごと）で進行度とステータスメッセージを定期反映させる実装が標準的です:
 
 ```go
 var HeavyProcessingTask = inspectiontaskbase.NewProgressReportableInspectionTask(
@@ -309,8 +309,8 @@ var HeavyProcessingTask = inspectiontaskbase.NewProgressReportableInspectionTask
         total := len(logs)
         processed := 0
 
-        // 1秒ごとに progress を更新する ProgressUpdator を生成
-        updater := progressutil.NewProgressUpdator(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
+        // 1秒ごとに progress を更新する ProgressUpdater を生成
+        updater := progressutil.NewProgressUpdater(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
             tp.Percentage = float32(processed) / float32(total)
             tp.Message = fmt.Sprintf("Processed %d/%d logs", processed, total)
         })

--- a/pkg/task/inspection/commonlogk8saudit/README.md
+++ b/pkg/task/inspection/commonlogk8saudit/README.md
@@ -24,9 +24,16 @@ graph TD
     NonSuccessGrouper[NonSuccessLogGrouperTask]
     ChangeTargetGrouper[ChangeTargetGrouperTask]
     
-    %% Manifest & Lifetime
+    %% Manifest, Lifetime & Inventory
     ManifestGenerator[ManifestGeneratorTask]
     LifetimeTracker[ResourceLifetimeTrackerTask]
+
+    NodeNameDiscovery[NodeNameDiscoveryTask]
+    ResourceUIDDiscovery[ResourceUIDDiscoveryTask]
+    ResourceUIDPF[ResourceUIDPatternFinderTask]
+    ContainerIDDiscovery[ContainerIDDiscoveryTask]
+    ContainerIDPF[ContainerIDPatternFinderTask]
+    IPLeaseDiscovery[IPLeaseHistoryDiscoveryTask]
     
     %% History Modifiers
     NamespaceRequestHM[NamespaceRequestHistoryModifierTask]
@@ -44,6 +51,13 @@ graph TD
     Provider --> SuccessFilter
     Provider --> NonSuccessFilter
     Provider --> LogSummaryGrouper
+    Provider --> NodeNameDiscovery
+    Provider --> ResourceUIDDiscovery
+    Provider --> ContainerIDDiscovery
+    Provider --> IPLeaseDiscovery
+
+    ResourceUIDDiscovery --> ResourceUIDPF
+    ContainerIDDiscovery --> ContainerIDPF
     
     SuccessFilter --> LogSorter
     NonSuccessFilter --> NonSuccessGrouper
@@ -102,6 +116,15 @@ graph TD
 
 - **`ManifestGeneratorTask`**: Reconstructs the resource manifest at each point in time by applying the changes from the audit logs. It uses `K8sResourceMergeConfigTask` to handle specific merge strategies for different Kubernetes resources.
 - **`ResourceLifetimeTrackerTask`**: Tracks the lifetime of each resource (creation and deletion). It determines when a resource is created or deleted based on the audit logs and manifest changes.
+
+### Discovery & Inventory Tasks
+
+- **`NodeNameDiscoveryTask`**: Scans audit logs to discover and collect cluster node names.
+- **`ResourceUIDDiscoveryTask`**: Collects mappings between resource UIDs and their identity (Kind, Namespace, Name).
+- **`ResourceUIDPatternFinderTask`**: Builds a pattern finder (`PatternFinder`) from aggregated UIDs for efficient reference resolution.
+- **`ContainerIDDiscoveryTask`**: Collects mappings between container IDs and container identities from pod creation logs.
+- **`ContainerIDPatternFinderTask`**: Builds a pattern finder from aggregated container IDs.
+- **`IPLeaseHistoryDiscoveryTask`**: Discovers IP lease histories from audit logs to resolve IP-to-Pod associations at any timestamp.
 
 ### History Modifiers
 

--- a/pkg/task/inspection/commonlogk8saudit/README_ja.md
+++ b/pkg/task/inspection/commonlogk8saudit/README_ja.md
@@ -1,0 +1,129 @@
+# 共通 K8s 監査ログインスペクションタスク
+
+本パッケージ (`commonlogk8saudit`) は、Kubernetes 監査ログを処理するためのインスペクションタスク群を提供します。
+監査ログを解析してマニフェストを生成・復元し、リソースの状態変化やインベントリ情報（コンテナ ID、ノード名、リソース UID、IP リース履歴等）を追跡してタイムラインを構築します。
+
+## タスクグラフ (Task Graph)
+
+```mermaid
+graph TD
+    %% 外部依存 (External Dependencies)
+    Provider[K8sAuditLogProviderRef]
+    MergeConfig[K8sResourceMergeConfigTask]
+
+    classDef external stroke-dasharray: 5 5;
+    class Provider,MergeConfig external;
+
+    Serializer[K8sAuditLogSerializerTask]
+    SuccessFilter[SuccessLogFilterTask]
+    NonSuccessFilter[NonSuccessLogFilterTask]
+    LogSorter[LogSorterTask]
+    
+    %% グルーパー (Groupers)
+    LogSummaryGrouper[LogSummaryGrouperTask]
+    NonSuccessGrouper[NonSuccessLogGrouperTask]
+    ChangeTargetGrouper[ChangeTargetGrouperTask]
+    
+    %% マニフェスト・ライフタイム・インベントリ (Manifest, Lifetime & Inventory)
+    ManifestGenerator[ManifestGeneratorTask]
+    LifetimeTracker[ResourceLifetimeTrackerTask]
+    
+    NodeNameDiscovery[NodeNameDiscoveryTask]
+    ResourceUIDDiscovery[ResourceUIDDiscoveryTask]
+    ResourceUIDPF[ResourceUIDPatternFinderTask]
+    ContainerIDDiscovery[ContainerIDDiscoveryTask]
+    ContainerIDPF[ContainerIDPatternFinderTask]
+    IPLeaseDiscovery[IPLeaseHistoryDiscoveryTask]
+    
+    %% 履歴モディファイア (History Modifiers)
+    NamespaceRequestHM[NamespaceRequestHistoryModifierTask]
+    LogSummaryHM[LogSummaryHistoryModifierTask]
+    NonSuccessHM[NonSuccessLogHistoryModifierTask]
+    RevisionHM[ResourceRevisionHistoryModifierTask]
+    OwnerRefHM[ResourceOwnerReferenceModifierTask]
+    EndpointHM[EndpointResourceHistoryModifierTask]
+    PodPhaseHM[PodPhaseHistoryModifierTask]
+    ContainerHM[ContainerHistoryModifierTask]
+    ConditionHM[ConditionHistoryModifierTask]
+
+    %% 接続関係 (Connections)
+    Provider --> Serializer
+    Provider --> SuccessFilter
+    Provider --> NonSuccessFilter
+    Provider --> LogSummaryGrouper
+    Provider --> NodeNameDiscovery
+    Provider --> ResourceUIDDiscovery
+    Provider --> ContainerIDDiscovery
+    Provider --> IPLeaseDiscovery
+    
+    ResourceUIDDiscovery --> ResourceUIDPF
+    ContainerIDDiscovery --> ContainerIDPF
+    
+    SuccessFilter --> LogSorter
+    NonSuccessFilter --> NonSuccessGrouper
+    
+    LogSorter --> ChangeTargetGrouper
+    
+    ChangeTargetGrouper --> ManifestGenerator
+    MergeConfig --> ManifestGenerator
+    
+    ManifestGenerator --> LifetimeTracker
+    Serializer --> LifetimeTracker
+
+    ManifestGenerator --> NamespaceRequestHM
+    Serializer --> NamespaceRequestHM
+    
+    %% 各種履歴モディファイアへの依存関係
+    LogSummaryGrouper --> LogSummaryHM
+    Serializer --> LogSummaryHM
+    
+    NonSuccessGrouper --> NonSuccessHM
+    Serializer --> NonSuccessHM
+    
+    LifetimeTracker --> RevisionHM
+    Serializer --> RevisionHM
+    
+    LifetimeTracker --> OwnerRefHM
+    Serializer --> OwnerRefHM
+    
+    LifetimeTracker --> EndpointHM
+    Serializer --> EndpointHM
+    
+    LifetimeTracker --> PodPhaseHM
+    Serializer --> PodPhaseHM
+    
+    LifetimeTracker --> ContainerHM
+    Serializer --> ContainerHM
+    
+    LifetimeTracker --> ConditionHM
+    Serializer --> ConditionHM
+```
+
+## タスク詳細説明 (Task Descriptions)
+
+### 共通タスク (Filter, Grouper, Serializers 等)
+
+- **`K8sAuditLogProviderRef`**: 外部から生 Kubernetes 監査ログの配列を提供するタスク参照です。
+- **`K8sAuditLogSerializerTask`**: イベントやリビジョンの紐付け前に、ログデータを履歴データストアにシリアライズ・登録します。
+- **`SuccessLogFilterTask`**: クラスタ状態を変える正常成功レスポンスのログのみを抽出します。
+- **`NonSuccessLogFilterTask`**: エラーやアクセス権拒否など、非成功レスポンスのログのみを抽出します。
+- **`LogSorterTask`**: 正常ログをタイムスタンプ順にソートします。
+- **`LogSummaryGrouperTask`**: リソースパスごとにログをグループ化し、各リソースに対する操作サマリー生成用データを構築します。
+- **`NonSuccessLogGrouperTask`**: 非成功ログをリソースパスごとにグループ化します。
+- **`ChangeTargetGrouperTask`**: サブリソース（`status`, `scale` 等）の操作や一括削除（delete collection）操作を解決し、実際の変更対象リソースパスごとにログをグループ化します。
+
+### インベントリ・ディスカバリ系タスク (Discovery / Inventory Tasks)
+
+- **`NodeNameDiscoveryTask`**: 監査ログを走査してクラスタに出現するノード名一覧を発見・収集します。
+- **`ResourceUIDDiscoveryTask`**: 各リソース（Pod 等）の UID とリソース ID (Kind, Namespace, Name) のマッピングを収集します。
+- **`ResourceUIDPatternFinderTask`**: 収集された UID のパターン検索器（`PatternFinder`）を構築し、他のタスクからの高速参照を可能にします。
+- **`ContainerIDDiscoveryTask`**: Pod 作成時等に出現するコンテナ ID とコンテナ識別子（Pod 名、コンテナ名等）のマッピング情報を収集します。
+- **`ContainerIDPatternFinderTask`**: 収集されたコンテナ ID のパターン検索器を構築します。
+- **`IPLeaseHistoryDiscoveryTask`**: 監査ログ中に記録された IP アドレス割り当て（リース）の履歴を収集し、特定のタイムスタンプにおける IP から Pod への名前解決情報を提供します。
+
+### 履歴モディファイア (History Modifiers)
+
+- **`ResourceLifetimeTrackerTask`**: マニフェスト生成結果から各リソースの生成・削除時点（ライフタイム）を判定・追跡します。
+- **`ResourceRevisionHistoryModifierTask`**: 各リソースのステータスやマニフェスト差分を持つリビジョンをタイムライン上に記録します。
+- **`ResourceOwnerReferenceModifierTask`**: リソース間の所有関係（Owner Reference）を追跡して関連を付与します。
+- **`EndpointResourceHistoryModifierTask` / `PodPhaseHistoryModifierTask` / `ContainerHistoryModifierTask` / `ConditionHistoryModifierTask`**: それぞれ Endpoint リソース、Pod Phase 遷移、コンテナ状態遷移、リソース Condition 履歴を解析・タイムラインへ記録します。


### PR DESCRIPTION
- Modernize task system conceptual guide (docs/en/khi-task-system-concept.md & docs/ja/khi-task-system-concept.md) to reflect current v6 standards, package suffix conventions (_contract/_impl), and updated utilities.
- Split monolithic conceptual guide into dedicated topic files under task-system/:
  - 01-syntax-and-modes.md: DAG basics, Task[T] syntax, logging, package naming rules, Run/DryRun execution modes, and tasktest unit testing.
  - 02-log-processing-cookbook.md: Log processing pipeline, 6 major task cookbooks, and declarative timeline path assertions (*khifilev6.TimelinePath / AssertTimeline).
  - 03-advanced-and-form-tasks.md: Task server registration, label selectors, Inventory-Discovery dynamic inclusion model (InventoryTaskBuilder & merger strategy), formtask builders, and low-level progress/cache utilities.
- Synchronize English and Japanese documentation and update related architecture/parser README guides.