### PR TITLE
feat: display the summary of envoy access logs

### DIFF
--- a/pkg/core/inspection/logutil/envoy.go
+++ b/pkg/core/inspection/logutil/envoy.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EnvoyResponseFlag represents standard Envoy response flags.
+// See: https://github.com/envoyproxy/envoy/blob/main/docs/root/configuration/advanced/substitution_formatter.rst
+type EnvoyResponseFlag string
+
+const (
+	EnvoyResponseFlagNoError                    EnvoyResponseFlag = "-"
+	EnvoyResponseFlagNoHealthyUpstream          EnvoyResponseFlag = "UH"
+	EnvoyResponseFlagUpstreamConnectionFailure  EnvoyResponseFlag = "UF"
+	EnvoyResponseFlagUpstreamOverflow           EnvoyResponseFlag = "UO"
+	EnvoyResponseFlagNoRouteFound               EnvoyResponseFlag = "NR"
+	EnvoyResponseFlagUpstreamRetryLimitExceeded EnvoyResponseFlag = "URX"
+	EnvoyResponseFlagNoClusterFound             EnvoyResponseFlag = "NC"
+	EnvoyResponseFlagDurationTimeout            EnvoyResponseFlag = "DT"
+
+	// HTTP only
+	EnvoyResponseFlagDownstreamConnectionTermination  EnvoyResponseFlag = "DC"
+	EnvoyResponseFlagFailedLocalHealthCheck           EnvoyResponseFlag = "LH"
+	EnvoyResponseFlagUpstreamRequestTimeout           EnvoyResponseFlag = "UT"
+	EnvoyResponseFlagLocalReset                       EnvoyResponseFlag = "LR"
+	EnvoyResponseFlagUpstreamRemoteReset              EnvoyResponseFlag = "UR"
+	EnvoyResponseFlagUpstreamConnectionTermination    EnvoyResponseFlag = "UC"
+	EnvoyResponseFlagDelayInjected                    EnvoyResponseFlag = "DI"
+	EnvoyResponseFlagFaultInjected                    EnvoyResponseFlag = "FI"
+	EnvoyResponseFlagRateLimited                      EnvoyResponseFlag = "RL"
+	EnvoyResponseFlagUnauthorizedExternalService      EnvoyResponseFlag = "UAEX"
+	EnvoyResponseFlagRateLimitServiceError            EnvoyResponseFlag = "RLSE"
+	EnvoyResponseFlagInvalidEnvoyRequestHeaders       EnvoyResponseFlag = "IH"
+	EnvoyResponseFlagStreamIdleTimeout                EnvoyResponseFlag = "SI"
+	EnvoyResponseFlagDownstreamProtocolError          EnvoyResponseFlag = "DPE"
+	EnvoyResponseFlagUpstreamProtocolError            EnvoyResponseFlag = "UPE"
+	EnvoyResponseFlagUpstreamMaxStreamDurationReached EnvoyResponseFlag = "UMSDR"
+	EnvoyResponseFlagResponseFromCacheFilter          EnvoyResponseFlag = "RFCF"
+	EnvoyResponseFlagNoFilterConfigFound              EnvoyResponseFlag = "NFCF"
+	EnvoyResponseFlagOverloadManagerTerminated        EnvoyResponseFlag = "OM"
+	EnvoyResponseFlagDnsResolutionFailed              EnvoyResponseFlag = "DF"
+	EnvoyResponseFlagDropOverload                     EnvoyResponseFlag = "DO"
+	EnvoyResponseFlagDownstreamRemoteReset            EnvoyResponseFlag = "DR"
+	EnvoyResponseFlagUnconditionalDropOverload        EnvoyResponseFlag = "UDO"
+)
+
+// EnvoyResponseFlags represents a collection of Envoy response flags.
+type EnvoyResponseFlags []EnvoyResponseFlag
+
+// ParseEnvoyResponseFlags parses single or comma-separated Envoy response flag strings.
+func ParseEnvoyResponseFlags(raw string) EnvoyResponseFlags {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return EnvoyResponseFlags{}
+	}
+	parts := strings.Split(raw, ",")
+	flags := make(EnvoyResponseFlags, len(parts))
+	for i, p := range parts {
+		flags[i] = EnvoyResponseFlag(strings.TrimSpace(p))
+	}
+	return flags
+}
+
+// String returns the comma-separated flag representation (e.g. "UH,URX").
+func (f EnvoyResponseFlags) String() string {
+	strs := make([]string, len(f))
+	for i, flag := range f {
+		strs[i] = string(flag)
+	}
+	return strings.Join(strs, ",")
+}
+
+// Summary returns human-readable descriptions of the flags joined by comma.
+func (f EnvoyResponseFlags) Summary() string {
+	msgs := make([]string, len(f))
+	for i, flag := range f {
+		if desc, ok := EnvoyResponseFlagDescriptions[flag]; ok {
+			msgs[i] = desc
+		} else {
+			msgs[i] = string(flag)
+		}
+	}
+	return strings.Join(msgs, ", ")
+}
+
+// HasError returns true if there is any error flag present, excluding non-error flags such as NoError, RFCF, and DI.
+func (f EnvoyResponseFlags) HasError() bool {
+	for _, flag := range f {
+		if flag != EnvoyResponseFlagNoError &&
+			flag != EnvoyResponseFlagResponseFromCacheFilter &&
+			flag != EnvoyResponseFlagDelayInjected {
+			return true
+		}
+	}
+	return false
+}
+
+// Contains returns true if the specified flag is present in the response flags.
+func (f EnvoyResponseFlags) Contains(flag EnvoyResponseFlag) bool {
+	for _, item := range f {
+		if item == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// EnvoyResponseFlagDescriptions maps Envoy response flags to their human-readable descriptions.
+var EnvoyResponseFlagDescriptions = map[EnvoyResponseFlag]string{
+	EnvoyResponseFlagNoError:                          "OK",
+	EnvoyResponseFlagNoHealthyUpstream:                "No healthy upstream",
+	EnvoyResponseFlagUpstreamConnectionFailure:        "Upstream connection failure",
+	EnvoyResponseFlagUpstreamOverflow:                 "Upstream overflow",
+	EnvoyResponseFlagNoRouteFound:                     "No route found",
+	EnvoyResponseFlagUpstreamRetryLimitExceeded:       "Upstream retry limit exceeded",
+	EnvoyResponseFlagNoClusterFound:                   "No cluster found",
+	EnvoyResponseFlagDurationTimeout:                  "Duration timeout",
+	EnvoyResponseFlagDownstreamConnectionTermination:  "Downstream connection termination",
+	EnvoyResponseFlagFailedLocalHealthCheck:           "Failed local health check",
+	EnvoyResponseFlagUpstreamRequestTimeout:           "Upstream request timeout",
+	EnvoyResponseFlagLocalReset:                       "Local reset",
+	EnvoyResponseFlagUpstreamRemoteReset:              "Upstream remote reset",
+	EnvoyResponseFlagUpstreamConnectionTermination:    "Upstream connection termination",
+	EnvoyResponseFlagDelayInjected:                    "Delay injected",
+	EnvoyResponseFlagFaultInjected:                    "Fault injected",
+	EnvoyResponseFlagRateLimited:                      "Rate limited",
+	EnvoyResponseFlagUnauthorizedExternalService:      "Unauthorized external service",
+	EnvoyResponseFlagRateLimitServiceError:            "Rate limit service error",
+	EnvoyResponseFlagInvalidEnvoyRequestHeaders:       "Invalid Envoy request headers",
+	EnvoyResponseFlagStreamIdleTimeout:                "Stream idle timeout",
+	EnvoyResponseFlagDownstreamProtocolError:          "Downstream protocol error",
+	EnvoyResponseFlagUpstreamProtocolError:            "Upstream protocol error",
+	EnvoyResponseFlagUpstreamMaxStreamDurationReached: "Upstream max stream duration reached",
+	EnvoyResponseFlagResponseFromCacheFilter:          "Response from cache filter",
+	EnvoyResponseFlagNoFilterConfigFound:              "No filter config found",
+	EnvoyResponseFlagOverloadManagerTerminated:        "Overload manager terminated",
+	EnvoyResponseFlagDnsResolutionFailed:              "DNS resolution failed",
+	EnvoyResponseFlagDropOverload:                     "Drop overload",
+	EnvoyResponseFlagDownstreamRemoteReset:            "Downstream remote reset",
+	EnvoyResponseFlagUnconditionalDropOverload:        "Unconditional drop overload",
+}
+
+// FormatEnvoySummary formats an Envoy access log summary line with status code, method, request URL, and optional response flags.
+func FormatEnvoySummary(statusCode int, method, requestURL string, responseFlags EnvoyResponseFlags) string {
+	summary := fmt.Sprintf("%d %s %s", statusCode, method, requestURL)
+	if len(responseFlags) == 0 || (len(responseFlags) == 1 && responseFlags[0] == EnvoyResponseFlagNoError) {
+		return summary
+	}
+	return fmt.Sprintf("【%s(%s)】%s", responseFlags.Summary(), responseFlags.String(), summary)
+}

--- a/pkg/core/inspection/logutil/envoy_accesslog.go
+++ b/pkg/core/inspection/logutil/envoy_accesslog.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// EnvoyAccessLogTimestampFieldKey is the key stored in Fields for the timestamp in an Envoy access log.
+const EnvoyAccessLogTimestampFieldKey = "@timestamp"
+
+// EnvoyAccessLogMethodFieldKey is the key stored in Fields for the HTTP method.
+const EnvoyAccessLogMethodFieldKey = "method"
+
+// EnvoyAccessLogPathFieldKey is the key stored in Fields for the request path.
+const EnvoyAccessLogPathFieldKey = "path"
+
+// EnvoyAccessLogProtocolFieldKey is the key stored in Fields for the protocol.
+const EnvoyAccessLogProtocolFieldKey = "protocol"
+
+// EnvoyAccessLogStatusCodeFieldKey is the key stored in Fields for the response status code.
+const EnvoyAccessLogStatusCodeFieldKey = "status_code"
+
+// EnvoyAccessLogResponseFlagsFieldKey is the key stored in Fields for the response flags.
+const EnvoyAccessLogResponseFlagsFieldKey = "response_flags"
+
+// EnvoyAccessLogAuthorityFieldKey is the key stored in Fields for the request authority/host.
+const EnvoyAccessLogAuthorityFieldKey = "authority"
+
+// EnvoyAccessLogUpstreamHostFieldKey is the key stored in Fields for the upstream host.
+const EnvoyAccessLogUpstreamHostFieldKey = "upstream_host"
+
+// EnvoyAccessLogUpstreamClusterFieldKey is the key stored in Fields for the upstream cluster.
+const EnvoyAccessLogUpstreamClusterFieldKey = "upstream_cluster"
+
+// EnvoyAccessLogDurationFieldKey is the key stored in Fields for the total duration.
+const EnvoyAccessLogDurationFieldKey = "duration"
+
+// EnvoyAccessLogUserAgentFieldKey is the key stored in Fields for the user agent.
+const EnvoyAccessLogUserAgentFieldKey = "user_agent"
+
+// EnvoyAccessLogRequestIDFieldKey is the key stored in Fields for the request ID.
+const EnvoyAccessLogRequestIDFieldKey = "request_id"
+
+// EnvoyAccessLogUpstreamLocalAddressFieldKey is the key stored in Fields for the upstream local address.
+const EnvoyAccessLogUpstreamLocalAddressFieldKey = "upstream_local_address"
+
+// EnvoyAccessLogDownstreamLocalAddressFieldKey is the key stored in Fields for the downstream local address.
+const EnvoyAccessLogDownstreamLocalAddressFieldKey = "downstream_local_address"
+
+// EnvoyAccessLogDownstreamRemoteAddressFieldKey is the key stored in Fields for the downstream remote address.
+const EnvoyAccessLogDownstreamRemoteAddressFieldKey = "downstream_remote_address"
+
+// EnvoyAccessLogRequestedServerNameFieldKey is the key stored in Fields for the requested server name (SNI).
+const EnvoyAccessLogRequestedServerNameFieldKey = "requested_server_name"
+
+// EnvoyAccessLogRouteNameFieldKey is the key stored in Fields for the route name.
+const EnvoyAccessLogRouteNameFieldKey = "route_name"
+
+// envoyAccessLogRegex matches default Istio access log text format:
+// [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS%
+// "%UPSTREAM_TRANSPORT_FAILURE_REASON%" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%"
+// "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%" %UPSTREAM_CLUSTER_RAW% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%
+//
+// See: https://istio.io/latest/docs/tasks/observability/logs/access-log/#default-access-log-format
+var envoyAccessLogRegex = regexp.MustCompile(
+	`^\[(?P<startTime>[^\]]+)\]\s+"(?P<method>[A-Z]+)\s+(?P<path>\S+)\s+(?P<protocol>[^"]+)"\s+(?P<statusCode>\d{3})\s+(?P<responseFlags>\S+)\s+(?P<responseCodeDetails>\S+)\s+(?P<connTerminationDetails>\S+)\s+"(?P<upstreamFailureReason>[^"]*)"\s+(?P<bytesReceived>\S+)\s+(?P<bytesSent>\S+)\s+(?P<duration>\S+)\s+(?P<upstreamServiceTime>\S+)\s+"(?P<xForwardedFor>[^"]*)"\s+"(?P<userAgent>[^"]*)"\s+"(?P<requestId>[^"]*)"\s+"(?P<authority>[^"]*)"\s+"(?P<upstreamHost>[^"]*)"\s+(?P<upstreamCluster>\S+)\s+(?P<upstreamLocalAddress>\S+)\s+(?P<downstreamLocalAddress>\S+)\s+(?P<downstreamRemoteAddress>\S+)\s+(?P<requestedServerName>\S+)\s+(?P<routeName>\S+)`,
+)
+
+// EnvoyAccessLogTextParser parses access log lines formatted in the default Istio text format.
+type EnvoyAccessLogTextParser struct{}
+
+// NewEnvoyAccessLogTextParser creates a new EnvoyAccessLogTextParser instance.
+func NewEnvoyAccessLogTextParser() *EnvoyAccessLogTextParser {
+	return &EnvoyAccessLogTextParser{}
+}
+
+// TryParse attempts to parse the given message as an Istio access log.
+func (p *EnvoyAccessLogTextParser) TryParse(message string) *ParseStructuredLogResult {
+	match := envoyAccessLogRegex.FindStringSubmatch(message)
+	if match == nil {
+		return nil
+	}
+
+	subexpNames := envoyAccessLogRegex.SubexpNames()
+	fields := make(map[string]string)
+	for i, name := range subexpNames {
+		if i != 0 && name != "" {
+			fields[name] = match[i]
+		}
+	}
+
+	statusCodeStr := fields["statusCode"]
+	statusCode, err := strconv.Atoi(statusCodeStr)
+	if err != nil {
+		return nil
+	}
+
+	method := fields["method"]
+	path := fields["path"]
+	protocol := fields["protocol"]
+	responseFlagsStr := fields["responseFlags"]
+	responseFlags := ParseEnvoyResponseFlags(responseFlagsStr)
+	authority := fields["authority"]
+	startTime := fields["startTime"]
+
+	requestURL := buildEnvoyRequestURL(authority, path)
+	summary := FormatEnvoySummary(statusCode, method, requestURL, responseFlags)
+	severity := parseEnvoySeverity(statusCode, responseFlags)
+
+	parsedFields := map[string]any{
+		OriginalMessageFieldKey:             message,
+		MainMessageStructuredFieldKey:       summary,
+		SeverityStructuredFieldKey:          severity,
+		EnvoyAccessLogTimestampFieldKey:     startTime,
+		EnvoyAccessLogMethodFieldKey:        method,
+		EnvoyAccessLogPathFieldKey:          path,
+		EnvoyAccessLogProtocolFieldKey:      protocol,
+		EnvoyAccessLogStatusCodeFieldKey:    statusCodeStr,
+		EnvoyAccessLogResponseFlagsFieldKey: responseFlagsStr,
+		EnvoyAccessLogAuthorityFieldKey:     authority,
+		EnvoyAccessLogDurationFieldKey:      fields["duration"],
+		EnvoyAccessLogUserAgentFieldKey:     fields["userAgent"],
+		EnvoyAccessLogRequestIDFieldKey:     fields["requestId"],
+	}
+
+	if upstreamHost, ok := fields["upstreamHost"]; ok && upstreamHost != "" && upstreamHost != "-" {
+		parsedFields[EnvoyAccessLogUpstreamHostFieldKey] = upstreamHost
+	}
+	if upstreamCluster, ok := fields["upstreamCluster"]; ok && upstreamCluster != "" && upstreamCluster != "-" {
+		parsedFields[EnvoyAccessLogUpstreamClusterFieldKey] = upstreamCluster
+	}
+	if upstreamLocalAddress, ok := fields["upstreamLocalAddress"]; ok && upstreamLocalAddress != "" && upstreamLocalAddress != "-" {
+		parsedFields[EnvoyAccessLogUpstreamLocalAddressFieldKey] = upstreamLocalAddress
+	}
+	if downstreamLocalAddress, ok := fields["downstreamLocalAddress"]; ok && downstreamLocalAddress != "" && downstreamLocalAddress != "-" {
+		parsedFields[EnvoyAccessLogDownstreamLocalAddressFieldKey] = downstreamLocalAddress
+	}
+	if downstreamRemoteAddress, ok := fields["downstreamRemoteAddress"]; ok && downstreamRemoteAddress != "" && downstreamRemoteAddress != "-" {
+		parsedFields[EnvoyAccessLogDownstreamRemoteAddressFieldKey] = downstreamRemoteAddress
+	}
+	if requestedServerName, ok := fields["requestedServerName"]; ok && requestedServerName != "" && requestedServerName != "-" {
+		parsedFields[EnvoyAccessLogRequestedServerNameFieldKey] = requestedServerName
+	}
+	if routeName, ok := fields["routeName"]; ok && routeName != "" && routeName != "-" {
+		parsedFields[EnvoyAccessLogRouteNameFieldKey] = routeName
+	}
+
+	return &ParseStructuredLogResult{
+		Fields: parsedFields,
+	}
+}
+
+var _ StructuredLogParser = (*EnvoyAccessLogTextParser)(nil)
+
+func buildEnvoyRequestURL(authority, path string) string {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+	if authority != "" && authority != "-" {
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		return "http://" + authority + path
+	}
+	return path
+}
+
+func parseEnvoySeverity(statusCode int, responseFlags EnvoyResponseFlags) *pb.Severity {
+	if statusCode >= 500 {
+		return inspectioncore_contract.SeverityError
+	}
+	if statusCode >= 400 {
+		return inspectioncore_contract.SeverityWarning
+	}
+	if responseFlags.HasError() {
+		return inspectioncore_contract.SeverityError
+	}
+	return inspectioncore_contract.SeverityInfo
+}

--- a/pkg/core/inspection/logutil/envoy_accesslog_test.go
+++ b/pkg/core/inspection/logutil/envoy_accesslog_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"testing"
+
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestEnvoyAccessLogTextParser_TryParse(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		want  *ParseStructuredLogResult
+	}{
+		{
+			name:  "standard envoy log from user example with status 502 and no response flags",
+			input: `[2026-08-10T08:50:55.958Z] "HEAD / HTTP/1.1" 502 - via_upstream - "-" 0 0 6 5 "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "136.68.163.124" "136.68.163.124:80" PassthroughCluster 10.4.1.8:33606 136.68.163.124:80 10.4.1.8:59778 - allow_any`,
+			want: &ParseStructuredLogResult{
+				Fields: map[string]any{
+					OriginalMessageFieldKey:                       `[2026-08-10T08:50:55.958Z] "HEAD / HTTP/1.1" 502 - via_upstream - "-" 0 0 6 5 "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "136.68.163.124" "136.68.163.124:80" PassthroughCluster 10.4.1.8:33606 136.68.163.124:80 10.4.1.8:59778 - allow_any`,
+					MainMessageStructuredFieldKey:                 "502 HEAD http://136.68.163.124/",
+					SeverityStructuredFieldKey:                    inspectioncore_contract.SeverityError,
+					EnvoyAccessLogTimestampFieldKey:               "2026-08-10T08:50:55.958Z",
+					EnvoyAccessLogMethodFieldKey:                  "HEAD",
+					EnvoyAccessLogPathFieldKey:                    "/",
+					EnvoyAccessLogProtocolFieldKey:                "HTTP/1.1",
+					EnvoyAccessLogStatusCodeFieldKey:              "502",
+					EnvoyAccessLogResponseFlagsFieldKey:           "-",
+					EnvoyAccessLogAuthorityFieldKey:               "136.68.163.124",
+					EnvoyAccessLogUpstreamHostFieldKey:            "136.68.163.124:80",
+					EnvoyAccessLogUpstreamClusterFieldKey:         "PassthroughCluster",
+					EnvoyAccessLogDurationFieldKey:                "6",
+					EnvoyAccessLogUserAgentFieldKey:               "curl/8.21.0",
+					EnvoyAccessLogRequestIDFieldKey:               "55667739-e394-4814-91b2-2cdd90744892",
+					EnvoyAccessLogUpstreamLocalAddressFieldKey:    "10.4.1.8:33606",
+					EnvoyAccessLogDownstreamLocalAddressFieldKey:  "136.68.163.124:80",
+					EnvoyAccessLogDownstreamRemoteAddressFieldKey: "10.4.1.8:59778",
+					EnvoyAccessLogRouteNameFieldKey:               "allow_any",
+				},
+			},
+		},
+		{
+			name:  "upstream connection failure (UF) with status 503",
+			input: `[2026-08-10T08:50:55.958Z] "GET / HTTP/1.1" 503 UF - - "-" 0 0 6 - "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "10.4.0.5" "10.4.0.5:80" outbound|80||foo.default.svc.cluster.local - - 10.4.1.8:59778 - -`,
+			want: &ParseStructuredLogResult{
+				Fields: map[string]any{
+					OriginalMessageFieldKey:                       `[2026-08-10T08:50:55.958Z] "GET / HTTP/1.1" 503 UF - - "-" 0 0 6 - "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "10.4.0.5" "10.4.0.5:80" outbound|80||foo.default.svc.cluster.local - - 10.4.1.8:59778 - -`,
+					MainMessageStructuredFieldKey:                 "【Upstream connection failure(UF)】503 GET http://10.4.0.5/",
+					SeverityStructuredFieldKey:                    inspectioncore_contract.SeverityError,
+					EnvoyAccessLogTimestampFieldKey:               "2026-08-10T08:50:55.958Z",
+					EnvoyAccessLogMethodFieldKey:                  "GET",
+					EnvoyAccessLogPathFieldKey:                    "/",
+					EnvoyAccessLogProtocolFieldKey:                "HTTP/1.1",
+					EnvoyAccessLogStatusCodeFieldKey:              "503",
+					EnvoyAccessLogResponseFlagsFieldKey:           "UF",
+					EnvoyAccessLogAuthorityFieldKey:               "10.4.0.5",
+					EnvoyAccessLogUpstreamHostFieldKey:            "10.4.0.5:80",
+					EnvoyAccessLogUpstreamClusterFieldKey:         "outbound|80||foo.default.svc.cluster.local",
+					EnvoyAccessLogDurationFieldKey:                "6",
+					EnvoyAccessLogUserAgentFieldKey:               "curl/8.21.0",
+					EnvoyAccessLogRequestIDFieldKey:               "55667739-e394-4814-91b2-2cdd90744892",
+					EnvoyAccessLogDownstreamRemoteAddressFieldKey: "10.4.1.8:59778",
+				},
+			},
+		},
+		{
+			name:  "successful 200 GET request",
+			input: `[2026-08-10T08:50:55.958Z] "GET /api/v1/users HTTP/1.1" 200 - - - "-" 100 200 10 9 "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "example.com" "10.4.0.5:80" outbound|80||foo.default.svc.cluster.local 10.4.1.8:33606 10.4.0.5:80 10.4.1.8:59778 - default`,
+			want: &ParseStructuredLogResult{
+				Fields: map[string]any{
+					OriginalMessageFieldKey:                       `[2026-08-10T08:50:55.958Z] "GET /api/v1/users HTTP/1.1" 200 - - - "-" 100 200 10 9 "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "example.com" "10.4.0.5:80" outbound|80||foo.default.svc.cluster.local 10.4.1.8:33606 10.4.0.5:80 10.4.1.8:59778 - default`,
+					MainMessageStructuredFieldKey:                 "200 GET http://example.com/api/v1/users",
+					SeverityStructuredFieldKey:                    inspectioncore_contract.SeverityInfo,
+					EnvoyAccessLogTimestampFieldKey:               "2026-08-10T08:50:55.958Z",
+					EnvoyAccessLogMethodFieldKey:                  "GET",
+					EnvoyAccessLogPathFieldKey:                    "/api/v1/users",
+					EnvoyAccessLogProtocolFieldKey:                "HTTP/1.1",
+					EnvoyAccessLogStatusCodeFieldKey:              "200",
+					EnvoyAccessLogResponseFlagsFieldKey:           "-",
+					EnvoyAccessLogAuthorityFieldKey:               "example.com",
+					EnvoyAccessLogUpstreamHostFieldKey:            "10.4.0.5:80",
+					EnvoyAccessLogUpstreamClusterFieldKey:         "outbound|80||foo.default.svc.cluster.local",
+					EnvoyAccessLogDurationFieldKey:                "10",
+					EnvoyAccessLogUserAgentFieldKey:               "curl/8.21.0",
+					EnvoyAccessLogRequestIDFieldKey:               "55667739-e394-4814-91b2-2cdd90744892",
+					EnvoyAccessLogUpstreamLocalAddressFieldKey:    "10.4.1.8:33606",
+					EnvoyAccessLogDownstreamLocalAddressFieldKey:  "10.4.0.5:80",
+					EnvoyAccessLogDownstreamRemoteAddressFieldKey: "10.4.1.8:59778",
+					EnvoyAccessLogRouteNameFieldKey:               "default",
+				},
+			},
+		},
+		{
+			name:  "404 route not found (NR)",
+			input: `[2026-08-10T08:50:55.958Z] "POST /invalid HTTP/1.1" 404 NR - - "-" 0 0 1 - "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "example.com" "-" - - - 10.4.1.8:59778 - -`,
+			want: &ParseStructuredLogResult{
+				Fields: map[string]any{
+					OriginalMessageFieldKey:                       `[2026-08-10T08:50:55.958Z] "POST /invalid HTTP/1.1" 404 NR - - "-" 0 0 1 - "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "example.com" "-" - - - 10.4.1.8:59778 - -`,
+					MainMessageStructuredFieldKey:                 "【No route found(NR)】404 POST http://example.com/invalid",
+					SeverityStructuredFieldKey:                    inspectioncore_contract.SeverityWarning,
+					EnvoyAccessLogTimestampFieldKey:               "2026-08-10T08:50:55.958Z",
+					EnvoyAccessLogMethodFieldKey:                  "POST",
+					EnvoyAccessLogPathFieldKey:                    "/invalid",
+					EnvoyAccessLogProtocolFieldKey:                "HTTP/1.1",
+					EnvoyAccessLogStatusCodeFieldKey:              "404",
+					EnvoyAccessLogResponseFlagsFieldKey:           "NR",
+					EnvoyAccessLogAuthorityFieldKey:               "example.com",
+					EnvoyAccessLogDurationFieldKey:                "1",
+					EnvoyAccessLogUserAgentFieldKey:               "curl/8.21.0",
+					EnvoyAccessLogRequestIDFieldKey:               "55667739-e394-4814-91b2-2cdd90744892",
+					EnvoyAccessLogDownstreamRemoteAddressFieldKey: "10.4.1.8:59778",
+				},
+			},
+		},
+		{
+			name:  "istio-proxy access log with failure details from container stdout",
+			input: `[2026-08-17T04:59:08.906Z] "GET / HTTP/1.1" 503 UF upstream_reset_before_response_started{remote_connection_failure,delayed_connect_error:_111} - "delayed_connect_error:_111" 0 152 0 - "-" "GoogleHC/1.0" "b8b3448c-05f3-4f65-aed2-9e63c89cc662" "10.4.0.5" "10.4.0.5:8080" inbound|8080|| - 10.4.0.5:8080 35.191.227.195:48158 - default`,
+			want: &ParseStructuredLogResult{
+				Fields: map[string]any{
+					OriginalMessageFieldKey:                       `[2026-08-17T04:59:08.906Z] "GET / HTTP/1.1" 503 UF upstream_reset_before_response_started{remote_connection_failure,delayed_connect_error:_111} - "delayed_connect_error:_111" 0 152 0 - "-" "GoogleHC/1.0" "b8b3448c-05f3-4f65-aed2-9e63c89cc662" "10.4.0.5" "10.4.0.5:8080" inbound|8080|| - 10.4.0.5:8080 35.191.227.195:48158 - default`,
+					MainMessageStructuredFieldKey:                 "【Upstream connection failure(UF)】503 GET http://10.4.0.5/",
+					SeverityStructuredFieldKey:                    inspectioncore_contract.SeverityError,
+					EnvoyAccessLogTimestampFieldKey:               "2026-08-17T04:59:08.906Z",
+					EnvoyAccessLogMethodFieldKey:                  "GET",
+					EnvoyAccessLogPathFieldKey:                    "/",
+					EnvoyAccessLogProtocolFieldKey:                "HTTP/1.1",
+					EnvoyAccessLogStatusCodeFieldKey:              "503",
+					EnvoyAccessLogResponseFlagsFieldKey:           "UF",
+					EnvoyAccessLogAuthorityFieldKey:               "10.4.0.5",
+					EnvoyAccessLogUpstreamHostFieldKey:            "10.4.0.5:8080",
+					EnvoyAccessLogUpstreamClusterFieldKey:         "inbound|8080||",
+					EnvoyAccessLogDurationFieldKey:                "0",
+					EnvoyAccessLogUserAgentFieldKey:               "GoogleHC/1.0",
+					EnvoyAccessLogRequestIDFieldKey:               "b8b3448c-05f3-4f65-aed2-9e63c89cc662",
+					EnvoyAccessLogDownstreamLocalAddressFieldKey:  "10.4.0.5:8080",
+					EnvoyAccessLogDownstreamRemoteAddressFieldKey: "35.191.227.195:48158",
+					EnvoyAccessLogRouteNameFieldKey:               "default",
+				},
+			},
+		},
+		{
+			name:  "multiple response flags (UH,URX) with status 503",
+			input: `[2026-08-10T08:50:55.958Z] "GET /productpage HTTP/1.1" 503 UH,URX - - "-" 0 0 10 - "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "example.com" "10.4.0.5:80" outbound|80||foo.default.svc.cluster.local - - 10.4.1.8:59778 - default`,
+			want: &ParseStructuredLogResult{
+				Fields: map[string]any{
+					OriginalMessageFieldKey:                       `[2026-08-10T08:50:55.958Z] "GET /productpage HTTP/1.1" 503 UH,URX - - "-" 0 0 10 - "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "example.com" "10.4.0.5:80" outbound|80||foo.default.svc.cluster.local - - 10.4.1.8:59778 - default`,
+					MainMessageStructuredFieldKey:                 "【No healthy upstream, Upstream retry limit exceeded(UH,URX)】503 GET http://example.com/productpage",
+					SeverityStructuredFieldKey:                    inspectioncore_contract.SeverityError,
+					EnvoyAccessLogTimestampFieldKey:               "2026-08-10T08:50:55.958Z",
+					EnvoyAccessLogMethodFieldKey:                  "GET",
+					EnvoyAccessLogPathFieldKey:                    "/productpage",
+					EnvoyAccessLogProtocolFieldKey:                "HTTP/1.1",
+					EnvoyAccessLogStatusCodeFieldKey:              "503",
+					EnvoyAccessLogResponseFlagsFieldKey:           "UH,URX",
+					EnvoyAccessLogAuthorityFieldKey:               "example.com",
+					EnvoyAccessLogUpstreamHostFieldKey:            "10.4.0.5:80",
+					EnvoyAccessLogUpstreamClusterFieldKey:         "outbound|80||foo.default.svc.cluster.local",
+					EnvoyAccessLogDurationFieldKey:                "10",
+					EnvoyAccessLogUserAgentFieldKey:               "curl/8.21.0",
+					EnvoyAccessLogRequestIDFieldKey:               "55667739-e394-4814-91b2-2cdd90744892",
+					EnvoyAccessLogDownstreamRemoteAddressFieldKey: "10.4.1.8:59778",
+					EnvoyAccessLogRouteNameFieldKey:               "default",
+				},
+			},
+		},
+		{
+			name:  "plain text log (rejected)",
+			input: "2026-08-10T08:50:55.958Z info starting server on port 8080",
+			want:  nil,
+		},
+	}
+
+	parser := NewEnvoyAccessLogTextParser()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parser.TryParse(tc.input)
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("TryParse() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/core/inspection/logutil/envoy_test.go
+++ b/pkg/core/inspection/logutil/envoy_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseEnvoyResponseFlags(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		want  EnvoyResponseFlags
+	}{
+		{
+			name:  "known single flag",
+			input: "UH",
+			want:  EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream},
+		},
+		{
+			name:  "no error flag (-)",
+			input: "-",
+			want:  EnvoyResponseFlags{EnvoyResponseFlagNoError},
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  EnvoyResponseFlags{},
+		},
+		{
+			name:  "comma separated multiple known flags",
+			input: "UH,URX",
+			want:  EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream, EnvoyResponseFlagUpstreamRetryLimitExceeded},
+		},
+		{
+			name:  "comma separated flags with unknown flag",
+			input: "UH,UNKNOWN_FLAG,URX",
+			want:  EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream, "UNKNOWN_FLAG", EnvoyResponseFlagUpstreamRetryLimitExceeded},
+		},
+		{
+			name:  "comma separated flags with whitespace",
+			input: " UF , NR ",
+			want:  EnvoyResponseFlags{EnvoyResponseFlagUpstreamConnectionFailure, EnvoyResponseFlagNoRouteFound},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseEnvoyResponseFlags(tc.input)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ParseEnvoyResponseFlags() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEnvoyResponseFlags_String(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input EnvoyResponseFlags
+		want  string
+	}{
+		{
+			name:  "empty flags",
+			input: EnvoyResponseFlags{},
+			want:  "",
+		},
+		{
+			name:  "no error flag (-)",
+			input: EnvoyResponseFlags{EnvoyResponseFlagNoError},
+			want:  "-",
+		},
+		{
+			name:  "single flag",
+			input: EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream},
+			want:  "UH",
+		},
+		{
+			name:  "multiple flags",
+			input: EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream, EnvoyResponseFlagUpstreamRetryLimitExceeded},
+			want:  "UH,URX",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.String()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("EnvoyResponseFlags.String() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEnvoyResponseFlags_Summary(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input EnvoyResponseFlags
+		want  string
+	}{
+		{
+			name:  "empty flags",
+			input: EnvoyResponseFlags{},
+			want:  "",
+		},
+		{
+			name:  "no error flag (-)",
+			input: EnvoyResponseFlags{EnvoyResponseFlagNoError},
+			want:  "OK",
+		},
+		{
+			name:  "single known flag",
+			input: EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream},
+			want:  "No healthy upstream",
+		},
+		{
+			name:  "multiple known flags",
+			input: EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream, EnvoyResponseFlagUpstreamRetryLimitExceeded},
+			want:  "No healthy upstream, Upstream retry limit exceeded",
+		},
+		{
+			name:  "unknown flag",
+			input: EnvoyResponseFlags{"UNKNOWN_FLAG"},
+			want:  "UNKNOWN_FLAG",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.Summary()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("EnvoyResponseFlags.Summary() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEnvoyResponseFlags_HasError(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input EnvoyResponseFlags
+		want  bool
+	}{
+		{
+			name:  "empty flags",
+			input: EnvoyResponseFlags{},
+			want:  false,
+		},
+		{
+			name:  "no error flag",
+			input: EnvoyResponseFlags{EnvoyResponseFlagNoError},
+			want:  false,
+		},
+		{
+			name:  "cache filter response flag",
+			input: EnvoyResponseFlags{EnvoyResponseFlagResponseFromCacheFilter},
+			want:  false,
+		},
+		{
+			name:  "delay injected response flag",
+			input: EnvoyResponseFlags{EnvoyResponseFlagDelayInjected},
+			want:  false,
+		},
+		{
+			name:  "error response flag",
+			input: EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream},
+			want:  true,
+		},
+		{
+			name:  "mixed non-error and error response flags",
+			input: EnvoyResponseFlags{EnvoyResponseFlagResponseFromCacheFilter, EnvoyResponseFlagNoHealthyUpstream},
+			want:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.HasError()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("EnvoyResponseFlags.HasError() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEnvoyResponseFlags_Contains(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      EnvoyResponseFlags
+		targetFlag EnvoyResponseFlag
+		want       bool
+	}{
+		{
+			name:       "empty flags",
+			input:      EnvoyResponseFlags{},
+			targetFlag: EnvoyResponseFlagNoHealthyUpstream,
+			want:       false,
+		},
+		{
+			name:       "flag present",
+			input:      EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream, EnvoyResponseFlagUpstreamRetryLimitExceeded},
+			targetFlag: EnvoyResponseFlagNoHealthyUpstream,
+			want:       true,
+		},
+		{
+			name:       "flag absent",
+			input:      EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream},
+			targetFlag: EnvoyResponseFlagNoRouteFound,
+			want:       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.Contains(tc.targetFlag)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("EnvoyResponseFlags.Contains() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFormatEnvoySummary(t *testing.T) {
+	testCases := []struct {
+		name          string
+		statusCode    int
+		method        string
+		requestURL    string
+		responseFlags EnvoyResponseFlags
+		want          string
+	}{
+		{
+			name:          "standard summary without response flags",
+			statusCode:    200,
+			method:        "GET",
+			requestURL:    "http://example.com/api/v1/users",
+			responseFlags: EnvoyResponseFlags{EnvoyResponseFlagNoError},
+			want:          "200 GET http://example.com/api/v1/users",
+		},
+		{
+			name:          "summary with empty response flags",
+			statusCode:    200,
+			method:        "GET",
+			requestURL:    "http://example.com/api/v1/users",
+			responseFlags: EnvoyResponseFlags{},
+			want:          "200 GET http://example.com/api/v1/users",
+		},
+		{
+			name:          "summary with single response flag",
+			statusCode:    503,
+			method:        "GET",
+			requestURL:    "http://10.4.0.5/",
+			responseFlags: EnvoyResponseFlags{EnvoyResponseFlagUpstreamConnectionFailure},
+			want:          "【Upstream connection failure(UF)】503 GET http://10.4.0.5/",
+		},
+		{
+			name:          "summary with multiple response flags",
+			statusCode:    503,
+			method:        "GET",
+			requestURL:    "/productpage",
+			responseFlags: EnvoyResponseFlags{EnvoyResponseFlagNoHealthyUpstream, EnvoyResponseFlagUpstreamRetryLimitExceeded},
+			want:          "【No healthy upstream, Upstream retry limit exceeded(UH,URX)】503 GET /productpage",
+		},
+		{
+			name:          "summary with unknown response flag",
+			statusCode:    500,
+			method:        "POST",
+			requestURL:    "/submit",
+			responseFlags: EnvoyResponseFlags{"CUSTOM_FLAG"},
+			want:          "【CUSTOM_FLAG(CUSTOM_FLAG)】500 POST /submit",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatEnvoySummary(tc.statusCode, tc.method, tc.requestURL, tc.responseFlags)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("FormatEnvoySummary() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogcsm/contract/fieldset.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/fieldset.go
@@ -20,83 +20,9 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khierrors"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 )
-
-type ResponseFlag string
-
-const (
-	ResponseFlagNoError                    ResponseFlag = "-"
-	ResponseFlagNoHealthyUpstream                       = "UH"
-	ResponseFlagUpstreamConnectionFailure               = "UF"
-	ResponseFlagUpstreamOverflow                        = "UO"
-	ResponseFlagNoRouteFound                            = "NR"
-	ResponseFlagUpstreamRetryLimitExceeded              = "URX"
-	ResponseFlagNoClusterFound                          = "NC"
-	ResponseFlagDurationTimeout                         = "DT"
-
-	// HTTP only
-	ResponseFlagDownstreamConnectionTermination  = "DC"
-	ResponseFlagFailedLocalHealthCheck           = "LH"
-	ResponseFlagUpstreamRequestTimeout           = "UT"
-	ResponseFlagLocalReset                       = "LR"
-	ResponseFlagUpstreamRemoteReset              = "UR"
-	ResponseFlagUpstreamConnectionTermination    = "UC"
-	ResponseFlagDelayInjected                    = "DI"
-	ResponseFlagFaultInjected                    = "FI"
-	ResponseFlagRateLimited                      = "RL"
-	ResponseFlagUnauthorizedExternalService      = "UAEX"
-	ResponseFlagRateLimitServiceError            = "RLSE"
-	ResponseFlagInvalidEnvoyRequestHeaders       = "IH"
-	ResponseFlagStreamIdleTimeout                = "SI"
-	ResponseFlagDownstreamProtocolError          = "DPE"
-	ResponseFlagUpstreamProtocolError            = "UPE"
-	ResponseFlagUpstreamMaxStreamDurationReached = "UMSDR"
-	ResponseFlagResponseFromCacheFilter          = "RFCF"
-	ResponseFlagNoFilterConfigFound              = "NFCF"
-	ResponseFlagOverloadManagerTerminated        = "OM"
-	ResponseFlagDnsResolutionFailed              = "DF"
-	ResponseFlagDropOverload                     = "DO"
-	ResponseFlagDownstreamRemoteReset            = "DR"
-	ResponseFlagUnconditionalDropOverload        = "UDO"
-
-	ResponseFlagInvalid = "INVALID"
-)
-
-var HumanReadableErrorMessage map[ResponseFlag]string = map[ResponseFlag]string{
-	ResponseFlagNoError:                          "OK",
-	ResponseFlagNoHealthyUpstream:                "No healthy upstream",
-	ResponseFlagUpstreamConnectionFailure:        "Upstream connection failure",
-	ResponseFlagUpstreamOverflow:                 "Upstream overflow",
-	ResponseFlagNoRouteFound:                     "No route found",
-	ResponseFlagUpstreamRetryLimitExceeded:       "Upstream retry limit exceeded",
-	ResponseFlagNoClusterFound:                   "No cluster found",
-	ResponseFlagDurationTimeout:                  "Duration timeout",
-	ResponseFlagDownstreamConnectionTermination:  "Downstream connection termination",
-	ResponseFlagFailedLocalHealthCheck:           "Failed local health check",
-	ResponseFlagUpstreamRequestTimeout:           "Upstream request timeout",
-	ResponseFlagLocalReset:                       "Local reset",
-	ResponseFlagUpstreamRemoteReset:              "Upstream remote reset",
-	ResponseFlagUpstreamConnectionTermination:    "Upstream connection termination",
-	ResponseFlagDelayInjected:                    "Delay injected",
-	ResponseFlagFaultInjected:                    "Fault injected",
-	ResponseFlagRateLimited:                      "Rate limited",
-	ResponseFlagUnauthorizedExternalService:      "Unauthorized external service",
-	ResponseFlagRateLimitServiceError:            "Rate limit service error",
-	ResponseFlagInvalidEnvoyRequestHeaders:       "Invalid Envoy request headers",
-	ResponseFlagStreamIdleTimeout:                "Stream idle timeout",
-	ResponseFlagDownstreamProtocolError:          "Downstream protocol error",
-	ResponseFlagUpstreamProtocolError:            "Upstream protocol error",
-	ResponseFlagUpstreamMaxStreamDurationReached: "Upstream max stream duration reached",
-	ResponseFlagResponseFromCacheFilter:          "Response from cache filter",
-	ResponseFlagNoFilterConfigFound:              "No filter config found",
-	ResponseFlagOverloadManagerTerminated:        "Overload manager terminated",
-	ResponseFlagDnsResolutionFailed:              "DNS resolution failed",
-	ResponseFlagDropOverload:                     "Drop overload",
-	ResponseFlagDownstreamRemoteReset:            "Downstream remote reset",
-	ResponseFlagUnconditionalDropOverload:        "Unconditional drop overload",
-	ResponseFlagInvalid:                          "Unknown response flag",
-}
 
 type AccessLogType string
 
@@ -105,9 +31,10 @@ const (
 	AccessLogTypeServer AccessLogType = "server"
 )
 
+// IstioAccessLogFieldSet holds structured fields for Istio access logs.
 type IstioAccessLogFieldSet struct {
-	Type         AccessLogType
-	ResponseFlag ResponseFlag
+	Type          AccessLogType
+	ResponseFlags logutil.EnvoyResponseFlags
 
 	SourceNamespace string
 	SourceName      string
@@ -120,21 +47,6 @@ type IstioAccessLogFieldSet struct {
 	ReporterPodName       string
 	ReporterPodNamespace  string
 	ReporterContainerName string
-}
-
-// ResponseFlagMessage returns a human readable message describing response flag.
-func (i *IstioAccessLogFieldSet) ResponseFlagMessage() string {
-	rawFlags := strings.Split(string(i.ResponseFlag), ",")
-	var messages []string
-	for _, rawFlag := range rawFlags {
-		trimmed := strings.TrimSpace(rawFlag)
-		if message, ok := HumanReadableErrorMessage[ResponseFlag(trimmed)]; ok {
-			messages = append(messages, message)
-		} else {
-			messages = append(messages, trimmed)
-		}
-	}
-	return strings.Join(messages, ", ")
 }
 
 // Kind implements log.FieldSet.
@@ -154,7 +66,7 @@ func (i *IstioAccessLogFieldSetReader) FieldSetKind() string {
 // Read implements log.FieldSetReader.
 func (i *IstioAccessLogFieldSetReader) Read(reader *structured.NodeReader) (log.FieldSet, error) {
 	var result IstioAccessLogFieldSet
-	result.ResponseFlag = ResponseFlag(reader.ReadStringOrDefault("labels.response_flag", string(ResponseFlagInvalid)))
+	result.ResponseFlags = logutil.ParseEnvoyResponseFlags(reader.ReadStringOrDefault("labels.response_flag", ""))
 	result.SourceNamespace = reader.ReadStringOrDefault("labels.source_namespace", "")
 	result.SourceName = reader.ReadStringOrDefault("labels.source_name", "")
 	result.DestinationNamespace = reader.ReadStringOrDefault("labels.destination_namespace", "")

--- a/pkg/task/inspection/googlecloudlogcsm/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/fieldset_test.go
@@ -17,6 +17,7 @@ package googlecloudlogcsm_contract
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	"github.com/google/go-cmp/cmp"
 )
@@ -46,7 +47,7 @@ resource:
 `,
 			want: &IstioAccessLogFieldSet{
 				Type:                        AccessLogTypeServer,
-				ResponseFlag:                ResponseFlagNoHealthyUpstream,
+				ResponseFlags:               logutil.EnvoyResponseFlags{logutil.EnvoyResponseFlagNoHealthyUpstream},
 				SourceNamespace:             "default",
 				SourceName:                  "istio-ingressgateway",
 				DestinationNamespace:        "default",
@@ -76,7 +77,7 @@ resource:
 `,
 			want: &IstioAccessLogFieldSet{
 				Type:                        AccessLogTypeClient,
-				ResponseFlag:                ResponseFlagNoError,
+				ResponseFlags:               logutil.EnvoyResponseFlags{logutil.EnvoyResponseFlagNoError},
 				SourceNamespace:             "default",
 				SourceName:                  "productpage-v1",
 				DestinationNamespace:        "default",
@@ -86,6 +87,36 @@ resource:
 				ReporterPodName:             "productpage-v1",
 				ReporterPodNamespace:        "default",
 				ReporterContainerName:       "",
+			},
+		},
+		{
+			desc: "server access log with multiple response flags",
+			input: `
+logName: "projects/test-project/logs/server-accesslog-stackdriver"
+labels:
+  response_flag: "UH,URX"
+  source_namespace: "default"
+  source_name: "istio-ingressgateway"
+  destination_namespace: "default"
+  destination_service_name: "productpage"
+  destination_service_host: productpage.default.svc.cluster.local
+resource:
+  labels:
+    pod_name: "productpage-v1"
+    namespace_name: "default"
+    container_name: "istio-proxy"
+`,
+			want: &IstioAccessLogFieldSet{
+				Type:                        AccessLogTypeServer,
+				ResponseFlags:               logutil.EnvoyResponseFlags{logutil.EnvoyResponseFlagNoHealthyUpstream, logutil.EnvoyResponseFlagUpstreamRetryLimitExceeded},
+				SourceNamespace:             "default",
+				SourceName:                  "istio-ingressgateway",
+				DestinationNamespace:        "default",
+				DestinationServiceName:      "productpage",
+				DestinationServiceNamespace: "default",
+				ReporterPodName:             "productpage-v1",
+				ReporterPodNamespace:        "default",
+				ReporterContainerName:       "istio-proxy",
 			},
 		},
 		{
@@ -99,7 +130,7 @@ resource:
 `,
 			want: &IstioAccessLogFieldSet{
 				Type:                   AccessLogTypeClient,
-				ResponseFlag:           ResponseFlagInvalid,
+				ResponseFlags:          logutil.EnvoyResponseFlags{},
 				SourceNamespace:        "",
 				SourceName:             "",
 				DestinationNamespace:   "",
@@ -124,45 +155,6 @@ resource:
 			got := log.MustGetFieldSet(l, &IstioAccessLogFieldSet{})
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("IstioAccessLogLabelsFieldSet mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestIstioAccessLogFieldSet_ResponseFlagMessage(t *testing.T) {
-	testCases := []struct {
-		desc string
-		flag ResponseFlag
-		want string
-	}{
-		{
-			desc: "known flag",
-			flag: ResponseFlagNoHealthyUpstream,
-			want: "No healthy upstream",
-		},
-		{
-			desc: "unknown flag",
-			flag: "SOME_UNKNOWN_FLAG",
-			want: "SOME_UNKNOWN_FLAG",
-		},
-		{
-			desc: "comma separated known flags",
-			flag: "UH,URX",
-			want: "No healthy upstream, Upstream retry limit exceeded",
-		},
-		{
-			desc: "comma separated containing unknown flags",
-			flag: "UH,UNKNOWN,URX",
-			want: "No healthy upstream, UNKNOWN, Upstream retry limit exceeded",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			fs := &IstioAccessLogFieldSet{ResponseFlag: tc.flag}
-			got := fs.ResponseFlagMessage()
-			if got != tc.want {
-				t.Errorf("ResponseFlagMessage() got = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/pkg/task/inspection/googlecloudlogcsm/impl/form_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/form_task.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khierrors"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/formtask"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -58,13 +59,13 @@ var InputCSMResponseFlagsTask = formtask.NewSetFormTaskBuilder(googlecloudlogcsm
 		result := []inspectionmetadata.SetParameterFormFieldOptionItem{
 			{ID: "@any", Description: "[Alias] Matches any response flag"},
 		}
-		ids := make([]string, 0, len(googlecloudlogcsm_contract.HumanReadableErrorMessage))
-		for flag := range googlecloudlogcsm_contract.HumanReadableErrorMessage {
+		ids := make([]string, 0, len(logutil.EnvoyResponseFlagDescriptions))
+		for flag := range logutil.EnvoyResponseFlagDescriptions {
 			ids = append(ids, string(flag))
 		}
 		sort.Strings(ids)
 		for _, id := range ids {
-			message := googlecloudlogcsm_contract.HumanReadableErrorMessage[googlecloudlogcsm_contract.ResponseFlag(id)]
+			message := logutil.EnvoyResponseFlagDescriptions[logutil.EnvoyResponseFlag(id)]
 			if id == "-" {
 				id = "OK"
 				message = "It's '-' in the response flag field because '-' means subtracting operator in this form."
@@ -108,7 +109,7 @@ func convertInputOnlyResponseFlagToActualFlag(flags []string) []string {
 	result := make([]string, 0, len(flags))
 	for _, flag := range flags {
 		if flag == "ok" {
-			result = append(result, string(googlecloudlogcsm_contract.ResponseFlagNoError))
+			result = append(result, string(logutil.EnvoyResponseFlagNoError))
 		} else {
 			result = append(result, strings.ToUpper(flag))
 		}
@@ -118,7 +119,7 @@ func convertInputOnlyResponseFlagToActualFlag(flags []string) []string {
 
 func verifyResponseFlags(flags []string) error {
 	for _, flag := range flags {
-		if _, found := googlecloudlogcsm_contract.HumanReadableErrorMessage[googlecloudlogcsm_contract.ResponseFlag(flag)]; !found {
+		if _, found := logutil.EnvoyResponseFlagDescriptions[logutil.EnvoyResponseFlag(flag)]; !found {
 			return fmt.Errorf("unknown response flag: %q: %w", flag, khierrors.ErrInvalidInput)
 		}
 	}

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -69,10 +70,7 @@ func (i *CSMTrafficLogLogIngester) ProcessLog(ctx context.Context, l *log.Log) (
 		return nil, err
 	}
 
-	summary := fmt.Sprintf("%d %s %s", gcpCommonAccessLog.Status, gcpCommonAccessLog.Method, gcpCommonAccessLog.RequestURL)
-	if istioAccessLog.ResponseFlag != googlecloudlogcsm_contract.ResponseFlagNoError {
-		summary = fmt.Sprintf("【%s(%s)】", istioAccessLog.ResponseFlagMessage(), istioAccessLog.ResponseFlag) + summary
-	}
+	summary := logutil.FormatEnvoySummary(gcpCommonAccessLog.Status, gcpCommonAccessLog.Method, gcpCommonAccessLog.RequestURL, istioAccessLog.ResponseFlags)
 	cs.SetSummary(summary)
 	cs.SetLogType(googlecloudlogcsm_contract.LogTypeCSMTrafficLog)
 

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logutil"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -44,8 +45,21 @@ func TestCSMTrafficLogLogIngester_ProcessLog(t *testing.T) {
 				RequestURL: "/productpage",
 			},
 			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
-				Type:         googlecloudlogcsm_contract.AccessLogTypeServer,
-				ResponseFlag: googlecloudlogcsm_contract.ResponseFlagNoError,
+				Type:          googlecloudlogcsm_contract.AccessLogTypeServer,
+				ResponseFlags: logutil.EnvoyResponseFlags{logutil.EnvoyResponseFlagNoError},
+			},
+			wantSummary: "200 GET /productpage",
+		},
+		{
+			desc: "server access log with missing response flags",
+			inputGCPAccessLog: &googlecloudcommon_contract.GCPAccessLogFieldSet{
+				Status:     200,
+				Method:     "GET",
+				RequestURL: "/productpage",
+			},
+			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
+				Type:          googlecloudlogcsm_contract.AccessLogTypeServer,
+				ResponseFlags: logutil.EnvoyResponseFlags{},
 			},
 			wantSummary: "200 GET /productpage",
 		},
@@ -57,8 +71,8 @@ func TestCSMTrafficLogLogIngester_ProcessLog(t *testing.T) {
 				RequestURL: "/productpage",
 			},
 			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
-				Type:         googlecloudlogcsm_contract.AccessLogTypeServer,
-				ResponseFlag: googlecloudlogcsm_contract.ResponseFlagNoHealthyUpstream,
+				Type:          googlecloudlogcsm_contract.AccessLogTypeServer,
+				ResponseFlags: logutil.EnvoyResponseFlags{logutil.EnvoyResponseFlagNoHealthyUpstream},
 			},
 			wantSummary: "【No healthy upstream(UH)】503 GET /productpage",
 		},
@@ -70,8 +84,8 @@ func TestCSMTrafficLogLogIngester_ProcessLog(t *testing.T) {
 				RequestURL: "/productpage",
 			},
 			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
-				Type:         googlecloudlogcsm_contract.AccessLogTypeServer,
-				ResponseFlag: "UH,URX",
+				Type:          googlecloudlogcsm_contract.AccessLogTypeServer,
+				ResponseFlags: logutil.EnvoyResponseFlags{logutil.EnvoyResponseFlagNoHealthyUpstream, logutil.EnvoyResponseFlagUpstreamRetryLimitExceeded},
 			},
 			wantSummary: "【No healthy upstream, Upstream retry limit exceeded(UH,URX)】503 GET /productpage",
 		},
@@ -112,7 +126,7 @@ func TestCSMTrafficLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			},
 			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
 				Type:                        googlecloudlogcsm_contract.AccessLogTypeServer,
-				ResponseFlag:                googlecloudlogcsm_contract.ResponseFlagNoError,
+				ResponseFlags:               logutil.EnvoyResponseFlags{logutil.EnvoyResponseFlagNoError},
 				ReporterPodNamespace:        "default",
 				ReporterPodName:             "productpage-v1",
 				ReporterContainerName:       "istio-proxy",
@@ -163,7 +177,7 @@ func TestCSMTrafficLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 			},
 			inputIstioAccessLog: &googlecloudlogcsm_contract.IstioAccessLogFieldSet{
 				Type:                        googlecloudlogcsm_contract.AccessLogTypeClient,
-				ResponseFlag:                googlecloudlogcsm_contract.ResponseFlagNoError,
+				ResponseFlags:               logutil.EnvoyResponseFlags{logutil.EnvoyResponseFlagNoError},
 				ReporterPodNamespace:        "default",
 				ReporterPodName:             "productpage-v1",
 				SourceNamespace:             "default",

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/fieldset_test.go
@@ -171,6 +171,88 @@ labels:
 
 }
 
+func TestK8sContainerLogFieldSetReader_IstioProxyParsedMessage(t *testing.T) {
+	inputYAML := `resource:
+  labels:
+    cluster_name: test-cluster
+    namespace_name: default
+    pod_name: frontend-pod
+    container_name: istio-proxy
+textPayload: '[2026-08-10T08:50:55.958Z] "HEAD / HTTP/1.1" 502 - via_upstream - "-" 0 0 6 5 "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "123.45.167.189" "123.45.167.189:80" PassthroughCluster 10.4.1.8:33606 123.45.167.189:80 10.4.1.8:59778 - allow_any'`
+
+	l, err := log.NewLogFromYAMLString(inputYAML)
+	if err != nil {
+		t.Fatalf("failed to parse log from yaml: %v", err)
+	}
+	l.SetFieldSetReader(&K8sContainerLogFieldSetReader{})
+	containerFieldSet, err := log.GetFieldSet(l, &K8sContainerLogFieldSet{})
+	if err != nil {
+		t.Fatalf("failed to extract container field set: %v", err)
+	}
+	if containerFieldSet.ParsedMessage == nil {
+		t.Fatalf("expected ParsedMessage not to be nil for istio-proxy")
+	}
+	mainMsg, err := containerFieldSet.ParsedMessage.MainMessage()
+	if err != nil {
+		t.Fatalf("MainMessage() failed: %v", err)
+	}
+	wantMsg := "502 HEAD http://123.45.167.189/"
+	if mainMsg != wantMsg {
+		t.Errorf("MainMessage() = %q, want %q", mainMsg, wantMsg)
+	}
+}
+
+func TestK8sContainerLogFieldSetReader_IstioProxyNonAccessLog(t *testing.T) {
+	inputYAML := `insertId: d041l2rc48z6lx5t
+logName: projects/tse-kakeru/logs/stdout
+labels:
+  compute.googleapis.com/resource_name: gke-keigof-0804-clus-keigof-0804-node-dc914732-d5fd
+  k8s-pod/app: nginx-server
+  k8s-pod/pod-template-hash: 8646bbcd65
+  k8s-pod/security_istio_io/tlsMode: istio
+  k8s-pod/service_istio_io/canonical-name: nginx-server
+  k8s-pod/service_istio_io/canonical-revision: latest
+  logging.gke.io/top_level_controller_name: nginx-server
+  logging.gke.io/top_level_controller_type: Deployment
+textPayload: "2026-08-20T04:46:31.353537Z\tinfo\txdsproxy\tconnected to upstream XDS server: meshconfig.googleapis.com:443"
+resource:
+  type: k8s_container
+  labels:
+    cluster_name: keigof-0804-cluster
+    container_name: istio-proxy
+    location: asia-northeast1
+    namespace_name: default
+    pod_name: nginx-server-8646bbcd65-6d969
+    project_id: tse-kakeru
+severity: INFO
+receiveTimestamp: '2026-08-20T04:46:34.341075649Z'
+timestamp: '2026-08-20T04:46:31.353884563Z'`
+
+	l, err := log.NewLogFromYAMLString(inputYAML)
+	if err != nil {
+		t.Fatalf("failed to parse log from yaml: %v", err)
+	}
+	l.SetFieldSetReader(&K8sContainerLogFieldSetReader{})
+	containerFieldSet, err := log.GetFieldSet(l, &K8sContainerLogFieldSet{})
+	if err != nil {
+		t.Fatalf("failed to extract container field set: %v", err)
+	}
+	wantMsg := "2026-08-20T04:46:31.353537Z\tinfo\txdsproxy\tconnected to upstream XDS server: meshconfig.googleapis.com:443"
+	if containerFieldSet.Message != wantMsg {
+		t.Errorf("Message = %q, want %q", containerFieldSet.Message, wantMsg)
+	}
+	if containerFieldSet.ParsedMessage == nil {
+		t.Fatalf("expected ParsedMessage not to be nil")
+	}
+	mainMsg, err := containerFieldSet.ParsedMessage.MainMessage()
+	if err != nil {
+		t.Fatalf("MainMessage() failed: %v", err)
+	}
+	if mainMsg != wantMsg {
+		t.Errorf("MainMessage() = %q, want %q", mainMsg, wantMsg)
+	}
+}
+
 func TestK8sContainerLogFieldSet_GroupKey(t *testing.T) {
 	fs := &K8sContainerLogFieldSet{
 		Namespace: "test-namespace",

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/parser.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/parser.go
@@ -33,4 +33,13 @@ var DefaultContainerLogParser = logutil.NewSelectorLogParser[ContainerLogContext
 		logutil.NewLogfmtTextParser(),
 		&logutil.FallbackRawTextLogParser{},
 	),
+	logutil.ParserRule[ContainerLogContext]{
+		Match: func(ctx ContainerLogContext) bool {
+			return ctx.ContainerName == "istio-proxy"
+		},
+		Parser: logutil.NewMultiTextLogParser(
+			logutil.NewEnvoyAccessLogTextParser(),
+			&logutil.FallbackRawTextLogParser{},
+		),
+	},
 )

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
@@ -113,6 +113,55 @@ func TestLogIngester_ProcessLog(t *testing.T) {
 					HasLogType(googlecloudlogk8scontainer_contract.LogTypeContainer)
 			},
 		},
+		{
+			name: "container log with istio envoy access log with error response flag",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: time.Date(2026, 8, 10, 8, 50, 55, 0, time.UTC),
+				},
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityInfo,
+				},
+				&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+					Namespace:     "default",
+					PodName:       "frontend-pod",
+					ContainerName: "istio-proxy",
+					Message:       `[2026-08-10T08:50:55.958Z] "GET / HTTP/1.1" 503 UF - - "-" 0 0 6 - "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "10.4.0.5" "10.4.0.5:80" outbound|80||foo.default.svc.cluster.local - - 10.4.1.8:59778 - -`,
+					ParsedMessage: logutil.NewEnvoyAccessLogTextParser().TryParse(`[2026-08-10T08:50:55.958Z] "GET / HTTP/1.1" 503 UF - - "-" 0 0 6 - "-" "curl/8.21.0" "55667739-e394-4814-91b2-2cdd90744892" "10.4.0.5" "10.4.0.5:80" outbound|80||foo.default.svc.cluster.local - - 10.4.1.8:59778 - -`),
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("【Upstream connection failure(UF)】503 GET http://10.4.0.5/").
+					HasSeverity(inspectioncore_contract.SeverityError).
+					HasLogType(googlecloudlogk8scontainer_contract.LogTypeContainer)
+			},
+		},
+		{
+			name: "istio-proxy non-access-log control plane log",
+			input: log.NewLogWithFieldSetsForTest(
+				&log.CommonFieldSet{
+					Timestamp: time.Date(2026, 8, 20, 4, 46, 31, 353884563, time.UTC),
+				},
+				&inspectioncore_contract.DefaultSeverityFieldSet{
+					Severity: inspectioncore_contract.SeverityInfo,
+				},
+				&googlecloudlogk8scontainer_contract.K8sContainerLogFieldSet{
+					Namespace:     "default",
+					PodName:       "nginx-server-8646bbcd65-6d969",
+					ContainerName: "istio-proxy",
+					Message:       "2026-08-20T04:46:31.353537Z\tinfo\txdsproxy\tconnected to upstream XDS server: meshconfig.googleapis.com:443",
+					ParsedMessage: (&logutil.FallbackRawTextLogParser{}).TryParse("2026-08-20T04:46:31.353537Z\tinfo\txdsproxy\tconnected to upstream XDS server: meshconfig.googleapis.com:443"),
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("2026-08-20T04:46:31.353537Z\tinfo\txdsproxy\tconnected to upstream XDS server: meshconfig.googleapis.com:443").
+					HasSeverity(inspectioncore_contract.SeverityInfo).
+					HasLogType(googlecloudlogk8scontainer_contract.LogTypeContainer).
+					HasTimestamp(time.Date(2026, 8, 20, 4, 46, 31, 353884563, time.UTC))
+			},
+		},
 	}
 
 	ingester := &containerLogIngester{}


### PR DESCRIPTION
## Summary
- **Text Envoy log parsing & summary**: Added `EnvoyAccessLogTextParser` to parse text access logs from container stdout and format them with response flag explanations (e.g. `【Upstream connection failure(UF)】503 GET http://10.4.0.5/`).
- **Common Envoy utilities**: Extracted Envoy response flag definitions and summary formatting logic into `pkg/core/inspection/logutil/envoy.go` to share across both container logs and CSM Traffic Logs.

## Motivation
While CSM Traffic Logs already formatted Envoy access logs with human-readable response flags in their summaries, container stdout logs (`istio-proxy`) did not parse or format them similarly. We want to align the summary experience of text-based Envoy access logs with CSM Traffic Logs.