### PR TITLE
fix(inspection): deduplicate feature tasks by SelectionPriority in SetInspectionType

### DIFF
--- a/pkg/core/inspection/runner.go
+++ b/pkg/core/inspection/runner.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -162,6 +163,7 @@ func (i *InspectionTaskRunner) SetInspectionType(inspectionType string) error {
 			filteredTasks = append(filteredTasks, task)
 		}
 	}
+	filteredTasks = deduplicateTasksByPriority(filteredTasks)
 
 	var err error
 	i.availableTasks, err = coretask.NewTaskSet(filteredTasks)
@@ -197,6 +199,39 @@ func (i *InspectionTaskRunner) isTaskCompatible(task coretask.UntypedTask, curre
 
 	// 3. Defaults to true if neither is defined (global tasks)
 	return true
+}
+
+// deduplicateTasksByPriority retains only the task with the highest LabelKeyTaskSelectionPriority for each TaskRef, sorted by reference name.
+func deduplicateTasksByPriority(tasks []coretask.UntypedTask) []coretask.UntypedTask {
+	bestTaskForRef := map[string]coretask.UntypedTask{}
+	for _, task := range tasks {
+		refID := task.UntypedID().ReferenceIDString()
+		existing, found := bestTaskForRef[refID]
+		if !found {
+			bestTaskForRef[refID] = task
+			continue
+		}
+
+		priorityExisting := typedmap.GetOrDefault(existing.Labels(), coretask.LabelKeyTaskSelectionPriority, 0)
+		priorityNew := typedmap.GetOrDefault(task.Labels(), coretask.LabelKeyTaskSelectionPriority, 0)
+		if priorityNew > priorityExisting {
+			bestTaskForRef[refID] = task
+		} else if priorityNew == priorityExisting {
+			if strings.Compare(task.UntypedID().String(), existing.UntypedID().String()) > 0 {
+				slog.Warn("Multiple tasks for same RefID. Choosing the lexicographically larger task ID.", "refID", refID, "taskID1", task.UntypedID().String(), "taskID2", existing.UntypedID().String())
+				bestTaskForRef[refID] = task
+			}
+		}
+	}
+
+	deduplicated := make([]coretask.UntypedTask, 0, len(bestTaskForRef))
+	for _, task := range bestTaskForRef {
+		deduplicated = append(deduplicated, task)
+	}
+	slices.SortFunc(deduplicated, func(a, b coretask.UntypedTask) int {
+		return strings.Compare(a.UntypedID().ReferenceIDString(), b.UntypedID().ReferenceIDString())
+	})
+	return deduplicated
 }
 
 // FeatureList returns the list of available features for the current inspection type.

--- a/pkg/core/inspection/runner_test.go
+++ b/pkg/core/inspection/runner_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestInspectionTaskRunner_Interceptor(t *testing.T) {
@@ -192,6 +193,230 @@ func TestIsTaskCompatible(t *testing.T) {
 			got := runner.isTaskCompatible(task, tt.currentType)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("isTaskCompatible() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeduplicateTasksByPriority(t *testing.T) {
+	taskRefA := taskid.NewTaskReference[any]("task-a")
+	taskRefB := taskid.NewTaskReference[any]("task-b")
+
+	taskAImpl1 := coretask.NewTask(
+		taskid.NewImplementationID(taskRefA, "impl1"),
+		nil,
+		func(ctx context.Context) (any, error) { return nil, nil },
+		coretask.WithSelectionPriority(10),
+	)
+	taskAImpl2 := coretask.NewTask(
+		taskid.NewImplementationID(taskRefA, "impl2"),
+		nil,
+		func(ctx context.Context) (any, error) { return nil, nil },
+		coretask.WithSelectionPriority(100),
+	)
+	taskAImpl3 := coretask.NewTask(
+		taskid.NewImplementationID(taskRefA, "impl3"),
+		nil,
+		func(ctx context.Context) (any, error) { return nil, nil },
+		coretask.WithSelectionPriority(50),
+	)
+	taskBImpl1 := coretask.NewTask(
+		taskid.NewImplementationID(taskRefB, "impl1"),
+		nil,
+		func(ctx context.Context) (any, error) { return nil, nil },
+		coretask.WithSelectionPriority(0),
+	)
+	taskATie1 := coretask.NewTask(
+		taskid.NewImplementationID(taskRefA, "tie-a"),
+		nil,
+		func(ctx context.Context) (any, error) { return nil, nil },
+		coretask.WithSelectionPriority(20),
+	)
+	taskATie2 := coretask.NewTask(
+		taskid.NewImplementationID(taskRefA, "tie-b"),
+		nil,
+		func(ctx context.Context) (any, error) { return nil, nil },
+		coretask.WithSelectionPriority(20),
+	)
+
+	tests := []struct {
+		name    string
+		tasks   []coretask.UntypedTask
+		wantIDs []string
+	}{
+		{
+			name:    "single task remains unchanged",
+			tasks:   []coretask.UntypedTask{taskAImpl1},
+			wantIDs: []string{"task-a#impl1"},
+		},
+		{
+			name:    "distinct TaskRefs are all retained",
+			tasks:   []coretask.UntypedTask{taskAImpl1, taskBImpl1},
+			wantIDs: []string{"task-a#impl1", "task-b#impl1"},
+		},
+		{
+			name:    "same TaskRef selects highest priority task",
+			tasks:   []coretask.UntypedTask{taskAImpl1, taskAImpl2, taskAImpl3},
+			wantIDs: []string{"task-a#impl2"},
+		},
+		{
+			name:    "multiple TaskRefs select respective highest priority tasks",
+			tasks:   []coretask.UntypedTask{taskAImpl1, taskAImpl2, taskBImpl1},
+			wantIDs: []string{"task-a#impl2", "task-b#impl1"},
+		},
+		{
+			name:    "same priority tie-break deterministically chooses higher string ID",
+			tasks:   []coretask.UntypedTask{taskATie1, taskATie2},
+			wantIDs: []string{"task-a#tie-b"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTasks := deduplicateTasksByPriority(tc.tasks)
+			gotIDs := make([]string, 0, len(gotTasks))
+			for _, task := range gotTasks {
+				gotIDs = append(gotIDs, task.UntypedID().String())
+			}
+
+			if diff := cmp.Diff(tc.wantIDs, gotIDs, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("deduplicateTasksByPriority() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetInspectionType_SelectionPriority(t *testing.T) {
+	tests := []struct {
+		name                 string
+		tasks                []coretask.UntypedTask
+		inspectionType       InspectionType
+		wantAvailableTaskIDs []string
+		wantFeatureListIDs   []string
+		wantEnabledFeatures  []string
+	}{
+		{
+			name: "selects specialized task with higher priority over generic task",
+			inspectionType: InspectionType{
+				Id:     "gke-inspection",
+				Name:   "GKE Inspection",
+				Labels: map[string]string{"platform": "gke"},
+			},
+			tasks: []coretask.UntypedTask{
+				// Generic implementation with priority 0, default feature
+				coretask.NewTask(
+					taskid.NewImplementationID(taskid.NewTaskReference[any]("audit-log-parser"), "generic"),
+					nil,
+					func(ctx context.Context) (any, error) { return nil, nil },
+					inspectioncore_contract.FeatureTaskLabel("Generic Audit Logs", "Generic description", 100, true),
+					coretask.WithSelectionPriority(0),
+				),
+				// GKE specialized implementation with priority 100, default feature
+				coretask.NewTask(
+					taskid.NewImplementationID(taskid.NewTaskReference[any]("audit-log-parser"), "gke"),
+					nil,
+					func(ctx context.Context) (any, error) { return nil, nil },
+					inspectioncore_contract.FeatureTaskLabel("GKE Audit Logs", "GKE description", 100, true),
+					inspectioncore_contract.InspectionTypeLabelSelector(map[string]string{"platform": "gke"}),
+					coretask.WithSelectionPriority(100),
+				),
+			},
+			wantAvailableTaskIDs: []string{"audit-log-parser#gke"},
+			wantFeatureListIDs:   []string{"audit-log-parser#gke"},
+			wantEnabledFeatures:  []string{"audit-log-parser#gke"},
+		},
+		{
+			name: "higher priority task with defaultFeature false overrides generic defaultFeature true",
+			inspectionType: InspectionType{
+				Id:     "gke-inspection",
+				Name:   "GKE Inspection",
+				Labels: map[string]string{"platform": "gke"},
+			},
+			tasks: []coretask.UntypedTask{
+				// Generic implementation with priority 0, default feature = true
+				coretask.NewTask(
+					taskid.NewImplementationID(taskid.NewTaskReference[any]("custom-feature"), "generic"),
+					nil,
+					func(ctx context.Context) (any, error) { return nil, nil },
+					inspectioncore_contract.FeatureTaskLabel("Generic Feature", "Generic description", 100, true),
+					coretask.WithSelectionPriority(0),
+				),
+				// GKE specialized implementation with priority 50, default feature = false
+				coretask.NewTask(
+					taskid.NewImplementationID(taskid.NewTaskReference[any]("custom-feature"), "gke"),
+					nil,
+					func(ctx context.Context) (any, error) { return nil, nil },
+					inspectioncore_contract.FeatureTaskLabel("GKE Feature", "GKE description", 100, false),
+					inspectioncore_contract.InspectionTypeLabelSelector(map[string]string{"platform": "gke"}),
+					coretask.WithSelectionPriority(50),
+				),
+			},
+			wantAvailableTaskIDs: []string{"custom-feature#gke"},
+			wantFeatureListIDs:   []string{"custom-feature#gke"},
+			wantEnabledFeatures:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, err := NewServer(&inspectioncore_contract.IOConfig{TemporaryFolder: t.TempDir()})
+			if err != nil {
+				t.Fatalf("NewServer failed: %v", err)
+			}
+
+			if err := server.AddInspectionType(tc.inspectionType); err != nil {
+				t.Fatalf("AddInspectionType failed: %v", err)
+			}
+
+			for _, task := range tc.tasks {
+				if err := server.AddTask(task); err != nil {
+					t.Fatalf("AddTask failed: %v", err)
+				}
+			}
+
+			inspectionID, err := server.CreateInspection(tc.inspectionType.Id)
+			if err != nil {
+				t.Fatalf("CreateInspection failed: %v", err)
+			}
+			runner := server.GetInspection(inspectionID)
+
+			// Verify available tasks
+			gotAvailableTasks := runner.availableTasks.GetAll()
+			gotAvailableIDs := []string{}
+			for _, task := range gotAvailableTasks {
+				// Exclude internal serializer/inspection core tasks from assertion if any
+				for _, expectedID := range tc.wantAvailableTaskIDs {
+					if task.UntypedID().String() == expectedID {
+						gotAvailableIDs = append(gotAvailableIDs, task.UntypedID().String())
+					}
+				}
+			}
+			if diff := cmp.Diff(tc.wantAvailableTaskIDs, gotAvailableIDs, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("availableTasks mismatch (-want +got):\n%s", diff)
+			}
+
+			// Verify FeatureList
+			featureList, err := runner.FeatureList()
+			if err != nil {
+				t.Fatalf("FeatureList failed: %v", err)
+			}
+			gotFeatureListIDs := []string{}
+			for _, f := range featureList {
+				gotFeatureListIDs = append(gotFeatureListIDs, f.Id)
+			}
+			if diff := cmp.Diff(tc.wantFeatureListIDs, gotFeatureListIDs, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("FeatureList mismatch (-want +got):\n%s", diff)
+			}
+
+			// Verify enabledFeatures
+			gotEnabledFeatures := []string{}
+			for fID, enabled := range runner.enabledFeatures {
+				if enabled {
+					gotEnabledFeatures = append(gotEnabledFeatures, fID)
+				}
+			}
+			if diff := cmp.Diff(tc.wantEnabledFeatures, gotEnabledFeatures, cmpopts.SortSlices(func(a, b string) bool { return a < b }), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("enabledFeatures mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/core/task/graphresolver.go
+++ b/pkg/core/task/graphresolver.go
@@ -70,10 +70,12 @@ func NewGraphResolver(maxIteration int, rules ...GraphResolverRule) *GraphResolv
 // or the `MaxIteration` limit is reached.
 func (r *GraphResolver) Resolve(requiredTasks []UntypedTask, availableTasks []UntypedTask) ([]UntypedTask, error) {
 	currentTasks := slices.Clone(requiredTasks)
+	sortedAvailableTasks := slices.Clone(availableTasks)
+	slices.SortFunc(sortedAvailableTasks, compareTaskByReference)
 	for iter := 0; iter < r.MaxIteration; iter++ {
 		stabled := true
 		for _, rule := range r.Rules {
-			result, err := rule.Resolve(currentTasks, availableTasks)
+			result, err := rule.Resolve(currentTasks, sortedAvailableTasks)
 			if err != nil {
 				return nil, fmt.Errorf("failed to call Resolve function for the rule %s\n%s", rule.Name(), err.Error())
 			}
@@ -87,6 +89,10 @@ func (r *GraphResolver) Resolve(requiredTasks []UntypedTask, availableTasks []Un
 		}
 	}
 	return nil, fmt.Errorf("failed to complete the resolution of tasks included in the task graph in given iteration count %d ", r.MaxIteration)
+}
+
+func compareTaskByReference(a, b UntypedTask) int {
+	return strings.Compare(a.UntypedID().ReferenceIDString(), b.UntypedID().ReferenceIDString())
 }
 
 // RequiredTaskLabelGraphResolverRule is a resolver rule that adds tasks to the graph
@@ -159,11 +165,11 @@ func (d *TaskDependencyGraphResolverRule) Resolve(currentGraphTasks []UntypedTas
 	if len(missingReferences) > 0 {
 		result.Changed = true
 		for _, ref := range missingReferences {
-			highest, err := findHighestPriorityUntypedTaskForTaskReference(ref, availableTasks)
+			task, err := findUntypedTaskForTaskReference(ref, availableTasks)
 			if err != nil {
 				return GraphResolverRuleResult{}, err
 			}
-			result.Tasks = append(result.Tasks, highest)
+			result.Tasks = append(result.Tasks, task)
 		}
 	}
 	return result, nil
@@ -268,15 +274,15 @@ func (s *SubsequentTaskRefsGraphResolverRule) Resolve(currentGraphTasks []Untype
 	}
 
 	for idStr, taskRef := range missingSubsequentTaskReferences {
-		highest, err := findHighestPriorityUntypedTaskForTaskReference(taskRef, availableTasks)
+		task, err := findUntypedTaskForTaskReference(taskRef, availableTasks)
 		if err != nil {
 			return GraphResolverRuleResult{}, err
 		}
-		overridenHighest := newDependencyOverridenUntypedTask(highest)
+		overridenTask := newDependencyOverridenUntypedTask(task)
 		for _, requestedSuccessor := range missingSubsequentTaskReqquestedBy[idStr] {
-			overridenHighest.AddDependency(requestedSuccessor.UntypedID().GetUntypedReference())
+			overridenTask.AddDependency(requestedSuccessor.UntypedID().GetUntypedReference())
 		}
-		result.Tasks = append(result.Tasks, overridenHighest)
+		result.Tasks = append(result.Tasks, overridenTask)
 		result.Changed = true
 	}
 	return result, nil
@@ -311,32 +317,21 @@ func getMapOfReferenceIDs(tasks []UntypedTask) map[string]taskid.UntypedTaskRefe
 	return taskReferenceMap
 }
 
-// findHighestPriorityUntypedTaskForTaskReference searches the list of available tasks for all tasks
-// matching the given reference and returns the one with the highest `LabelKeyTaskSelectionPriority`.
+// findUntypedTaskForTaskReference searches the sorted list of available tasks for a task
+// matching the given reference using binary search and returns it.
 // It returns an error if no matching task is found.
-func findHighestPriorityUntypedTaskForTaskReference(ref taskid.UntypedTaskReference, availableTasks []UntypedTask) (UntypedTask, error) {
-	var matched []UntypedTask
-	for _, candidateTask := range availableTasks {
-		candidateRefID := candidateTask.UntypedID().GetUntypedReference()
-		if ref.ReferenceIDString() == candidateRefID.ReferenceIDString() {
-			matched = append(matched, candidateTask)
-		}
-	}
-
-	if len(matched) == 0 {
-		var availableTaskIDs []string
-		for _, task := range availableTasks {
-			availableTaskIDs = append(availableTaskIDs, "*"+task.UntypedID().String())
-		}
-		return nil, fmt.Errorf("failed to resolve task dependency. No available task can be referenced as '%s'.\nAvailable tasks:\n%s", ref.ReferenceIDString(), strings.Join(availableTaskIDs, "\n"))
-	}
-
-	// pick one of matched task with the highest priority
-	slices.SortFunc(matched, func(a, b UntypedTask) int {
-		priorityA := typedmap.GetOrDefault(a.Labels(), LabelKeyTaskSelectionPriority, 0)
-		priorityB := typedmap.GetOrDefault(b.Labels(), LabelKeyTaskSelectionPriority, 0)
-		return priorityA - priorityB
+func findUntypedTaskForTaskReference(ref taskid.UntypedTaskReference, availableTasks []UntypedTask) (UntypedTask, error) {
+	target := ref.ReferenceIDString()
+	idx, found := slices.BinarySearchFunc(availableTasks, target, func(t UntypedTask, target string) int {
+		return strings.Compare(t.UntypedID().ReferenceIDString(), target)
 	})
+	if found {
+		return availableTasks[idx], nil
+	}
 
-	return matched[len(matched)-1], nil
+	var availableTaskIDs []string
+	for _, task := range availableTasks {
+		availableTaskIDs = append(availableTaskIDs, "*"+task.UntypedID().String())
+	}
+	return nil, fmt.Errorf("failed to resolve task dependency. No available task can be referenced as '%s'.\nAvailable tasks:\n%s", ref.ReferenceIDString(), strings.Join(availableTaskIDs, "\n"))
 }

--- a/pkg/core/task/graphresolver_test.go
+++ b/pkg/core/task/graphresolver_test.go
@@ -176,14 +176,15 @@ func newMockTask(idStr string, implID string, opts mockTaskOptions) UntypedTask 
 }
 
 func TestDependencyResolverGraphResolverRule_Resolve(t *testing.T) {
-	providerRef := taskid.NewTaskReference[any]("provider")
+	providerRefA := taskid.NewTaskReference[any]("provider-a")
+	providerRefB := taskid.NewTaskReference[any]("provider-b")
 	unresolvableRef := taskid.NewTaskReference[any]("unresolvable")
 
-	providerTask := newMockTask("provider", "default", mockTaskOptions{priority: 10})
-	providerTaskLowPrio := newMockTask("provider", "low", mockTaskOptions{priority: 5})
-	providerTaskHighPrio := newMockTask("provider", "high", mockTaskOptions{priority: 20})
+	providerTaskA := newMockTask("provider-a", "default", mockTaskOptions{})
+	providerTaskB := newMockTask("provider-b", "default", mockTaskOptions{})
 
-	consumerTask := newMockTask("consumer", "default", mockTaskOptions{dependencies: []taskid.UntypedTaskReference{providerRef}})
+	consumerTask := newMockTask("consumer", "default", mockTaskOptions{dependencies: []taskid.UntypedTaskReference{providerRefA}})
+	multiConsumerTask := newMockTask("multi-consumer", "default", mockTaskOptions{dependencies: []taskid.UntypedTaskReference{providerRefA, providerRefB}})
 	unresolvableConsumerTask := newMockTask("unresolvable-consumer", "default", mockTaskOptions{dependencies: []taskid.UntypedTaskReference{unresolvableRef}})
 
 	testCases := []struct {
@@ -197,40 +198,40 @@ func TestDependencyResolverGraphResolverRule_Resolve(t *testing.T) {
 		{
 			name:              "should resolve a simple dependency",
 			currentGraphTasks: []UntypedTask{consumerTask},
-			availableTasks:    []UntypedTask{providerTask, consumerTask},
-			expectedTasks:     []string{"consumer#default", "provider#default"},
+			availableTasks:    []UntypedTask{consumerTask, providerTaskA},
+			expectedTasks:     []string{"consumer#default", "provider-a#default"},
 			expectedChanged:   true,
 			expectErr:         false,
 		},
 		{
 			name:              "should do nothing if dependency is already satisfied",
-			currentGraphTasks: []UntypedTask{consumerTask, providerTask},
-			availableTasks:    []UntypedTask{providerTask, consumerTask},
-			expectedTasks:     []string{"consumer#default", "provider#default"},
+			currentGraphTasks: []UntypedTask{consumerTask, providerTaskA},
+			availableTasks:    []UntypedTask{consumerTask, providerTaskA},
+			expectedTasks:     []string{"consumer#default", "provider-a#default"},
 			expectedChanged:   false,
 			expectErr:         false,
 		},
 		{
 			name:              "should return an error for unresolvable dependency",
 			currentGraphTasks: []UntypedTask{unresolvableConsumerTask},
-			availableTasks:    []UntypedTask{providerTask},
+			availableTasks:    []UntypedTask{providerTaskA},
 			expectedTasks:     nil,
 			expectedChanged:   false,
 			expectErr:         true,
 		},
 		{
-			name:              "should select the highest priority task",
-			currentGraphTasks: []UntypedTask{consumerTask},
-			availableTasks:    []UntypedTask{consumerTask, providerTask, providerTaskLowPrio, providerTaskHighPrio},
-			expectedTasks:     []string{"consumer#default", "provider#high"},
+			name:              "should resolve multiple dependencies",
+			currentGraphTasks: []UntypedTask{multiConsumerTask},
+			availableTasks:    []UntypedTask{multiConsumerTask, providerTaskA, providerTaskB},
+			expectedTasks:     []string{"multi-consumer#default", "provider-a#default", "provider-b#default"},
 			expectedChanged:   true,
 			expectErr:         false,
 		},
 		{
 			name:              "should do nothing if there are no dependencies",
-			currentGraphTasks: []UntypedTask{providerTask},
-			availableTasks:    []UntypedTask{providerTask, consumerTask},
-			expectedTasks:     []string{"provider#default"},
+			currentGraphTasks: []UntypedTask{providerTaskA},
+			availableTasks:    []UntypedTask{consumerTask, providerTaskA},
+			expectedTasks:     []string{"provider-a#default"},
 			expectedChanged:   false,
 			expectErr:         false,
 		},


### PR DESCRIPTION
## Problem
When multiple compatible task implementations share the same `TaskRef` (e.g. a generic parser task vs. a platform-specialized parser task), the final task graph only ever selects a single implementation based on `SelectionPriority`.
However, during inspection creation (`SetInspectionType`), all compatible implementations were registered into `availableTasks` and exposed in `FeatureList()`. This caused tasks that would never actually be included in the final task graph to appear in the feature selection UI, making feature toggling for those tasks confusing and ineffective.
## Solution
- **Upfront Task Deduplication**: Deduplicate compatible tasks in `SetInspectionType` (`pkg/core/inspection/runner.go`) by selecting only the implementation with the highest `coretask.LabelKeyTaskSelectionPriority` per `TaskRef` (tie-breaking deterministically by implementation ID string).
- **GraphResolver Simplification**: Since `availableTasks` is now guaranteed to have unique `TaskRef`s upfront, removed the redundant runtime priority sorting in `GraphResolver` (`pkg/core/task/graphresolver.go`) and optimized task lookup via `slices.BinarySearchFunc` over pre-sorted tasks.
## Key Changes
- `pkg/core/inspection/runner.go`: Added `deduplicateTasksByPriority` and invoked it in `SetInspectionType` immediately after compatibility filtering.
- `pkg/core/task/graphresolver.go`: Pre-sorted `availableTasks` in `GraphResolver.Resolve` and replaced `findHighestPriorityUntypedTaskForTaskReference` with binary search in `findUntypedTaskForTaskReference`.
- `pkg/core/inspection/runner_test.go`: Added `TestDeduplicateTasksByPriority` and `TestSetInspectionType_SelectionPriority` to verify feature list and task deduplication behavior.
- `pkg/core/task/graphresolver_test.go`: Updated unit tests to match binary search lookup.
## Verification
- `make build-go` passed.
- `make test-go` passed.
- `make lint-go` passed.
- `make pre-commit` passed.