### PR TITLE
refactor: rename terminology from CSM Access log to Traffic log

### DIFF
--- a/pkg/task/inspection/googlecloudlogcsm/README.md
+++ b/pkg/task/inspection/googlecloudlogcsm/README.md
@@ -1,32 +1,32 @@
 # Cloud Service Mesh (CSM) Inspection Tasks
 
-This package (`googlecloudlogcsm`) contains tasks for inspecting Cloud Service Mesh (CSM) access logs. It handles querying logs, parsing Envoy-related fields, and mapping them to KHI timeline events.
+This package (`googlecloudlogcsm`) contains tasks for inspecting Cloud Service Mesh (CSM) traffic logs. It handles querying logs, parsing Envoy-related fields, and mapping them to KHI timeline events.
 
 ## Task Overview
 
 The CSM inspection pipeline handles the following:
 
 1. **Inputs**: Capturing user-specified filters such as Envoy response flags.
-2. **Log Fetching**: Querying Cloud Logging for CSM access logs.
+2. **Log Fetching**: Querying Cloud Logging for CSM traffic logs.
 3. **Inventory**: Extracting mappings between NEGs (Network Endpoint Groups) and BackendServices from Kubernetes Event logs and Audit logs.
 4. **Parsing & Mapping**: Reading log fields and mapping them to resource timelines.
 
 ### Inventory Tasks
 
-These tasks are used to discover associations that are not directly present in the access logs but are required for proper resource mapping. They are provided by shared Google Cloud components and log provider packages.
+These tasks are used to discover associations that are not directly present in the traffic logs but are required for proper resource mapping. They are provided by shared Google Cloud components and log provider packages.
 
 - **`EventLogNEGDiscoveryTask`** (in `googlecloudlogk8sevent`): Discovers NEG to BackendService mappings by parsing Kubernetes Event logs.
 - **`AuditLogNEGDiscoveryTask`** (in `googlecloudlogk8saudit`): Discovers NEG to BackendService mappings by parsing Kubernetes Audit logs (via resource manifests).
 - **`NEGToBackendServiceInventoryTask`** (in `googlecloudk8scommon`): Aggregates the discovery results into a single consolidated inventory map.
 
-### CSM Access Log Pipeline
+### CSM Traffic Log Pipeline
 
 - **`InputCSMResponseFlagsTask`**: Form input for filtering logs by Envoy response flags.
-- **`ListLogEntriesTask`**: Fetches CSM access logs from Cloud Logging.
+- **`ListLogEntriesTask`**: Fetches CSM traffic logs from Cloud Logging.
 - **`FieldSetReaderTask`**: Parses raw logs into `CSMFieldSet` to extract structured fields.
 - **`LogIngesterTask`**: Ingests the logs into the final KHI history.
 - **`LogGrouperTask`**: Groups logs by the reporter pod.
-- **`LogToTimelineMapperTask`**: Maps CSM access log events to resource timelines, utilizing the NEG inventory for accurate service association.
+- **`LogToTimelineMapperTask`**: Maps CSM traffic log events to resource timelines, utilizing the NEG inventory for accurate service association.
 
 ## Task Relationship Diagram
 
@@ -49,7 +49,7 @@ graph TD
     EventDiscovery --> Inventory[NEGToBackendServiceInventoryTask]:::inventory
     AuditDiscovery --> Inventory
 
-    %% CSM Access Log Pipeline
+    %% CSM Traffic Log Pipeline
     FlagsInput[InputCSMResponseFlagsTask]:::input
     FlagsInput --> ListLogs[ListLogEntriesTask]:::query
     ListLogs --> FieldSetRead[FieldSetReaderTask]:::query

--- a/pkg/task/inspection/googlecloudlogcsm/contract/log_type.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/log_type.go
@@ -22,5 +22,5 @@ import (
 // These are registered as package-level variables so they are initialized immediately
 // when this package is imported.
 var (
-	LogTypeCSMAccessLog = style.MustRegisterLogType("CSM access", "Cloud Service Mesh Access Logs", style.MustForceConvertSRGBHex("#FF8500"), style.ColorWhite)
+	LogTypeCSMTrafficLog = style.MustRegisterLogType("CSM traffic", "Cloud Service Mesh Traffic Logs", style.MustForceConvertSRGBHex("#FF8500"), style.ColorWhite)
 )

--- a/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
@@ -22,15 +22,15 @@ import (
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 )
 
-const TaskIDPrefix = "cloud.google.com/log/csm-accesslog/"
+const TaskIDPrefix = "cloud.google.com/log/csm-trafficlog/"
 
 // ClusterIdentityTaskID is the task id for aliasing the cluster identity.
 var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scommon_contract.GoogleCloudClusterIdentity](TaskIDPrefix + "cluster-identity")
 
-// InputCSMResponseFlagsTaskID is the task ID for the form input that specifies which Envoy response flags to filter CSM access logs by.
+// InputCSMResponseFlagsTaskID is the task ID for the form input that specifies which Envoy response flags to filter CSM traffic logs by.
 var InputCSMResponseFlagsTaskID = taskid.NewDefaultImplementationID[*gcpqueryutil.SetFilterParseResult](TaskIDPrefix + "input/response-flags")
 
-// ListLogEntriesTaskID is the task ID for the task that queries CSM access logs from Cloud Logging.
+// ListLogEntriesTaskID is the task ID for the task that queries CSM traffic logs from Cloud Logging.
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "list-log-entries")
 
 // FieldSetReaderTaskID is the task id to read the CSM related fieldset for processing the log in the later task.
@@ -39,10 +39,10 @@ var FieldSetReaderTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDP
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
 var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "log-ingester")
 
-// LogGrouperTaskID is the task ID to group CSM access logs by their reporter pod for parallel processing.
+// LogGrouperTaskID is the task ID to group CSM traffic logs by their reporter pod for parallel processing.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "grouper")
 
-// LogToTimelineMapperTaskID is the task ID for associating CSM access log events with resource timelines.
+// LogToTimelineMapperTaskID is the task ID for associating CSM traffic log events with resource timelines.
 var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](TaskIDPrefix + "timeline-mapper")
 
 // InputFleetProjectIDTaskID is the task ID for the form input that specifies the Fleet Project ID where CSM control plane logs are stored.

--- a/pkg/task/inspection/googlecloudlogcsm/contract/timeline_path.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/timeline_path.go
@@ -43,7 +43,7 @@ func MustCSMServerAccessTimeline(ctx context.Context, clusterName string, podNam
 	}
 	return builder.TimelineAccumulator.GetPath(podPath, khifilev6.PathSegment{
 		Name: suffix,
-		Type: TimelineTypeCSMAccessLog,
+		Type: TimelineTypeCSMTrafficLog,
 	})
 }
 
@@ -54,7 +54,7 @@ func MustCSMClientAccessTimeline(ctx context.Context, clusterName string, podNam
 
 	return builder.TimelineAccumulator.GetPath(podPath, khifilev6.PathSegment{
 		Name: "client",
-		Type: TimelineTypeCSMAccessLog,
+		Type: TimelineTypeCSMTrafficLog,
 	})
 }
 
@@ -65,7 +65,7 @@ func MustCSMServiceServerAccessTimeline(ctx context.Context, clusterName string,
 
 	return builder.TimelineAccumulator.GetPath(servicePath, khifilev6.PathSegment{
 		Name: "server",
-		Type: TimelineTypeCSMAccessLog,
+		Type: TimelineTypeCSMTrafficLog,
 	})
 }
 
@@ -76,6 +76,6 @@ func MustCSMServiceClientAccessTimeline(ctx context.Context, clusterName string,
 
 	return builder.TimelineAccumulator.GetPath(servicePath, khifilev6.PathSegment{
 		Name: "client",
-		Type: TimelineTypeCSMAccessLog,
+		Type: TimelineTypeCSMTrafficLog,
 	})
 }

--- a/pkg/task/inspection/googlecloudlogcsm/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/timeline_type.go
@@ -22,9 +22,9 @@ import (
 // These are registered as package-level variables so they are initialized immediately
 // when this package is imported.
 var (
-	TimelineTypeCSMAccessLog = style.MustRegisterTimelineType(
+	TimelineTypeCSMTrafficLog = style.MustRegisterTimelineType(
 		"csm",
-		"CSM Access logs related to this resource",
+		"CSM Traffic logs related to this resource",
 		"shuffle",
 		0.6,
 		style.ColorWhite,

--- a/pkg/task/inspection/googlecloudlogcsm/impl/form_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/form_task.go
@@ -53,7 +53,7 @@ var InputCSMResponseFlagsTask = formtask.NewSetFormTaskBuilder(googlecloudlogcsm
 	WithAllowAddAll(false).
 	WithAllowRemoveAll(false).
 	WithAllowCustomValue(true).
-	WithDescription("Response flags used for filtering CSM access logs. Note '-' in response flags is corresponded to 'OK' in this form.").
+	WithDescription("Response flags used for filtering CSM traffic logs. Note '-' in response flags is corresponded to 'OK' in this form.").
 	WithOptionsFunc(func(ctx context.Context, previousValues []string) ([]inspectionmetadata.SetParameterFormFieldOptionItem, error) {
 		result := []inspectionmetadata.SetParameterFormFieldOptionItem{
 			{ID: "@any", Description: "[Alias] Matches any response flag"},

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task.go
@@ -27,28 +27,28 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-// FieldSetReaderTask is a task that reads CSM access logs field sets.
+// FieldSetReaderTask is a task that reads CSM traffic logs field sets.
 var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(googlecloudlogcsm_contract.FieldSetReaderTaskID, googlecloudlogcsm_contract.ListLogEntriesTaskID.Ref(), []log.FieldSetReader{
 	&googlecloudcommon_contract.GCPAccessLogFieldSetReader{},
 	&googlecloudlogcsm_contract.IstioAccessLogFieldSetReader{},
 	&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
 })
 
-// CSMAccessLogLogIngester ingests CSM access logs.
-type CSMAccessLogLogIngester struct{}
+// CSMTrafficLogLogIngester ingests CSM traffic logs.
+type CSMTrafficLogLogIngester struct{}
 
 // RawLogTask returns the task reference that provides raw logs.
-func (i *CSMAccessLogLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
+func (i *CSMTrafficLogLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogcsm_contract.FieldSetReaderTaskID.Ref()
 }
 
 // Dependencies returns the task dependencies.
-func (i *CSMAccessLogLogIngester) Dependencies() []taskid.UntypedTaskReference {
+func (i *CSMTrafficLogLogIngester) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{}
 }
 
 // ProcessLog parses raw log entry and populates the LogChangeSet.
-func (i *CSMAccessLogLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
+func (i *CSMTrafficLogLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
 	cs, err := khifilev6.NewLogChangeSet(l)
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func (i *CSMAccessLogLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*
 		summary = fmt.Sprintf("【%s(%s)】", istioAccessLog.ResponseFlagMessage(), istioAccessLog.ResponseFlag) + summary
 	}
 	cs.SetSummary(summary)
-	cs.SetLogType(googlecloudlogcsm_contract.LogTypeCSMAccessLog)
+	cs.SetLogType(googlecloudlogcsm_contract.LogTypeCSMTrafficLog)
 
 	if severityFS, err := log.GetFieldSet(l, &inspectioncore_contract.DefaultSeverityFieldSet{}); err == nil {
 		cs.SetSeverity(severityFS.Severity)
@@ -83,15 +83,15 @@ func (i *CSMAccessLogLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*
 	return cs, nil
 }
 
-var _ inspectiontaskbase.LogIngester = (*CSMAccessLogLogIngester)(nil)
+var _ inspectiontaskbase.LogIngester = (*CSMTrafficLogLogIngester)(nil)
 
-// LogIngesterTask is the task that executes CSMAccessLogLogIngester.
+// LogIngesterTask is the task that executes CSMTrafficLogLogIngester.
 var LogIngesterTask = inspectiontaskbase.NewLogIngesterTask(
 	googlecloudlogcsm_contract.LogIngesterTaskID,
-	&CSMAccessLogLogIngester{},
+	&CSMTrafficLogLogIngester{},
 )
 
-// LogGrouperTask groups CSM access logs by their reporter pod.
+// LogGrouperTask groups CSM traffic logs by their reporter pod.
 var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogcsm_contract.LogGrouperTaskID, googlecloudlogcsm_contract.FieldSetReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) string {
 		istioAccessLogFieldSet := log.MustGetFieldSet(l, &googlecloudlogcsm_contract.IstioAccessLogFieldSet{})
@@ -99,30 +99,30 @@ var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(googlecloudlogcsm_cont
 	},
 )
 
-// CSMAccessLogLogToTimelineMapper maps CSM access logs to resource timelines.
-type CSMAccessLogLogToTimelineMapper struct {
+// CSMTrafficLogLogToTimelineMapper maps CSM traffic logs to resource timelines.
+type CSMTrafficLogLogToTimelineMapper struct {
 	inspectiontaskbase.StatelessMapperBase
 }
 
 // LogIngesterTask returns a reference to the task that provides ingested logs.
-func (m *CSMAccessLogLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *CSMTrafficLogLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
 	return googlecloudlogcsm_contract.LogIngesterTaskID.Ref()
 }
 
 // Dependencies returns additional task dependencies.
-func (m *CSMAccessLogLogToTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
+func (m *CSMTrafficLogLogToTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(),
 	}
 }
 
 // GroupedLogTask returns a reference to the task that provides the grouped logs.
-func (m *CSMAccessLogLogToTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+func (m *CSMTrafficLogLogToTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
 	return googlecloudlogcsm_contract.LogGrouperTaskID.Ref()
 }
 
 // ProcessLogByGroup maps each log inside a group to one or more timeline events.
-func (m *CSMAccessLogLogToTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
+func (m *CSMTrafficLogLogToTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	istioAccessLog, err := log.GetFieldSet(l, &googlecloudlogcsm_contract.IstioAccessLogFieldSet{})
 	if err != nil {
 		return nil, struct{}{}, err
@@ -155,15 +155,15 @@ func (m *CSMAccessLogLogToTimelineMapper) ProcessLogByGroup(ctx context.Context,
 	return cs, struct{}{}, nil
 }
 
-var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*CSMAccessLogLogToTimelineMapper)(nil)
+var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*CSMTrafficLogLogToTimelineMapper)(nil)
 
-// LogToTimelineMapperTask maps CSM access logs to timelines.
+// LogToTimelineMapperTask maps CSM traffic logs to timelines.
 var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
 	googlecloudlogcsm_contract.LogToTimelineMapperTaskID,
-	&CSMAccessLogLogToTimelineMapper{},
+	&CSMTrafficLogLogToTimelineMapper{},
 	inspectioncore_contract.FeatureTaskLabel(
-		"CSM Access Logs",
-		"Gather CSM access logs to visualize network traffic flows and latency under client or server Pod timelines.",
+		"CSM Traffic Logs",
+		"Gather CSM traffic logs to visualize network traffic flows and latency under client or server Pod timelines.",
 		10000,
 		false,
 	),

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
 )
 
-func TestCSMAccessLogLogIngester_ProcessLog(t *testing.T) {
+func TestCSMTrafficLogLogIngester_ProcessLog(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		inputGCPAccessLog   *googlecloudcommon_contract.GCPAccessLogFieldSet
@@ -77,7 +77,7 @@ func TestCSMAccessLogLogIngester_ProcessLog(t *testing.T) {
 		},
 	}
 
-	ingester := &CSMAccessLogLogIngester{}
+	ingester := &CSMTrafficLogLogIngester{}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			l := log.NewLogWithFieldSetsForTest(
@@ -91,12 +91,12 @@ func TestCSMAccessLogLogIngester_ProcessLog(t *testing.T) {
 			}
 			testchangeset.AssertLog(t, cs).
 				HasSummary(tc.wantSummary).
-				HasLogType(googlecloudlogcsm_contract.LogTypeCSMAccessLog)
+				HasLogType(googlecloudlogcsm_contract.LogTypeCSMTrafficLog)
 		})
 	}
 }
 
-func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
+func TestCSMTrafficLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		inputGCPAccessLog   *googlecloudcommon_contract.GCPAccessLogFieldSet
@@ -129,7 +129,7 @@ func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind},
 					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
 					khifilev6.PathSegment{Name: "istio-ingressgateway", Type: inspectioncore_contract.TimelineTypeResource},
-					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMTrafficLog},
 				)
 				wantProductpagePath := builder.TimelineAccumulator.GetPath(nil,
 					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
@@ -137,7 +137,7 @@ func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind},
 					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
 					khifilev6.PathSegment{Name: "productpage-v1", Type: inspectioncore_contract.TimelineTypeResource},
-					khifilev6.PathSegment{Name: "server:istio-proxy", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+					khifilev6.PathSegment{Name: "server:istio-proxy", Type: googlecloudlogcsm_contract.TimelineTypeCSMTrafficLog},
 				)
 				wantServicePath := builder.TimelineAccumulator.GetPath(nil,
 					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
@@ -145,7 +145,7 @@ func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					khifilev6.PathSegment{Name: "service", Type: inspectioncore_contract.TimelineTypeKind},
 					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
 					khifilev6.PathSegment{Name: "productpage", Type: inspectioncore_contract.TimelineTypeResource},
-					khifilev6.PathSegment{Name: "server", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+					khifilev6.PathSegment{Name: "server", Type: googlecloudlogcsm_contract.TimelineTypeCSMTrafficLog},
 				)
 
 				testchangeset.AssertTimeline(t, cs).
@@ -180,7 +180,7 @@ func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind},
 					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
 					khifilev6.PathSegment{Name: "details-v1", Type: inspectioncore_contract.TimelineTypeResource},
-					khifilev6.PathSegment{Name: "server", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+					khifilev6.PathSegment{Name: "server", Type: googlecloudlogcsm_contract.TimelineTypeCSMTrafficLog},
 				)
 				wantProductpagePath := builder.TimelineAccumulator.GetPath(nil,
 					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
@@ -188,7 +188,7 @@ func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind},
 					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
 					khifilev6.PathSegment{Name: "productpage-v1", Type: inspectioncore_contract.TimelineTypeResource},
-					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMTrafficLog},
 				)
 				wantDetailsServicePath := builder.TimelineAccumulator.GetPath(nil,
 					khifilev6.PathSegment{Name: "test-cluster", Type: inspectioncore_contract.TimelineTypeK8sCluster},
@@ -196,7 +196,7 @@ func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					khifilev6.PathSegment{Name: "service", Type: inspectioncore_contract.TimelineTypeKind},
 					khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace},
 					khifilev6.PathSegment{Name: "details", Type: inspectioncore_contract.TimelineTypeResource},
-					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMAccessLog},
+					khifilev6.PathSegment{Name: "client", Type: googlecloudlogcsm_contract.TimelineTypeCSMTrafficLog},
 				)
 
 				testchangeset.AssertTimeline(t, cs).
@@ -207,7 +207,7 @@ func TestCSMAccessLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 		},
 	}
 
-	mapper := &CSMAccessLogLogToTimelineMapper{}
+	mapper := &CSMTrafficLogLogToTimelineMapper{}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			builder := khifilev6.NewBuilder()

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
@@ -29,7 +29,7 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-func csmAccessLogsFilter(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, responseFlagsSetFilter *gcpqueryutil.SetFilterParseResult, namespaceSetFilter *gcpqueryutil.SetFilterParseResult) string {
+func csmTrafficLogsFilter(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, responseFlagsSetFilter *gcpqueryutil.SetFilterParseResult, namespaceSetFilter *gcpqueryutil.SetFilterParseResult) string {
 	responseFlagsFilterStr := responseFlagsFilter(responseFlagsSetFilter)
 	namespaceFilterStr := namespaceFilter(namespaceSetFilter)
 	return fmt.Sprintf(`LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
@@ -75,22 +75,22 @@ func namespaceFilter(filter *gcpqueryutil.SetFilterParseResult) string {
 			selectedNamespaces = append(selectedNamespaces, fmt.Sprintf(`"%s"`, additive))
 		}
 		if len(selectedNamespaces) == 0 {
-			return `resource.labels.namespace_name="" -- Invalid: No namespaces are remained to filter for CSM access log.`
+			return `resource.labels.namespace_name="" -- Invalid: No namespaces are remained to filter for CSM traffic log.`
 		}
 		return fmt.Sprintf(`resource.labels.namespace_name:(%s)`, strings.Join(selectedNamespaces, " OR "))
 	}
 }
 
-type CSMAccessLogListLogEntryTaskSetting struct{}
+type CSMTrafficLogListLogEntryTaskSetting struct{}
 
 // DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *CSMAccessLogListLogEntryTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
+func (c *CSMTrafficLogListLogEntryTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
 // Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *CSMAccessLogListLogEntryTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+func (c *CSMTrafficLogListLogEntryTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(),
 		googlecloudk8scommon_contract.InputNamespaceFilterTaskID.Ref(),
@@ -99,11 +99,11 @@ func (c *CSMAccessLogListLogEntryTaskSetting) Dependencies() []taskid.UntypedTas
 }
 
 // Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *CSMAccessLogListLogEntryTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
+func (c *CSMTrafficLogListLogEntryTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
 	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
 
-		QueryName: "CSM access logs",
-		ExampleQuery: csmAccessLogsFilter(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		QueryName: "CSM Traffic logs",
+		ExampleQuery: csmTrafficLogsFilter(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
 			ProjectID:   "test-project",
 			Location:    "test-location",
 			ClusterName: "test-cluster",
@@ -112,23 +112,23 @@ func (c *CSMAccessLogListLogEntryTaskSetting) Description() *googlecloudcommon_c
 }
 
 // LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *CSMAccessLogListLogEntryTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+func (c *CSMTrafficLogListLogEntryTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref())
 	namespaceFilter := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputNamespaceFilterTaskID.Ref())
 	responseFlagsFilter := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.InputCSMResponseFlagsTaskID.Ref())
-	return []string{csmAccessLogsFilter(cluster, responseFlagsFilter, namespaceFilter)}, nil
+	return []string{csmTrafficLogsFilter(cluster, responseFlagsFilter, namespaceFilter)}, nil
 }
 
 // TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *CSMAccessLogListLogEntryTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
+func (c *CSMTrafficLogListLogEntryTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogcsm_contract.ListLogEntriesTaskID
 }
 
 // TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *CSMAccessLogListLogEntryTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
+func (c *CSMTrafficLogListLogEntryTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*CSMAccessLogListLogEntryTaskSetting)(nil)
+var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*CSMTrafficLogListLogEntryTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&CSMAccessLogListLogEntryTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&CSMTrafficLogListLogEntryTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
@@ -75,7 +75,7 @@ func namespaceFilter(filter *gcpqueryutil.SetFilterParseResult) string {
 			selectedNamespaces = append(selectedNamespaces, fmt.Sprintf(`"%s"`, additive))
 		}
 		if len(selectedNamespaces) == 0 {
-			return `resource.labels.namespace_name="" -- Invalid: No namespaces are remained to filter for CSM traffic log.`
+			return `resource.labels.namespace_name="" -- Invalid: No namespaces remain to filter for CSM traffic logs.`
 		}
 		return fmt.Sprintf(`resource.labels.namespace_name:(%s)`, strings.Join(selectedNamespaces, " OR "))
 	}

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestCsmAccessLogsFilter(t *testing.T) {
+func TestCsmTrafficLogsFilter(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		cluster             googlecloudk8scommon_contract.GoogleCloudClusterIdentity
@@ -98,7 +98,7 @@ resource.labels.cluster_name="test-cluster"`,
 			},
 			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
 labels.response_flag:("UH")
-resource.labels.namespace_name="" -- Invalid: No namespaces are remained to filter for CSM access log.
+resource.labels.namespace_name="" -- Invalid: No namespaces are remained to filter for CSM traffic log.
 resource.labels.project_id="test-project"
 resource.labels.location="test-location"
 resource.labels.cluster_name="test-cluster"`,
@@ -166,9 +166,9 @@ resource.labels.cluster_name="test-cluster"`,
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := csmAccessLogsFilter(tc.cluster, tc.responseFlagsFilter, tc.namespaceFilter)
+			got := csmTrafficLogsFilter(tc.cluster, tc.responseFlagsFilter, tc.namespaceFilter)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("csmAccessLogsFilter() mismatch (-want +got):\n%s", diff)
+				t.Errorf("csmTrafficLogsFilter() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -241,10 +241,10 @@ resource.labels.cluster_name="azureClusters/test-cluster"`,
 				t.Fatalf("unexpected error running cluster identity task: %v", err)
 			}
 
-			got := csmAccessLogsFilter(idRes, &gcpqueryutil.SetFilterParseResult{Additives: []string{"UH"}}, &gcpqueryutil.SetFilterParseResult{Additives: []string{"default"}})
+			got := csmTrafficLogsFilter(idRes, &gcpqueryutil.SetFilterParseResult{Additives: []string{"UH"}}, &gcpqueryutil.SetFilterParseResult{Additives: []string{"default"}})
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("csmAccessLogsFilter() mismatch (-want +got):\n%s", diff)
+				t.Errorf("csmTrafficLogsFilter() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task_test.go
@@ -98,7 +98,7 @@ resource.labels.cluster_name="test-cluster"`,
 			},
 			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
 labels.response_flag:("UH")
-resource.labels.namespace_name="" -- Invalid: No namespaces are remained to filter for CSM traffic log.
+resource.labels.namespace_name="" -- Invalid: No namespaces remain to filter for CSM traffic logs.
 resource.labels.project_id="test-project"
 resource.labels.location="test-location"
 resource.labels.cluster_name="test-cluster"`,

--- a/pkg/task/inspection/googlecloudlogcsm/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/registration.go
@@ -22,7 +22,7 @@ import (
 
 /*
  graph TD
-  subgraph "CSM Access Log"
+  subgraph "CSM Traffic Log"
     direction LR
     InputCSMResponseFlagsTask(Input CSM Response Flags)
     ListLogEntriesTask(List Log Entries)

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
@@ -44,7 +44,7 @@ var CSMTrafficDirectorFieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTas
 var CSMTrafficDirectorLogIngesterTask = googlecloudcommon_contract.NewGCPOperationLogIngesterTask(
 	googlecloudlogcsm_contract.CSMTrafficDirectorLogIngesterTaskID,
 	googlecloudlogcsm_contract.CSMTrafficDirectorFieldSetReaderTaskID.Ref(),
-	googlecloudlogcsm_contract.LogTypeCSMAccessLog,
+	googlecloudlogcsm_contract.LogTypeCSMTrafficLog,
 )
 
 // CSMTrafficDirectorLogGrouperTask is a task that groups CSM Traffic Director logs by their resource name.

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
@@ -68,7 +68,7 @@ func TestCSMTrafficDirectorLogIngester_ProcessLog(t *testing.T) {
 		},
 	}
 
-	ingester := googlecloudcommon_contract.NewGCPOperationLogIngester(googlecloudlogcsm_contract.CSMTrafficDirectorFieldSetReaderTaskID.Ref(), googlecloudlogcsm_contract.LogTypeCSMAccessLog)
+	ingester := googlecloudcommon_contract.NewGCPOperationLogIngester(googlecloudlogcsm_contract.CSMTrafficDirectorFieldSetReaderTaskID.Ref(), googlecloudlogcsm_contract.LogTypeCSMTrafficLog)
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			l := log.NewLogWithFieldSetsForTest(
@@ -81,7 +81,7 @@ func TestCSMTrafficDirectorLogIngester_ProcessLog(t *testing.T) {
 			}
 			testchangeset.AssertLog(t, cs).
 				HasSummary(tc.wantSummary).
-				HasLogType(googlecloudlogcsm_contract.LogTypeCSMAccessLog)
+				HasLogType(googlecloudlogcsm_contract.LogTypeCSMTrafficLog)
 		})
 	}
 }


### PR DESCRIPTION
Updated terminology from CSM Access Logs to CSM Traffic Logs since the [public documentation](https://docs.cloud.google.com/service-mesh/docs/observability/access-logs?hl=en) distinguishes the traffic logs from the envoy access logs.