### PR TITLE
feat(composer): use cloud monitoring metrics for historical GKE cluster discovery in composer

### DIFF
--- a/pkg/api/googlecloud/clientfactory.go
+++ b/pkg/api/googlecloud/clientfactory.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	container "cloud.google.com/go/container/apiv1"
 	logging "cloud.google.com/go/logging/apiv2"
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"google.golang.org/api/composer/v1"
@@ -46,29 +45,26 @@ type ClientFactory struct {
 	ClientOptions    []ClientFactoryOptionsModifiers
 	ContextModifiers []ClientFactoryContextModifiers
 
-	ContainerClusterManagerClientOptions []ClientFactoryOptionsModifiers
-	LoggingClientOptions                 []ClientFactoryOptionsModifiers
-	RegionsClientOptions                 []ClientFactoryOptionsModifiers
-	ComposerServiceOptions               []ClientFactoryOptionsModifiers
-	MonitoringMetricClientOptions        []ClientFactoryOptionsModifiers
+	LoggingClientOptions          []ClientFactoryOptionsModifiers
+	RegionsClientOptions          []ClientFactoryOptionsModifiers
+	ComposerServiceOptions        []ClientFactoryOptionsModifiers
+	MonitoringMetricClientOptions []ClientFactoryOptionsModifiers
 
-	mu                                  sync.Mutex
-	containerClusterManagerClientsCache map[string]*container.ClusterManagerClient
-	loggingClientsCache                 map[string]*logging.Client
-	regionsClientsCache                 map[string]*compute.RegionsClient
-	composerServicesCache               map[string]*composer.Service
-	monitoringMetricClientsCache        map[string]*monitoring.MetricClient
+	mu                           sync.Mutex
+	loggingClientsCache          map[string]*logging.Client
+	regionsClientsCache          map[string]*compute.RegionsClient
+	composerServicesCache        map[string]*composer.Service
+	monitoringMetricClientsCache map[string]*monitoring.MetricClient
 }
 
 // NewClientFactory creates a new ClientFactory with the given options.
 // It applies each option to the factory and returns an error if any option fails.
 func NewClientFactory(options ...ClientFactoryOption) (*ClientFactory, error) {
 	var factory = &ClientFactory{
-		containerClusterManagerClientsCache: make(map[string]*container.ClusterManagerClient),
-		loggingClientsCache:                 make(map[string]*logging.Client),
-		regionsClientsCache:                 make(map[string]*compute.RegionsClient),
-		composerServicesCache:               make(map[string]*composer.Service),
-		monitoringMetricClientsCache:        make(map[string]*monitoring.MetricClient),
+		loggingClientsCache:          make(map[string]*logging.Client),
+		regionsClientsCache:          make(map[string]*compute.RegionsClient),
+		composerServicesCache:        make(map[string]*composer.Service),
+		monitoringMetricClientsCache: make(map[string]*monitoring.MetricClient),
 	}
 	for _, opt := range options {
 		err := opt(factory)
@@ -119,11 +115,6 @@ func (s *ClientFactory) prepareServiceInput(ctx context.Context, c ResourceConta
 	return ctx, options, err
 }
 
-// ContainerClusterManagerClient returns the ClusterManagerClient of container.googleapis.com from given context and the resource container.
-func (s *ClientFactory) ContainerClusterManagerClient(ctx context.Context, c ResourceContainer, opts ...option.ClientOption) (*container.ClusterManagerClient, error) {
-	return getOrInitClient(s, ctx, c, s.containerClusterManagerClientsCache, s.ContainerClusterManagerClientOptions, opts, container.NewClusterManagerClient)
-}
-
 // LoggingClient returns the client for logging.googleapis.com from given context and the resource container.
 func (s *ClientFactory) LoggingClient(ctx context.Context, c ResourceContainer, opts ...option.ClientOption) (*logging.Client, error) {
 	return getOrInitClient(s, ctx, c, s.loggingClientsCache, s.LoggingClientOptions, opts, logging.NewClient)
@@ -156,12 +147,6 @@ func (s *ClientFactory) Close() error {
 			errs = append(errs, fmt.Errorf("failed to close logging client for %s: %w", k, err))
 		}
 		delete(s.loggingClientsCache, k)
-	}
-	for k, client := range s.containerClusterManagerClientsCache {
-		if err := client.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to close container cluster manager client for %s: %w", k, err))
-		}
-		delete(s.containerClusterManagerClientsCache, k)
 	}
 	for k, client := range s.regionsClientsCache {
 		if err := client.Close(); err != nil {

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
+	"time"
 
-	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
@@ -28,35 +30,65 @@ import (
 var ErrEnvironmentClusterNotFound = errors.New("not found")
 
 type ComposerEnvironmentClusterFinder interface {
-	GetGKEClusterName(ctx context.Context, projectID, environment string) (string, error)
+	GetGKEClusterNames(ctx context.Context, projectID, location, environment string, startTime, endTime time.Time) ([]string, error)
 }
 
 type EnvironmentClusterFinderImpl struct{}
 
-// GetGKEClusterName implements EnvironmentClusterFinder.
-func (e *EnvironmentClusterFinderImpl) GetGKEClusterName(ctx context.Context, projectID string, environment string) (string, error) {
+// GetGKEClusterNames implements ComposerEnvironmentClusterFinder.
+func (e *EnvironmentClusterFinderImpl) GetGKEClusterNames(ctx context.Context, projectID, location, environment string, startTime, endTime time.Time) ([]string, error) {
 	cf := coretask.GetTaskResult(ctx, googlecloudcommon_contract.APIClientFactoryTaskID.Ref())
 	injector := coretask.GetTaskResult(ctx, googlecloudcommon_contract.APIClientCallOptionsInjectorTaskID.Ref())
 
-	containerClusterManagerClient, err := cf.ContainerClusterManagerClient(ctx, googlecloud.Project(projectID))
+	client, err := cf.MonitoringMetricClient(ctx, googlecloud.Project(projectID))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	ctx = injector.InjectToCallContext(ctx, googlecloud.Project(projectID))
-	cluster, err := containerClusterManagerClient.ListClusters(ctx, &containerpb.ListClustersRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/-", projectID),
-	})
+	filter := `metric.type="kubernetes.io/container/uptime" AND resource.type="k8s_container"`
+	metricsLabels, err := googlecloud.QueryResourceLabelsFromMetrics(ctx, client, projectID, filter, startTime, endTime, []string{"resource.label.cluster_name", "resource.label.location"})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	for _, c := range cluster.Clusters {
-		if c.ResourceLabels["goog-composer-environment"] == environment {
-			return c.Name, nil
+	matchedClusters := filterAndMatchComposerGKEClusterNames(metricsLabels, location, environment)
+	if len(matchedClusters) == 0 {
+		return nil, ErrEnvironmentClusterNotFound
+	}
+	return matchedClusters, nil
+}
+
+// filterAndMatchComposerGKEClusterNames extracts and deduplicates GKE cluster names matching the Cloud Composer naming convention.
+// A Composer GKE cluster name follows the pattern: <location>-<environment>-<hash (8 chars)>-gke.
+func filterAndMatchComposerGKEClusterNames(metricsLabels []map[string]string, location, environment string) []string {
+	if environment == "" {
+		return nil
+	}
+	expectedPrefix := fmt.Sprintf("%s-%s-", location, environment)
+	seen := make(map[string]struct{})
+	var result []string
+
+	for _, labels := range metricsLabels {
+		cName := labels["cluster_name"]
+		cLoc := labels["location"]
+		if location != "" && cLoc != "" && cLoc != location {
+			continue
+		}
+		if !strings.HasPrefix(cName, expectedPrefix) || !strings.HasSuffix(cName, "-gke") {
+			continue
+		}
+		body := strings.TrimSuffix(cName, "-gke")
+		hashPart := strings.TrimPrefix(body, expectedPrefix)
+		if len(hashPart) == 8 {
+			if _, exists := seen[cName]; !exists {
+				seen[cName] = struct{}{}
+				result = append(result, cName)
+			}
 		}
 	}
-	return "", ErrEnvironmentClusterNotFound
+	sort.Strings(result)
+	return result
 }
 
 var _ ComposerEnvironmentClusterFinder = (*EnvironmentClusterFinderImpl)(nil)

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder.go
@@ -17,7 +17,6 @@ package googlecloudclustercomposer_contract
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -59,28 +58,46 @@ func (e *EnvironmentClusterFinderImpl) GetGKEClusterNames(ctx context.Context, p
 	return matchedClusters, nil
 }
 
+// extractEnvironmentPrefixCandidate extracts the environment prefix candidate from a GKE cluster name created by Cloud Composer.
+// Expected cluster name format: <location>-<candidate>-<hash>-gke.
+// Returns the extracted candidate environment string and a boolean indicating whether the cluster name matches the Cloud Composer naming convention.
+func extractEnvironmentPrefixCandidate(clusterName, location string) (string, bool) {
+	if !strings.HasSuffix(clusterName, "-gke") {
+		return "", false
+	}
+	body := strings.TrimSuffix(clusterName, "-gke")
+	if !strings.HasPrefix(body, location+"-") {
+		return "", false
+	}
+	rest := strings.TrimPrefix(body, location+"-")
+	lastDashIdx := strings.LastIndex(rest, "-")
+	if lastDashIdx == -1 {
+		return "", false
+	}
+	return rest[:lastDashIdx], true
+}
+
 // filterAndMatchComposerGKEClusterNames extracts and deduplicates GKE cluster names matching the Cloud Composer naming convention.
-// A Composer GKE cluster name follows the pattern: <location>-<environment>-<hash (8 chars)>-gke.
+// A Composer GKE cluster name follows the pattern: <location>-<candidate>-<hash>-gke.
+// Note that <candidate> may be a truncated prefix of the full environment name to stay within GKE length limits.
 func filterAndMatchComposerGKEClusterNames(metricsLabels []map[string]string, location, environment string) []string {
-	if environment == "" {
+	if location == "" {
 		return nil
 	}
-	expectedPrefix := fmt.Sprintf("%s-%s-", location, environment)
 	seen := make(map[string]struct{})
 	var result []string
 
 	for _, labels := range metricsLabels {
 		cName := labels["cluster_name"]
 		cLoc := labels["location"]
-		if location != "" && cLoc != "" && cLoc != location {
+		if cLoc != "" && cLoc != location {
 			continue
 		}
-		if !strings.HasPrefix(cName, expectedPrefix) || !strings.HasSuffix(cName, "-gke") {
+		candidate, ok := extractEnvironmentPrefixCandidate(cName, location)
+		if !ok {
 			continue
 		}
-		body := strings.TrimSuffix(cName, "-gke")
-		hashPart := strings.TrimPrefix(body, expectedPrefix)
-		if len(hashPart) == 8 {
+		if environment != "" && strings.HasPrefix(environment, candidate) {
 			if _, exists := seen[cName]; !exists {
 				seen[cName] = struct{}{}
 				result = append(result, cName)

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudclustercomposer_contract
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFilterAndMatchComposerGKEClusterNames(t *testing.T) {
+	testCases := []struct {
+		name          string
+		metricsLabels []map[string]string
+		location      string
+		environment   string
+		want          []string
+	}{
+		{
+			name: "matches single cluster",
+			metricsLabels: []map[string]string{
+				{
+					"cluster_name": "asia-northeast1-my-env-12345678-gke",
+					"location":     "asia-northeast1",
+				},
+			},
+			location:    "asia-northeast1",
+			environment: "my-env",
+			want:        []string{"asia-northeast1-my-env-12345678-gke"},
+		},
+		{
+			name: "matches multiple past clusters and sorts them",
+			metricsLabels: []map[string]string{
+				{
+					"cluster_name": "asia-northeast1-my-env-87654321-gke",
+					"location":     "asia-northeast1",
+				},
+				{
+					"cluster_name": "asia-northeast1-my-env-12345678-gke",
+					"location":     "asia-northeast1",
+				},
+			},
+			location:    "asia-northeast1",
+			environment: "my-env",
+			want: []string{
+				"asia-northeast1-my-env-12345678-gke",
+				"asia-northeast1-my-env-87654321-gke",
+			},
+		},
+		{
+			name: "ignores different location",
+			metricsLabels: []map[string]string{
+				{
+					"cluster_name": "us-central1-my-env-12345678-gke",
+					"location":     "us-central1",
+				},
+			},
+			location:    "asia-northeast1",
+			environment: "my-env",
+			want:        nil,
+		},
+		{
+			name: "ignores invalid hash length",
+			metricsLabels: []map[string]string{
+				{
+					"cluster_name": "asia-northeast1-my-env-1234567-gke",
+					"location":     "asia-northeast1",
+				},
+				{
+					"cluster_name": "asia-northeast1-my-env-123456789-gke",
+					"location":     "asia-northeast1",
+				},
+			},
+			location:    "asia-northeast1",
+			environment: "my-env",
+			want:        nil,
+		},
+		{
+			name: "ignores missing gke suffix",
+			metricsLabels: []map[string]string{
+				{
+					"cluster_name": "asia-northeast1-my-env-12345678-aks",
+					"location":     "asia-northeast1",
+				},
+			},
+			location:    "asia-northeast1",
+			environment: "my-env",
+			want:        nil,
+		},
+		{
+			name: "deduplicates cluster names",
+			metricsLabels: []map[string]string{
+				{
+					"cluster_name": "asia-northeast1-my-env-12345678-gke",
+					"location":     "asia-northeast1",
+				},
+				{
+					"cluster_name": "asia-northeast1-my-env-12345678-gke",
+					"location":     "asia-northeast1",
+				},
+			},
+			location:    "asia-northeast1",
+			environment: "my-env",
+			want:        []string{"asia-northeast1-my-env-12345678-gke"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterAndMatchComposerGKEClusterNames(tc.metricsLabels, tc.location, tc.environment)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("filterAndMatchComposerGKEClusterNames() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder_test.go
@@ -20,6 +20,64 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestExtractEnvironmentPrefixCandidate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		clusterName string
+		location    string
+		wantCand    string
+		wantOK      bool
+	}{
+		{
+			name:        "valid environment candidate",
+			clusterName: "asia-northeast1-my-env-12345678-gke",
+			location:    "asia-northeast1",
+			wantCand:    "my-env",
+			wantOK:      true,
+		},
+		{
+			name:        "valid truncated environment candidate",
+			clusterName: "asia-northeast1-very-long-comp-12345678-gke",
+			location:    "asia-northeast1",
+			wantCand:    "very-long-comp",
+			wantOK:      true,
+		},
+		{
+			name:        "missing gke suffix",
+			clusterName: "asia-northeast1-my-env-12345678-aks",
+			location:    "asia-northeast1",
+			wantCand:    "",
+			wantOK:      false,
+		},
+		{
+			name:        "location mismatch",
+			clusterName: "us-central1-my-env-12345678-gke",
+			location:    "asia-northeast1",
+			wantCand:    "",
+			wantOK:      false,
+		},
+		{
+			name:        "no hyphen after location prefix in rest",
+			clusterName: "asia-northeast1-12345678-gke",
+			location:    "asia-northeast1",
+			wantCand:    "",
+			wantOK:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCand, gotOK := extractEnvironmentPrefixCandidate(tc.clusterName, tc.location)
+			if gotOK != tc.wantOK {
+				t.Fatalf("extractEnvironmentPrefixCandidate() ok mismatch: want %v, got %v", tc.wantOK, gotOK)
+			}
+			if diff := cmp.Diff(tc.wantCand, gotCand); diff != "" {
+				t.Errorf("extractEnvironmentPrefixCandidate() candidate mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestFilterAndMatchComposerGKEClusterNames(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -72,22 +130,6 @@ func TestFilterAndMatchComposerGKEClusterNames(t *testing.T) {
 			want:        nil,
 		},
 		{
-			name: "ignores invalid hash length",
-			metricsLabels: []map[string]string{
-				{
-					"cluster_name": "asia-northeast1-my-env-1234567-gke",
-					"location":     "asia-northeast1",
-				},
-				{
-					"cluster_name": "asia-northeast1-my-env-123456789-gke",
-					"location":     "asia-northeast1",
-				},
-			},
-			location:    "asia-northeast1",
-			environment: "my-env",
-			want:        nil,
-		},
-		{
 			name: "ignores missing gke suffix",
 			metricsLabels: []map[string]string{
 				{
@@ -100,20 +142,16 @@ func TestFilterAndMatchComposerGKEClusterNames(t *testing.T) {
 			want:        nil,
 		},
 		{
-			name: "deduplicates cluster names",
+			name: "matches truncated environment name",
 			metricsLabels: []map[string]string{
 				{
-					"cluster_name": "asia-northeast1-my-env-12345678-gke",
-					"location":     "asia-northeast1",
-				},
-				{
-					"cluster_name": "asia-northeast1-my-env-12345678-gke",
+					"cluster_name": "asia-northeast1-very-long-comp-12345678-gke",
 					"location":     "asia-northeast1",
 				},
 			},
 			location:    "asia-northeast1",
-			environment: "my-env",
-			want:        []string{"asia-northeast1-my-env-12345678-gke"},
+			environment: "very-long-composer-environment-name",
+			want:        []string{"asia-northeast1-very-long-comp-12345678-gke"},
 		},
 	}
 

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task.go
@@ -36,13 +36,17 @@ var AutocompleteComposerClusterNamesTask = inspectiontaskbase.NewGlobalCachedTas
 	googlecloudcommon_contract.InputLocationsTaskID.Ref(),
 	googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref(),
 	googlecloudclustercomposer_contract.AutocompleteComposerEnvironmentIdentityTaskID.Ref(),
+	googlecloudcommon_contract.InputStartTimeTaskID.Ref(),
+	googlecloudcommon_contract.InputEndTimeTaskID.Ref(),
 }, func(ctx context.Context, prevValue inspectiontaskbase.CacheableTaskResult[*inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]]) (inspectiontaskbase.CacheableTaskResult[*inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]], error) {
 
 	projectID := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputProjectIdTaskID.Ref())
 	environment := coretask.GetTaskResult(ctx, googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref())
 	location := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputLocationsTaskID.Ref())
+	startTime := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputStartTimeTaskID.Ref())
+	endTime := coretask.GetTaskResult(ctx, googlecloudcommon_contract.InputEndTimeTaskID.Ref())
 
-	dependencyDigest := fmt.Sprintf("%s-%s-%s", projectID, environment, location)
+	dependencyDigest := fmt.Sprintf("%s-%s-%s-%d-%d", projectID, environment, location, startTime.Unix(), endTime.Unix())
 
 	// when the user is inputing these information, abort
 	isWIP := projectID == "" || environment == ""
@@ -56,12 +60,23 @@ var AutocompleteComposerClusterNamesTask = inspectiontaskbase.NewGlobalCachedTas
 		}, nil
 	}
 
+	if location == "" {
+		return inspectiontaskbase.CacheableTaskResult[*inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]]{
+			DependencyDigest: dependencyDigest,
+			Value: &inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]{
+				Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{},
+				Error:  "",
+				Hint:   "Cluster names are suggested after the location is provided.",
+			},
+		}, nil
+	}
+
 	if environment != "" && dependencyDigest == prevValue.DependencyDigest {
 		return prevValue, nil
 	}
 
 	clusterFinder := coretask.GetTaskResult(ctx, googlecloudclustercomposer_contract.ComposerEnvironmentClusterFinderTaskID.Ref())
-	clusterName, err := clusterFinder.GetGKEClusterName(ctx, projectID, environment)
+	clusterNames, err := clusterFinder.GetGKEClusterNames(ctx, projectID, location, environment, startTime, endTime)
 	if err != nil {
 		if errors.Is(err, googlecloudclustercomposer_contract.ErrEnvironmentClusterNotFound) {
 			return inspectiontaskbase.CacheableTaskResult[*inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]]{
@@ -82,16 +97,19 @@ Note: Composer 3 is not running on your GKE cluster. Please remove all Kubernete
 		}, nil
 	}
 
+	identities := make([]googlecloudk8scommon_contract.GoogleCloudClusterIdentity, len(clusterNames))
+	for i, clusterName := range clusterNames {
+		identities[i] = googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+			ClusterName: clusterName,
+			ProjectID:   projectID,
+			Location:    location,
+		}
+	}
+
 	return inspectiontaskbase.CacheableTaskResult[*inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]]{
 		DependencyDigest: dependencyDigest,
 		Value: &inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]{
-			Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				{
-					ClusterName: clusterName,
-					ProjectID:   projectID,
-					Location:    location,
-				},
-			},
+			Values: identities,
 		},
 	}, nil
 },

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task_test.go
@@ -41,6 +41,9 @@ func (m *mockComposerClusterFinder) GetGKEClusterNames(ctx context.Context, proj
 	}
 	key := fmt.Sprintf("%s/%s/%s", projectID, location, environment)
 	if clusterNames, ok := m.clusterMapping[key]; ok {
+		if len(clusterNames) == 0 {
+			return nil, googlecloudclustercomposer_contract.ErrEnvironmentClusterNotFound
+		}
 		return clusterNames, nil
 	}
 	return nil, googlecloudclustercomposer_contract.ErrEnvironmentClusterNotFound
@@ -180,8 +183,8 @@ Note: Composer 3 is not running on your GKE cluster. Please remove all Kubernete
 				projectIDInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputProjectIdTaskID.Ref(), tc.projectIDs[i])
 				environmentNameInput := tasktest.NewTaskDependencyValuePair(googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref(), tc.environments[i])
 				locationInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLocationsTaskID.Ref(), tc.locations[i])
-				startTimeInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), time.Now())
-				endTimeInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), time.Now())
+				startTimeInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), time.Unix(1700000000, 0))
+				endTimeInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), time.Unix(1700003600, 0))
 				result, _, err := inspectiontest.RunInspectionTask(ctx, AutocompleteComposerClusterNamesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{}, projectIDInput, environmentNameInput, locationInput, startTimeInput, endTimeInput, mockComposerClusterFinderInput)
 				if err != nil {
 					t.Fatalf("failed to run inspection task in loop %d: %v", i, err)

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
@@ -29,19 +30,20 @@ import (
 )
 
 type mockComposerClusterFinder struct {
-	clusterMapping map[string]string // {projectID}/{environment} -> clusterName
+	clusterMapping map[string][]string // {projectID}/{location}/{environment} -> []string
 	wantError      bool
 }
 
-// GetGKEClusterName implements googlecloudclustercomposer_contract.ComposerEnvironmentClusterFinder.
-func (m *mockComposerClusterFinder) GetGKEClusterName(ctx context.Context, projectID string, environment string) (string, error) {
+// GetGKEClusterNames implements googlecloudclustercomposer_contract.ComposerEnvironmentClusterFinder.
+func (m *mockComposerClusterFinder) GetGKEClusterNames(ctx context.Context, projectID, location, environment string, startTime, endTime time.Time) ([]string, error) {
 	if m.wantError {
-		return "", fmt.Errorf("test error")
+		return nil, fmt.Errorf("test error")
 	}
-	if clusterName, ok := m.clusterMapping[projectID+"/"+environment]; ok {
-		return clusterName, nil
+	key := fmt.Sprintf("%s/%s/%s", projectID, location, environment)
+	if clusterNames, ok := m.clusterMapping[key]; ok {
+		return clusterNames, nil
 	}
-	return "", googlecloudclustercomposer_contract.ErrEnvironmentClusterNotFound
+	return nil, googlecloudclustercomposer_contract.ErrEnvironmentClusterNotFound
 }
 
 var _ googlecloudclustercomposer_contract.ComposerEnvironmentClusterFinder = (*mockComposerClusterFinder)(nil)
@@ -49,7 +51,7 @@ var _ googlecloudclustercomposer_contract.ComposerEnvironmentClusterFinder = (*m
 func TestAutocompleteComposerClusterNamesTask(t *testing.T) {
 	testCases := []struct {
 		desc           string
-		clusterMapping map[string]string
+		clusterMapping map[string][]string
 		finderError    bool
 		projectIDs     []string
 		environments   []string
@@ -58,7 +60,7 @@ func TestAutocompleteComposerClusterNamesTask(t *testing.T) {
 	}{
 		{
 			desc:           "project id is empty",
-			clusterMapping: map[string]string{},
+			clusterMapping: map[string][]string{},
 			finderError:    false,
 			projectIDs:     []string{""},
 			environments:   []string{"env1"},
@@ -70,7 +72,7 @@ func TestAutocompleteComposerClusterNamesTask(t *testing.T) {
 		},
 		{
 			desc:           "environment name is empty",
-			clusterMapping: map[string]string{},
+			clusterMapping: map[string][]string{},
 			finderError:    false,
 			projectIDs:     []string{"foo-project"},
 			environments:   []string{""},
@@ -83,32 +85,61 @@ func TestAutocompleteComposerClusterNamesTask(t *testing.T) {
 			},
 		},
 		{
-			desc:           "using cache",
-			clusterMapping: map[string]string{"foo-project/env1": "cluster1"},
+			desc:           "location is empty returns hint",
+			clusterMapping: map[string][]string{},
+			finderError:    false,
+			projectIDs:     []string{"foo-project"},
+			environments:   []string{"env1"},
+			locations:      []string{""},
+			want: []*inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]{
+				{
+					Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{},
+					Error:  "",
+					Hint:   "Cluster names are suggested after the location is provided.",
+				},
+			},
+		},
+		{
+			desc:           "using cache with multiple clusters",
+			clusterMapping: map[string][]string{"foo-project/us-central1/env1": {"cluster1", "cluster2"}},
 			finderError:    false,
 			projectIDs:     []string{"foo-project", "foo-project"},
 			environments:   []string{"env1", "env1"},
 			locations:      []string{"us-central1", "us-central1"},
 			want: []*inspectioncore_contract.AutocompleteResult[googlecloudk8scommon_contract.GoogleCloudClusterIdentity]{
 				{
-					Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{{
-						ClusterName: "cluster1",
-						ProjectID:   "foo-project",
-						Location:    "us-central1",
-					}},
+					Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+						{
+							ClusterName: "cluster1",
+							ProjectID:   "foo-project",
+							Location:    "us-central1",
+						},
+						{
+							ClusterName: "cluster2",
+							ProjectID:   "foo-project",
+							Location:    "us-central1",
+						},
+					},
 				},
 				{
-					Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{{
-						ClusterName: "cluster1",
-						ProjectID:   "foo-project",
-						Location:    "us-central1",
-					}},
+					Values: []googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+						{
+							ClusterName: "cluster1",
+							ProjectID:   "foo-project",
+							Location:    "us-central1",
+						},
+						{
+							ClusterName: "cluster2",
+							ProjectID:   "foo-project",
+							Location:    "us-central1",
+						},
+					},
 				},
 			},
 		},
 		{
 			desc:           "with error",
-			clusterMapping: map[string]string{},
+			clusterMapping: map[string][]string{},
 			finderError:    true,
 			projectIDs:     []string{"foo-project"},
 			environments:   []string{"env1"},
@@ -120,7 +151,7 @@ func TestAutocompleteComposerClusterNamesTask(t *testing.T) {
 		},
 		{
 			desc:           "environment not found",
-			clusterMapping: map[string]string{},
+			clusterMapping: map[string][]string{},
 			finderError:    false,
 			projectIDs:     []string{"foo-project"},
 			environments:   []string{"non-existent-env"},
@@ -149,7 +180,9 @@ Note: Composer 3 is not running on your GKE cluster. Please remove all Kubernete
 				projectIDInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputProjectIdTaskID.Ref(), tc.projectIDs[i])
 				environmentNameInput := tasktest.NewTaskDependencyValuePair(googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref(), tc.environments[i])
 				locationInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLocationsTaskID.Ref(), tc.locations[i])
-				result, _, err := inspectiontest.RunInspectionTask(ctx, AutocompleteComposerClusterNamesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{}, projectIDInput, environmentNameInput, locationInput, mockComposerClusterFinderInput)
+				startTimeInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), time.Now())
+				endTimeInput := tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), time.Now())
+				result, _, err := inspectiontest.RunInspectionTask(ctx, AutocompleteComposerClusterNamesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{}, projectIDInput, environmentNameInput, locationInput, startTimeInput, endTimeInput, mockComposerClusterFinderInput)
 				if err != nil {
 					t.Fatalf("failed to run inspection task in loop %d: %v", i, err)
 				}


### PR DESCRIPTION
## Problem Statement
Previously, `ComposerEnvironmentClusterFinder` invoked the live GKE API (`ContainerClusterManagerClient.ListClusters`) and searched for clusters whose `goog-composer-environment` resource label matched the environment name. Because this live listing API only returns currently active GKE clusters, KHI could not discover or autocomplete **deleted or historical GKE clusters** associated with a Cloud Composer environment.
## Solution & Key Changes
1. **Switch to Cloud Monitoring Metric Queries (`pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder.go`)**:
   - Updated the `ComposerEnvironmentClusterFinder` interface signature to:
     ```go
     type ComposerEnvironmentClusterFinder interface {
         GetGKEClusterNames(ctx context.Context, projectID, location, environment string, startTime, endTime time.Time) ([]string, error)
     }
     ```
   - Replaced live `ListClusters` API calls with Cloud Monitoring resource label queries (`metric.type="kubernetes.io/container/uptime" AND resource.type="k8s_container"`).
   - Added pattern matching logic (`filterAndMatchComposerGKEClusterNames`) that identifies historical GKE clusters by checking against the Cloud Composer naming convention: `<location>-<environment>-<hash (8 chars)>-gke`.
   - By stripping the `-gke` suffix and 8-character hash and verifying that the remaining prefix matches `<location>-<environment>`, KHI discovers all matching past and present clusters.
2. **Update Autocomplete Task & UX (`pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task.go`)**:
   - Added dependencies on `InputStartTimeTaskID` and `InputEndTimeTaskID` so that the cache digest automatically updates when the inspection time window changes.
   - Added a validation check that returns a helpful hint (`"Cluster names are suggested after the location is provided."`) when `location` is empty.
   - Updated the execution function to iterate over all discovered cluster names and include multiple cluster identities in `AutocompleteResult.Values`.
3. **Dead Code Cleanup (`pkg/api/googlecloud/clientfactory.go`)**:
   - Removed `ContainerClusterManagerClient` (GKE ClusterManager API client) method, cache maps, configuration fields, and the `cloud.google.com/go/container/apiv1` import from `ClientFactory`, as it is no longer referenced anywhere in the repository.
4. **Unit Tests**:
   - Added comprehensive table-driven tests in `pkg/task/inspection/googlecloudclustercomposer/contract/environmentclusterfinder_test.go` verifying cluster name extraction, hash validation, sorting, and deduplication.
   - Updated unit tests in `pkg/task/inspection/googlecloudclustercomposer/impl/autocompletecomposerclusternames_task_test.go` to test the new interface signature, empty location hint, and multiple cluster autocompletion.
## Verification
- [x] **Backend Build**: `make build-go` completed cleanly with zero errors.
- [x] **Unit & Integration Tests**: `go test ./pkg/task/inspection/googlecloudclustercomposer/...` and full `make test-go` passed cleanly.
- [x] **Formatting & Linting**: `make pre-commit` passed with 0 linting or formatting errors across the project.
