### PR TITLE
feat(inspection): handle GKE dryRun audit logs as events (#866)

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/contract/fieldset.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/fieldset.go
@@ -99,6 +99,8 @@ type K8sAuditLogFieldSet struct {
 	IsFirst bool
 	// IsLast is true if the log is the last log of the operation.
 	IsLast bool
+	// IsDryRun is true if the request was a dry run.
+	IsDryRun bool
 
 	// APIVersion is the API version of the resource (e.g., "apps/v1").
 	APIVersion string

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
@@ -186,6 +186,9 @@ func (c *conditionLogToTimelineMapperTaskSetting) ProcessLog(ctx context.Context
 
 	commonFieldSet := log.MustGetFieldSet(event.Log, &log.CommonFieldSet{})
 	k8sFieldSet := log.MustGetFieldSet(event.Log, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+	if k8sFieldSet.IsDryRun {
+		return cs, state, nil
+	}
 	ownerPath := MustResolveTimelinePath(ctx, k8sFieldSet.ClusterName, event.ResourceIdentity)
 
 	bodyReader, hasBody := event.GetLastBodyReader("target")

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
@@ -634,4 +634,77 @@ status:
 				StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceDeleted,
 			}, nodeComparer)
 	})
+
+	t.Run("DryRun log should be ignored", func(t *testing.T) {
+		builder := khifilev6.NewBuilder()
+		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
+		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
+		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
+		ns := builder.TimelineAccumulator.GetPath(kind, khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace})
+		parentPath := builder.TimelineAccumulator.GetPath(ns, khifilev6.PathSegment{Name: "nginx", Type: inspectioncore_contract.TimelineTypeResource})
+		conditionPath := builder.TimelineAccumulator.GetPath(parentPath, khifilev6.PathSegment{Name: "Ready", Type: commonlogk8saudit_contract.TimelineTypeResourceCondition})
+
+		ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+		commonFieldSet := &log.CommonFieldSet{
+			Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		k8sFieldSet := &commonlogk8saudit_contract.K8sAuditLogFieldSet{
+			Verb:        commonlogk8saudit_contract.VerbUpdate,
+			Principal:   "user-1",
+			ClusterName: "k8s",
+			IsDryRun:    true,
+		}
+		logObj := log.NewLogWithFieldSetsForTest(commonFieldSet, k8sFieldSet)
+
+		bodyYAML := `
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    lastTransitionTime: "2024-01-01T00:00:00Z"
+`
+		bodyReader := structured.NewNodeReader(parseYAML(bodyYAML))
+
+		resIdentity := &commonlogk8saudit_contract.ResourceIdentity{
+			APIVersion: "core/v1",
+			Kind:       "pod",
+			Namespace:  "default",
+			Name:       "nginx",
+		}
+
+		groupSet := commonlogk8saudit_contract.RelatedGroupSet{
+			Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
+				"target": {
+					Resource: resIdentity,
+					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
+						{Log: logObj, ResourceBodyReader: bodyReader, ResourceBodyYAML: bodyYAML},
+					},
+				},
+			},
+		}
+
+		event := commonlogk8saudit_contract.MultiGroupLogEvent{
+			Log:              logObj,
+			GroupRole:        "target",
+			ResourceIdentity: resIdentity,
+			EventType:        commonlogk8saudit_contract.ChangeEventTypeModification,
+			GroupSet:         groupSet,
+		}
+
+		initialState := &conditionLogToTimelineMapperTaskState{
+			AvailableTypes: map[string]struct{}{"Ready": {}},
+			ConditionWalkers: map[string]*conditionWalker{
+				"Ready": newConditionWalker(conditionPath, "Ready"),
+			},
+		}
+
+		cs, _, err := taskSetting.ProcessLog(ctx, event, initialState)
+		if err != nil {
+			t.Fatalf("ProcessLog failed: %v", err)
+		}
+
+		testchangeset.AssertTimeline(t, cs).
+			HasNoRevision(conditionPath)
+	})
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task.go
@@ -147,11 +147,14 @@ func (c *containerLogToTimelineMapperTaskSetting) ProcessLog(ctx context.Context
 			containerStateWalkers: map[string]*containerStateWalker{},
 		}
 	}
-	if event.GroupRole != "pod" {
-		return nil, state, nil
-	}
-
 	cs := khifilev6.NewTimelineChangeSet(event.Log)
+	if event.GroupRole != "pod" {
+		return cs, state, nil
+	}
+	k8sFieldSet := log.MustGetFieldSet(event.Log, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+	if k8sFieldSet.IsDryRun {
+		return cs, state, nil
+	}
 	bodyReader, hasBody := event.GetLastBodyReader("pod")
 
 	currentStateReaders := map[string]*structured.NodeReader{}

--- a/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task_test.go
@@ -426,6 +426,7 @@ func TestContainerLogToTimelineMapperTask_ProcessLog(t *testing.T) {
 		nilBody       bool
 		eventType     commonlogk8saudit_contract.ChangeEventType
 		verb          *pb.Verb
+		isDryRun      bool
 		initialState  *containerLogToTimelineMapperTaskState
 		wantState     *containerLogToTimelineMapperTaskState
 		wantRevisions []*khifilev6.StagingRevision
@@ -571,6 +572,59 @@ status:
 				},
 			},
 		},
+		{
+			name:     "DryRun log should be ignored",
+			pass:     1,
+			isDryRun: true,
+			yaml: `
+status:
+  containerStatuses:
+  - name: main-container
+    state:
+      running:
+        startedAt: "2024-01-01T00:00:00Z"
+    ready: true
+`,
+			initialState: &containerLogToTimelineMapperTaskState{
+				containerIdentities: map[string]*containerStatusIdentity{
+					"main-container": {
+						containerName: "main-container",
+						containerType: ContainerTypeContainer,
+					},
+				},
+				containerStateWalkers: map[string]*containerStateWalker{
+					"main-container": {
+						containerIdentity: &containerStatusIdentity{
+							containerName: "main-container",
+							containerType: ContainerTypeContainer,
+						},
+						podNamespace: podNamespace,
+						podName:      podName,
+						lastState:    "no state",
+					},
+				},
+			},
+			wantState: &containerLogToTimelineMapperTaskState{
+				containerIdentities: map[string]*containerStatusIdentity{
+					"main-container": {
+						containerName: "main-container",
+						containerType: ContainerTypeContainer,
+					},
+				},
+				containerStateWalkers: map[string]*containerStateWalker{
+					"main-container": {
+						containerIdentity: &containerStatusIdentity{
+							containerName: "main-container",
+							containerType: ContainerTypeContainer,
+						},
+						podNamespace: podNamespace,
+						podName:      podName,
+						lastState:    "no state",
+					},
+				},
+			},
+			wantRevisions: []*khifilev6.StagingRevision{},
+		},
 	}
 
 	for _, tc := range tests {
@@ -604,6 +658,7 @@ status:
 			k8sFieldSet.Verb = verb
 			k8sFieldSet.Principal = "user-1"
 			k8sFieldSet.ClusterName = "k8s"
+			k8sFieldSet.IsDryRun = tc.isDryRun
 
 			resIdentity := &commonlogk8saudit_contract.ResourceIdentity{
 				APIVersion: "core/v1",

--- a/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task.go
@@ -176,6 +176,9 @@ func (e *endpointResourceLogToTimelineMapperTaskSetting) ProcessLog(ctx context.
 	cs := khifilev6.NewTimelineChangeSet(event.Log)
 	commonLogFieldSet := log.MustGetFieldSet(event.Log, &log.CommonFieldSet{})
 	k8sFieldSet := log.MustGetFieldSet(event.Log, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+	if k8sFieldSet.IsDryRun {
+		return cs, state, nil
+	}
 
 	bodyReader, _ := event.GetLastBodyReader("target")
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task_test.go
@@ -63,6 +63,7 @@ func TestEndpointLogToTimelineMapperTask_ProcessLog(t *testing.T) {
 		yaml         string
 		eventType    commonlogk8saudit_contract.ChangeEventType
 		verb         *pb.Verb
+		isDryRun     bool
 		initialState *endpointResourceLogToTimelineMapperState
 		wantState    *endpointResourceLogToTimelineMapperState
 		assert       func(t *testing.T, cs *khifilev6.TimelineChangeSet, builder *khifilev6.Builder)
@@ -543,6 +544,43 @@ metadata:
 				}
 			},
 		},
+		{
+			name:         "Pass 1: DryRun log should be ignored",
+			isPreProcess: false,
+			isDryRun:     true,
+			yaml: `
+endpoints:
+- conditions:
+    ready: true
+  targetRef:
+    kind: Pod
+    name: my-pod
+    namespace: default
+    uid: pod-uid-1
+`,
+			eventType: commonlogk8saudit_contract.ChangeEventTypeModification,
+			verb:      commonlogk8saudit_contract.VerbUpdate,
+			initialState: &endpointResourceLogToTimelineMapperState{
+				serviceNames: map[string]struct{}{"my-service": {}},
+				foundPods: map[string]*podIdentity{
+					"pod-uid-1": {uid: "pod-uid-1", name: "my-pod", namespace: "default"},
+				},
+				lastStates: map[string]*pb.RevisionState{},
+			},
+			wantState: &endpointResourceLogToTimelineMapperState{
+				serviceNames: map[string]struct{}{"my-service": {}},
+				foundPods: map[string]*podIdentity{
+					"pod-uid-1": {uid: "pod-uid-1", name: "my-pod", namespace: "default"},
+				},
+				lastStates: map[string]*pb.RevisionState{},
+			},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, builder *khifilev6.Builder) {
+				ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+				expectedPodPath := MustResolvePodEndpointSliceTimelinePath(ctx, "k8s", "default", "my-endpoint", "default", "my-pod")
+				testchangeset.AssertTimeline(t, cs).
+					HasNoRevision(expectedPodPath)
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -567,6 +605,7 @@ metadata:
 					Verb:        tc.verb,
 					Principal:   "user-1",
 					ClusterName: "k8s",
+					IsDryRun:    tc.isDryRun,
 				},
 			)
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task.go
@@ -67,6 +67,9 @@ func isPod(apiVersion string, pluralKind string) bool {
 // DetectLifetimeLogEvent detects if the log is the timing to create or delete the timeline resource and update the log field.
 func (r *lifeTimeTrackerTaskSetting) DetectLifetimeLogEvent(ctx context.Context, l *commonlogk8saudit_contract.ResourceManifestLog, prevGroupData *lifeTimeTrackerGroupState) (*lifeTimeTrackerGroupState, error) {
 	k8sFieldSet := log.MustGetFieldSet(l.Log, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+	if k8sFieldSet.IsDryRun {
+		return prevGroupData, nil
+	}
 	isFirst := false
 	if prevGroupData == nil {
 		prevGroupData = &lifeTimeTrackerGroupState{}

--- a/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task_test.go
@@ -115,6 +115,21 @@ status:
 			wantResourceDeleted: true,
 		},
 		{
+			desc: "dry run create should not mark resource created",
+			inputK8sAuditLogFieldSet: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				Verb:         commonlogk8saudit_contract.VerbCreate,
+				APIVersion:   "core/v1",
+				PluralKind:   "pods",
+				Namespace:    "default",
+				ResourceName: "test",
+				IsDryRun:     true,
+			},
+			prevState:           nil,
+			wantState:           nil,
+			wantResourceCreated: false,
+			wantResourceDeleted: false,
+		},
+		{
 			desc:                     "update with finalizers (deletion started)",
 			inputK8sAuditLogFieldSet: newTestK8sAuditLogFieldSet(commonlogk8saudit_contract.VerbUpdate, "core/v1", "pods"),
 			resourceBodyYAML: `

--- a/pkg/task/inspection/commonlogk8saudit/impl/logsummary_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/logsummary_task.go
@@ -63,13 +63,18 @@ func (i *k8sAuditLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khif
 		return nil, err
 	}
 
+	var summary string
 	if k8sFieldSet.IsError {
 		cs.SetSeverity(inspectioncore_contract.SeverityError)
-		cs.SetSummary(fmt.Sprintf("【%s(%d)】%s %s", k8sFieldSet.StatusMessage, k8sFieldSet.StatusCode, k8sFieldSet.VerbString(), k8sFieldSet.RequestURI))
+		summary = fmt.Sprintf("【%s(%d)】%s %s", k8sFieldSet.StatusMessage, k8sFieldSet.StatusCode, k8sFieldSet.VerbString(), k8sFieldSet.RequestURI)
 	} else {
 		cs.SetSeverity(inspectioncore_contract.SeverityInfo)
-		cs.SetSummary(fmt.Sprintf("%s %s", k8sFieldSet.VerbString(), k8sFieldSet.RequestURI))
+		summary = fmt.Sprintf("%s %s", k8sFieldSet.VerbString(), k8sFieldSet.RequestURI)
 	}
+	if k8sFieldSet.IsDryRun {
+		summary = "【DryRun】" + summary
+	}
+	cs.SetSummary(summary)
 
 	return cs, nil
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/logsummary_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/logsummary_task_test.go
@@ -79,6 +79,54 @@ func TestK8sAuditLogIngester_ProcessLog(t *testing.T) {
 					HasSummary("【Conflict(409)】Create /api/v1/namespaces/default/pods/test-pod")
 			},
 		},
+		{
+			name: "dry run info log ingestion",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: testTime},
+				&commonlogk8saudit_contract.K8sAuditLogFieldSet{
+					APIVersion:   "core/v1",
+					PluralKind:   "pods",
+					Namespace:    "default",
+					ResourceName: "test-pod",
+					RequestURI:   "/api/v1/namespaces/default/pods/test-pod",
+					Verb:         commonlogk8saudit_contract.VerbCreate,
+					IsError:      false,
+					IsDryRun:     true,
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(testTime).
+					HasSeverity(inspectioncore_contract.SeverityInfo).
+					HasLogType(commonlogk8saudit_contract.LogTypeAudit).
+					HasSummary("【DryRun】Create /api/v1/namespaces/default/pods/test-pod")
+			},
+		},
+		{
+			name: "dry run error log ingestion",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: testTime},
+				&commonlogk8saudit_contract.K8sAuditLogFieldSet{
+					APIVersion:    "core/v1",
+					PluralKind:    "pods",
+					Namespace:     "default",
+					ResourceName:  "test-pod",
+					RequestURI:    "/api/v1/namespaces/default/pods/test-pod",
+					Verb:          commonlogk8saudit_contract.VerbCreate,
+					IsError:       true,
+					StatusCode:    409,
+					StatusMessage: "Conflict",
+					IsDryRun:      true,
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(testTime).
+					HasSeverity(inspectioncore_contract.SeverityError).
+					HasLogType(commonlogk8saudit_contract.LogTypeAudit).
+					HasSummary("【DryRun】【Conflict(409)】Create /api/v1/namespaces/default/pods/test-pod")
+			},
+		},
 	}
 
 	ingester := &k8sAuditLogIngester{}

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
@@ -124,6 +124,13 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 		g.prevRevisionReader = structured.NewNodeReader(structured.NewEmptyMapNode())
 	}
 	fieldSet := log.MustGetFieldSet(l, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+	if fieldSet.IsDryRun {
+		return &commonlogk8saudit_contract.ResourceManifestLog{
+			Log:                l,
+			ResourceBodyYAML:   g.prevRevisionBody,
+			ResourceBodyReader: g.prevRevisionReader,
+		}, nil
+	}
 	currentBodyReader := fieldSet.Response
 	partial := false
 	if currentBodyReader == nil {

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
@@ -29,6 +29,7 @@ type testGroupManifestGeneratorInput struct {
 	verb         *pb.Verb
 	requestYAML  string
 	responseYAML string
+	isDryRun     bool
 }
 
 func TestGroupManifestGenerator(t *testing.T) {
@@ -294,6 +295,42 @@ metadata:
 				"# Resource data is unavailable. Audit logs for this resource is recorded at metadata level.",
 			},
 		},
+		{
+			desc: "dry run log should not override existing values",
+			inputs: []*testGroupManifestGeneratorInput{
+				{
+					verb: commonlogk8saudit_contract.VerbCreate,
+					responseYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    foo: bar`,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbUpdate,
+					responseYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    qux: quux`,
+					isDryRun: true,
+				},
+			},
+			wantBodies: []string{
+				`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    foo: bar
+`,
+				`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    foo: bar
+`,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -320,6 +357,7 @@ metadata:
 					Verb:        verb,
 					Request:     request,
 					Response:    response,
+					IsDryRun:    input.isDryRun,
 				}))
 			}
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task.go
@@ -93,6 +93,9 @@ func (r *resourceOwnerReferenceTimelineMapperTaskSetting) ProcessLog(ctx context
 	if err != nil {
 		return cs, struct{}{}, err
 	}
+	if k8sFieldSet.IsDryRun {
+		return cs, struct{}{}, nil
+	}
 
 	aliasPath := MustResolveTimelinePath(ctx, k8sFieldSet.ClusterName, event.ResourceIdentity)
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task_test.go
@@ -48,9 +48,10 @@ func TestResourceOwnerReferenceTimelineMapperTask_ProcessLog(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		yaml   string
-		assert func(t *testing.T, cs *khifilev6.TimelineChangeSet, ctx context.Context)
+		name     string
+		yaml     string
+		isDryRun bool
+		assert   func(t *testing.T, cs *khifilev6.TimelineChangeSet, ctx context.Context)
 	}{
 		{
 			name: "No Owner References",
@@ -219,6 +220,32 @@ metadata:
 					HasNoAlias(expectedTargetPath)
 			},
 		},
+		{
+			name:     "DryRun log should be ignored",
+			isDryRun: true,
+			yaml: `
+metadata:
+  name: nginx
+  namespace: default
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: ReplicaSet
+    name: nginx-replicaset
+    uid: uid-1
+`,
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, ctx context.Context) {
+				ownerPath := MustResolveTimelinePath(ctx, "k8s", &commonlogk8saudit_contract.ResourceIdentity{
+					APIVersion: "apps/v1",
+					Kind:       "replicaset",
+					Namespace:  "default",
+					Name:       "nginx-replicaset",
+				})
+				expectedTargetPath := commonlogk8saudit_contract.MustOwnedResourceTimeline(ctx, ownerPath, "nginx[kind:pod]")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasNoAlias(expectedTargetPath)
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -235,6 +262,7 @@ metadata:
 				Namespace:    "default",
 				ClusterName:  "k8s",
 				Verb:         commonlogk8saudit_contract.VerbUpdate,
+				IsDryRun:     tc.isDryRun,
 			}
 			commonFs := &log.CommonFieldSet{
 				Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task.go
@@ -155,6 +155,10 @@ func (c *podPhaseLogToTimelineMapperTaskSetting) PreProcessLog(ctx context.Conte
 	}
 
 	commonLogFieldSet := log.MustGetFieldSet(event.Log, &log.CommonFieldSet{})
+	k8sFieldSet := log.MustGetFieldSet(event.Log, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+	if k8sFieldSet.IsDryRun {
+		return prevGroupData, nil
+	}
 	eventTime := commonLogFieldSet.Timestamp
 
 	switch passIndex {
@@ -227,6 +231,9 @@ func (c *podPhaseLogToTimelineMapperTaskSetting) ProcessLog(ctx context.Context,
 
 	commonLogFieldSet := log.MustGetFieldSet(event.Log, &log.CommonFieldSet{})
 	k8sFieldSet := log.MustGetFieldSet(event.Log, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+	if k8sFieldSet.IsDryRun {
+		return cs, prevGroupData, nil
+	}
 	eventTime := commonLogFieldSet.Timestamp
 
 	var targetBodyReader *structured.NodeReader

--- a/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task_test.go
@@ -62,6 +62,7 @@ func TestPodPhaseLogToTimelineMapperTaskSetting_ProcessLog(t *testing.T) {
 		eventType commonlogk8saudit_contract.ChangeEventType
 		verb      *pb.Verb
 		time      time.Time
+		isDryRun  bool
 	}
 
 	type wantRevision struct {
@@ -452,6 +453,28 @@ status:
 				},
 			},
 		},
+		{
+			name:        "dry run log should be ignored",
+			namespace:   "default",
+			podName:     "test-pod",
+			clusterName: "k8s",
+			steps: []step{
+				{
+					role:      "pod",
+					eventType: commonlogk8saudit_contract.ChangeEventTypeCreation,
+					verb:      commonlogk8saudit_contract.VerbCreate,
+					time:      baseTime,
+					isDryRun:  true,
+					yaml: `
+metadata:
+  uid: uid-1
+status:
+  phase: Running
+`,
+				},
+			},
+			wantRevisions: []wantRevision{},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -501,6 +524,7 @@ status:
 					Namespace:    tc.namespace,
 					ClusterName:  tc.clusterName,
 					Verb:         step.verb,
+					IsDryRun:     step.isDryRun,
 				}
 				commonFs := &log.CommonFieldSet{
 					Timestamp: step.time,

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper.go
@@ -174,6 +174,9 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSetting) handleParentChangeForSu
 			return nil
 		}
 		k8sFieldSet := log.MustGetFieldSet(event.Log, &commonlogk8saudit_contract.K8sAuditLogFieldSet{})
+		if k8sFieldSet.IsDryRun {
+			return nil
+		}
 		targetPath := MustResolveTimelinePath(ctx, k8sFieldSet.ClusterName, targetGroup.Resource)
 
 		commonLogFieldSet := log.MustGetFieldSet(event.Log, &log.CommonFieldSet{})
@@ -209,6 +212,11 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSetting) handleTargetChange(ctx 
 
 	if prevGroupData == nil {
 		prevGroupData = newResourceRevisionLogToTimelineMapperState()
+	}
+
+	if k8sFieldSet.IsDryRun {
+		cs.AddEvent(targetPath)
+		return prevGroupData, nil
 	}
 
 	if k8sFieldSet.Verb == commonlogk8saudit_contract.VerbDeleteCollection && prevGroupData.WasCompletelyRemoved {

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_test.go
@@ -75,6 +75,7 @@ func TestResourceRevisionLogToTimelineMapperTaskSetting_ProcessLog(t *testing.T)
 		bodyYAML   string
 		role       string
 		eventType  commonlogk8saudit_contract.ChangeEventType
+		isDryRun   bool
 		wantState  *resourceRevisionLogToTimelineMapperState
 		assert     func(t *testing.T, cs *khifilev6.TimelineChangeSet, node structured.Node)
 	}{
@@ -534,6 +535,22 @@ uid: "test-uid"`,
 					}, nodeComparer)
 			},
 		},
+		{
+			name:       "DryRun create event recorded as event instead of revision",
+			inputState: nil,
+			verb:       commonlogk8saudit_contract.VerbCreate,
+			bodyYAML: `metadata:
+  uid: "test-uid"`,
+			role:      "target",
+			eventType: commonlogk8saudit_contract.ChangeEventTypeModification,
+			isDryRun:  true,
+			wantState: &resourceRevisionLogToTimelineMapperState{},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, node structured.Node) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(parentPath).
+					HasNoRevision(parentPath)
+			},
+		},
 	}
 
 	mapperSetting := &ResourceRevisionLogToTimelineMapperTaskSetting{
@@ -564,6 +581,7 @@ uid: "test-uid"`,
 				Namespace:    "default",
 				ClusterName:  "k8s",
 				Verb:         tc.verb,
+				IsDryRun:     tc.isDryRun,
 			}
 			commonFs := &log.CommonFieldSet{
 				Timestamp: testTime,

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/fieldset.go
@@ -42,6 +42,7 @@ func (g *GCPK8sAuditLogFieldSetReader) Read(reader *structured.NodeReader) (log.
 	methodName := reader.ReadStringOrDefault("protoPayload.methodName", "")
 	result.ClusterName = reader.ReadStringOrDefault("resource.labels.cluster_name", "unknown")
 	result.RequestURI = resourceName
+	result.IsDryRun = reader.ReadStringOrDefault("labels.command\\.gke\\.io/dryRun", "") != ""
 
 	apiVersion, pluralKind, namespace, name, subResourceName, verb := parseKubernetesOperation(resourceName, methodName)
 	result.APIVersion = apiVersion

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/fieldset_test.go
@@ -208,6 +208,28 @@ func TestGCPK8sAuditLogFieldSetReader_Read(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with dry run label",
+			input: `{
+				"labels": {
+					"command.gke.io/dryRun": "All"
+				},
+				"protoPayload": {
+					"resourceName": "core/v1/namespaces/default/pods/nginx",
+					"methodName": "io.k8s.core.v1.pods.create"
+				}
+			}`,
+			want: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				RequestURI:   "core/v1/namespaces/default/pods/nginx",
+				APIVersion:   "core/v1",
+				PluralKind:   "pods",
+				Namespace:    "default",
+				ResourceName: "nginx",
+				ClusterName:  "unknown",
+				Verb:         commonlogk8saudit_contract.VerbCreate,
+				IsDryRun:     true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
Fixes #866

In GKE, when `.labels["command.gke.io/dryRun"]` contains a non-empty string, the audit log represents a dry-run request that was not actually applied to cluster resources.
Previously, KHI treated these dry-run audit logs as actual resource mutations, which caused misleading timeline revisions and altered resource state tracking.

This PR ensures that dry-run audit logs are clearly visually distinguishable in summaries and are recorded as timeline events without mutating resource states or creating revisions.

## Key Changes
- **FieldSet Definition & Parser (`K8sAuditLogFieldSet`)**:
  - Added `IsDryRun bool` to `K8sAuditLogFieldSet`.
  - Updated `GCPK8sAuditLogFieldSetReader` to check `.labels["command.gke.io/dryRun"]`.
- **Log Summary Ingester (`logsummary_task.go`)**:
  - Prepend `【DryRun】` to the summary string when `IsDryRun == true`.
- **Resource Timeline Mapper (`resourcemapper.go`)**:
  - Record dry-run update/patch/create/delete logs as timeline Events (`cs.AddEvent(targetPath)`) instead of Revisions.
  - Skip resource state mutations and subresource propagation for dry-run requests.
- **Secondary Mappers & Generators**:
  - Added early returns when `IsDryRun == true` in `endpointmapper_task`, `containermapper_task`, `conditionmapper_task`, `podphasemapper_task`, `ownerreferencemapper_task`, `lifetimetracker_task`, and `manifest_generator_task` so that dry-run logs do not create unexpected Revisions/Aliases or overwrite existing manifest state.

## Testing
- Added Table-Driven unit tests for all affected components (`fieldset_test.go`, `logsummary_task_test.go`, `resourcemapper_test.go`, `manifest_generator_task_test.go`, `lifetimetracker_task_test.go`, and all secondary mapper tests).
- Verified that all backend build, test, format, lint, and pre-commit checks pass (`make build-go`, `make test-go`, `make format-go`, `make lint-go`, `make pre-commit`).
