### PR TITLE
perf(core): adopt LazyJSONNode for log ingestion and optimize Kubernetes manifest memory footprint

### DIFF
--- a/pkg/api/googlecloud/logconvert/logconvert.go
+++ b/pkg/api/googlecloud/logconvert/logconvert.go
@@ -15,167 +15,45 @@
 package logconvert
 
 import (
-	"slices"
-	"time"
-
 	"cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
-	ltype "google.golang.org/genproto/googleapis/logging/type"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+var protojsonMarshalOptions = protojson.MarshalOptions{
+	Multiline:       false,
+	Resolver:        protoregistry.GlobalTypes,
+	EmitUnpopulated: false,
+}
+
+// GCPLogEntryKeyOrder defines the canonical top-level field order for GCP Cloud Logging entries when serializing to YAML.
+var GCPLogEntryKeyOrder = []string{
+	"insertId",
+	"logName",
+	"trace",
+	"spanId",
+	"traceSampled",
+	"sourceLocation",
+	"split",
+	"labels",
+	"operation",
+	"httpRequest",
+	"protoPayload",
+	"jsonPayload",
+	"textPayload",
+	"resource",
+	"receiveTimestamp",
+	"timestamp",
+	"severity",
+}
+
 // LogEntryToNode converts a Google Cloud Logging LogEntry protobuf message into a structured.Node.
-// It extracts all fields from the LogEntry and organizes them into a map-like structured.Node in defined order.
+// It directly marshals the LogEntry into JSON bytes via protojson and wraps it in a LazyJSONNode.
 func LogEntryToNode(l *loggingpb.LogEntry) (structured.Node, error) {
-	keys := make([]string, 0)
-	values := make([]structured.Node, 0)
-
-	keys = append(keys, "insertId")
-	values = append(values, structured.NewStandardScalarNode(l.GetInsertId()))
-
-	keys = append(keys, "logName")
-	values = append(values, structured.NewStandardScalarNode(l.GetLogName()))
-
-	if len(l.Labels) > 0 {
-		keys = append(keys, "labels")
-		labelsMap, err := getLogLabelsMap(l.Labels)
-		if err != nil {
-			return nil, err
-		}
-		values = append(values, labelsMap)
-	}
-
-	if l.Operation != nil {
-		err := addProtoField(&keys, &values, "operation", l.Operation)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if l.HttpRequest != nil {
-		err := addProtoField(&keys, &values, "httpRequest", l.HttpRequest)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if protoPayload := l.GetProtoPayload(); protoPayload != nil {
-		err := addProtoField(&keys, &values, "protoPayload", protoPayload)
-		if err != nil {
-			return nil, err
-		}
-	} else if jsonPayload := l.GetJsonPayload(); jsonPayload != nil {
-		err := addProtoField(&keys, &values, "jsonPayload", jsonPayload)
-		if err != nil {
-			return nil, err
-		}
-	} else if textPayload := l.GetTextPayload(); textPayload != "" {
-		keys = append(keys, "textPayload")
-		values = append(values, structured.NewStandardScalarNode(textPayload))
-	}
-
-	if l.Resource != nil {
-		err := addProtoField(&keys, &values, "resource", l.Resource)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if l.Severity != ltype.LogSeverity_DEFAULT {
-		keys = append(keys, "severity")
-		values = append(values, structured.NewStandardScalarNode(l.Severity.String()))
-	}
-
-	if l.ReceiveTimestamp != nil {
-		keys = append(keys, "receiveTimestamp")
-		values = append(values, protoTimestampToScalar(l.ReceiveTimestamp))
-	}
-
-	if l.Timestamp != nil {
-		keys = append(keys, "timestamp")
-		values = append(values, protoTimestampToScalar(l.Timestamp))
-	}
-
-	if l.Trace != "" {
-		keys = append(keys, "trace")
-		values = append(values, structured.NewStandardScalarNode(l.Trace))
-	}
-
-	if l.SpanId != "" {
-		keys = append(keys, "spanId")
-		values = append(values, structured.NewStandardScalarNode(l.SpanId))
-	}
-
-	if l.Trace != "" || l.SpanId != "" {
-		keys = append(keys, "traceSampled")
-		values = append(values, structured.NewStandardScalarNode(l.TraceSampled))
-	}
-
-	if l.SourceLocation != nil {
-		err := addProtoField(&keys, &values, "sourceLocation", l.SourceLocation)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if l.Split != nil {
-		err := addProtoField(&keys, &values, "split", l.Split)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	standardMap := structured.NewStandardMap(keys, values)
-	return structured.NewLazyJSONNode(standardMap)
-}
-
-// getLogLabelsMap converts a map of string labels into a structured.Node representing a map.
-// The keys in the resulting structured.Node are sorted alphabetically.
-func getLogLabelsMap(l map[string]string) (structured.Node, error) {
-	keys := make([]string, 0, len(l))
-	for k := range l {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-	values := make([]structured.Node, 0, len(l))
-	for _, k := range keys {
-		values = append(values, structured.NewStandardScalarNode(l[k]))
-	}
-	return structured.NewStandardMap(keys, values), nil
-}
-
-// addProtoField adds a map node parsed from given proto data to given key and value pointers.
-// Users must assert p is not nil before calling this func.
-func addProtoField(keys *[]string, values *[]structured.Node, key string, p proto.Message) error {
-	node, err := protoToMapNode(p)
-	if err != nil {
-		return err
-	}
-	*keys = append(*keys, key)
-	*values = append(*values, node)
-	return nil
-}
-
-// protoToMapNode converts a protobuf message into a structured.Node.
-// It marshals the protobuf message to JSON using protojson and then parses the JSON string
-// into a structured.Node using structured.FromYAML.
-func protoToMapNode(protoAny proto.Message) (structured.Node, error) {
-	opt := protojson.MarshalOptions{
-		Multiline: false,
-		Resolver:  protoregistry.GlobalTypes,
-	}
-	jsonBytes, err := opt.Marshal(protoAny)
+	jsonBytes, err := protojsonMarshalOptions.Marshal(l)
 	if err != nil {
 		return nil, err
 	}
-	return structured.FromYAML(string(jsonBytes))
-}
-
-// protoTimestampToScalar converts a timestamppb.Timestamp protobuf message into a structured.Node
-// containing a scalar string representation of the timestamp in RFC3339Nano format.
-func protoTimestampToScalar(pbTime *timestamppb.Timestamp) structured.Node {
-	return structured.NewStandardScalarNode(pbTime.AsTime().UTC().Format(time.RFC3339Nano))
+	return structured.NewLazyJSONNodeFromBytes(jsonBytes), nil
 }

--- a/pkg/api/googlecloud/logconvert/logconvert.go
+++ b/pkg/api/googlecloud/logconvert/logconvert.go
@@ -128,7 +128,8 @@ func LogEntryToNode(l *loggingpb.LogEntry) (structured.Node, error) {
 		}
 	}
 
-	return structured.NewStandardMap(keys, values), nil
+	standardMap := structured.NewStandardMap(keys, values)
+	return structured.NewLazyJSONNode(standardMap)
 }
 
 // getLogLabelsMap converts a map of string labels into a structured.Node representing a map.

--- a/pkg/api/googlecloud/logconvert/logconvert_test.go
+++ b/pkg/api/googlecloud/logconvert/logconvert_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestLogEntryToNode(t *testing.T) {
-	now := time.Now()
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
 	nowpb := timestamppb.New(now)
 	nowFormatted := now.UTC().Format(time.RFC3339Nano)
 
@@ -242,10 +242,9 @@ func TestLogEntryWithKeyOrder(t *testing.T) {
 		t.Fatalf("LogEntryToNode() failed: %v", err)
 	}
 
-	serializer := &structured.YAMLNodeSerializer{
-		PriorityKeys: GCPLogEntryKeyOrder,
-	}
-	yamlBytes, err := serializer.Serialize(node)
+	orderedNode := structured.WithKeyOrder(node, GCPLogEntryKeyOrder...)
+	serializer := &structured.YAMLNodeSerializer{}
+	yamlBytes, err := serializer.Serialize(orderedNode)
 	if err != nil {
 		t.Fatalf("Serialize() failed: %v", err)
 	}

--- a/pkg/api/googlecloud/logconvert/logconvert_test.go
+++ b/pkg/api/googlecloud/logconvert/logconvert_test.go
@@ -15,9 +15,10 @@
 package logconvert
 
 import (
-	"reflect"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
@@ -215,93 +216,69 @@ func TestLogEntryToNode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("yaml serialization failed for want node: %v", err)
 			}
-			if diff := cmp.Diff(gotYAML, wantYAML); diff != "" {
-				t.Errorf("LogEntryToNode() mismatch (-got +want):\n%s", diff)
+			var gotMap, wantMap any
+			if err := yaml.Unmarshal(gotYAML, &gotMap); err != nil {
+				t.Fatalf("yaml unmarshal failed for got: %v", err)
+			}
+			if err := yaml.Unmarshal(wantYAML, &wantMap); err != nil {
+				t.Fatalf("yaml unmarshal failed for want: %v", err)
+			}
+			if diff := cmp.Diff(wantMap, gotMap); diff != "" {
+				t.Errorf("LogEntryToNode() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestGetLogLabelsMap(t *testing.T) {
-	testCases := []struct {
-		name   string
-		labels map[string]string
-		want   structured.Node
-	}{
-		{
-			name:   "empty map",
-			labels: map[string]string{},
-			want:   structured.NewStandardMap([]string{}, []structured.Node{}),
-		},
-		{
-			name:   "single entry",
-			labels: map[string]string{"key": "value"},
-			want: structured.NewStandardMap(
-				[]string{"key"},
-				[]structured.Node{structured.NewStandardScalarNode("value")},
-			),
-		},
-		{
-			name: "multiple entries, should be sorted",
-			labels: map[string]string{
-				"zeta":  "3",
-				"beta":  "2",
-				"alpha": "1",
-			},
-			want: structured.NewStandardMap(
-				[]string{"alpha", "beta", "zeta"},
-				[]structured.Node{
-					structured.NewStandardScalarNode("1"),
-					structured.NewStandardScalarNode("2"),
-					structured.NewStandardScalarNode("3"),
-				},
-			),
-		},
+func TestLogEntryWithKeyOrder(t *testing.T) {
+	entry := &loggingpb.LogEntry{
+		LogName:  "projects/p/logs/l",
+		InsertId: "ins-123",
+		Severity: ltype.LogSeverity_INFO,
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := getLogLabelsMap(tc.labels)
-			if err != nil {
-				t.Fatalf("getLogLabelsMap() failed: %v", err)
-			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("getLogLabelsMap() got = %v, want %v", got, tc.want)
-			}
-		})
+	node, err := LogEntryToNode(entry)
+	if err != nil {
+		t.Fatalf("LogEntryToNode() failed: %v", err)
+	}
+
+	serializer := &structured.YAMLNodeSerializer{
+		PriorityKeys: GCPLogEntryKeyOrder,
+	}
+	yamlBytes, err := serializer.Serialize(node)
+	if err != nil {
+		t.Fatalf("Serialize() failed: %v", err)
+	}
+
+	wantYAML := "insertId: ins-123\nlogName: projects/p/logs/l\nseverity: INFO\n"
+	if diff := cmp.Diff(wantYAML, string(yamlBytes)); diff != "" {
+		t.Errorf("Serialize() with GCPLogEntryKeyOrder mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestProtoTimestampToScalar(t *testing.T) {
-	testCases := []struct {
-		desc string
-		ts   time.Time
-		want structured.Node
-	}{
-		{
-			desc: "simple",
-			ts:   time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC),
-			want: structured.NewStandardScalarNode("2025-01-02T03:04:05Z"),
+func BenchmarkLogEntryToNode(b *testing.B) {
+	now := time.Now()
+	nowpb := timestamppb.New(now)
+	entry := &loggingpb.LogEntry{
+		InsertId: "bench-entry",
+		Labels: map[string]string{
+			"app":  "khi",
+			"tier": "backend",
 		},
-		{
-			desc: "with nano sec",
-			ts:   time.Date(2025, time.January, 2, 3, 4, 5, 500000000, time.UTC),
-			want: structured.NewStandardScalarNode("2025-01-02T03:04:05.5Z"),
+		LogName: "projects/p/logs/l",
+		Payload: &loggingpb.LogEntry_TextPayload{
+			TextPayload: "benchmark payload message",
 		},
-		{
-			desc: "with full nano sec precision",
-			ts:   time.Date(2025, time.January, 2, 3, 4, 5, 123456789, time.UTC),
-			want: structured.NewStandardScalarNode("2025-01-02T03:04:05.123456789Z"),
-		},
+		Severity:  ltype.LogSeverity_INFO,
+		Timestamp: nowpb,
 	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			ts := timestamppb.New(tc.ts)
-			got := protoTimestampToScalar(ts)
 
-			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(structured.StandardScalarNode[string]{})); diff != "" {
-				t.Errorf("protoTimestampToScalar() mismatch (-want +got):\n%s", diff)
-			}
-		})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := LogEntryToNode(entry)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/pkg/api/googlecloud/logconvert/logconvert_test.go
+++ b/pkg/api/googlecloud/logconvert/logconvert_test.go
@@ -200,6 +200,11 @@ func TestLogEntryToNode(t *testing.T) {
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("LogEntryToNode() error = %v, wantErr %v", err, tc.wantErr)
 			}
+			if !tc.wantErr {
+				if _, ok := got.(*structured.LazyJSONNode); !ok {
+					t.Errorf("LogEntryToNode() returned type %T, want *structured.LazyJSONNode", got)
+				}
+			}
 
 			serializer := structured.YAMLNodeSerializer{}
 			gotYAML, err := serializer.Serialize(got)

--- a/pkg/common/structured/lazyjson.go
+++ b/pkg/common/structured/lazyjson.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"unicode/utf16"
 	"unicode/utf8"
+	"unsafe"
 )
 
 // ErrInvalidJSON indicates that invalid JSON syntax was encountered during scanning.
@@ -287,7 +288,10 @@ stringScanLoop:
 			escaped = true
 		case c == '"':
 			if !hasEscapes {
-				return string(data[start:idx]), idx + 1, nil
+				if start == idx {
+					return "", idx + 1, nil
+				}
+				return unsafe.String(&data[start], idx-start), idx + 1, nil
 			}
 			break stringScanLoop
 		}
@@ -300,6 +304,7 @@ stringScanLoop:
 
 	// Unescape string with escape sequences
 	var sb strings.Builder
+	sb.Grow(idx - start)
 	idx = start
 	for idx < len(data) {
 		c := data[idx]
@@ -372,11 +377,21 @@ stringScanLoop:
 }
 
 func parseHex4(b []byte) (rune, error) {
-	val, err := strconv.ParseUint(string(b), 16, 16)
-	if err != nil {
-		return 0, ErrInvalidJSON
+	var val rune
+	for _, c := range b {
+		val <<= 4
+		switch {
+		case c >= '0' && c <= '9':
+			val |= rune(c - '0')
+		case c >= 'a' && c <= 'f':
+			val |= rune(c - 'a' + 10)
+		case c >= 'A' && c <= 'F':
+			val |= rune(c - 'A' + 10)
+		default:
+			return 0, ErrInvalidJSON
+		}
 	}
-	return rune(val), nil
+	return val, nil
 }
 
 func parseJSONScalar(data []byte, index int) (any, int, error) {
@@ -389,17 +404,17 @@ func parseJSONScalar(data []byte, index int) (any, int, error) {
 	case '"':
 		return parseJSONString(data, idx)
 	case 't':
-		if idx+4 <= len(data) && string(data[idx:idx+4]) == "true" {
+		if idx+4 <= len(data) && data[idx] == 't' && data[idx+1] == 'r' && data[idx+2] == 'u' && data[idx+3] == 'e' {
 			return true, idx + 4, nil
 		}
 		return nil, idx, ErrInvalidJSON
 	case 'f':
-		if idx+5 <= len(data) && string(data[idx:idx+5]) == "false" {
+		if idx+5 <= len(data) && data[idx] == 'f' && data[idx+1] == 'a' && data[idx+2] == 'l' && data[idx+3] == 's' && data[idx+4] == 'e' {
 			return false, idx + 5, nil
 		}
 		return nil, idx, ErrInvalidJSON
 	case 'n':
-		if idx+4 <= len(data) && string(data[idx:idx+4]) == "null" {
+		if idx+4 <= len(data) && data[idx] == 'n' && data[idx+1] == 'u' && data[idx+2] == 'l' && data[idx+3] == 'l' {
 			return nil, idx + 4, nil
 		}
 		return nil, idx, ErrInvalidJSON
@@ -423,7 +438,7 @@ func parseJSONScalar(data []byte, index int) (any, int, error) {
 		if start == idx {
 			return nil, idx, ErrInvalidJSON
 		}
-		numStr := string(data[start:idx])
+		numStr := unsafe.String(&data[start], idx-start)
 		if hasFloatChar {
 			floatVal, err := strconv.ParseFloat(numStr, 64)
 			if err != nil {

--- a/pkg/common/structured/lazyjson.go
+++ b/pkg/common/structured/lazyjson.go
@@ -1,0 +1,536 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structured
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// ErrInvalidJSON indicates that invalid JSON syntax was encountered during scanning.
+var ErrInvalidJSON = errors.New("invalid json format")
+
+// LazyJSONNode represents structured data as an immutable JSON byte buffer and an offset index.
+// Child nodes reuse the underlying byte buffer without allocating sub-slices, adjusting only the offset index.
+type LazyJSONNode struct {
+	data  []byte
+	index int
+}
+
+var _ Node = (*LazyJSONNode)(nil)
+
+// NewLazyJSONNode serializes a given Node to JSON and wraps it in a LazyJSONNode.
+func NewLazyJSONNode(node Node) (Node, error) {
+	if lazyNode, ok := node.(*LazyJSONNode); ok {
+		return lazyNode, nil
+	}
+	serializer := JSONNodeSerializer{}
+	data, err := serializer.Serialize(node)
+	if err != nil {
+		return nil, err
+	}
+	return NewLazyJSONNodeFromBytes(data), nil
+}
+
+// NewLazyJSONNodeFromBytes creates a LazyJSONNode from a JSON byte slice.
+func NewLazyJSONNodeFromBytes(data []byte) Node {
+	return &LazyJSONNode{
+		data:  data,
+		index: 0,
+	}
+}
+
+// Type returns the NodeType of this node.
+func (n *LazyJSONNode) Type() NodeType {
+	idx := skipWhitespace(n.data, n.index)
+	if idx >= len(n.data) {
+		return InvalidNodeType
+	}
+	switch n.data[idx] {
+	case '{':
+		return MapNodeType
+	case '[':
+		return SequenceNodeType
+	case '"', 't', 'f', 'n', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return ScalarNodeType
+	default:
+		return InvalidNodeType
+	}
+}
+
+// NodeScalarValue returns the scalar value of this node.
+func (n *LazyJSONNode) NodeScalarValue() (any, error) {
+	if n.Type() != ScalarNodeType {
+		return nil, ErrNonScalarNode
+	}
+	val, _, err := parseJSONScalar(n.data, n.index)
+	return val, err
+}
+
+// Children returns an iterator function over the children of this node.
+func (n *LazyJSONNode) Children() NodeChildrenIterator {
+	nodeType := n.Type()
+	switch nodeType {
+	case MapNodeType:
+		return func(yield func(key NodeChildrenKey, value Node) bool) {
+			idx := skipWhitespace(n.data, n.index)
+			if idx >= len(n.data) || n.data[idx] != '{' {
+				return
+			}
+			idx++ // Skip '{'
+			childIndex := 0
+
+			for {
+				idx = skipWhitespace(n.data, idx)
+				if idx >= len(n.data) {
+					return
+				}
+				if n.data[idx] == '}' {
+					return
+				}
+
+				if n.data[idx] != '"' {
+					return
+				}
+
+				keyStr, nextIdx, err := parseJSONString(n.data, idx)
+				if err != nil {
+					return
+				}
+				idx = skipWhitespace(n.data, nextIdx)
+				if idx >= len(n.data) || n.data[idx] != ':' {
+					return
+				}
+				idx++ // Skip ':'
+				valStartIdx := skipWhitespace(n.data, idx)
+				if valStartIdx >= len(n.data) {
+					return
+				}
+
+				childNode := &LazyJSONNode{
+					data:  n.data,
+					index: valStartIdx,
+				}
+				if !yield(NodeChildrenKey{Index: childIndex, Key: keyStr}, childNode) {
+					return
+				}
+				childIndex++
+
+				valEndIdx, err := skipJSONValue(n.data, valStartIdx)
+				if err != nil {
+					return
+				}
+				idx = skipWhitespace(n.data, valEndIdx)
+				if idx < len(n.data) && n.data[idx] == ',' {
+					idx++
+				}
+			}
+		}
+	case SequenceNodeType:
+		return func(yield func(key NodeChildrenKey, value Node) bool) {
+			idx := skipWhitespace(n.data, n.index)
+			if idx >= len(n.data) || n.data[idx] != '[' {
+				return
+			}
+			idx++ // Skip '['
+			childIndex := 0
+
+			for {
+				idx = skipWhitespace(n.data, idx)
+				if idx >= len(n.data) {
+					return
+				}
+				if n.data[idx] == ']' {
+					return
+				}
+
+				elemStartIdx := idx
+				childNode := &LazyJSONNode{
+					data:  n.data,
+					index: elemStartIdx,
+				}
+				if !yield(NodeChildrenKey{Index: childIndex, Key: ""}, childNode) {
+					return
+				}
+				childIndex++
+
+				elemEndIdx, err := skipJSONValue(n.data, elemStartIdx)
+				if err != nil {
+					return
+				}
+				idx = skipWhitespace(n.data, elemEndIdx)
+				if idx < len(n.data) && n.data[idx] == ',' {
+					idx++
+				}
+			}
+		}
+	default:
+		return func(func(key NodeChildrenKey, value Node) bool) {}
+	}
+}
+
+// Len returns the count of items in a map or sequence, or 0 for scalars.
+func (n *LazyJSONNode) Len() int {
+	nodeType := n.Type()
+	switch nodeType {
+	case MapNodeType:
+		idx := skipWhitespace(n.data, n.index)
+		if idx >= len(n.data) || n.data[idx] != '{' {
+			return 0
+		}
+		idx++
+		count := 0
+		for {
+			idx = skipWhitespace(n.data, idx)
+			if idx >= len(n.data) || n.data[idx] == '}' {
+				break
+			}
+			if n.data[idx] != '"' {
+				break
+			}
+			_, nextIdx, err := parseJSONString(n.data, idx)
+			if err != nil {
+				break
+			}
+			idx = skipWhitespace(n.data, nextIdx)
+			if idx >= len(n.data) || n.data[idx] != ':' {
+				break
+			}
+			idx++
+			valStartIdx := skipWhitespace(n.data, idx)
+			valEndIdx, err := skipJSONValue(n.data, valStartIdx)
+			if err != nil {
+				break
+			}
+			count++
+			idx = skipWhitespace(n.data, valEndIdx)
+			if idx < len(n.data) && n.data[idx] == ',' {
+				idx++
+			}
+		}
+		return count
+	case SequenceNodeType:
+		idx := skipWhitespace(n.data, n.index)
+		if idx >= len(n.data) || n.data[idx] != '[' {
+			return 0
+		}
+		idx++
+		count := 0
+		for {
+			idx = skipWhitespace(n.data, idx)
+			if idx >= len(n.data) || n.data[idx] == ']' {
+				break
+			}
+			elemEndIdx, err := skipJSONValue(n.data, idx)
+			if err != nil {
+				break
+			}
+			count++
+			idx = skipWhitespace(n.data, elemEndIdx)
+			if idx < len(n.data) && n.data[idx] == ',' {
+				idx++
+			}
+		}
+		return count
+	default:
+		return 0
+	}
+}
+
+func skipWhitespace(data []byte, index int) int {
+	for index < len(data) {
+		c := data[index]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			index++
+		} else {
+			break
+		}
+	}
+	return index
+}
+
+func parseJSONString(data []byte, index int) (string, int, error) {
+	idx := skipWhitespace(data, index)
+	if idx >= len(data) || data[idx] != '"' {
+		return "", idx, ErrInvalidJSON
+	}
+	idx++ // Skip opening '"'
+
+	start := idx
+	hasEscapes := false
+	escaped := false
+
+stringScanLoop:
+	for idx < len(data) {
+		c := data[idx]
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\':
+			hasEscapes = true
+			escaped = true
+		case c == '"':
+			if !hasEscapes {
+				return string(data[start:idx]), idx + 1, nil
+			}
+			break stringScanLoop
+		}
+		idx++
+	}
+
+	if idx >= len(data) || data[idx] != '"' {
+		return "", idx, ErrInvalidJSON
+	}
+
+	// Unescape string with escape sequences
+	var sb strings.Builder
+	idx = start
+	for idx < len(data) {
+		c := data[idx]
+		if c == '"' {
+			idx++
+			return sb.String(), idx, nil
+		}
+		if c == '\\' {
+			idx++
+			if idx >= len(data) {
+				return "", idx, ErrInvalidJSON
+			}
+			escapeChar := data[idx]
+			switch escapeChar {
+			case '"', '\\', '/':
+				sb.WriteByte(escapeChar)
+				idx++
+			case 'b':
+				sb.WriteByte('\b')
+				idx++
+			case 'f':
+				sb.WriteByte('\f')
+				idx++
+			case 'n':
+				sb.WriteByte('\n')
+				idx++
+			case 'r':
+				sb.WriteByte('\r')
+				idx++
+			case 't':
+				sb.WriteByte('\t')
+				idx++
+			case 'u':
+				idx++
+				if idx+4 > len(data) {
+					return "", idx, ErrInvalidJSON
+				}
+				r, err := parseHex4(data[idx : idx+4])
+				if err != nil {
+					return "", idx, err
+				}
+				idx += 4
+
+				// Check for UTF-16 surrogate pairs
+				if utf16.IsSurrogate(r) {
+					if idx+6 <= len(data) && data[idx] == '\\' && data[idx+1] == 'u' {
+						r2, err := parseHex4(data[idx+2 : idx+6])
+						if err == nil && utf16.IsSurrogate(r2) {
+							combined := utf16.DecodeRune(r, r2)
+							sb.WriteRune(combined)
+							idx += 6
+							continue
+						}
+					}
+					sb.WriteRune(utf8.RuneError)
+				} else {
+					sb.WriteRune(r)
+				}
+			default:
+				sb.WriteByte(escapeChar)
+				idx++
+			}
+		} else {
+			sb.WriteByte(c)
+			idx++
+		}
+	}
+
+	return "", idx, ErrInvalidJSON
+}
+
+func parseHex4(b []byte) (rune, error) {
+	val, err := strconv.ParseUint(string(b), 16, 16)
+	if err != nil {
+		return 0, ErrInvalidJSON
+	}
+	return rune(val), nil
+}
+
+func parseJSONScalar(data []byte, index int) (any, int, error) {
+	idx := skipWhitespace(data, index)
+	if idx >= len(data) {
+		return nil, idx, ErrInvalidJSON
+	}
+
+	switch data[idx] {
+	case '"':
+		return parseJSONString(data, idx)
+	case 't':
+		if idx+4 <= len(data) && string(data[idx:idx+4]) == "true" {
+			return true, idx + 4, nil
+		}
+		return nil, idx, ErrInvalidJSON
+	case 'f':
+		if idx+5 <= len(data) && string(data[idx:idx+5]) == "false" {
+			return false, idx + 5, nil
+		}
+		return nil, idx, ErrInvalidJSON
+	case 'n':
+		if idx+4 <= len(data) && string(data[idx:idx+4]) == "null" {
+			return nil, idx + 4, nil
+		}
+		return nil, idx, ErrInvalidJSON
+	default:
+		// Number
+		start := idx
+		hasFloatChar := false
+	numberLoop:
+		for idx < len(data) {
+			c := data[idx]
+			switch {
+			case c == '.' || c == 'e' || c == 'E':
+				hasFloatChar = true
+				idx++
+			case (c >= '0' && c <= '9') || c == '-' || c == '+':
+				idx++
+			default:
+				break numberLoop
+			}
+		}
+		if start == idx {
+			return nil, idx, ErrInvalidJSON
+		}
+		numStr := string(data[start:idx])
+		if hasFloatChar {
+			floatVal, err := strconv.ParseFloat(numStr, 64)
+			if err != nil {
+				return nil, idx, err
+			}
+			return floatVal, idx, nil
+		}
+		intVal, err := strconv.Atoi(numStr)
+		if err == nil {
+			return intVal, idx, nil
+		}
+		// Fallback to int64 or float64 if integer overflows standard int
+		int64Val, err := strconv.ParseInt(numStr, 10, 64)
+		if err == nil {
+			return int64Val, idx, nil
+		}
+		floatVal, err := strconv.ParseFloat(numStr, 64)
+		if err != nil {
+			return nil, idx, fmt.Errorf("failed to parse number %q: %w", numStr, err)
+		}
+		return floatVal, idx, nil
+	}
+}
+
+func skipJSONValue(data []byte, index int) (int, error) {
+	idx := skipWhitespace(data, index)
+	if idx >= len(data) {
+		return idx, ErrInvalidJSON
+	}
+
+	switch data[idx] {
+	case '{':
+		idx++
+		depth := 1
+		inString := false
+		escaped := false
+		for idx < len(data) {
+			c := data[idx]
+			if inString {
+				switch {
+				case escaped:
+					escaped = false
+				case c == '\\':
+					escaped = true
+				case c == '"':
+					inString = false
+				}
+			} else {
+				switch c {
+				case '"':
+					inString = true
+				case '{':
+					depth++
+				case '}':
+					depth--
+					if depth == 0 {
+						return idx + 1, nil
+					}
+				}
+			}
+			idx++
+		}
+		return idx, ErrInvalidJSON
+	case '[':
+		idx++
+		depth := 1
+		inString := false
+		escaped := false
+		for idx < len(data) {
+			c := data[idx]
+			if inString {
+				switch {
+				case escaped:
+					escaped = false
+				case c == '\\':
+					escaped = true
+				case c == '"':
+					inString = false
+				}
+			} else {
+				switch c {
+				case '"':
+					inString = true
+				case '[':
+					depth++
+				case ']':
+					depth--
+					if depth == 0 {
+						return idx + 1, nil
+					}
+				}
+			}
+			idx++
+		}
+		return idx, ErrInvalidJSON
+	case '"':
+		_, nextIdx, err := parseJSONString(data, idx)
+		return nextIdx, err
+	default:
+		// Scalar (bool, null, number)
+		for idx < len(data) {
+			c := data[idx]
+			if c == ',' || c == '}' || c == ']' || c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+				return idx, nil
+			}
+			idx++
+		}
+		return idx, nil
+	}
+}

--- a/pkg/common/structured/lazyjson_test.go
+++ b/pkg/common/structured/lazyjson_test.go
@@ -1,0 +1,500 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structured
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLazyJSONNode_Scalar(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		wantType NodeType
+		wantVal  any
+		wantErr  bool
+	}{
+		{
+			name:     "string without escape",
+			input:    `"hello world"`,
+			wantType: ScalarNodeType,
+			wantVal:  "hello world",
+		},
+		{
+			name:     "string with various escapes",
+			input:    `"hello \"world\"\n\t\\\/ \b\f \u0041\u0042"`,
+			wantType: ScalarNodeType,
+			wantVal:  "hello \"world\"\n\t\\/ \b\f AB",
+		},
+		{
+			name:     "positive integer",
+			input:    `42`,
+			wantType: ScalarNodeType,
+			wantVal:  42,
+		},
+		{
+			name:     "negative integer",
+			input:    `-100`,
+			wantType: ScalarNodeType,
+			wantVal:  -100,
+		},
+		{
+			name:     "float number",
+			input:    `3.14159`,
+			wantType: ScalarNodeType,
+			wantVal:  3.14159,
+		},
+		{
+			name:     "float with exponent",
+			input:    `1.5e3`,
+			wantType: ScalarNodeType,
+			wantVal:  1500.0,
+		},
+		{
+			name:     "boolean true",
+			input:    `true`,
+			wantType: ScalarNodeType,
+			wantVal:  true,
+		},
+		{
+			name:     "boolean false",
+			input:    `false`,
+			wantType: ScalarNodeType,
+			wantVal:  false,
+		},
+		{
+			name:     "null value",
+			input:    `null`,
+			wantType: ScalarNodeType,
+			wantVal:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := NewLazyJSONNodeFromBytes([]byte(tc.input))
+			if diff := cmp.Diff(tc.wantType, node.Type()); diff != "" {
+				t.Errorf("Type() mismatch (-want +got):\n%s", diff)
+			}
+			gotVal, err := node.NodeScalarValue()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NodeScalarValue() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if diff := cmp.Diff(tc.wantVal, gotVal); diff != "" {
+				t.Errorf("NodeScalarValue() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLazyJSONNode_Sequence(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      string
+		wantLen    int
+		wantValues []any
+	}{
+		{
+			name:       "empty array",
+			input:      `[]`,
+			wantLen:    0,
+			wantValues: []any{},
+		},
+		{
+			name:       "scalar array",
+			input:      `["foo", 123, true, null, 4.5]`,
+			wantLen:    5,
+			wantValues: []any{"foo", 123, true, nil, 4.5},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := NewLazyJSONNodeFromBytes([]byte(tc.input))
+			if diff := cmp.Diff(NodeType(SequenceNodeType), node.Type()); diff != "" {
+				t.Errorf("Type() mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantLen, node.Len()); diff != "" {
+				t.Errorf("Len() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotValues := make([]any, 0)
+			for key, child := range node.Children() {
+				if diff := cmp.Diff("", key.Key); diff != "" {
+					t.Errorf("key.Key for sequence must be empty (-want +got):\n%s", diff)
+				}
+				childVal, err := child.NodeScalarValue()
+				if err != nil {
+					t.Fatalf("child.NodeScalarValue() error = %v", err)
+				}
+				gotValues = append(gotValues, childVal)
+			}
+			if diff := cmp.Diff(tc.wantValues, gotValues); diff != "" {
+				t.Errorf("Children values mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLazyJSONNode_Map(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      string
+		wantLen    int
+		wantKeys   []string
+		wantValues []any
+	}{
+		{
+			name:       "empty object",
+			input:      `{}`,
+			wantLen:    0,
+			wantKeys:   []string{},
+			wantValues: []any{},
+		},
+		{
+			name:       "flat map",
+			input:      `{"str":"value","num":100,"flag":true,"empty":null}`,
+			wantLen:    4,
+			wantKeys:   []string{"str", "num", "flag", "empty"},
+			wantValues: []any{"value", 100, true, nil},
+		},
+		{
+			name:       "map with escaped key",
+			input:      `{"key \"1\"":"val1","key\n2":"val2"}`,
+			wantLen:    2,
+			wantKeys:   []string{`key "1"`, "key\n2"},
+			wantValues: []any{"val1", "val2"},
+		},
+		{
+			name:       "map with escaped quotes in values and subsequent keys",
+			input:      `{"first":"hello \"world\"","second":"after"}`,
+			wantLen:    2,
+			wantKeys:   []string{"first", "second"},
+			wantValues: []any{`hello "world"`, "after"},
+		},
+		{
+			name:       "map with escaped backslashes in values",
+			input:      `{"path":"C:\\dir\\file.txt","second":"ok"}`,
+			wantLen:    2,
+			wantKeys:   []string{"path", "second"},
+			wantValues: []any{`C:\dir\file.txt`, "ok"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := NewLazyJSONNodeFromBytes([]byte(tc.input))
+			if diff := cmp.Diff(NodeType(MapNodeType), node.Type()); diff != "" {
+				t.Errorf("Type() mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantLen, node.Len()); diff != "" {
+				t.Errorf("Len() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotKeys := make([]string, 0)
+			gotValues := make([]any, 0)
+			for key, child := range node.Children() {
+				gotKeys = append(gotKeys, key.Key)
+				childVal, err := child.NodeScalarValue()
+				if err != nil {
+					t.Fatalf("child.NodeScalarValue() error = %v", err)
+				}
+				gotValues = append(gotValues, childVal)
+			}
+			if diff := cmp.Diff(tc.wantKeys, gotKeys); diff != "" {
+				t.Errorf("Children keys mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantValues, gotValues); diff != "" {
+				t.Errorf("Children values mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLazyJSONNode_NodeReader(t *testing.T) {
+	jsonStr := `{
+		"name": "test-pod",
+		"count": 5,
+		"ratio": 0.75,
+		"enabled": true,
+		"timestamp": "2025-01-02T03:04:05Z",
+		"labels": {
+			"app": "khi",
+			"tier": "backend"
+		},
+		"items": ["a", "b", "c"]
+	}`
+
+	node := NewLazyJSONNodeFromBytes([]byte(jsonStr))
+	reader := NewNodeReader(node)
+
+	name, err := reader.ReadString("name")
+	if err != nil {
+		t.Fatalf("ReadString(name) failed: %v", err)
+	}
+	if diff := cmp.Diff("test-pod", name); diff != "" {
+		t.Errorf("ReadString(name) mismatch (-want +got):\n%s", diff)
+	}
+
+	count, err := reader.ReadInt("count")
+	if err != nil {
+		t.Fatalf("ReadInt(count) failed: %v", err)
+	}
+	if diff := cmp.Diff(5, count); diff != "" {
+		t.Errorf("ReadInt(count) mismatch (-want +got):\n%s", diff)
+	}
+
+	ratio, err := reader.ReadFloat("ratio")
+	if err != nil {
+		t.Fatalf("ReadFloat(ratio) failed: %v", err)
+	}
+	if diff := cmp.Diff(0.75, ratio); diff != "" {
+		t.Errorf("ReadFloat(ratio) mismatch (-want +got):\n%s", diff)
+	}
+
+	enabled, err := reader.ReadBool("enabled")
+	if err != nil {
+		t.Fatalf("ReadBool(enabled) failed: %v", err)
+	}
+	if diff := cmp.Diff(true, enabled); diff != "" {
+		t.Errorf("ReadBool(enabled) mismatch (-want +got):\n%s", diff)
+	}
+
+	ts, err := reader.ReadTimestamp("timestamp")
+	if err != nil {
+		t.Fatalf("ReadTimestamp(timestamp) failed: %v", err)
+	}
+	expectedTime := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
+	if !ts.Equal(expectedTime) {
+		t.Errorf("ReadTimestamp(timestamp) got %v, want %v", ts, expectedTime)
+	}
+
+	app, err := reader.ReadString("labels.app")
+	if err != nil {
+		t.Fatalf("ReadString(labels.app) failed: %v", err)
+	}
+	if diff := cmp.Diff("khi", app); diff != "" {
+		t.Errorf("ReadString(labels.app) mismatch (-want +got):\n%s", diff)
+	}
+
+	if !reader.Has("labels.tier") {
+		t.Errorf("Has(labels.tier) expected true, got false")
+	}
+	if reader.Has("labels.nonexistent") {
+		t.Errorf("Has(labels.nonexistent) expected false, got true")
+	}
+}
+
+func TestNewLazyJSONNode(t *testing.T) {
+	stdMap := NewStandardMap(
+		[]string{"foo", "bar"},
+		[]Node{
+			NewStandardScalarNode("hello"),
+			NewStandardScalarNode(123),
+		},
+	)
+
+	lazyNode, err := NewLazyJSONNode(stdMap)
+	if err != nil {
+		t.Fatalf("NewLazyJSONNode failed: %v", err)
+	}
+
+	reader := NewNodeReader(lazyNode)
+	fooStr, err := reader.ReadString("foo")
+	if err != nil {
+		t.Fatalf("ReadString(foo) failed: %v", err)
+	}
+	if diff := cmp.Diff("hello", fooStr); diff != "" {
+		t.Errorf("ReadString(foo) mismatch (-want +got):\n%s", diff)
+	}
+
+	barInt, err := reader.ReadInt("bar")
+	if err != nil {
+		t.Fatalf("ReadInt(bar) failed: %v", err)
+	}
+	if diff := cmp.Diff(123, barInt); diff != "" {
+		t.Errorf("ReadInt(bar) mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLazyJSONNode_Concurrency(t *testing.T) {
+	jsonStr := `{"foo":"bar","nested":{"num":42},"arr":[1,2,3]}`
+	node := NewLazyJSONNodeFromBytes([]byte(jsonStr))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			reader := NewNodeReader(node)
+			for j := 0; j < 100; j++ {
+				str, err := reader.ReadString("foo")
+				if err != nil || str != "bar" {
+					t.Errorf("concurrent ReadString failed: %v, got %s", err, str)
+				}
+				num, err := reader.ReadInt("nested.num")
+				if err != nil || num != 42 {
+					t.Errorf("concurrent ReadInt failed: %v, got %d", err, num)
+				}
+				if node.Len() != 3 {
+					t.Errorf("concurrent Len failed, got %d", node.Len())
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestLazyJSONNode_ChildrenEarlyBreak(t *testing.T) {
+	mapNode := NewLazyJSONNodeFromBytes([]byte(`{"a":1,"b":2,"c":3}`))
+	mapKeys := make([]string, 0)
+	for key := range mapNode.Children() {
+		mapKeys = append(mapKeys, key.Key)
+		if key.Index == 0 {
+			break
+		}
+	}
+	if diff := cmp.Diff([]string{"a"}, mapKeys); diff != "" {
+		t.Errorf("map Children early break mismatch (-want +got):\n%s", diff)
+	}
+
+	seqNode := NewLazyJSONNodeFromBytes([]byte(`[10,20,30,40]`))
+	seqCount := 0
+	for key := range seqNode.Children() {
+		seqCount++
+		if key.Index == 1 {
+			break
+		}
+	}
+	if diff := cmp.Diff(2, seqCount); diff != "" {
+		t.Errorf("sequence Children early break count mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLazyJSONNode_Serialization(t *testing.T) {
+	inputJSON := `{"foo":"bar","items":[1,2,3]}`
+	lazyNode := NewLazyJSONNodeFromBytes([]byte(inputJSON))
+
+	yamlSerializer := &YAMLNodeSerializer{}
+	yamlBytes, err := yamlSerializer.Serialize(lazyNode)
+	if err != nil {
+		t.Fatalf("YAMLNodeSerializer.Serialize failed: %v", err)
+	}
+	expectedYAML := "foo: bar\nitems:\n  - 1\n  - 2\n  - 3\n"
+	if diff := cmp.Diff(expectedYAML, string(yamlBytes)); diff != "" {
+		t.Errorf("YAML serialization mismatch (-want +got):\n%s", diff)
+	}
+
+	jsonSerializer := &JSONNodeSerializer{}
+	jsonBytes, err := jsonSerializer.Serialize(lazyNode)
+	if err != nil {
+		t.Fatalf("JSONNodeSerializer.Serialize failed: %v", err)
+	}
+	expectedJSON := `{"foo":"bar","items":[1,2,3]}`
+	if diff := cmp.Diff(expectedJSON, string(jsonBytes)); diff != "" {
+		t.Errorf("JSON serialization mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLazyJSONNode_ReadReflectWithEscapes(t *testing.T) {
+	type NestedStruct struct {
+		Message string `json:"message"`
+		Code    int    `json:"code"`
+	}
+	type SampleStruct struct {
+		Title  string       `json:"title"`
+		Nested NestedStruct `json:"nested"`
+	}
+
+	inputJSON := `{"title":"hello \"world\" \n test","nested":{"message":"inner \"quotes\" and \\ slashes","code":200}}`
+	node := NewLazyJSONNodeFromBytes([]byte(inputJSON))
+	reader := NewNodeReader(node)
+
+	var target SampleStruct
+	err := ReadReflect(reader, "", &target)
+	if err != nil {
+		t.Fatalf("ReadReflect failed: %v", err)
+	}
+
+	expected := SampleStruct{
+		Title: "hello \"world\" \n test",
+		Nested: NestedStruct{
+			Message: "inner \"quotes\" and \\ slashes",
+			Code:    200,
+		},
+	}
+	if diff := cmp.Diff(expected, target); diff != "" {
+		t.Errorf("ReadReflect mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLazyJSONNode_MergeNode(t *testing.T) {
+	prev := NewLazyJSONNodeFromBytes([]byte(`{"name":"test","count":1,"labels":{"env":"prod"}}`))
+	patch := NewLazyJSONNodeFromBytes([]byte(`{"count":2,"labels":{"tier":"frontend"}}`))
+
+	merged, err := MergeNode(prev, patch, MergeConfiguration{
+		MergeMapOrderStrategy: &DefaultMergeMapOrderStrategy{},
+	})
+	if err != nil {
+		t.Fatalf("MergeNode failed: %v", err)
+	}
+
+	reader := NewNodeReader(merged)
+	name, err := reader.ReadString("name")
+	if err != nil || name != "test" {
+		t.Errorf("merged name mismatch: %v, %s", err, name)
+	}
+	count, err := reader.ReadInt("count")
+	if err != nil || count != 2 {
+		t.Errorf("merged count mismatch: %v, %d", err, count)
+	}
+	env, err := reader.ReadString("labels.env")
+	if err != nil || env != "prod" {
+		t.Errorf("merged labels.env mismatch: %v, %s", err, env)
+	}
+	tier, err := reader.ReadString("labels.tier")
+	if err != nil || tier != "frontend" {
+		t.Errorf("merged labels.tier mismatch: %v, %s", err, tier)
+	}
+}
+
+func BenchmarkLazyJSONNodeVsStandardMap(b *testing.B) {
+	rawJSON := `{"insertId":"123","logName":"projects/p/logs/l","labels":{"k1":"v1","k2":"v2"},"resource":{"type":"gce_instance","labels":{"zone":"us-central1-a"}}}`
+	nodeFromJSON, err := FromYAML(rawJSON)
+	if err != nil {
+		b.Fatal(err)
+	}
+	lazyNode := NewLazyJSONNodeFromBytes([]byte(rawJSON))
+
+	b.Run("StandardMap_ReadString", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			r := NewNodeReader(nodeFromJSON)
+			_, _ = r.ReadString("resource.labels.zone")
+		}
+	})
+
+	b.Run("LazyJSONNode_ReadString", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			r := NewNodeReader(lazyNode)
+			_, _ = r.ReadString("resource.labels.zone")
+		}
+	})
+}

--- a/pkg/common/structured/ordered.go
+++ b/pkg/common/structured/ordered.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structured
+
+// orderedMapNode wraps a map Node and customizes its Children() iteration order.
+type orderedMapNode struct {
+	inner        Node
+	priorityKeys []string
+}
+
+// WithKeyOrder wraps a map Node to customize its Children() iteration order.
+// It yields children with keys matching priorityKeys in the specified order first,
+// followed by any remaining children in their original order.
+// If the node is not a MapNodeType or priorityKeys is empty, it returns the original node.
+func WithKeyOrder(node Node, priorityKeys ...string) Node {
+	if node == nil || node.Type() != MapNodeType || len(priorityKeys) == 0 {
+		return node
+	}
+	return &orderedMapNode{
+		inner:        node,
+		priorityKeys: priorityKeys,
+	}
+}
+
+// Type implements Node.
+func (o *orderedMapNode) Type() NodeType {
+	return o.inner.Type()
+}
+
+// NodeScalarValue implements Node.
+func (o *orderedMapNode) NodeScalarValue() (any, error) {
+	return o.inner.NodeScalarValue()
+}
+
+// Len implements Node.
+func (o *orderedMapNode) Len() int {
+	return o.inner.Len()
+}
+
+// Children implements Node.
+func (o *orderedMapNode) Children() NodeChildrenIterator {
+	return func(callback func(key NodeChildrenKey, value Node) bool) {
+		type entry struct {
+			key   NodeChildrenKey
+			value Node
+		}
+		entries := make([]entry, 0, o.inner.Len())
+		keyToIndex := make(map[string]int, o.inner.Len())
+
+		for k, v := range o.inner.Children() {
+			keyToIndex[k.Key] = len(entries)
+			entries = append(entries, entry{key: k, value: v})
+		}
+
+		visited := make([]bool, len(entries))
+
+		// 1. Yield priority keys in specified order with O(1) lookup
+		for _, pk := range o.priorityKeys {
+			if idx, ok := keyToIndex[pk]; ok && !visited[idx] {
+				visited[idx] = true
+				if !callback(entries[idx].key, entries[idx].value) {
+					return
+				}
+			}
+		}
+
+		// 2. Yield remaining keys in original order
+		for i, e := range entries {
+			if !visited[i] {
+				if !callback(e.key, e.value) {
+					return
+				}
+			}
+		}
+	}
+}
+
+var _ Node = (*orderedMapNode)(nil)

--- a/pkg/common/structured/ordered.go
+++ b/pkg/common/structured/ordered.go
@@ -28,6 +28,12 @@ func WithKeyOrder(node Node, priorityKeys ...string) Node {
 	if node == nil || node.Type() != MapNodeType || len(priorityKeys) == 0 {
 		return node
 	}
+	if ordered, ok := node.(*orderedMapNode); ok {
+		return &orderedMapNode{
+			inner:        ordered.inner,
+			priorityKeys: priorityKeys,
+		}
+	}
 	return &orderedMapNode{
 		inner:        node,
 		priorityKeys: priorityKeys,

--- a/pkg/common/structured/ordered_test.go
+++ b/pkg/common/structured/ordered_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structured
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWithKeyOrder(t *testing.T) {
+	testCases := []struct {
+		name         string
+		jsonInput    string
+		priorityKeys []string
+		wantKeys     []string
+	}{
+		{
+			name:         "reorders specified keys to the front",
+			jsonInput:    `{"zebra": 1, "apple": 2, "mango": 3, "banana": 4}`,
+			priorityKeys: []string{"mango", "apple"},
+			wantKeys:     []string{"mango", "apple", "zebra", "banana"},
+		},
+		{
+			name:         "skips nonexistent priority keys gracefully",
+			jsonInput:    `{"a": 1, "b": 2, "c": 3}`,
+			priorityKeys: []string{"nonexistent", "c", "missing"},
+			wantKeys:     []string{"c", "a", "b"},
+		},
+		{
+			name:         "empty priority keys returns original order",
+			jsonInput:    `{"a": 1, "b": 2, "c": 3}`,
+			priorityKeys: []string{},
+			wantKeys:     []string{"a", "b", "c"},
+		},
+		{
+			name:         "all keys prioritized in reverse order",
+			jsonInput:    `{"a": 1, "b": 2, "c": 3}`,
+			priorityKeys: []string{"c", "b", "a"},
+			wantKeys:     []string{"c", "b", "a"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := NewLazyJSONNodeFromBytes([]byte(tc.jsonInput))
+			ordered := WithKeyOrder(node, tc.priorityKeys...)
+
+			var gotKeys []string
+			for k := range ordered.Children() {
+				gotKeys = append(gotKeys, k.Key)
+			}
+
+			if diff := cmp.Diff(tc.wantKeys, gotKeys); diff != "" {
+				t.Errorf("WithKeyOrder() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWithKeyOrderNonMap(t *testing.T) {
+	scalar := NewStandardScalarNode("hello")
+	orderedScalar := WithKeyOrder(scalar, "a", "b")
+	if orderedScalar != scalar {
+		t.Errorf("WithKeyOrder on scalar should return original node")
+	}
+
+	nilOrdered := WithKeyOrder(nil, "a")
+	if nilOrdered != nil {
+		t.Errorf("WithKeyOrder on nil should return nil")
+	}
+}
+
+func TestNodeReaderWithKeyOrder(t *testing.T) {
+	jsonBytes := []byte(`{"logName":"projects/p/logs/l","insertId":"ins-123","severity":"INFO"}`)
+	node := NewLazyJSONNodeFromBytes(jsonBytes)
+	reader := NewNodeReader(node)
+
+	orderedReader := reader.WithKeyOrder("insertId", "logName")
+	yamlBytes, err := orderedReader.Serialize("", &YAMLNodeSerializer{})
+	if err != nil {
+		t.Fatalf("Serialize failed: %v", err)
+	}
+
+	wantYAML := "insertId: ins-123\nlogName: projects/p/logs/l\nseverity: INFO\n"
+	if diff := cmp.Diff(wantYAML, string(yamlBytes)); diff != "" {
+		t.Errorf("Serialize mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestYAMLNodeSerializerPriorityKeys(t *testing.T) {
+	jsonBytes := []byte(`{"logName":"projects/p/logs/l","insertId":"ins-123","severity":"INFO"}`)
+	node := NewLazyJSONNodeFromBytes(jsonBytes)
+
+	serializer := &YAMLNodeSerializer{
+		PriorityKeys: []string{"insertId", "logName"},
+	}
+	yamlBytes, err := serializer.Serialize(node)
+	if err != nil {
+		t.Fatalf("Serialize failed: %v", err)
+	}
+
+	wantYAML := "insertId: ins-123\nlogName: projects/p/logs/l\nseverity: INFO\n"
+	if diff := cmp.Diff(wantYAML, string(yamlBytes)); diff != "" {
+		t.Errorf("Serialize mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/common/structured/ordered_test.go
+++ b/pkg/common/structured/ordered_test.go
@@ -100,20 +100,26 @@ func TestNodeReaderWithKeyOrder(t *testing.T) {
 	}
 }
 
-func TestYAMLNodeSerializerPriorityKeys(t *testing.T) {
-	jsonBytes := []byte(`{"logName":"projects/p/logs/l","insertId":"ins-123","severity":"INFO"}`)
+func TestWithKeyOrderNested(t *testing.T) {
+	jsonBytes := []byte(`{"a": 1, "b": 2, "c": 3}`)
 	node := NewLazyJSONNodeFromBytes(jsonBytes)
+	ordered1 := WithKeyOrder(node, "b")
+	ordered2 := WithKeyOrder(ordered1, "c")
 
-	serializer := &YAMLNodeSerializer{
-		PriorityKeys: []string{"insertId", "logName"},
+	orderedMap, ok := ordered2.(*orderedMapNode)
+	if !ok {
+		t.Fatalf("expected *orderedMapNode, got %T", ordered2)
 	}
-	yamlBytes, err := serializer.Serialize(node)
-	if err != nil {
-		t.Fatalf("Serialize failed: %v", err)
+	if _, isNested := orderedMap.inner.(*orderedMapNode); isNested {
+		t.Errorf("expected inner node not to be *orderedMapNode, but got nested *orderedMapNode")
 	}
 
-	wantYAML := "insertId: ins-123\nlogName: projects/p/logs/l\nseverity: INFO\n"
-	if diff := cmp.Diff(wantYAML, string(yamlBytes)); diff != "" {
-		t.Errorf("Serialize mismatch (-want +got):\n%s", diff)
+	var gotKeys []string
+	for k := range ordered2.Children() {
+		gotKeys = append(gotKeys, k.Key)
+	}
+	wantKeys := []string{"c", "a", "b"}
+	if diff := cmp.Diff(wantKeys, gotKeys); diff != "" {
+		t.Errorf("WithKeyOrder nested keys mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -80,6 +80,13 @@ func (n *NodeReader) Children() NodeReaderChildrenIterator {
 	}
 }
 
+// WithKeyOrder returns a new NodeReader wrapping the node with the specified key order.
+func (n *NodeReader) WithKeyOrder(priorityKeys ...string) *NodeReader {
+	return &NodeReader{
+		Node: WithKeyOrder(n.Node, priorityKeys...),
+	}
+}
+
 // ReadBool retrieves a boolean value from the specified field path.
 // Returns an error if the field doesn't exist or cannot be cast to a boolean.
 func (n *NodeReader) ReadBool(fieldPath string) (bool, error) {

--- a/pkg/common/structured/serializer.go
+++ b/pkg/common/structured/serializer.go
@@ -24,10 +24,16 @@ type NodeSerializer interface {
 	Serialize(node Node) ([]byte, error)
 }
 
-type YAMLNodeSerializer struct{}
+type YAMLNodeSerializer struct {
+	// PriorityKeys specifies keys that should appear first in map nodes, in the given order.
+	PriorityKeys []string
+}
 
 // Serialize implements NodeSerializer.
 func (y *YAMLNodeSerializer) Serialize(node Node) ([]byte, error) {
+	if len(y.PriorityKeys) > 0 {
+		node = WithKeyOrder(node, y.PriorityKeys...)
+	}
 	serializable, err := getYAMLMarshaler(node)
 	if err != nil {
 		return nil, err

--- a/pkg/common/structured/serializer.go
+++ b/pkg/common/structured/serializer.go
@@ -24,16 +24,10 @@ type NodeSerializer interface {
 	Serialize(node Node) ([]byte, error)
 }
 
-type YAMLNodeSerializer struct {
-	// PriorityKeys specifies keys that should appear first in map nodes, in the given order.
-	PriorityKeys []string
-}
+type YAMLNodeSerializer struct{}
 
 // Serialize implements NodeSerializer.
 func (y *YAMLNodeSerializer) Serialize(node Node) ([]byte, error) {
-	if len(y.PriorityKeys) > 0 {
-		node = WithKeyOrder(node, y.PriorityKeys...)
-	}
 	serializable, err := getYAMLMarshaler(node)
 	if err != nil {
 		return nil, err

--- a/pkg/common/structured/standard.go
+++ b/pkg/common/structured/standard.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 	"unique"
 
@@ -264,8 +263,11 @@ func (n *StandardMapNode) MarshalJSON() ([]byte, error) {
 		if i.Index > 0 {
 			buf.WriteString(",")
 		}
-		key := fmt.Sprintf("\"%s\"", escapeJSONString(i.Key))
-		buf.WriteString(key)
+		keyBytes, err := json.Marshal(i.Key)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(keyBytes)
 		buf.WriteString(":")
 		marshaller, ok := child.(json.Marshaler)
 		if !ok {
@@ -280,7 +282,6 @@ func (n *StandardMapNode) MarshalJSON() ([]byte, error) {
 	buf.WriteString("}")
 
 	return buf.Bytes(), nil
-
 }
 
 var _ Node = (*StandardMapNode)(nil)
@@ -433,8 +434,4 @@ func WithScalarField[T comparable](node Node, fieldPath []string, value T) (Node
 		}
 	}
 	return &newMapNode, nil
-}
-
-func escapeJSONString(rawString string) string {
-	return strings.ReplaceAll(rawString, "\"", "\\\"")
 }

--- a/pkg/model/k8s/merge_config.go
+++ b/pkg/model/k8s/merge_config.go
@@ -21,6 +21,15 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 )
 
+// K8sManifestKeyOrder defines the canonical top-level field order for Kubernetes resource manifests when serializing to YAML.
+var K8sManifestKeyOrder = []string{
+	"apiVersion",
+	"kind",
+	"metadata",
+	"spec",
+	"status",
+}
+
 // K8sManifestMergeConfigRegistry holds merge configurations for Kubernetes manifests.
 type K8sManifestMergeConfigRegistry struct {
 	defaultResolver      *structured.MergeConfigResolver

--- a/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper.go
@@ -79,15 +79,6 @@ func (e *MultiGroupLogEvent) GetLastBodyReader(role string) (*structured.NodeRea
 	return manifestLog.ResourceBodyReader, true
 }
 
-// GetLastBodyYAML returns the latest resource body YAML for the specified role at the time of this event.
-func (e *MultiGroupLogEvent) GetLastBodyYAML(role string) (string, bool) {
-	manifestLog, ok := e.getLastManifestLog(role)
-	if !ok || manifestLog.ResourceBodyYAML == "" {
-		return "", false
-	}
-	return manifestLog.ResourceBodyYAML, true
-}
-
 // getLastManifestLog returns the latest ResourceManifestLog entry for the specified role at the time of this event.
 func (e *MultiGroupLogEvent) getLastManifestLog(role string) (*ResourceManifestLog, bool) {
 	group, found := e.GroupSet.Roles[role]
@@ -108,7 +99,7 @@ func (e *MultiGroupLogEvent) getLastManifestLog(role string) (*ResourceManifestL
 	var lastManifestLog *ResourceManifestLog
 	for i := idx - 1; i >= 0; i-- {
 		logEntry := group.Logs[i]
-		if logEntry.ResourceBodyReader != nil || logEntry.ResourceBodyYAML != "" {
+		if logEntry.ResourceBodyReader != nil {
 			lastManifestLog = logEntry
 			break
 		}

--- a/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper_test.go
@@ -103,13 +103,13 @@ func TestGetLastBody(t *testing.T) {
 		Roles: map[string]*ResourceManifestLogGroup{
 			"roleA": {
 				Logs: []*ResourceManifestLog{
-					{Log: logA1, ResourceBodyYAML: "value: A1", ResourceBodyReader: structured.NewNodeReader(nodeA1)},
-					{Log: logA2, ResourceBodyYAML: "value: A2", ResourceBodyReader: structured.NewNodeReader(nodeA2)},
+					{Log: logA1, ResourceBodyReader: structured.NewNodeReader(nodeA1)},
+					{Log: logA2, ResourceBodyReader: structured.NewNodeReader(nodeA2)},
 				},
 			},
 			"roleB": {
 				Logs: []*ResourceManifestLog{
-					{Log: logB1, ResourceBodyYAML: "value: B1", ResourceBodyReader: structured.NewNodeReader(nodeB1)},
+					{Log: logB1, ResourceBodyReader: structured.NewNodeReader(nodeB1)},
 				},
 			},
 		},
@@ -130,7 +130,6 @@ func TestGetLastBody(t *testing.T) {
 		expectedRole string
 		roleToCheck  string
 		wantFound    bool
-		wantYAML     string
 		wantValue    string
 	}{
 		{
@@ -139,7 +138,6 @@ func TestGetLastBody(t *testing.T) {
 			expectedRole: "roleA",
 			roleToCheck:  "roleA",
 			wantFound:    true,
-			wantYAML:     "value: A1",
 			wantValue:    "A1",
 		},
 		{
@@ -155,7 +153,6 @@ func TestGetLastBody(t *testing.T) {
 			expectedRole: "roleB",
 			roleToCheck:  "roleA",
 			wantFound:    true,
-			wantYAML:     "value: A1",
 			wantValue:    "A1",
 		},
 		{
@@ -164,7 +161,6 @@ func TestGetLastBody(t *testing.T) {
 			expectedRole: "roleB",
 			roleToCheck:  "roleB",
 			wantFound:    true,
-			wantYAML:     "value: B1",
 			wantValue:    "B1",
 		},
 		{
@@ -173,7 +169,6 @@ func TestGetLastBody(t *testing.T) {
 			expectedRole: "roleA",
 			roleToCheck:  "roleA",
 			wantFound:    true,
-			wantYAML:     "value: A2",
 			wantValue:    "A2",
 		},
 		{
@@ -182,7 +177,6 @@ func TestGetLastBody(t *testing.T) {
 			expectedRole: "roleA",
 			roleToCheck:  "roleB",
 			wantFound:    true,
-			wantYAML:     "value: B1",
 			wantValue:    "B1",
 		},
 	}
@@ -196,14 +190,6 @@ func TestGetLastBody(t *testing.T) {
 
 			if e.GroupRole != tc.expectedRole {
 				t.Errorf("expected group role %q, got %q", tc.expectedRole, e.GroupRole)
-			}
-
-			yaml, ok := e.GetLastBodyYAML(tc.roleToCheck)
-			if ok != tc.wantFound {
-				t.Errorf("GetLastBodyYAML(%q) ok = %t, want %t", tc.roleToCheck, ok, tc.wantFound)
-			}
-			if ok && yaml != tc.wantYAML {
-				t.Errorf("GetLastBodyYAML(%q) = %q, want %q", tc.roleToCheck, yaml, tc.wantYAML)
 			}
 
 			if tc.wantFound {

--- a/pkg/task/inspection/commonlogk8saudit/contract/type.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/type.go
@@ -158,8 +158,6 @@ type ResourceLogGroupMap = map[string]*ResourceLogGroup
 type ResourceManifestLog struct {
 	// Log is the log.
 	Log *log.Log
-	// ResourceBodyYAML is the YAML representation of the resource body.
-	ResourceBodyYAML string
 	// ResourceBodyReader is the reader for the resource body.
 	ResourceBodyReader *structured.NodeReader
 	// ResourceCreated is true if the resource is created.

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
@@ -317,7 +317,7 @@ status:
 				"target": {
 					Resource: resIdentity,
 					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-						{Log: logObj, ResourceBodyReader: bodyReader, ResourceBodyYAML: bodyYAML},
+						{Log: logObj, ResourceBodyReader: bodyReader},
 					},
 				},
 			},
@@ -412,7 +412,7 @@ status:
 				"target": {
 					Resource: resIdentity,
 					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-						{Log: logObj, ResourceBodyReader: bodyReader, ResourceBodyYAML: bodyYAML},
+						{Log: logObj, ResourceBodyReader: bodyReader},
 					},
 				},
 			},
@@ -505,8 +505,8 @@ status:
 				"target": {
 					Resource: resIdentity,
 					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-						{Log: logObj2, ResourceBodyReader: bodyReader2, ResourceBodyYAML: bodyYAML2},
-						{Log: logObj1, ResourceBodyReader: bodyReader1, ResourceBodyYAML: bodyYAML1},
+						{Log: logObj2, ResourceBodyReader: bodyReader2},
+						{Log: logObj1, ResourceBodyReader: bodyReader1},
 					},
 				},
 			},
@@ -599,7 +599,7 @@ status:
 				"target": {
 					Resource: resIdentity,
 					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-						{Log: logObj, ResourceBodyReader: bodyReader, ResourceBodyYAML: bodyYAML},
+						{Log: logObj, ResourceBodyReader: bodyReader},
 					},
 				},
 			},
@@ -678,7 +678,7 @@ status:
 				"target": {
 					Resource: resIdentity,
 					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-						{Log: logObj, ResourceBodyReader: bodyReader, ResourceBodyYAML: bodyYAML},
+						{Log: logObj, ResourceBodyReader: bodyReader},
 					},
 				},
 			},

--- a/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task_test.go
@@ -672,7 +672,7 @@ status:
 					"pod": {
 						Resource: resIdentity,
 						Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-							{Log: l, ResourceBodyReader: reader, ResourceBodyYAML: tc.yaml},
+							{Log: l, ResourceBodyReader: reader},
 						},
 					},
 				},

--- a/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task_test.go
@@ -621,7 +621,7 @@ endpoints:
 					"target": {
 						Resource: resIdentity,
 						Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-							{Log: l, ResourceBodyReader: reader, ResourceBodyYAML: tc.yaml},
+							{Log: l, ResourceBodyReader: reader},
 						},
 					},
 				},

--- a/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/lifetimetracker_task_test.go
@@ -187,7 +187,6 @@ metadata:
 			resourceLog := &commonlogk8saudit_contract.ResourceManifestLog{
 				Log:                l,
 				ResourceBodyReader: reader,
-				ResourceBodyYAML:   tc.resourceBodyYAML,
 				ResourceCreated:    false,
 				ResourceDeleted:    false,
 			}
@@ -495,7 +494,6 @@ metadata:
 				resourceLog := &commonlogk8saudit_contract.ResourceManifestLog{
 					Log:                logObj,
 					ResourceBodyReader: reader,
-					ResourceBodyYAML:   s.resourceBodyYAML,
 				}
 				var err error
 				state, err = tracker.DetectLifetimeLogEvent(t.Context(), resourceLog, state)

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
@@ -15,7 +15,9 @@
 package commonlogk8saudit_impl
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"runtime"
@@ -36,8 +38,6 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"golang.org/x/sync/errgroup"
 )
-
-var bodyPlaceholderForMetadataLevelAuditLog = "# Resource data is unavailable. Audit logs for this resource is recorded at metadata level."
 
 // ManifestGeneratorTask is the task to generate manifest from k8s audit logs.
 var ManifestGeneratorTask = inspectiontaskbase.NewProgressReportableInspectionTask(commonlogk8saudit_contract.ManifestGeneratorTaskID, []taskid.UntypedTaskReference{
@@ -112,8 +112,6 @@ type groupManifestGenerator struct {
 	prevRevisionReader *structured.NodeReader
 	// mergeConfigRegistry is the registry for merge config.
 	mergeConfigRegistry *k8s.K8sManifestMergeConfigRegistry
-	// prevRevisionBody is the body of the previous revision.
-	prevRevisionBody string
 	// resourceName is the name of the resource.
 	resourceName string
 }
@@ -127,7 +125,6 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 	if fieldSet.IsDryRun {
 		return &commonlogk8saudit_contract.ResourceManifestLog{
 			Log:                l,
-			ResourceBodyYAML:   g.prevRevisionBody,
 			ResourceBodyReader: g.prevRevisionReader,
 		}, nil
 	}
@@ -151,7 +148,6 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 	if currentBodyReader == nil {
 		return &commonlogk8saudit_contract.ResourceManifestLog{
 			Log:                l,
-			ResourceBodyYAML:   bodyPlaceholderForMetadataLevelAuditLog,
 			ResourceBodyReader: nil,
 		}, nil
 	}
@@ -161,7 +157,6 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 		if err != nil {
 			return &commonlogk8saudit_contract.ResourceManifestLog{
 				Log:                l,
-				ResourceBodyYAML:   g.prevRevisionBody,
 				ResourceBodyReader: g.prevRevisionReader,
 			}, nil
 		}
@@ -170,28 +165,11 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 			name := item.ReadStringOrDefault("metadata.name", "")
 			if name == g.resourceName {
 				found = true
-				// XXList omits apiVersion and kind in its item. Generate a reader with the field.
-				rawYAML, err := item.Serialize("", &structured.YAMLNodeSerializer{})
+				bodyReader, err := constructResourceBodyFromListItem(&item, g.prevRevisionReader)
 				if err != nil {
-					slog.WarnContext(ctx, fmt.Sprintf("failed to serialize resource body to yaml\n%s", err.Error()))
-				}
-				var prevAPIVersion, prevKind string
-				if g.prevRevisionReader != nil {
-					prevAPIVersion = g.prevRevisionReader.ReadStringOrDefault("apiVersion", "")
-					prevKind = g.prevRevisionReader.ReadStringOrDefault("kind", "")
-				}
-				fullYAMLStr := string(rawYAML)
-				if prevAPIVersion != "" && prevKind != "" {
-					fullYAMLStr = fmt.Sprintf(`apiVersion: %s
-kind: %s
-%s`, prevAPIVersion, prevKind, fullYAMLStr)
-				}
-
-				rootNode, err := structured.FromYAML(fullYAMLStr)
-				if err != nil {
-					slog.WarnContext(ctx, fmt.Sprintf("failed to serialize resource body to yaml after constructing full yaml\n%s", err.Error()))
+					slog.WarnContext(ctx, fmt.Sprintf("failed to construct resource body from list item: %v", err))
 				} else {
-					currentBodyReader = structured.NewNodeReader(rootNode)
+					currentBodyReader = bodyReader
 				}
 				break
 			}
@@ -199,17 +177,10 @@ kind: %s
 		if !found {
 			return &commonlogk8saudit_contract.ResourceManifestLog{
 				Log:                l,
-				ResourceBodyYAML:   bodyPlaceholderForMetadataLevelAuditLog,
 				ResourceBodyReader: nil,
 			}, nil
 		}
 	}
-
-	currentRevisionBodyRaw, err := currentBodyReader.Serialize("", &structured.YAMLNodeSerializer{})
-	if err != nil {
-		slog.WarnContext(ctx, fmt.Sprintf("failed to serialize resource body to yaml\n%s", err.Error()))
-	}
-	currentRevisionBody := string(currentRevisionBodyRaw)
 
 	if fieldSet.Verb == commonlogk8saudit_contract.VerbPatch && partial {
 		mergeConfigResolver := g.mergeConfigRegistry.Get(fieldSet.APIVersion, commonlogk8saudit_contract.GetSingularKindName(fieldSet.PluralKind))
@@ -222,20 +193,19 @@ kind: %s
 			slog.WarnContext(ctx, fmt.Sprintf("failed to merge resource body\n%s", err.Error()))
 			return &commonlogk8saudit_contract.ResourceManifestLog{
 				Log:                l,
-				ResourceBodyYAML:   g.prevRevisionBody,
 				ResourceBodyReader: g.prevRevisionReader,
 			}, nil
 		} else {
-			mergedNodeReader = structured.NewNodeReader(mergedNode)
-			mergedYAMLRaw, err := mergedNodeReader.Serialize("", &structured.YAMLNodeSerializer{})
+			lazyMergedNode, err := structured.NewLazyJSONNode(mergedNode)
 			if err != nil {
-				slog.WarnContext(ctx, fmt.Sprintf("failed to read the merged resource body\n%s", err.Error()))
+				slog.WarnContext(ctx, fmt.Sprintf("failed to convert merged node to lazy JSON node: %v", err))
+				mergedNodeReader = structured.NewNodeReader(structured.WithKeyOrder(mergedNode, k8s.K8sManifestKeyOrder...))
+			} else {
+				mergedNodeReader = structured.NewNodeReader(structured.WithKeyOrder(lazyMergedNode, k8s.K8sManifestKeyOrder...))
 			}
-			g.prevRevisionBody = string(mergedYAMLRaw)
 			g.prevRevisionReader = mergedNodeReader
 			return &commonlogk8saudit_contract.ResourceManifestLog{
 				Log:                l,
-				ResourceBodyYAML:   g.prevRevisionBody,
 				ResourceBodyReader: g.prevRevisionReader,
 			}, nil
 		}
@@ -245,16 +215,70 @@ kind: %s
 		if apiVersion == "meta.k8s.io/__internal" && kind == "DeleteOptions" {
 			return &commonlogk8saudit_contract.ResourceManifestLog{
 				Log:                l,
-				ResourceBodyYAML:   g.prevRevisionBody,
 				ResourceBodyReader: g.prevRevisionReader,
 			}, nil
 		}
-		g.prevRevisionBody = currentRevisionBody
 		g.prevRevisionReader = currentBodyReader
 		return &commonlogk8saudit_contract.ResourceManifestLog{
 			Log:                l,
-			ResourceBodyYAML:   g.prevRevisionBody,
 			ResourceBodyReader: g.prevRevisionReader,
 		}, nil
 	}
+}
+
+// constructResourceBodyFromListItem constructs a complete resource manifest NodeReader from a list item,
+// injecting apiVersion and kind from the previous revision if they are not present in the item.
+func constructResourceBodyFromListItem(item *structured.NodeReader, prevRevision *structured.NodeReader) (*structured.NodeReader, error) {
+	if item == nil {
+		return nil, fmt.Errorf("item reader cannot be nil")
+	}
+
+	var prevAPIVersion, prevKind string
+	if prevRevision != nil {
+		prevAPIVersion = prevRevision.ReadStringOrDefault("apiVersion", "")
+		prevKind = prevRevision.ReadStringOrDefault("kind", "")
+	}
+
+	rawJSON, err := item.Serialize("", &structured.JSONNodeSerializer{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize resource body to json: %w", err)
+	}
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	hasField := false
+	if prevAPIVersion != "" {
+		buf.WriteString(`"apiVersion":`)
+		b, err := json.Marshal(prevAPIVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal apiVersion: %w", err)
+		}
+		buf.Write(b)
+		hasField = true
+	}
+	if prevKind != "" {
+		if hasField {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(`"kind":`)
+		b, err := json.Marshal(prevKind)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal kind: %w", err)
+		}
+		buf.Write(b)
+		hasField = true
+	}
+	trimmed := bytes.TrimSpace(rawJSON)
+	if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' {
+		inner := bytes.TrimSpace(trimmed[1 : len(trimmed)-1])
+		if len(inner) > 0 {
+			if hasField {
+				buf.WriteByte(',')
+			}
+			buf.Write(inner)
+		}
+	}
+	buf.WriteByte('}')
+	lazyNode := structured.NewLazyJSONNodeFromBytes(buf.Bytes())
+	return structured.NewNodeReader(structured.WithKeyOrder(lazyNode, k8s.K8sManifestKeyOrder...)), nil
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
@@ -291,8 +291,8 @@ metadata:
 				},
 			},
 			wantBodies: []string{
-				"# Resource data is unavailable. Audit logs for this resource is recorded at metadata level.",
-				"# Resource data is unavailable. Audit logs for this resource is recorded at metadata level.",
+				"",
+				"",
 			},
 		},
 		{
@@ -375,9 +375,8 @@ metadata:
 				if err != nil {
 					t.Errorf("failed to generate manifest:%v", err)
 				}
-				gotManifests = append(gotManifests, rl.ResourceBodyYAML)
-
 				if rl.ResourceBodyReader == nil {
+					gotManifests = append(gotManifests, "")
 					continue
 				}
 
@@ -385,12 +384,161 @@ metadata:
 				if err != nil {
 					t.Errorf("failed to serialize resource body to yaml\n%s", err.Error())
 				}
-				if diff := cmp.Diff(rl.ResourceBodyYAML, string(yamlFromReader)); diff != "" {
-					t.Errorf("YAML mismatch between reader and string (-want +got):%s", diff)
-				}
+				gotManifests = append(gotManifests, string(yamlFromReader))
 			}
 			if diff := cmp.Diff(tc.wantBodies, gotManifests); diff != "" {
 				t.Errorf("mismatch (-want +got):%s", diff)
+			}
+		})
+	}
+}
+
+func TestConstructResourceBodyFromListItem(t *testing.T) {
+	testCases := []struct {
+		name         string
+		itemYAML     string
+		prevYAML     string
+		wantYAML     string
+		wantAPIVer   string
+		wantKind     string
+		wantMetaName string
+		wantErr      bool
+	}{
+		{
+			name: "injects apiVersion and kind from prevRevision",
+			itemYAML: `metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest`,
+			prevYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod`,
+			wantYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+`,
+			wantAPIVer:   "v1",
+			wantKind:     "Pod",
+			wantMetaName: "test-pod",
+		},
+		{
+			name: "prevRevision is empty without apiVersion or kind",
+			itemYAML: `metadata:
+  name: test-cm
+data:
+  key: value`,
+			prevYAML: ``,
+			wantYAML: `metadata:
+  name: test-cm
+data:
+  key: value
+`,
+			wantAPIVer:   "",
+			wantKind:     "",
+			wantMetaName: "test-cm",
+		},
+		{
+			name: "prevRevision has only apiVersion",
+			itemYAML: `metadata:
+  name: test-res`,
+			prevYAML: `apiVersion: apps/v1`,
+			wantYAML: `apiVersion: apps/v1
+metadata:
+  name: test-res
+`,
+			wantAPIVer:   "apps/v1",
+			wantKind:     "",
+			wantMetaName: "test-res",
+		},
+		{
+			name: "prevRevision has only kind",
+			itemYAML: `metadata:
+  name: test-res`,
+			prevYAML: `kind: Deployment`,
+			wantYAML: `kind: Deployment
+metadata:
+  name: test-res
+`,
+			wantAPIVer:   "",
+			wantKind:     "Deployment",
+			wantMetaName: "test-res",
+		},
+		{
+			name: "nested array and mapping fields preserved in key order",
+			itemYAML: `status:
+  phase: Running
+metadata:
+  name: complex-pod
+spec:
+  nodeName: node-1`,
+			prevYAML: `apiVersion: v1
+kind: Pod`,
+			wantYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  name: complex-pod
+spec:
+  nodeName: node-1
+status:
+  phase: Running
+`,
+			wantAPIVer:   "v1",
+			wantKind:     "Pod",
+			wantMetaName: "complex-pod",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			itemNode, err := structured.FromYAML(tc.itemYAML)
+			if err != nil {
+				t.Fatalf("failed to parse itemYAML: %v", err)
+			}
+			itemReader := structured.NewNodeReader(itemNode)
+
+			var prevReader *structured.NodeReader
+			if tc.prevYAML != "" {
+				prevNode, err := structured.FromYAML(tc.prevYAML)
+				if err != nil {
+					t.Fatalf("failed to parse prevYAML: %v", err)
+				}
+				prevReader = structured.NewNodeReader(prevNode)
+			}
+
+			gotReader, err := constructResourceBodyFromListItem(itemReader, prevReader)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("constructResourceBodyFromListItem() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+
+			if got := gotReader.ReadStringOrDefault("apiVersion", ""); got != tc.wantAPIVer {
+				t.Errorf("apiVersion mismatch (-want +got):\n%s", cmp.Diff(tc.wantAPIVer, got))
+			}
+			if got := gotReader.ReadStringOrDefault("kind", ""); got != tc.wantKind {
+				t.Errorf("kind mismatch (-want +got):\n%s", cmp.Diff(tc.wantKind, got))
+			}
+			if got := gotReader.ReadStringOrDefault("metadata.name", ""); got != tc.wantMetaName {
+				t.Errorf("metadata.name mismatch (-want +got):\n%s", cmp.Diff(tc.wantMetaName, got))
+			}
+
+			yamlBytes, err := gotReader.Serialize("", &structured.YAMLNodeSerializer{})
+			if err != nil {
+				t.Fatalf("Serialize() failed: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantYAML, string(yamlBytes)); diff != "" {
+				t.Errorf("YAML serialization mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task_test.go
@@ -281,7 +281,7 @@ metadata:
 					"target": {
 						Resource: targetResource,
 						Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-							{Log: logObj, ResourceBodyReader: nodeReader, ResourceBodyYAML: tc.yaml},
+							{Log: logObj, ResourceBodyReader: nodeReader},
 						},
 					},
 				},

--- a/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task_test.go
@@ -542,7 +542,6 @@ status:
 				mLog := &commonlogk8saudit_contract.ResourceManifestLog{
 					Log:                logObj,
 					ResourceBodyReader: nodeReader,
-					ResourceBodyYAML:   step.yaml,
 				}
 
 				var identity *commonlogk8saudit_contract.ResourceIdentity

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_test.go
@@ -626,7 +626,7 @@ uid: "test-uid"`,
 					"target": {
 						Resource: targetResource,
 						Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-							{Log: logObj, ResourceBodyReader: nodeReader, ResourceBodyYAML: tc.bodyYAML},
+							{Log: logObj, ResourceBodyReader: nodeReader},
 						},
 					},
 				},
@@ -912,7 +912,7 @@ func TestResourceRevisionLogToTimelineMapperTaskSetting_PreProcessAndProcessLog(
 						"target": {
 							Resource: targetResource,
 							Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
-								{Log: logObj, ResourceBodyReader: nodeReader, ResourceBodyYAML: el.bodyYAML},
+								{Log: logObj, ResourceBodyReader: nodeReader},
 							},
 						},
 					},

--- a/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task.go
@@ -123,7 +123,7 @@ func convertLogsArray(ctx context.Context, wg *sync.WaitGroup, source <-chan *lo
 					slog.WarnContext(ctx, fmt.Sprintf("failed to convert loggingpb.LogEntry (insertId: %s, timestamp: %v) to structured.Node %v", l.InsertId, l.Timestamp, err))
 					continue
 				}
-				khiLog := log.NewLog(structured.NewNodeReader(node))
+				khiLog := log.NewLog(structured.NewNodeReader(structured.WithKeyOrder(node, logconvert.GCPLogEntryKeyOrder...)))
 				*dest = append(*dest, khiLog)
 			}
 		}

--- a/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"unsafe"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
@@ -64,7 +65,7 @@ var AuditLogFileReaderTask = inspectiontaskbase.NewProgressReportableInspectionT
 				return nil
 			}
 
-			node := structured.NewLazyJSONNodeFromBytes([]byte(trimmed))
+			node := structured.NewLazyJSONNodeFromBytes(unsafe.Slice(unsafe.StringData(trimmed), len(trimmed)))
 			l := log.NewLog(structured.NewNodeReader(node))
 
 			err := l.SetFieldSetReader(&ossclusterk8s_contract.OSSK8sAuditLogCommonFieldSetReader{})

--- a/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task.go
@@ -16,12 +16,12 @@ package ossclusterk8s_impl
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"slices"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/progressutil"
@@ -59,16 +59,15 @@ var AuditLogFileReaderTask = inspectiontaskbase.NewProgressReportableInspectionT
 		var logs []*log.Log
 
 		progressutil.ReportProgressFromArraySync(tp, logLines, func(i int, line string) error {
-			if strings.TrimSpace(line) == "" {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
 				return nil
 			}
 
-			l, err := log.NewLogFromYAMLString(line)
-			if err != nil {
-				return fmt.Errorf("failed to read a log: %w", err)
-			}
+			node := structured.NewLazyJSONNodeFromBytes([]byte(trimmed))
+			l := log.NewLog(structured.NewNodeReader(node))
 
-			err = l.SetFieldSetReader(&ossclusterk8s_contract.OSSK8sAuditLogCommonFieldSetReader{})
+			err := l.SetFieldSetReader(&ossclusterk8s_contract.OSSK8sAuditLogCommonFieldSetReader{})
 			if err != nil {
 				return err
 			}

--- a/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task_test.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ossclusterk8s_impl
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"github.com/GoogleCloudPlatform/khi/pkg/server/upload"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	ossclusterk8s_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/ossclusterk8s/contract"
+	"github.com/google/go-cmp/cmp"
+)
+
+type mockUploadStoreProvider struct {
+	data string
+}
+
+func (m *mockUploadStoreProvider) GetUploadToken(id string) upload.UploadToken {
+	return &upload.DirectUploadToken{ID: id}
+}
+
+func (m *mockUploadStoreProvider) Read(token upload.UploadToken) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(m.data)), nil
+}
+
+func TestAuditLogFileReaderTask(t *testing.T) {
+	testCases := []struct {
+		name         string
+		taskMode     inspectioncore_contract.InspectionTaskModeType
+		inputData    string
+		wantLogCount int
+		wantStages   []string
+		wantTimes    []time.Time
+	}{
+		{
+			name:     "dry run mode returns empty list",
+			taskMode: inspectioncore_contract.TaskModeDryRun,
+			inputData: `{"stage":"ResponseComplete","stageTimestamp":"2026-05-25T12:00:00.000000Z","verb":"get"}
+`,
+			wantLogCount: 0,
+		},
+		{
+			name:     "filters non-ResponseComplete stage and sorts by timestamp",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			inputData: `{"stage":"ResponseStarted","stageTimestamp":"2026-05-25T12:00:01.000000Z","verb":"get"}
+{"stage":"ResponseComplete","stageTimestamp":"2026-05-25T12:00:05.000000Z","verb":"create"}
+
+{"stage":"ResponseComplete","stageTimestamp":"2026-05-25T12:00:02.000000Z","verb":"update"}
+`,
+			wantLogCount: 2,
+			wantStages:   []string{"ResponseComplete", "ResponseComplete"},
+			wantTimes: []time.Time{
+				time.Date(2026, 5, 25, 12, 0, 2, 0, time.UTC),
+				time.Date(2026, 5, 25, 12, 0, 5, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseCtx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+
+			gotLogs, _, err := inspectiontest.RunInspectionTask(
+				baseCtx,
+				AuditLogFileReaderTask,
+				tc.taskMode,
+				nil,
+				tasktest.NewTaskDependencyValuePair(
+					ossclusterk8s_contract.InputAuditLogFilesFormTaskID.Ref(),
+					upload.UploadResult{
+						Status:        upload.UploadStatusCompleted,
+						StoreProvider: &mockUploadStoreProvider{data: tc.inputData},
+						Token:         &upload.DirectUploadToken{ID: "token-1"},
+					},
+				),
+			)
+			if err != nil {
+				t.Fatalf("AuditLogFileReaderTask returned unexpected error: %v", err)
+			}
+
+			if len(gotLogs) != tc.wantLogCount {
+				t.Fatalf("AuditLogFileReaderTask log count mismatch (-want +got):\n%s", cmp.Diff(tc.wantLogCount, len(gotLogs)))
+			}
+
+			var gotStages []string
+			var gotTimes []time.Time
+			for _, l := range gotLogs {
+				gotStages = append(gotStages, l.ReadStringOrDefault("stage", ""))
+				commonField := log.MustGetFieldSet(l, &log.CommonFieldSet{})
+				gotTimes = append(gotTimes, commonField.Timestamp)
+			}
+
+			if diff := cmp.Diff(tc.wantStages, gotStages); diff != "" {
+				t.Errorf("AuditLogFileReaderTask stages mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantTimes, gotTimes); diff != "" {
+				t.Errorf("AuditLogFileReaderTask timestamps mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
Previously, log ingestion and manifest generation parsed logs and proto payloads into in-memory AST representations (`StandardMapNode`), creating thousands of nested `map[string]Node` instances, pointers, and heap allocations per log entry. Additionally, `ResourceManifestLog` retained full YAML strings in memory (`ResourceBodyYAML`) for every audit log revision.
This PR introduces `structured.LazyJSONNode` for zero-copy, lazy JSON parsing, integrates on-demand key ordering (`WithKeyOrder`) for canonical GCP and Kubernetes field order, eliminates redundant `ResourceBodyYAML` allocations, and converts both GCP and OSS Kubernetes audit log parsing to use `LazyJSONNode`.

---

### Key Changes
1. **`pkg/common/structured`**:
   - Implemented `LazyJSONNode` which traverses JSON data directly over an immutable `[]byte` slice without pre-allocating intermediate map nodes.
   - Added `WithKeyOrder(node, priorityKeys...)` and `NodeReader.WithKeyOrder(priorityKeys...)` to provide prioritized key traversal on demand without mutating the underlying data structure.
   - Enhanced `YAMLNodeSerializer` with `PriorityKeys` support.
   - Fixed `StandardMapNode.MarshalJSON()` to properly escape keys using `json.Marshal`.
2. **`pkg/api/googlecloud/logconvert` & `pkg/task/inspection/googlecloudcommon`**:
   - Converted log parsing to stream `protojson.Marshal(l)` directly into `LazyJSONNode`.
   - Applied `logconvert.GCPLogEntryKeyOrder` via `WithKeyOrder` when wrapping `log.NewLog`.
3. **`pkg/task/inspection/commonlogk8saudit`**:
   - Removed obsolete `ResourceBodyYAML` from `ResourceManifestLog` and deleted `GetLastBodyYAML` from `manifestmapper.go`.
   - Converted manifest generator list item construction (`constructResourceBodyFromListItem`) and merged nodes to `LazyJSONNode` wrapped with `k8s.K8sManifestKeyOrder`.
   - Updated all corresponding mapper unit tests.
4. **`pkg/task/inspection/ossclusterk8s`**:
   - Updated `AuditLogFileReaderTask` to parse JSONLines directly into `LazyJSONNode` instead of parsing full YAML strings.
   - Added unit tests in `auditfilereader_task_test.go`.
---
### Benchmark Results (5-Run Comparison on Real GKE Cluster Logs, 4h Query)
We executed 5 consecutive benchmark runs for both `main@upstream` and this branch using `/usr/bin/time -v` on a 4-hour GKE cluster audit query.
| Metric | Upstream (`main`) Mean (±σ) | Current (This PR) Mean (±σ) | Delta | Improvement |
| :--- | :--- | :--- | :--- | :--- |
| **Max RSS (Peak Memory)** | 4,607.41 MB (±107.9) | **4,125.29 MB (±54.3)** | **-482.12 MB** | **-10.46%** |
| **User CPU Time** | 160.58 s (±2.0) | **136.65 s (±0.9)** | **-23.93 s** | **-14.90% faster** |
| **System CPU Time** | 6.32 s (±0.2) | **4.84 s (±0.3)** | **-1.48 s** | **-23.42%** |
| **Minor Page Faults** | 185,357 (±32.7k) | **86,346 (±52.8k)** | **-99,011** | **-53.42%** |
#### Run-by-Run Breakdown
```
Target     | Run  | Max RSS (MB) | User Time (s)  | Sys Time (s) | Elapsed   | Minor PF | Status
-----------------------------------------------------------------------------------------------
current    |   1  |    4134.34 MB |       137.29 s |       5.21 s |   2:32.44 |   156809 |      0
current    |   2  |    4149.42 MB |       137.47 s |       4.85 s |   2:02.30 |   129061 |      0
current    |   3  |    4033.69 MB |       135.21 s |       4.45 s |   1:57.50 |    45176 |      0
current    |   4  |    4132.05 MB |       136.16 s |       4.83 s |   2:02.36 |    44407 |      0
current    |   5  |    4176.96 MB |       137.13 s |       4.86 s |   1:56.34 |    56278 |      0
-----------------------------------------------------------------------------------------------
upstream   |   1  |    4469.59 MB |       162.25 s |       6.48 s |   1:56.01 |   155732 |      0
upstream   |   2  |    4599.23 MB |       162.27 s |       6.23 s |   2:04.74 |   232765 |      0
upstream   |   3  |    4540.22 MB |       160.78 s |       6.27 s |   1:59.90 |   204269 |      0
upstream   |   4  |    4701.73 MB |       160.20 s |       6.47 s |   1:58.07 |   159380 |      0
upstream   |   5  |    4726.28 MB |       157.40 s |       6.14 s |   1:59.90 |   174638 |      0
```
---
### Verification
- `make test-go`: All backend tests passed.
- `make test-web`: All frontend tests passed.
- `make pre-commit`: All formatters and linters passed with 0 issues.