### PR TITLE
fix: remove CSM traffic log from the container log filter

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task.go
@@ -35,6 +35,8 @@ func GenerateK8sContainerQuery(cluster googlecloudk8scommon_contract.GoogleCloud
 resource.labels.project_id="%s"
 resource.labels.location="%s"
 resource.labels.cluster_name="%s"
+-LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
 %s
 %s`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateNamespacesFilter(namespacesFilter), generatePodNamesFilter(podNamesFilter))
 }

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task_test.go
@@ -43,6 +43,8 @@ func TestGenerateK8sContainerQueryIsValid(t *testing.T) {
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
 -- Invalid: none of the resources will be selected. Ignoring namespace filter.
 -- Invalid: none of the resources will be selected. Ignoring pod name filter.`,
 		},
@@ -59,6 +61,8 @@ resource.labels.cluster_name="foo-cluster"
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
 resource.labels.namespace_name=("kube-system")
 -- Invalid: none of the resources will be selected. Ignoring pod name filter.`,
 		},
@@ -75,6 +79,8 @@ resource.labels.namespace_name=("kube-system")
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
 -- Invalid: none of the resources will be selected. Ignoring namespace filter.
 resource.labels.pod_name:("nginx-pod")`,
 		},
@@ -91,6 +97,8 @@ resource.labels.pod_name:("nginx-pod")`,
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
 resource.labels.namespace_name=("kube-system")
 resource.labels.pod_name:("nginx-pod")`,
 		},
@@ -107,6 +115,8 @@ resource.labels.pod_name:("nginx-pod")`,
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
 resource.labels.namespace_name=("kube-system" OR "istio-system")
 resource.labels.pod_name:("nginx-pod" OR "apache-pod")`,
 		},


### PR DESCRIPTION
Fixed the bug that caused CSM Traffic logs to be duplicated in k8s container logs.

Fixed:
<img width="1224" height="235" alt="image" src="https://github.com/user-attachments/assets/f682081b-49cd-4cc5-80cd-e6d75b16a46c" />
