### PR TITLE
Updated Go version to 1.26 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 ENV ROOT=/go/src/app
 RUN mkdir /built


### PR DESCRIPTION
I forgot to update the version in Dockerfile in PR #872. This PR just updates it for CD not to fail the release.