### PR TITLE
feat(task): manage task result lifecycle and automatically clean up unreferenced results

### DIFF
--- a/pkg/core/task/label.go
+++ b/pkg/core/task/label.go
@@ -129,3 +129,21 @@ func (w *withSubsequentTaskRef) Write(labels *typedmap.TypedMap) {
 }
 
 var _ LabelOpt = (*withSubsequentTaskRef)(nil)
+
+type taskResultRetentionLabelOptImpl struct {
+	retain bool
+}
+
+// Write implements LabelOpt.
+func (r *taskResultRetentionLabelOptImpl) Write(label *typedmap.TypedMap) {
+	typedmap.Set(label, LabelKeyTaskResultRetention, r.retain)
+}
+
+var _ LabelOpt = (*taskResultRetentionLabelOptImpl)(nil)
+
+// NewTaskResultRetentionLabel returns a LabelOpt to specify whether the task result should be retained after all dependent tasks finish.
+func NewTaskResultRetentionLabel(retain bool) LabelOpt {
+	return &taskResultRetentionLabelOptImpl{
+		retain: retain,
+	}
+}

--- a/pkg/core/task/runner.go
+++ b/pkg/core/task/runner.go
@@ -36,15 +36,18 @@ type Interceptor func(ctx context.Context, task UntypedTask, next func(context.C
 // LocalRunner executes a task graph defined by a TaskSet on the local machine.
 // It manages task dependencies, concurrent execution, and result aggregation.
 type LocalRunner struct {
-	resolvedTaskSet *TaskSet
-	resultVariable  *typedmap.TypedMap
-	resultError     error
-	started         bool
-	stopped         bool
-	taskWaiters     *typedmap.ReadonlyTypedMap
-	waiter          chan interface{}
-	taskStatuses    []*LocalRunnerTaskStat
-	interceptors    []Interceptor
+	resolvedTaskSet       *TaskSet
+	resultVariable        *typedmap.TypedMap
+	resultError           error
+	started               bool
+	stopped               bool
+	taskWaiters           *typedmap.ReadonlyTypedMap
+	waiter                chan interface{}
+	taskStatuses          []*LocalRunnerTaskStat
+	interceptors          []Interceptor
+	remainingDependents   map[string]int
+	remainingDependentsMu sync.Mutex
+	taskByRefID           map[string]UntypedTask
 }
 
 // LocalRunner implements task_interface.TaskRunner
@@ -77,6 +80,18 @@ func NewLocalRunner(taskSet *TaskSet) (*LocalRunner, error) {
 	}
 	taskStatuses := []*LocalRunnerTaskStat{}
 	taskWaiters := typedmap.NewTypedMap()
+	remainingDependents := make(map[string]int)
+	taskByRefID := make(map[string]UntypedTask)
+	for _, t := range taskSet.tasks {
+		refID := t.UntypedID().GetUntypedReference().ReferenceIDString()
+		taskByRefID[refID] = t
+		remainingDependents[refID] = 0
+	}
+	for _, t := range taskSet.tasks {
+		for _, dep := range dedupeTaskReferences(t.Dependencies()) {
+			remainingDependents[dep.ReferenceIDString()]++
+		}
+	}
 	for i := 0; i < len(taskSet.tasks); i++ {
 		taskStatuses = append(taskStatuses, &LocalRunnerTaskStat{
 			Phase: LocalRunnerTaskStatPhaseWaiting,
@@ -88,14 +103,16 @@ func NewLocalRunner(taskSet *TaskSet) (*LocalRunner, error) {
 		typedmap.Set(taskWaiters, waiterKeyForTask(taskSet.tasks[i].UntypedID().GetUntypedReference()), &waiter)
 	}
 	return &LocalRunner{
-		resolvedTaskSet: taskSet,
-		started:         false,
-		resultVariable:  nil,
-		resultError:     nil,
-		stopped:         false,
-		taskWaiters:     taskWaiters.AsReadonly(),
-		waiter:          make(chan interface{}),
-		taskStatuses:    taskStatuses,
+		resolvedTaskSet:     taskSet,
+		started:             false,
+		resultVariable:      nil,
+		resultError:         nil,
+		stopped:             false,
+		taskWaiters:         taskWaiters.AsReadonly(),
+		waiter:              make(chan interface{}),
+		taskStatuses:        taskStatuses,
+		remainingDependents: remainingDependents,
+		taskByRefID:         taskByRefID,
 	}, nil
 }
 
@@ -233,7 +250,45 @@ func (r *LocalRunner) runTask(graphCtx context.Context, taskDefIndex int) error 
 
 	r.releaseTaskWaiter(task.UntypedID())
 
+	r.cleanupCompletedTaskResults(task)
+
 	return nil
+}
+
+// isTaskResultRetained checks if the given task has the LabelKeyTaskResultRetention label set to true.
+func (r *LocalRunner) isTaskResultRetained(task UntypedTask) bool {
+	retained, found := typedmap.Get(task.Labels(), LabelKeyTaskResultRetention)
+	return found && retained
+}
+
+// cleanupCompletedTaskResults deletes task results whose dependent tasks have all finished and are not marked for retention.
+func (r *LocalRunner) cleanupCompletedTaskResults(completedTask UntypedTask) {
+	completedRefID := completedTask.UntypedID().GetUntypedReference().ReferenceIDString()
+
+	r.remainingDependentsMu.Lock()
+	defer r.remainingDependentsMu.Unlock()
+
+	// Check if the completed task itself has no dependents and should be released immediately.
+	rem := r.remainingDependents[completedRefID]
+	if rem == 0 && !r.isTaskResultRetained(completedTask) {
+		typedmap.Delete(r.resultVariable, typedmap.NewTypedKey[any](completedRefID))
+	}
+
+	// Decrement remaining dependents count for each dependency.
+	deps := dedupeTaskReferences(completedTask.Dependencies())
+	for _, dep := range deps {
+		depRefID := dep.ReferenceIDString()
+		r.remainingDependents[depRefID]--
+		remDep := r.remainingDependents[depRefID]
+
+		if remDep == 0 {
+			if depTask, found := r.taskByRefID[depRefID]; found {
+				if !r.isTaskResultRetained(depTask) {
+					typedmap.Delete(r.resultVariable, typedmap.NewTypedKey[any](depRefID))
+				}
+			}
+		}
+	}
 }
 
 func (r *LocalRunner) Tasks() []UntypedTask {

--- a/pkg/core/task/runner_test.go
+++ b/pkg/core/task/runner_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func createMockTask(id string, dependencies []string, runFunc func(ctx context.Context) (any, error)) UntypedTask {
+func createMockTask(id string, dependencies []string, runFunc func(ctx context.Context) (any, error), labelOpts ...LabelOpt) UntypedTask {
 	deps := make([]taskid.UntypedTaskReference, len(dependencies))
 	for i, dep := range dependencies {
 		deps[i] = taskid.NewTaskReference[any](dep)
@@ -36,6 +36,7 @@ func createMockTask(id string, dependencies []string, runFunc func(ctx context.C
 		taskid.NewDefaultImplementationID[any](id),
 		deps,
 		runFunc,
+		labelOpts...,
 	)
 }
 
@@ -43,7 +44,7 @@ func TestLocalRunner_SingleTask(t *testing.T) {
 	taskResult := "task_result"
 	task := createMockTask("task1", nil, func(ctx context.Context) (any, error) {
 		return taskResult, nil
-	})
+	}, NewTaskResultRetentionLabel(true))
 
 	taskSet, err := NewTaskSet([]UntypedTask{task})
 	if err != nil {
@@ -83,7 +84,7 @@ func TestLocalRunner_TasksWithDependencies(t *testing.T) {
 		executionOrder = append(executionOrder, "task1")
 		mu.Unlock()
 		return "result1", nil
-	})
+	}, NewTaskResultRetentionLabel(true))
 
 	task2 := createMockTask("task2", []string{"task1"}, func(ctx context.Context) (any, error) {
 		mu.Lock()
@@ -95,7 +96,7 @@ func TestLocalRunner_TasksWithDependencies(t *testing.T) {
 			panic("task1 result is not matching")
 		}
 		return "result2", nil
-	})
+	}, NewTaskResultRetentionLabel(true))
 
 	taskSet, err := NewTaskSet([]UntypedTask{task1, task2})
 	if err != nil {
@@ -141,6 +142,213 @@ func TestLocalRunner_TasksWithDependencies(t *testing.T) {
 	}
 	if task2Result != "result2" {
 		t.Errorf("Expected task2 result 'result2', got '%v'", task2Result)
+	}
+}
+
+func TestLocalRunner_ResultCleanup(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setupTasks func() []UntypedTask
+		verify     func(t *testing.T, runner *LocalRunner)
+	}{
+		{
+			name: "single task without retention is deleted immediately after completion",
+			setupTasks: func() []UntypedTask {
+				task := createMockTask("task1", nil, func(ctx context.Context) (any, error) {
+					return "result1", nil
+				})
+				return []UntypedTask{task}
+			},
+			verify: func(t *testing.T, runner *LocalRunner) {
+				_, found := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("task1"))
+				if found {
+					t.Errorf("expected task1 result to be deleted, but it was found")
+				}
+			},
+		},
+		{
+			name: "single task with retention is kept after completion",
+			setupTasks: func() []UntypedTask {
+				task := createMockTask("task1", nil, func(ctx context.Context) (any, error) {
+					return "result1", nil
+				}, NewTaskResultRetentionLabel(true))
+				return []UntypedTask{task}
+			},
+			verify: func(t *testing.T, runner *LocalRunner) {
+				val, found := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("task1"))
+				if !found {
+					t.Errorf("expected task1 result to be found, but it was not")
+				}
+				if val != "result1" {
+					t.Errorf("expected task1 result 'result1', got '%v'", val)
+				}
+			},
+		},
+		{
+			name: "dependency chain without retention deletes all intermediate results",
+			setupTasks: func() []UntypedTask {
+				task1 := createMockTask("task1", nil, func(ctx context.Context) (any, error) {
+					return "result1", nil
+				})
+				task2 := createMockTask("task2", []string{"task1"}, func(ctx context.Context) (any, error) {
+					task1Val := GetTaskResult(ctx, taskid.NewTaskReference[string]("task1"))
+					if task1Val != "result1" {
+						return nil, errors.New("unexpected task1 result")
+					}
+					return "result2", nil
+				})
+				return []UntypedTask{task1, task2}
+			},
+			verify: func(t *testing.T, runner *LocalRunner) {
+				_, found1 := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("task1"))
+				if found1 {
+					t.Errorf("expected task1 result to be deleted after task2 completes")
+				}
+				_, found2 := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("task2"))
+				if found2 {
+					t.Errorf("expected task2 result to be deleted because it has no dependents and no retention")
+				}
+			},
+		},
+		{
+			name: "dependency chain with upstream retained keeps upstream and deletes downstream",
+			setupTasks: func() []UntypedTask {
+				task1 := createMockTask("task1", nil, func(ctx context.Context) (any, error) {
+					return "result1", nil
+				}, NewTaskResultRetentionLabel(true))
+				task2 := createMockTask("task2", []string{"task1"}, func(ctx context.Context) (any, error) {
+					task1Val := GetTaskResult(ctx, taskid.NewTaskReference[string]("task1"))
+					if task1Val != "result1" {
+						return nil, errors.New("unexpected task1 result")
+					}
+					return "result2", nil
+				})
+				return []UntypedTask{task1, task2}
+			},
+			verify: func(t *testing.T, runner *LocalRunner) {
+				val1, found1 := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("task1"))
+				if !found1 {
+					t.Errorf("expected task1 result to be kept due to retention label")
+				}
+				if val1 != "result1" {
+					t.Errorf("expected task1 result 'result1', got '%v'", val1)
+				}
+				_, found2 := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("task2"))
+				if found2 {
+					t.Errorf("expected task2 result to be deleted")
+				}
+			},
+		},
+		{
+			name: "multi-dependent tasks all receive upstream result before it is deleted",
+			setupTasks: func() []UntypedTask {
+				task1 := createMockTask("task1", nil, func(ctx context.Context) (any, error) {
+					return "shared_result", nil
+				})
+				task2 := createMockTask("task2", []string{"task1"}, func(ctx context.Context) (any, error) {
+					val := GetTaskResult(ctx, taskid.NewTaskReference[string]("task1"))
+					if val != "shared_result" {
+						return nil, errors.New("task2: invalid task1 result")
+					}
+					time.Sleep(10 * time.Millisecond)
+					return "result2", nil
+				})
+				task3 := createMockTask("task3", []string{"task1"}, func(ctx context.Context) (any, error) {
+					val := GetTaskResult(ctx, taskid.NewTaskReference[string]("task1"))
+					if val != "shared_result" {
+						return nil, errors.New("task3: invalid task1 result")
+					}
+					time.Sleep(30 * time.Millisecond)
+					return "result3", nil
+				})
+				return []UntypedTask{task1, task2, task3}
+			},
+			verify: func(t *testing.T, runner *LocalRunner) {
+				_, found := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("task1"))
+				if found {
+					t.Errorf("expected task1 result to be deleted after all dependents finish")
+				}
+			},
+		},
+		{
+			name: "diamond dependency with final task retained",
+			setupTasks: func() []UntypedTask {
+				taskA := createMockTask("taskA", nil, func(ctx context.Context) (any, error) {
+					return "resA", nil
+				})
+				taskB := createMockTask("taskB", []string{"taskA"}, func(ctx context.Context) (any, error) {
+					resA := GetTaskResult(ctx, taskid.NewTaskReference[string]("taskA"))
+					return resA + "->B", nil
+				})
+				taskC := createMockTask("taskC", []string{"taskA"}, func(ctx context.Context) (any, error) {
+					resA := GetTaskResult(ctx, taskid.NewTaskReference[string]("taskA"))
+					return resA + "->C", nil
+				})
+				taskD := createMockTask("taskD", []string{"taskB", "taskC"}, func(ctx context.Context) (any, error) {
+					resB := GetTaskResult(ctx, taskid.NewTaskReference[string]("taskB"))
+					resC := GetTaskResult(ctx, taskid.NewTaskReference[string]("taskC"))
+					return resB + "+" + resC + "->D", nil
+				}, NewTaskResultRetentionLabel(true))
+				return []UntypedTask{taskA, taskB, taskC, taskD}
+			},
+			verify: func(t *testing.T, runner *LocalRunner) {
+				_, foundA := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("taskA"))
+				if foundA {
+					t.Errorf("expected taskA result to be deleted")
+				}
+				_, foundB := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("taskB"))
+				if foundB {
+					t.Errorf("expected taskB result to be deleted")
+				}
+				_, foundC := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("taskC"))
+				if foundC {
+					t.Errorf("expected taskC result to be deleted")
+				}
+				valD, foundD := GetTaskResultFromLocalRunner(runner, taskid.NewTaskReference[string]("taskD"))
+				if !foundD {
+					t.Errorf("expected taskD result to be retained")
+				}
+				expectedD := "resA->B+resA->C->D"
+				if valD != expectedD {
+					if diff := cmp.Diff(expectedD, valD); diff != "" {
+						t.Errorf("taskD result mismatch (-want +got):\n%s", diff)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tasks := tc.setupTasks()
+			taskSet, err := NewTaskSet(tasks)
+			if err != nil {
+				t.Fatalf("Failed to create task set: %v", err)
+			}
+
+			runnableSet, err := taskSet.ToRunnableTaskSet()
+			if err != nil {
+				t.Fatalf("Failed to sort task set: %v", err)
+			}
+
+			runner, err := NewLocalRunner(runnableSet)
+			if err != nil {
+				t.Fatalf("Failed to create runner: %v", err)
+			}
+
+			err = runner.Run(context.Background())
+			if err != nil {
+				t.Fatalf("Failed to run task: %v", err)
+			}
+
+			<-runner.Wait()
+
+			if _, err := runner.Result(); err != nil {
+				t.Fatalf("Runner completed with error: %v", err)
+			}
+
+			tc.verify(t, runner)
+		})
 	}
 }
 

--- a/pkg/core/task/task.go
+++ b/pkg/core/task/task.go
@@ -42,6 +42,9 @@ var LabelKeyRequiredTask = NewTaskLabelKey[bool](KHISystemPrefix + "required-tas
 // LabelKeySubsequentTaskRefs is the list of task references. These tasks are included in the task graph later and the included task reference this task.
 var LabelKeySubsequentTaskRefs = NewTaskLabelKey[[]taskid.UntypedTaskReference](KHISystemPrefix + "subsquent-task-refs")
 
+// LabelKeyTaskResultRetention indicates whether the task result should be retained in the runner after all dependent tasks finish.
+var LabelKeyTaskResultRetention = NewTaskLabelKey[bool](KHISystemPrefix + "task-result-retention")
+
 type UntypedTask interface {
 	UntypedID() taskid.UntypedTaskImplementationID
 	// Labels returns KHITaskLabelSet assigned to this task unit.

--- a/pkg/core/task/test/testutil.go
+++ b/pkg/core/task/test/testutil.go
@@ -57,9 +57,15 @@ func RunTask[T any](baseContext context.Context, task coretask.Task[T], taskDepe
 
 // RunTaskWithDependency runs a task as a graph. Supply the dependencies of the main task to resolve the graph correctly.
 func RunTaskWithDependency[T any](baseContext context.Context, mainTask coretask.Task[T], dependencies []coretask.UntypedTask) (T, error) {
-	taskCtx := prepareTaskContext(baseContext, mainTask)
+	retainedMainTask := coretask.NewTask(
+		mainTask.ID(),
+		mainTask.Dependencies(),
+		mainTask.Run,
+		append(coretask.FromLabels(mainTask.Labels()), coretask.NewTaskResultRetentionLabel(true))...,
+	)
+	taskCtx := prepareTaskContext(baseContext, retainedMainTask)
 
-	resolved, err := coretask.DefaultTaskGraphResolver.Resolve([]coretask.UntypedTask{mainTask}, dependencies)
+	resolved, err := coretask.DefaultTaskGraphResolver.Resolve([]coretask.UntypedTask{retainedMainTask}, dependencies)
 	if err != nil {
 		return *new(T), err
 	}

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
@@ -86,7 +86,7 @@ func (m *networkAPITimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log
 func (m *networkAPITimelineMapper) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(),
-		googlecloudk8scommon_contract.NEGNamesDiscoveryTaskID.Ref(),
+		googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(),
 		commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref(),
 		googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(),
 	}

--- a/pkg/task/inspection/inspectioncore/impl/serializer.go
+++ b/pkg/task/inspection/inspectioncore/impl/serializer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
@@ -90,4 +91,4 @@ var SerializeTask = inspectiontaskbase.NewProgressReportableInspectionTask(inspe
 		header.FileSize = fileSize
 	}
 	return store, nil
-})
+}, coretask.NewTaskResultRetentionLabel(true))


### PR DESCRIPTION

### Problem
Previously, `LocalRunner` retained all task results in memory (`resultVariable`) until the entire task graph execution finished. This kept intermediate results (such as large slices of ingested raw logs and intermediate parser data) in memory long after their dependent downstream tasks had completed, leading to high peak memory usage during large inspections.
### Solution
1. **Task Result Retention Label**:
   - Added `LabelKeyTaskResultRetention` (`khi.google.com/task-result-retention`) and `NewTaskResultRetentionLabel(retain bool)` in `pkg/core/task`.
   - Allows tasks to explicitly mark their results for retention across the entire task run.
2. **Automatic Lifecycle Cleanup in `LocalRunner`**:
   - In `NewLocalRunner`, initialize remaining dependent task counts (`remainingDependents`) for each task by inspecting `Dependencies()`.
   - In `runTask`, after a task finishes:
     - If the task itself has no dependent tasks and is not marked with the retention label, delete its result immediately.
     - Decrement the remaining dependent count for each of its upstream dependencies. When an upstream task's count reaches 0 and it is not marked with the retention label, automatically delete its result from `resultVariable`.
3. **Retain Final Inspection Result**:
   - Added `NewTaskResultRetentionLabel(true)` to `SerializeTask` so that `InspectionTaskRunner.Result()` can retrieve the final output `Store`.
4. **Bug Fix**:
   - Fixed `networkAPITimelineMapper.Dependencies()` in `googlecloudlognetworkapiaudit` to depend on `NEGNamesInventoryTaskID` instead of `NEGNamesDiscoveryTaskID`, matching `ProcessLogByGroup`'s retrieval.
5. **Testing**:
   - Updated `RunTaskWithDependency` test helper to ensure the target test task's result is retained for assertion.
   - Added comprehensive table-driven tests in `pkg/core/task/runner_test.go` covering immediate deletion, retention labels, dependency chains, multiple dependents, and diamond dependencies.
## Verification
- `make test-go` (All backend unit tests pass)
- `make lint-go` (0 issues)
- `make format-go`
- `make pre-commit` (0 issues)
- Verified job mode inspection with `/usr/bin/time -v`
