### PR TITLE
adding support for Managed airflow audit log

### DIFF
--- a/pkg/task/inspection/googlecloudclustercomposer/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/revision_state.go
@@ -130,4 +130,60 @@ var (
 		style.MustForceConvertSRGBHex("#fe0000"),
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
 	)
+	// RevisionStateManagedAirflowEnvironmentProvisioning indicates that the Managed Airflow environment is being created.
+	RevisionStateManagedAirflowEnvironmentProvisioning = style.MustRegisterRevisionState(
+		"Environment is being provisioned",
+		"deployed_code_history",
+		"The Managed Airflow environment is currently being provisioned.",
+		style.MustForceConvertSRGBHex("#6666ff"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+	// RevisionStateManagedAirflowEnvironmentExisting indicates that the Managed Airflow environment is active and running.
+	RevisionStateManagedAirflowEnvironmentExisting = style.MustRegisterRevisionState(
+		"Environment exists",
+		"deployed_code",
+		"The Managed Airflow environment exists and is active.",
+		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+	// RevisionStateManagedAirflowEnvironmentDeleting indicates that the Managed Airflow environment is being deleted.
+	RevisionStateManagedAirflowEnvironmentDeleting = style.MustRegisterRevisionState(
+		"Environment is being deleted",
+		"auto_delete",
+		"The Managed Airflow environment is undergoing deletion.",
+		style.Color{R: 0.8, G: 0.33333334, B: 0.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+	// RevisionStateManagedAirflowEnvironmentDeleted indicates that the Managed Airflow environment has been deleted.
+	RevisionStateManagedAirflowEnvironmentDeleted = style.MustRegisterRevisionState(
+		"Environment is deleted",
+		"delete_forever",
+		"The Managed Airflow environment has been deleted.",
+		style.Color{R: 0.8, G: 0.0, B: 0.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
+	)
+	// RevisionStateManagedAirflowEnvironmentProvisioningLogNotFound indicates that Managed Airflow environment provisioning started before the log collection window.
+	RevisionStateManagedAirflowEnvironmentProvisioningLogNotFound = style.MustRegisterRevisionState(
+		"Environment is being provisioned, but starting log not found",
+		"deployed_code_history",
+		"The Managed Airflow environment provisioning was started, but the starting log entry was not found in the selected time range.",
+		style.MustForceConvertSRGBHex("#6666ff"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
+	// RevisionStateManagedAirflowEnvironmentExistingLogNotFound indicates that Managed Airflow environment existed before the log collection window.
+	RevisionStateManagedAirflowEnvironmentExistingLogNotFound = style.MustRegisterRevisionState(
+		"Environment exists, but creation log not found",
+		"deployed_code",
+		"The Managed Airflow environment exists, but the creation or existence log entry was not found in the selected time range.",
+		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
+	// RevisionManagedAirflowEnvironmentDeletingLogNotFound indicates that Managed Airflow environment deletion started before the log collection window.
+	RevisionManagedAirflowEnvironmentDeletingLogNotFound = style.MustRegisterRevisionState(
+		"Environment is being deleted, but starting log not found",
+		"auto_delete",
+		"The Managed Airflow environment deletion was in progress, but the deletion starting log entry was not found in the selected time range.",
+		style.Color{R: 0.8, G: 0.33333334, B: 0.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
 )

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/timeline_path.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/timeline_path.go
@@ -16,6 +16,7 @@ package googlecloudclustercomposer_contract
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
@@ -27,6 +28,7 @@ import (
 func MustAirflowTimeline(ctx context.Context, environmentName string) *khifilev6.TimelinePath {
 	if environmentName == "" {
 		environmentName = "unknown"
+		slog.WarnContext(ctx, "environmentName is empty, using unknown instead")
 	}
 	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
 	return builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper.go
@@ -94,7 +94,7 @@ func (i *dagProcessorManagerLogIngester) ProcessLogByGroup(ctx context.Context, 
 	if err != nil {
 		return nil, prevGroupData, err
 	}
-	cs.SetLogType(googlecloudclustercomposer_contract.LogTypeComposerEnvironment)
+	cs.SetLogType(googlecloudclustercomposer_contract.LogTypeManagedAirflowEnvironment)
 
 	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
 		cs.SetTimestamp(commonFS.Timestamp)
@@ -243,7 +243,7 @@ var _ inspectiontaskbase.LogToTimelineMapper[*DagProcessorState] = (*dagProcesso
 var AirflowDagProcessorManagerLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(
 	googlecloudclustercomposer_contract.AirflowDagProcessorManagerLogToTimelineMapperTaskID,
 	&dagProcessorManagerTimelineMapper{
-		targetLogType: googlecloudclustercomposer_contract.LogTypeComposerEnvironment,
+		targetLogType: googlecloudclustercomposer_contract.LogTypeManagedAirflowEnvironment,
 		dagFilePath:   "/home/airflow/gcs/dags",
 	},
 )

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper_test.go
@@ -126,7 +126,7 @@ func TestDagProcessorMapperTask_ProcessLogByGroup(t *testing.T) {
 	}
 
 	mapper := &dagProcessorManagerTimelineMapper{
-		targetLogType: googlecloudclustercomposer_contract.LogTypeComposerEnvironment,
+		targetLogType: googlecloudclustercomposer_contract.LogTypeManagedAirflowEnvironment,
 		dagFilePath:   "/home/airflow/gcs/dags",
 	}
 	for _, tc := range testCases {

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/other.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/other.go
@@ -54,7 +54,7 @@ func (i *otherLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifile
 	if err != nil {
 		return nil, err
 	}
-	cs.SetLogType(googlecloudclustercomposer_contract.LogTypeComposerEnvironment)
+	cs.SetLogType(googlecloudclustercomposer_contract.LogTypeManagedAirflowEnvironment)
 
 	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
 		cs.SetTimestamp(commonFS.Timestamp)

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler.go
@@ -55,7 +55,7 @@ func (i *schedulerLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khi
 	if err != nil {
 		return nil, err
 	}
-	cs.SetLogType(googlecloudclustercomposer_contract.LogTypeComposerEnvironment)
+	cs.SetLogType(googlecloudclustercomposer_contract.LogTypeManagedAirflowEnvironment)
 
 	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
 		cs.SetTimestamp(commonFS.Timestamp)

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/worker.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/worker.go
@@ -55,7 +55,7 @@ func (i *workerLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifil
 	if err != nil {
 		return nil, err
 	}
-	cs.SetLogType(googlecloudclustercomposer_contract.LogTypeComposerEnvironment)
+	cs.SetLogType(googlecloudclustercomposer_contract.LogTypeManagedAirflowEnvironment)
 
 	if commonFS, err := log.GetFieldSet(l, &log.CommonFieldSet{}); err == nil {
 		cs.SetTimestamp(commonFS.Timestamp)

--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset.go
@@ -125,7 +125,10 @@ func (g *GCPOperationAuditLogFieldSetReader) Read(reader *structured.NodeReader)
 	result.OperationLast = reader.ReadBoolOrDefault("operation.last", false)
 	result.MethodName = reader.ReadStringOrDefault("protoPayload.methodName", "unknown")
 	result.ResourceName = reader.ReadStringOrDefault("protoPayload.resourceName", "unknown")
-	result.PrincipalEmail = reader.ReadStringOrDefault("protoPayload.authenticationInfo.principalEmail", "unknown")
+	result.PrincipalEmail = reader.ReadStringOrDefault("protoPayload.authenticationInfo.principalEmail", "")
+	if result.PrincipalEmail == "" {
+		result.PrincipalEmail = reader.ReadStringOrDefault("protoPayload.authenticationInfo.principalSubject", "unknown")
+	}
 	result.Status = reader.ReadIntOrDefault("protoPayload.status.code", -1)
 	result.StatusMessage = reader.ReadStringOrDefault("protoPayload.status.message", "")
 	result.Request, _ = reader.GetReader("protoPayload.request")

--- a/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/fieldset_test.go
@@ -72,6 +72,39 @@ func TestGCPAuditLogFieldSetReader(t *testing.T) {
 				Status:         0,
 			},
 		},
+		{
+			name: "audit log with principalSubject",
+			input: map[string]any{
+				"resource": map[string]any{
+					"labels": map[string]any{
+						"project_id": "p1",
+					},
+				},
+				"operation": map[string]any{
+					"id":    "op-2",
+					"first": true,
+					"last":  false,
+				},
+				"protoPayload": map[string]any{
+					"methodName":   "google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+					"resourceName": "projects/p1/locations/us-central1/environments/env-1",
+					"authenticationInfo": map[string]any{
+						"principalSubject": "serviceAccount:khi-sa@proj.iam.gserviceaccount.com",
+					},
+					"status": map[string]any{},
+				},
+			},
+			want: &GCPAuditLogFieldSet{
+				ProjectID:      "p1",
+				OperationID:    "op-2",
+				OperationFirst: true,
+				OperationLast:  false,
+				MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+				ResourceName:   "projects/p1/locations/us-central1/environments/env-1",
+				PrincipalEmail: "serviceAccount:khi-sa@proj.iam.gserviceaccount.com",
+				Status:         -1,
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go
@@ -46,6 +46,11 @@ func (t *GCPOperationTracker) HasStarted(operationID string) bool {
 	return hasStarted
 }
 
+// MarkStarted records that the operation start log for the given operation ID was observed.
+func (t *GCPOperationTracker) MarkStarted(operationID string) {
+	t.startedOperations[operationID] = struct{}{}
+}
+
 // HasResourceRevision returns true if any revision has been added to the given resource timeline path.
 func (t *GCPOperationTracker) HasResourceRevision(path *khifilev6.TimelinePath) bool {
 	_, has := t.hasResourceRevision[path.ID]
@@ -221,7 +226,7 @@ func (t *GCPOperationTracker) ProcessOperationLog(ctx context.Context, cs *khifi
 	}
 
 	if audit.Starting() {
-		t.startedOperations[audit.OperationID] = struct{}{}
+		t.MarkStarted(audit.OperationID)
 	}
 
 	_, hasStarted := t.startedOperations[audit.OperationID]

--- a/pkg/task/inspection/googlecloudcommon/contract/timeline.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/timeline.go
@@ -24,6 +24,23 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
+// MustManagedAirflowEnvironmentTimeline returns the timeline path for a Cloud Composer Environment under a GCP Project.
+func MustManagedAirflowEnvironmentTimeline(ctx context.Context, projectPath *khifilev6.TimelinePath, environmentName string) *khifilev6.TimelinePath {
+	if projectPath == nil || projectPath.Type.GetId() != TimelineTypeGCPProject.GetId() {
+		panic("parent timeline path must be GCP Project type")
+	}
+	if environmentName == "" {
+		environmentName = "unknown"
+		slog.WarnContext(ctx, "environmentName is empty, using unknown instead")
+	}
+
+	builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
+	return builder.TimelineAccumulator.GetPath(projectPath, khifilev6.PathSegment{
+		Name: environmentName,
+		Type: TimelineTypeManagedAirflowEnvironment,
+	})
+}
+
 // MustGKEClusterTimeline returns the timeline path for a GKE Cluster under a GCP Project.
 func MustGKEClusterTimeline(ctx context.Context, projectPath *khifilev6.TimelinePath, clusterName string) *khifilev6.TimelinePath {
 	if projectPath == nil || projectPath.Type.GetId() != TimelineTypeGCPProject.GetId() {

--- a/pkg/task/inspection/googlecloudcommon/contract/timeline_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/timeline_test.go
@@ -25,6 +25,75 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestMustComposerEnvironmentTimeline(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")
+
+	testCases := []struct {
+		name            string
+		parent          *khifilev6.TimelinePath
+		environmentName string
+		wantPanic       bool
+		panicMsg        string
+		wantName        string
+	}{
+		{
+			name:            "valid environment name",
+			parent:          projectTimeline,
+			environmentName: "my-composer-environment",
+			wantPanic:       false,
+			wantName:        "my-composer-environment",
+		},
+		{
+			name:            "empty environment name",
+			parent:          projectTimeline,
+			environmentName: "",
+			wantPanic:       false,
+			wantName:        "unknown",
+		},
+		{
+			name:            "nil project path",
+			parent:          nil,
+			environmentName: "my-composer-environment",
+			wantPanic:       true,
+			panicMsg:        "parent timeline path must be GCP Project type",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantPanic {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Errorf("MustComposerEnvironmentTimeline() did not panic, want panic: %s", tc.panicMsg)
+					} else if !strings.Contains(fmt.Sprint(r), tc.panicMsg) {
+						t.Errorf("MustComposerEnvironmentTimeline() panic = %v, want panic containing %q", r, tc.panicMsg)
+					}
+				}()
+			}
+
+			got := MustManagedAirflowEnvironmentTimeline(ctx, tc.parent, tc.environmentName)
+			if !tc.wantPanic {
+				if got == nil {
+					t.Fatal("expected timeline path to be not nil")
+				}
+				if diff := cmp.Diff(tc.wantName, got.Name.Resolve()); diff != "" {
+					t.Errorf("MustComposerEnvironmentTimeline() mismatch (-want +got):\n%s", diff)
+				}
+				if got.Type.GetId() != TimelineTypeManagedAirflowEnvironment.GetId() {
+					t.Errorf("MustComposerEnvironmentTimeline().Type = %v, want %v", got.Type, TimelineTypeManagedAirflowEnvironment)
+				}
+				if got.Parent == nil || got.Parent.Type.GetId() != TimelineTypeGCPProject.GetId() {
+					t.Errorf("MustComposerEnvironmentTimeline().Parent = %v, want GCP Project timeline", got.Parent)
+				}
+			}
+		})
+	}
+}
+
 func TestMustGKEClusterTimeline(t *testing.T) {
 	builder := khifilev6.NewBuilder()
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)

--- a/pkg/task/inspection/googlecloudcommon/contract/timeline_type.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/timeline_type.go
@@ -22,6 +22,20 @@ import (
 // These are registered as package-level variables so they are initialized immediately
 // when this package is imported.
 var (
+	// TimelineTypeManagedAirflowEnvironment is the timeline style for a Managed Airflow environment under a GCP project.
+	TimelineTypeManagedAirflowEnvironment = style.MustRegisterTimelineType(
+		"Managed Airflow",
+		"Timeline for Managed Airflow",
+		"cloud",
+		1.0,
+		style.Color{R: 0.780, G: 0.863, B: 1.000, A: 1.0},
+		style.ColorBlack,
+		style.Color{R: 0.780, G: 0.863, B: 1.000, A: 1.0},
+		style.ColorWhite,
+		true,
+		40,
+		style.AlphabeticalSortPolicy(),
+	)
 	TimelineTypeGKE = style.MustRegisterTimelineType(
 		"gke",
 		"Control plane operations and lifecycle logs of the GKE cluster",
@@ -112,7 +126,7 @@ var (
 		style.Color{R: 0.102, G: 0.451, B: 0.910, A: 1.0},
 		style.ColorWhite,
 		style.Color{R: 0.102, G: 0.451, B: 0.910, A: 1.0},
-		style.ColorWhite,
+		style.ColorBlack,
 		true,
 		30,
 		style.AlphabeticalSortPolicy(),

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/fieldset.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_contract
+
+import (
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+)
+
+// ComposerAuditLogResourceFieldSet represents resource identifiers extracted from a Cloud Composer audit log entry.
+type ComposerAuditLogResourceFieldSet struct {
+	EnvironmentName string
+	Location        string
+	ProjectID       string
+}
+
+// Kind returns the field set kind identifier.
+func (c *ComposerAuditLogResourceFieldSet) Kind() string {
+	return "composer_audit"
+}
+
+var _ log.FieldSet = (*ComposerAuditLogResourceFieldSet)(nil)
+
+// ComposerAuditLogResourceFieldSetReader parses resource identification fields from Cloud Composer audit logs.
+type ComposerAuditLogResourceFieldSetReader struct{}
+
+// FieldSetKind returns the kind identifier of the field set read by this reader.
+func (r *ComposerAuditLogResourceFieldSetReader) FieldSetKind() string {
+	return (&ComposerAuditLogResourceFieldSet{}).Kind()
+}
+
+// Read extracts Composer resource labels from the provided log node reader.
+func (r *ComposerAuditLogResourceFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
+	var result ComposerAuditLogResourceFieldSet
+	result.EnvironmentName = reader.ReadStringOrDefault("resource.labels.environment_name", "unknown")
+	result.Location = reader.ReadStringOrDefault("resource.labels.location", "unknown")
+	result.ProjectID = reader.ReadStringOrDefault("resource.labels.project_id", "unknown")
+	return &result, nil
+}
+
+var _ log.FieldSetReader = (*ComposerAuditLogResourceFieldSetReader)(nil)

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/fieldset_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_contract
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestComposerAuditLogResourceFieldSetReader(t *testing.T) {
+	reader := &ComposerAuditLogResourceFieldSetReader{}
+	testCases := []struct {
+		name    string
+		input   map[string]any
+		want    *ComposerAuditLogResourceFieldSet
+		wantErr bool
+	}{
+		{
+			name: "full resource labels",
+			input: map[string]any{
+				"resource": map[string]any{
+					"type": "cloud_composer_environment",
+					"labels": map[string]any{
+						"project_id":       "test-project",
+						"location":         "us-central1",
+						"environment_name": "cluster-8rlk9",
+					},
+				},
+			},
+			want: &ComposerAuditLogResourceFieldSet{
+				EnvironmentName: "cluster-8rlk9",
+				Location:        "us-central1",
+				ProjectID:       "test-project",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing labels default to unknown",
+			input: map[string]any{
+				"resource": map[string]any{
+					"type":   "cloud_composer_environment",
+					"labels": map[string]any{},
+				},
+			},
+			want: &ComposerAuditLogResourceFieldSet{
+				EnvironmentName: "unknown",
+				Location:        "unknown",
+				ProjectID:       "unknown",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := structured.FromGoValue(tc.input, &structured.AlphabeticalGoMapKeyOrderProvider{})
+			if err != nil {
+				t.Fatalf("failed to create structured node: %v", err)
+			}
+			nodeReader := structured.NewNodeReader(node)
+			gotFS, err := reader.Read(nodeReader)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Read() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			got, ok := gotFS.(*ComposerAuditLogResourceFieldSet)
+			if !ok {
+				t.Fatalf("Read() did not return *ComposerAuditLogResourceFieldSet, got %T", gotFS)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ComposerAuditLogResourceFieldSet mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/log_type.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/log_type.go
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package googlecloudclustercomposer_contract
+package googlecloudlogcomposerapiaudit_contract
 
 import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
 )
 
-// The following block defines the registered timeline style LogTypes.
-// These are registered as package-level variables so they are initialized immediately
-// when this package is imported.
 var (
-	LogTypeManagedAirflowEnvironment = style.MustRegisterLogType("managed airflow", "Managed Airflow Environment Logs", style.MustForceConvertSRGBHex("#88AA55"), style.ColorWhite)
+	// LogTypeManagedAirflowAPI is the log type style for Cloud Composer API audit logs.
+	LogTypeManagedAirflowAPI = style.MustRegisterLogType(
+		"Managed Airflow API",
+		"Managed Airflow API Logs",
+		style.MustForceConvertSRGBHex("#4285F4"),
+		style.ColorWhite,
+	)
 )

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/taskid.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_contract
+
+import (
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+)
+
+// ComposerAPIAuditLogTaskIDPrefix is the task ID prefix for Composer API audit log tasks.
+var ComposerAPIAuditLogTaskIDPrefix = "cloud.google.com/log/composer-api/"
+
+// ClusterIdentityTaskID is the task ID for aliasing the cluster/project identity.
+var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scommon_contract.GoogleCloudClusterIdentity](ComposerAPIAuditLogTaskIDPrefix + "cluster-identity")
+
+// ListLogEntriesTaskID is the task ID for the task that queries Composer API audit logs from Cloud Logging.
+var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](ComposerAPIAuditLogTaskIDPrefix + "query")
+
+// FieldSetReaderTaskID is the task ID to read field sets for processing Composer audit logs in later tasks.
+var FieldSetReaderTaskID = taskid.NewDefaultImplementationID[[]*log.Log](ComposerAPIAuditLogTaskIDPrefix + "fieldset-reader")
+
+// LogIngesterTaskID is the task ID to finalize Composer audit logs to be included in the final output.
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](ComposerAPIAuditLogTaskIDPrefix + "log-ingester")
+
+// LogGrouperTaskID is the task ID to group Composer audit logs by environment name.
+var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](ComposerAPIAuditLogTaskIDPrefix + "grouper")
+
+// LogToTimelineMapperTaskID is the task ID for associating events/revisions with Composer audit logs.
+var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](ComposerAPIAuditLogTaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/clusteridentity_task.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/clusteridentity_task.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_impl
+
+import (
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogcomposerapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract"
+)
+
+// ClusterIdentityAliasTask aliases the cluster identity task for Composer API audit log inspection.
+var ClusterIdentityAliasTask = coretask.NewAliasTask(
+	googlecloudlogcomposerapiaudit_contract.ClusterIdentityTaskID,
+	googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(),
+)

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/parser_tasks.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_impl
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudlogcomposerapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// FieldSetReaderTask reads and parses field sets from Cloud Composer audit logs.
+var FieldSetReaderTask = inspectiontaskbase.NewFieldSetReadTask(
+	googlecloudlogcomposerapiaudit_contract.FieldSetReaderTaskID,
+	googlecloudlogcomposerapiaudit_contract.ListLogEntriesTaskID.Ref(),
+	[]log.FieldSetReader{
+		&googlecloudcommon_contract.GCPOperationAuditLogFieldSetReader{},
+		&googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSetReader{},
+		&googlecloudcommon_contract.GCPDefaultSeverityFieldSetReader{},
+	},
+)
+
+// LogIngesterTask ingests Cloud Composer audit logs into KHI v6 format.
+var LogIngesterTask = googlecloudcommon_contract.NewGCPOperationLogIngesterTask(
+	googlecloudlogcomposerapiaudit_contract.LogIngesterTaskID,
+	googlecloudlogcomposerapiaudit_contract.FieldSetReaderTaskID.Ref(),
+	googlecloudlogcomposerapiaudit_contract.LogTypeManagedAirflowAPI,
+)
+
+// LogGrouperTask groups Cloud Composer audit logs by environment name.
+var LogGrouperTask = inspectiontaskbase.NewLogGrouperTask(
+	googlecloudlogcomposerapiaudit_contract.LogGrouperTaskID,
+	googlecloudlogcomposerapiaudit_contract.FieldSetReaderTaskID.Ref(),
+	func(ctx context.Context, l *log.Log) string {
+		resourceFieldSet, err := log.GetFieldSet(l, &googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{})
+		if err != nil {
+			return "unknown"
+		}
+		return resourceFieldSet.EnvironmentName
+	},
+)
+
+// LogToTimelineMapperTask maps Cloud Composer audit logs to timeline events and operation revisions.
+var LogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask[*googlecloudcommon_contract.GCPOperationTracker](
+	googlecloudlogcomposerapiaudit_contract.LogToTimelineMapperTaskID,
+	&composerAuditLogLogToTimelineMapperSetting{},
+	inspectioncore_contract.FeatureTaskLabel(
+		"Managed Airflow API Logs",
+		"Gather Managed Airflow API audit logs to visualize environment operations (creation, update, and deletion) on timelines.",
+		5500,
+		true,
+	),
+)
+
+type composerAuditLogLogToTimelineMapperSetting struct {
+	inspectiontaskbase.SinglePassMapperBase[*googlecloudcommon_contract.GCPOperationTracker]
+}
+
+// Dependencies returns additional task dependencies.
+func (s *composerAuditLogLogToTimelineMapperSetting) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// GroupedLogTask returns a reference to the log grouper task.
+func (s *composerAuditLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogcomposerapiaudit_contract.LogGrouperTaskID.Ref()
+}
+
+// LogIngesterTask returns a reference to the log ingester task.
+func (s *composerAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogcomposerapiaudit_contract.LogIngesterTaskID.Ref()
+}
+
+// ProcessLogByGroup maps a single Composer audit log entry to timeline events and revisions.
+func (s *composerAuditLogLogToTimelineMapperSetting) ProcessLogByGroup(
+	ctx context.Context,
+	l *log.Log,
+	tracker *googlecloudcommon_contract.GCPOperationTracker,
+) (*khifilev6.TimelineChangeSet, *googlecloudcommon_contract.GCPOperationTracker, error) {
+	if tracker == nil {
+		tracker = googlecloudcommon_contract.NewGCPOperationTracker()
+	}
+	commonFieldSet, err := log.GetFieldSet(l, &log.CommonFieldSet{})
+	if err != nil {
+		return nil, tracker, err
+	}
+	auditFieldSet, err := log.GetFieldSet(l, &googlecloudcommon_contract.GCPAuditLogFieldSet{})
+	if err != nil {
+		return nil, tracker, err
+	}
+	resourceFieldSet, err := log.GetFieldSet(l, &googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{})
+	if err != nil {
+		return nil, tracker, err
+	}
+
+	projectID := auditFieldSet.ProjectID
+	if projectID == "" || projectID == "unknown" {
+		projectID = resourceFieldSet.ProjectID
+	}
+
+	projectTimeline := googlecloudcommon_contract.MustGCPProjectTimeline(ctx, projectID)
+	envTimeline := googlecloudcommon_contract.MustManagedAirflowEnvironmentTimeline(ctx, projectTimeline, resourceFieldSet.EnvironmentName)
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+
+	methodNameParts := strings.Split(auditFieldSet.MethodName, ".")
+	shortMethodName := methodNameParts[len(methodNameParts)-1]
+
+	if auditFieldSet.ImmediateOperation() {
+		cs.AddEvent(envTimeline)
+		return cs, tracker, nil
+	}
+
+	operationTimeline := googlecloudcommon_contract.MustGCPOperationTimeline(ctx, envTimeline, shortMethodName, auditFieldSet.OperationID)
+
+	switch shortMethodName {
+	case "CreateEnvironment":
+		var bodyNode structured.Node
+		if auditFieldSet.Request != nil {
+			if subReader, err := auditFieldSet.Request.GetReader("environment"); err == nil {
+				bodyNode = subReader.Node
+			} else {
+				bodyNode = auditFieldSet.Request.Node
+			}
+		}
+
+		if auditFieldSet.Ending() && !tracker.HasStarted(auditFieldSet.OperationID) {
+			cs.AddRevision(envTimeline, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentProvisioningLogNotFound,
+				Principal:    auditFieldSet.PrincipalEmail,
+				ChangedTime:  time.Unix(0, 0),
+				ResourceBody: nil,
+			})
+			tracker.MarkResourceRevision(envTimeline)
+		}
+
+		var state *pb.RevisionState
+		if auditFieldSet.Ending() {
+			state = googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentExisting
+		} else {
+			state = googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentProvisioning
+		}
+
+		cs.AddRevision(envTimeline, &khifilev6.StagingRevision{
+			VerbType:     commonlogk8saudit_contract.VerbCreate,
+			StateType:    state,
+			Principal:    auditFieldSet.PrincipalEmail,
+			ChangedTime:  commonFieldSet.Timestamp,
+			ResourceBody: bodyNode,
+		})
+		tracker.MarkResourceRevision(envTimeline)
+
+	case "DeleteEnvironment":
+		if !auditFieldSet.Ending() && !tracker.HasResourceRevision(envTimeline) {
+			cs.AddRevision(envTimeline, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbCreate,
+				StateType:    googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentExistingLogNotFound,
+				Principal:    auditFieldSet.PrincipalEmail,
+				ChangedTime:  time.Unix(0, 0),
+				ResourceBody: nil,
+			})
+			tracker.MarkResourceRevision(envTimeline)
+		}
+
+		if auditFieldSet.Ending() && !tracker.HasStarted(auditFieldSet.OperationID) {
+			cs.AddRevision(envTimeline, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbDelete,
+				StateType:    googlecloudclustercomposer_contract.RevisionManagedAirflowEnvironmentDeletingLogNotFound,
+				Principal:    auditFieldSet.PrincipalEmail,
+				ChangedTime:  time.Unix(0, 0),
+				ResourceBody: nil,
+			})
+			tracker.MarkResourceRevision(envTimeline)
+		}
+
+		var state *pb.RevisionState
+		if auditFieldSet.Ending() {
+			state = googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentDeleted
+		} else {
+			state = googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentDeleting
+		}
+
+		cs.AddRevision(envTimeline, &khifilev6.StagingRevision{
+			VerbType:     commonlogk8saudit_contract.VerbDelete,
+			StateType:    state,
+			Principal:    auditFieldSet.PrincipalEmail,
+			ChangedTime:  commonFieldSet.Timestamp,
+			ResourceBody: nil,
+		})
+		tracker.MarkResourceRevision(envTimeline)
+	}
+
+	tracker.ProcessOperationLog(ctx, cs, operationTimeline, auditFieldSet, commonFieldSet.Timestamp)
+
+	return cs, tracker, nil
+}
+
+var _ inspectiontaskbase.LogToTimelineMapper[*googlecloudcommon_contract.GCPOperationTracker] = (*composerAuditLogLogToTimelineMapperSetting)(nil)

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/parser_tasks_test.go
@@ -1,0 +1,416 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_impl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudlogcomposerapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+	"github.com/google/go-cmp/cmp"
+)
+
+func testReaderFromYAML(t *testing.T, yaml string) *structured.NodeReader {
+	t.Helper()
+	node, err := structured.FromYAML(yaml)
+	if err != nil {
+		t.Fatalf("failed to parse yaml: %v", err)
+	}
+	return structured.NewNodeReader(node)
+}
+
+var compareNodeOption = cmp.Transformer("StructuredNodeToYAML", func(n structured.Node) string {
+	if n == nil {
+		return ""
+	}
+	serializer := &structured.YAMLNodeSerializer{}
+	bytes, err := serializer.Serialize(n)
+	if err != nil {
+		return "serialization error"
+	}
+	return string(bytes)
+})
+
+func TestComposerAuditLogToTimelineMapper(t *testing.T) {
+	testTime := time.Date(2026, time.August, 10, 0, 23, 12, 0, time.UTC)
+	testCommonFieldSet := &log.CommonFieldSet{
+		Timestamp: testTime,
+	}
+
+	testCases := []struct {
+		desc          string
+		inputResource googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet
+		inputAudit    googlecloudcommon_contract.GCPAuditLogFieldSet
+		setupTracker  func(tracker *googlecloudcommon_contract.GCPOperationTracker, envPath *khifilev6.TimelinePath)
+		assert        func(t *testing.T, cs *khifilev6.TimelineChangeSet, envPath *khifilev6.TimelinePath, opPath *khifilev6.TimelinePath)
+	}{
+		{
+			desc: "CreateEnvironment operation started adds provisioning revision and operation start",
+			inputResource: googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+				EnvironmentName: "test-environment",
+				Location:        "us-central1",
+				ProjectID:       "test-project",
+			},
+			inputAudit: googlecloudcommon_contract.GCPAuditLogFieldSet{
+				ProjectID:      "test-project",
+				OperationID:    "op-create-1",
+				OperationFirst: true,
+				OperationLast:  false,
+				MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+				PrincipalEmail: "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+				Request: testReaderFromYAML(t, `environment:
+  name: projects/test-project/locations/us-central1/environments/test-environment
+  config:
+    softwareConfig:
+      imageVersion: composer-3-airflow-2`),
+			},
+			setupTracker: func(tracker *googlecloudcommon_contract.GCPOperationTracker, envPath *khifilev6.TimelinePath) {},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, envPath *khifilev6.TimelinePath, opPath *khifilev6.TimelinePath) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(envPath, &khifilev6.StagingRevision{
+						VerbType:    commonlogk8saudit_contract.VerbCreate,
+						StateType:   googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentProvisioning,
+						Principal:   "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime: testTime,
+						ResourceBody: testReaderFromYAML(t, `name: projects/test-project/locations/us-central1/environments/test-environment
+config:
+  softwareConfig:
+    imageVersion: composer-3-airflow-2`).Node,
+					}, compareNodeOption).
+					HasRevision(opPath, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationStart,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationStarted,
+						Principal:   "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime: testTime,
+						ResourceBody: testReaderFromYAML(t, `environment:
+  name: projects/test-project/locations/us-central1/environments/test-environment
+  config:
+    softwareConfig:
+      imageVersion: composer-3-airflow-2`).Node,
+					}, compareNodeOption)
+			},
+		},
+		{
+			desc: "CreateEnvironment operation finished with start seen adds existing revision and operation succeed",
+			inputResource: googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+				EnvironmentName: "test-environment",
+				Location:        "us-central1",
+				ProjectID:       "test-project",
+			},
+			inputAudit: googlecloudcommon_contract.GCPAuditLogFieldSet{
+				ProjectID:      "test-project",
+				OperationID:    "op-create-1",
+				OperationFirst: false,
+				OperationLast:  true,
+				MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+				PrincipalEmail: "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+				Status:         0,
+			},
+			setupTracker: func(tracker *googlecloudcommon_contract.GCPOperationTracker, envPath *khifilev6.TimelinePath) {
+				tracker.MarkStarted("op-create-1")
+				tracker.MarkResourceRevision(envPath)
+			},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, envPath *khifilev6.TimelinePath, opPath *khifilev6.TimelinePath) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(envPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentExisting,
+						Principal:    "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+					}, compareNodeOption).
+					HasRevision(opPath, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationSucceed,
+						Principal:   "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime: testTime,
+					}, compareNodeOption)
+			},
+		},
+		{
+			desc: "CreateEnvironment operation finished without start log seen prepends LogNotFound revisions",
+			inputResource: googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+				EnvironmentName: "test-environment",
+				Location:        "us-central1",
+				ProjectID:       "test-project",
+			},
+			inputAudit: googlecloudcommon_contract.GCPAuditLogFieldSet{
+				ProjectID:      "test-project",
+				OperationID:    "op-create-missing-start",
+				OperationFirst: false,
+				OperationLast:  true,
+				MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+				PrincipalEmail: "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+				Status:         0,
+			},
+			setupTracker: func(tracker *googlecloudcommon_contract.GCPOperationTracker, envPath *khifilev6.TimelinePath) {},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, envPath *khifilev6.TimelinePath, opPath *khifilev6.TimelinePath) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(envPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentProvisioningLogNotFound,
+						Principal:    "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+					}, compareNodeOption).
+					HasRevision(envPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentExisting,
+						Principal:    "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+					}, compareNodeOption).
+					HasRevision(opPath, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationStart,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationStartedLogNotFound,
+						Principal:   "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime: time.Unix(0, 0),
+					}, compareNodeOption).
+					HasRevision(opPath, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationSucceed,
+						Principal:   "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime: testTime,
+					}, compareNodeOption)
+			},
+		},
+		{
+			desc: "DeleteEnvironment operation started adds deleting revision",
+			inputResource: googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+				EnvironmentName: "test-environment",
+				Location:        "us-central1",
+				ProjectID:       "test-project",
+			},
+			inputAudit: googlecloudcommon_contract.GCPAuditLogFieldSet{
+				ProjectID:      "test-project",
+				OperationID:    "op-delete-1",
+				OperationFirst: true,
+				OperationLast:  false,
+				MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.DeleteEnvironment",
+				PrincipalEmail: "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+			},
+			setupTracker: func(tracker *googlecloudcommon_contract.GCPOperationTracker, envPath *khifilev6.TimelinePath) {},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, envPath *khifilev6.TimelinePath, opPath *khifilev6.TimelinePath) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(envPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbCreate,
+						StateType:    googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentExistingLogNotFound,
+						Principal:    "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime:  time.Unix(0, 0),
+						ResourceBody: nil,
+					}, compareNodeOption).
+					HasRevision(envPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbDelete,
+						StateType:    googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentDeleting,
+						Principal:    "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+					}, compareNodeOption).
+					HasRevision(opPath, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationStart,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationStarted,
+						Principal:   "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime: testTime,
+					}, compareNodeOption)
+			},
+		},
+		{
+			desc: "DeleteEnvironment operation finished with start seen adds deleted revision",
+			inputResource: googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+				EnvironmentName: "test-environment",
+				Location:        "us-central1",
+				ProjectID:       "test-project",
+			},
+			inputAudit: googlecloudcommon_contract.GCPAuditLogFieldSet{
+				ProjectID:      "test-project",
+				OperationID:    "op-delete-1",
+				OperationFirst: false,
+				OperationLast:  true,
+				MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.DeleteEnvironment",
+				PrincipalEmail: "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+				Status:         0,
+			},
+			setupTracker: func(tracker *googlecloudcommon_contract.GCPOperationTracker, envPath *khifilev6.TimelinePath) {
+				tracker.MarkStarted("op-delete-1")
+				tracker.MarkResourceRevision(envPath)
+			},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, envPath *khifilev6.TimelinePath, opPath *khifilev6.TimelinePath) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(envPath, &khifilev6.StagingRevision{
+						VerbType:     commonlogk8saudit_contract.VerbDelete,
+						StateType:    googlecloudclustercomposer_contract.RevisionStateManagedAirflowEnvironmentDeleted,
+						Principal:    "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+					}, compareNodeOption).
+					HasRevision(opPath, &khifilev6.StagingRevision{
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationSucceed,
+						Principal:   "serviceAccount:khi-sa@test-project.iam.gserviceaccount.com",
+						ChangedTime: testTime,
+					}, compareNodeOption)
+			},
+		},
+		{
+			desc: "immediate operation creates event on environment timeline",
+			inputResource: googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+				EnvironmentName: "test-environment",
+				Location:        "us-central1",
+				ProjectID:       "test-project",
+			},
+			inputAudit: googlecloudcommon_contract.GCPAuditLogFieldSet{
+				ProjectID:      "test-project",
+				OperationID:    "",
+				OperationFirst: false,
+				OperationLast:  false,
+				MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.GetEnvironment",
+				PrincipalEmail: "user@example.com",
+			},
+			setupTracker: func(tracker *googlecloudcommon_contract.GCPOperationTracker, envPath *khifilev6.TimelinePath) {},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, envPath *khifilev6.TimelinePath, opPath *khifilev6.TimelinePath) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(envPath)
+			},
+		},
+	}
+
+	mapperSetting := &composerAuditLogLogToTimelineMapperSetting{}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			builder := khifilev6.NewBuilder()
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+			projectTimeline := googlecloudcommon_contract.MustGCPProjectTimeline(ctx, tc.inputResource.ProjectID)
+			envTimeline := googlecloudcommon_contract.MustManagedAirflowEnvironmentTimeline(ctx, projectTimeline, tc.inputResource.EnvironmentName)
+
+			var opTimeline *khifilev6.TimelinePath
+			if !tc.inputAudit.ImmediateOperation() {
+				opTimeline = googlecloudcommon_contract.MustGCPOperationTimeline(ctx, envTimeline, "CreateEnvironment", tc.inputAudit.OperationID)
+				if tc.inputAudit.MethodName == "google.cloud.orchestration.airflow.service.v1.Environments.DeleteEnvironment" {
+					opTimeline = googlecloudcommon_contract.MustGCPOperationTimeline(ctx, envTimeline, "DeleteEnvironment", tc.inputAudit.OperationID)
+				}
+			}
+
+			tracker := googlecloudcommon_contract.NewGCPOperationTracker()
+			tc.setupTracker(tracker, envTimeline)
+
+			l := log.NewLogWithFieldSetsForTest(testCommonFieldSet, &tc.inputAudit, &tc.inputResource)
+
+			cs, _, err := mapperSetting.ProcessLogByGroup(ctx, l, tracker)
+			if err != nil {
+				t.Fatalf("ProcessLogByGroup() error = %v", err)
+			}
+
+			if envTimeline.Parent == nil || envTimeline.Parent.Type.GetId() != googlecloudcommon_contract.TimelineTypeGCPProject.GetId() {
+				t.Errorf("expected envTimeline parent to be GCPProject timeline, got %v", envTimeline.Parent)
+			}
+			if diff := cmp.Diff(googlecloudcommon_contract.TimelineTypeManagedAirflowEnvironment.GetId(), envTimeline.Type.GetId()); diff != "" {
+				t.Errorf("expected envTimeline type to be ComposerEnvironment, diff (-want +got):\n%s", diff)
+			}
+
+			tc.assert(t, cs, envTimeline, opTimeline)
+		})
+	}
+}
+
+func TestComposerAuditLogIngester(t *testing.T) {
+	testTime := time.Date(2026, time.August, 10, 0, 23, 12, 0, time.UTC)
+	ingester := googlecloudcommon_contract.NewGCPOperationLogIngester(
+		googlecloudlogcomposerapiaudit_contract.FieldSetReaderTaskID.Ref(),
+		googlecloudlogcomposerapiaudit_contract.LogTypeManagedAirflowAPI,
+	)
+
+	testCases := []struct {
+		desc       string
+		inputLog   *log.Log
+		wantSumm   string
+		wantStatus int
+	}{
+		{
+			desc: "operation start log",
+			inputLog: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: testTime},
+				&inspectioncore_contract.DefaultSeverityFieldSet{Severity: inspectioncore_contract.SeverityInfo},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+					OperationFirst: true,
+					OperationLast:  false,
+					Status:         -1,
+				},
+				&googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+					EnvironmentName: "test-environment",
+				},
+			),
+			wantSumm: "Start: google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+		},
+		{
+			desc: "operation succeeded log",
+			inputLog: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: testTime},
+				&inspectioncore_contract.DefaultSeverityFieldSet{Severity: inspectioncore_contract.SeverityInfo},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+					OperationFirst: false,
+					OperationLast:  true,
+					Status:         -1,
+				},
+				&googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+					EnvironmentName: "test-environment",
+				},
+			),
+			wantSumm: "Succeeded: google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+		},
+		{
+			desc: "operation failed log",
+			inputLog: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{Timestamp: testTime},
+				&inspectioncore_contract.DefaultSeverityFieldSet{Severity: inspectioncore_contract.SeverityError},
+				&googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+					OperationFirst: false,
+					OperationLast:  true,
+					Status:         3,
+					StatusMessage:  "INVALID_ARGUMENT: invalid location",
+				},
+				&googlecloudlogcomposerapiaudit_contract.ComposerAuditLogResourceFieldSet{
+					EnvironmentName: "test-environment",
+				},
+			),
+			wantSumm: "Failed: [3: INVALID_ARGUMENT: invalid location] google.cloud.orchestration.airflow.service.v1.Environments.CreateEnvironment",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cs, err := ingester.ProcessLog(t.Context(), tc.inputLog)
+			if err != nil {
+				t.Fatalf("ProcessLog() error = %v", err)
+			}
+			testchangeset.AssertLog(t, cs).
+				HasSummary(tc.wantSumm).
+				HasLogType(googlecloudlogcomposerapiaudit_contract.LogTypeManagedAirflowAPI)
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/query_task.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_impl
+
+import (
+	"context"
+	"fmt"
+
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudlogcomposerapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// GenerateComposerAuditQuery generates a Cloud Logging filter string for Cloud Composer audit logs.
+func GenerateComposerAuditQuery(projectID, location, environmentName string) string {
+	locationFilter := ""
+	if location != "" && location != "all" {
+		locationFilter = fmt.Sprintf("resource.labels.location=\"%s\"\n", location)
+	}
+	environmentFilter := ""
+	if environmentName != "" {
+		environmentFilter = fmt.Sprintf("resource.labels.environment_name=\"%s\"\n", environmentName)
+	}
+
+	return fmt.Sprintf(`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+resource.type="cloud_composer_environment"
+resource.labels.project_id="%s"
+%s%sprotoPayload.serviceName="composer.googleapis.com"
+`, projectID, locationFilter, environmentFilter)
+}
+
+type composerAPIListLogEntriesTaskSetting struct{}
+
+// DefaultResourceNames returns the resource name for Cloud Logging queries.
+func (s *composerAPIListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogcomposerapiaudit_contract.ClusterIdentityTaskID.Ref())
+	return []string{fmt.Sprintf("projects/%s", clusterIdentity.ProjectID)}, nil
+}
+
+// Dependencies returns task dependencies for query construction.
+func (s *composerAPIListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{
+		googlecloudlogcomposerapiaudit_contract.ClusterIdentityTaskID.Ref(),
+		googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref(),
+	}
+}
+
+// Description returns user-facing task metadata and example query.
+func (s *composerAPIListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
+	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
+		QueryName:    "Composer API Audit logs",
+		ExampleQuery: GenerateComposerAuditQuery("test-project", "us-central1", "test-environment"),
+	}
+}
+
+// LogFilters returns the Cloud Logging query string.
+func (s *composerAPIListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogcomposerapiaudit_contract.ClusterIdentityTaskID.Ref())
+	environmentName := coretask.GetTaskResult(ctx, googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref())
+	return []string{GenerateComposerAuditQuery(clusterIdentity.ProjectID, clusterIdentity.Location, environmentName)}, nil
+}
+
+// TaskID returns the implementation ID of this query task.
+func (s *composerAPIListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
+	return googlecloudlogcomposerapiaudit_contract.ListLogEntriesTaskID
+}
+
+// TimePartitionCount returns the number of time partitions to use when querying logs.
+func (s *composerAPIListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
+	return 1, nil
+}
+
+var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*composerAPIListLogEntriesTaskSetting)(nil)
+
+// ListLogEntriesTask is the task that queries Cloud Composer audit logs from Cloud Logging.
+var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&composerAPIListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/query_task_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_impl
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGenerateComposerAuditQuery(t *testing.T) {
+	testCases := []struct {
+		name            string
+		projectID       string
+		location        string
+		environmentName string
+		want            string
+	}{
+		{
+			name:            "with location and environment name",
+			projectID:       "my-project",
+			location:        "us-central1",
+			environmentName: "env-1",
+			want: `(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+resource.type="cloud_composer_environment"
+resource.labels.project_id="my-project"
+resource.labels.location="us-central1"
+resource.labels.environment_name="env-1"
+protoPayload.serviceName="composer.googleapis.com"
+`,
+		},
+		{
+			name:            "empty location and environment name",
+			projectID:       "my-project",
+			location:        "",
+			environmentName: "",
+			want: `(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+resource.type="cloud_composer_environment"
+resource.labels.project_id="my-project"
+protoPayload.serviceName="composer.googleapis.com"
+`,
+		},
+		{
+			name:            "location all",
+			projectID:       "my-project",
+			location:        "all",
+			environmentName: "env-1",
+			want: `(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
+resource.type="cloud_composer_environment"
+resource.labels.project_id="my-project"
+resource.labels.environment_name="env-1"
+protoPayload.serviceName="composer.googleapis.com"
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GenerateComposerAuditQuery(tc.projectID, tc.location, tc.environmentName)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GenerateComposerAuditQuery() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/registration.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogcomposerapiaudit_impl
+
+import (
+	coreinspection "github.com/GoogleCloudPlatform/khi/pkg/core/inspection"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// Register registers all googlecloudlogcomposerapiaudit inspection tasks to the registry.
+func Register(registry coreinspection.InspectionTaskRegistry) error {
+	scopedWithLogSource := coreinspection.NewScopedRegistry(
+		registry,
+		inspectioncore_contract.InspectionTypeLabelSelector(map[string]string{
+			inspectioncore_contract.InspectionTypeLabelKeyLogSource:      "cloud_logging",
+			inspectioncore_contract.InspectionTypeLabelKeyEnvironment:    "googlecloud",
+			inspectioncore_contract.InspectionTypeLabelKeyBasePlatform:   "kubernetes",
+			googlecloudcommon_contract.InspectionTypeLabelKeyClusterType: "gke",
+			googlecloudcommon_contract.InspectionTypeLabelKeyProduct:     "composer",
+		}),
+	)
+	if err := coretask.RegisterTasks(scopedWithLogSource, ListLogEntriesTask); err != nil {
+		return err
+	}
+
+	scoped := coreinspection.NewScopedRegistry(
+		registry,
+		inspectioncore_contract.InspectionTypeLabelSelector(map[string]string{
+			inspectioncore_contract.InspectionTypeLabelKeyEnvironment:    "googlecloud",
+			inspectioncore_contract.InspectionTypeLabelKeyBasePlatform:   "kubernetes",
+			googlecloudcommon_contract.InspectionTypeLabelKeyClusterType: "gke",
+			googlecloudcommon_contract.InspectionTypeLabelKeyProduct:     "composer",
+		}),
+	)
+	return coretask.RegisterTasks(scoped,
+		ClusterIdentityAliasTask,
+		FieldSetReaderTask,
+		LogGrouperTask,
+		LogIngesterTask,
+		LogToTimelineMapperTask,
+	)
+}


### PR DESCRIPTION
### Summary
This PR adds support for Cloud Composer (`composer.googleapis.com`) API audit logs to KHI, allowing users to inspect environment-level operations and lifecycle transitions directly on the timeline.
### Key Changes
1. **New Inspection Package (`googlecloudlogcomposerapiaudit`)**:
   - **FieldSet Reader**: Implemented `ComposerAuditLogResourceFieldSet` (`fieldset.go`) to extract `environment_name`, `location`, and `project_id` from `resource.labels`.
   - **Log Type & Task Definitions**: Registered `LogTypeManagedAirflowAPI` (`log_type.go`) and task IDs.
   - **Query Generation**: Created query generator task filtering `log_id("cloudaudit.googleapis.com/activity")` and `serviceName="composer.googleapis.com"` (`query_task.go`).
   - **Ingester & Timeline Mapper**: Added `LogIngesterTask` and `LogToTimelineMapperTask` (`parser_tasks.go`) to map audit logs to operations and environment lifecycle revisions.
   - **Task Registration**: Registered under the `product: composer` inspection selector (`registration.go`).
2. **Timeline Structure & Hierarchy**:
   - Registered `TimelineTypeManagedAirflowEnvironment` (`Managed Airflow`) under GCP Project in `googlecloudcommon` (`timeline_type.go`).
   - Implemented `MustManagedAirflowEnvironmentTimeline(ctx, projectPath, environmentName)` (`timeline.go`).
   - Kept internal Airflow components (Scheduler, Worker, DAGs, Task Instances) timelines as root-level timelines.
3. **Lifecycle Revision States**:
   - Added `RevisionStateManagedAirflowEnvironment*` states matching GKE cluster/nodepool styling, labels, and icons in `revision_state.go`:
     - `CreateEnvironment`: `Environment is being provisioned` ➔ `Environment exists` (with `Log Not Found` fallback).
     - `DeleteEnvironment`: `Environment is being deleted` ➔ `Environment is deleted` (with `Log Not Found` fallback).
4. **Common GCP Contract Enhancements**:
   - Added `principalSubject` fallback in `GCPOperationAuditLogFieldSetReader` (`fieldset.go`) to support Workload Identity Service Accounts where `principalEmail` is empty.
   - Added `MarkStarted(operationID string)` helper in `GCPOperationTracker` (`operation_tracker.go`).
### Verification
- `make build-go`: Passed.
- `make test-go`: All backend tests passed.
- `make lint-go`: Passed with 0 issues.
- `make pre-commit`: All format and lint checks passed.