### PR TITLE
feat(inspection): structured log query estimation and inspection log volume UI redesign

### DIFF
--- a/pkg/api/googlecloud/logestimator/cached_estimator.go
+++ b/pkg/api/googlecloud/logestimator/cached_estimator.go
@@ -171,6 +171,9 @@ func (e *CachedStructuredLogEstimator) Close() {
 	for _, task := range e.activeTasks {
 		task.cancel()
 	}
+	for _, flight := range e.flights {
+		flight.cancel()
+	}
 	e.activeTasks = make(map[string]*taskFlight)
 	e.flights = make(map[string]*flightCall)
 	e.cache = make(map[string]*EstimateResult)

--- a/pkg/api/googlecloud/logestimator/cached_estimator.go
+++ b/pkg/api/googlecloud/logestimator/cached_estimator.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logestimator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+)
+
+type flightCall struct {
+	done   chan struct{}
+	res    *EstimateResult
+	err    error
+	cancel context.CancelFunc
+}
+
+type taskFlight struct {
+	cacheKey string
+	cancel   context.CancelFunc
+}
+
+// EstimatorProvider is a factory function to construct a StructuredLogEstimator for a container.
+type EstimatorProvider func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error)
+
+// CachedStructuredLogEstimator manages cached log volume estimates, singleflight in-flight deduplication,
+// and cancellation of outdated in-flight estimation queries per task slot.
+type CachedStructuredLogEstimator struct {
+	mu          sync.Mutex
+	cache       map[string]*EstimateResult
+	flights     map[string]*flightCall
+	activeTasks map[string]*taskFlight
+}
+
+// NewCachedStructuredLogEstimator creates a new CachedStructuredLogEstimator instance.
+func NewCachedStructuredLogEstimator() *CachedStructuredLogEstimator {
+	return &CachedStructuredLogEstimator{
+		cache:       make(map[string]*EstimateResult),
+		flights:     make(map[string]*flightCall),
+		activeTasks: make(map[string]*taskFlight),
+	}
+}
+
+// EstimateWithTaskSlot estimates the log volume for the given query, returning cached results when available.
+// If a query for the same input is already in flight, it deduplicates the request and waits for the shared result.
+// If a previous in-flight estimation for taskSlotKey has a different query or time range, it cancels the previous request.
+func (e *CachedStructuredLogEstimator) EstimateWithTaskSlot(
+	ctx context.Context,
+	taskSlotKey string,
+	container googlecloud.ResourceContainer,
+	query *StructuredLogQuery,
+	startTime, endTime time.Time,
+	provider EstimatorProvider,
+) (*EstimateResult, error) {
+	cacheKey := fmt.Sprintf("%s|%s|%d|%d",
+		container.Identifier(),
+		query.GenerateCloudLoggingQuery(),
+		startTime.UnixNano(),
+		endTime.UnixNano(),
+	)
+
+	e.mu.Lock()
+
+	// 1. Return cached result if present.
+	if res, ok := e.cache[cacheKey]; ok {
+		e.mu.Unlock()
+		return res, nil
+	}
+
+	// 2. If an in-flight query exists for this task slot with a different query, cancel it.
+	if taskSlotKey != "" {
+		if active, ok := e.activeTasks[taskSlotKey]; ok {
+			if active.cacheKey != cacheKey {
+				active.cancel()
+				delete(e.activeTasks, taskSlotKey)
+			}
+		}
+	}
+
+	// 3. Join in-flight execution if one already exists for this cacheKey.
+	if flight, ok := e.flights[cacheKey]; ok {
+		if taskSlotKey != "" {
+			e.activeTasks[taskSlotKey] = &taskFlight{
+				cacheKey: cacheKey,
+				cancel:   flight.cancel,
+			}
+		}
+		e.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-flight.done:
+			return flight.res, flight.err
+		}
+	}
+
+	// 4. Start a new in-flight execution.
+	callCtx, callCancel := context.WithCancel(context.Background())
+	flight := &flightCall{
+		done:   make(chan struct{}),
+		cancel: callCancel,
+	}
+	e.flights[cacheKey] = flight
+
+	if taskSlotKey != "" {
+		e.activeTasks[taskSlotKey] = &taskFlight{
+			cacheKey: cacheKey,
+			cancel:   callCancel,
+		}
+	}
+	e.mu.Unlock()
+
+	go func() {
+		var res *EstimateResult
+		var err error
+
+		defer func() {
+			e.mu.Lock()
+			flight.res = res
+			flight.err = err
+			if err == nil && res != nil {
+				e.cache[cacheKey] = res
+			}
+			delete(e.flights, cacheKey)
+			if taskSlotKey != "" {
+				if active, ok := e.activeTasks[taskSlotKey]; ok && active.cacheKey == cacheKey {
+					delete(e.activeTasks, taskSlotKey)
+				}
+			}
+			close(flight.done)
+			e.mu.Unlock()
+		}()
+
+		estimator, providerErr := provider(callCtx, container)
+		if providerErr != nil {
+			err = providerErr
+			return
+		}
+		res, err = estimator.Estimate(callCtx, container, query, startTime, endTime)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-flight.done:
+		return flight.res, flight.err
+	}
+}
+
+// Close cancels all active in-flight requests and clears the estimation cache.
+func (e *CachedStructuredLogEstimator) Close() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for _, task := range e.activeTasks {
+		task.cancel()
+	}
+	e.activeTasks = make(map[string]*taskFlight)
+	e.flights = make(map[string]*flightCall)
+	e.cache = make(map[string]*EstimateResult)
+}

--- a/pkg/api/googlecloud/logestimator/cached_estimator_test.go
+++ b/pkg/api/googlecloud/logestimator/cached_estimator_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logestimator
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/google/go-cmp/cmp"
+)
+
+type mockMetricLogCountFetcher struct {
+	delay    time.Duration
+	count    int64
+	err      error
+	callHook func(ctx context.Context)
+}
+
+func (m *mockMetricLogCountFetcher) QueryMetricCount(ctx context.Context, container googlecloud.ResourceContainer, metricFilter string, startTime, endTime time.Time) (int64, error) {
+	if m.callHook != nil {
+		m.callHook(ctx)
+	}
+	if m.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(m.delay):
+		}
+	}
+	return m.count, m.err
+}
+
+func TestCachedStructuredLogEstimator_CacheHit(t *testing.T) {
+	cachedEstimator := NewCachedStructuredLogEstimator()
+	defer cachedEstimator.Close()
+
+	var providerCalls int64
+	provider := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
+		atomic.AddInt64(&providerCalls, 1)
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{count: 100}, nil), nil
+	}
+
+	query := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+		Filters:       []LoggingMonitoringMatcher{ResourceLabel("cluster_name", Exact("cluster-1"))},
+	}
+	container := googlecloud.Project("test-project")
+	now := time.Now()
+	startTime := now.Add(-time.Hour)
+	endTime := now
+
+	// First call -> executes provider
+	res1, err := cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-1", container, query, startTime, endTime, provider)
+	if err != nil {
+		t.Fatalf("first EstimateWithTaskSlot() error = %v", err)
+	}
+	if res1.EstimatedCount != 100 {
+		t.Errorf("res1.EstimatedCount = %d, want 100", res1.EstimatedCount)
+	}
+
+	// Second call with identical inputs -> cache hit, provider is not called again
+	res2, err := cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-1", container, query, startTime, endTime, provider)
+	if err != nil {
+		t.Fatalf("second EstimateWithTaskSlot() error = %v", err)
+	}
+	if diff := cmp.Diff(res1, res2); diff != "" {
+		t.Errorf("cached result mismatch (-want +got):\n%s", diff)
+	}
+
+	if calls := atomic.LoadInt64(&providerCalls); calls != 1 {
+		t.Errorf("providerCalls = %d, want 1", calls)
+	}
+}
+
+func TestCachedStructuredLogEstimator_SingleflightDeduplication(t *testing.T) {
+	cachedEstimator := NewCachedStructuredLogEstimator()
+	defer cachedEstimator.Close()
+
+	var providerCalls int64
+	provider := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
+		atomic.AddInt64(&providerCalls, 1)
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
+			delay: 50 * time.Millisecond,
+			count: 200,
+		}, nil), nil
+	}
+
+	query := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+		Filters:       []LoggingMonitoringMatcher{ResourceLabel("cluster_name", Exact("cluster-1"))},
+	}
+	container := googlecloud.Project("test-project")
+	now := time.Now()
+	startTime := now.Add(-time.Hour)
+	endTime := now
+
+	var wg sync.WaitGroup
+	results := make([]*EstimateResult, 5)
+	errs := make([]error, 5)
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			res, err := cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-slot", container, query, startTime, endTime, provider)
+			results[idx] = res
+			errs[idx] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < 5; i++ {
+		if errs[i] != nil {
+			t.Errorf("results[%d] had error: %v", i, errs[i])
+		}
+		if results[i] == nil || results[i].EstimatedCount != 200 {
+			t.Errorf("results[%d] = %v, want EstimatedCount=200", i, results[i])
+		}
+	}
+
+	if calls := atomic.LoadInt64(&providerCalls); calls != 1 {
+		t.Errorf("providerCalls = %d, want 1", calls)
+	}
+}
+
+func TestCachedStructuredLogEstimator_OutdatedQueryCancellation(t *testing.T) {
+	cachedEstimator := NewCachedStructuredLogEstimator()
+	defer cachedEstimator.Close()
+
+	query1Cancelled := make(chan struct{})
+	provider1 := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
+			delay: 500 * time.Millisecond,
+			callHook: func(queryCtx context.Context) {
+				go func() {
+					<-queryCtx.Done()
+					close(query1Cancelled)
+				}()
+			},
+			count: 100,
+		}, nil), nil
+	}
+
+	provider2 := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
+			delay: 10 * time.Millisecond,
+			count: 300,
+		}, nil), nil
+	}
+
+	query1 := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+		Filters:       []LoggingMonitoringMatcher{ResourceLabel("cluster_name", Exact("cluster-1"))},
+	}
+	query2 := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+		Filters:       []LoggingMonitoringMatcher{ResourceLabel("cluster_name", Exact("cluster-2"))},
+	}
+
+	container := googlecloud.Project("test-project")
+	now := time.Now()
+	startTime := now.Add(-time.Hour)
+	endTime := now
+
+	// Start query1 on taskSlot
+	go func() {
+		_, _ = cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-slot-A", container, query1, startTime, endTime, provider1)
+	}()
+
+	// Allow query1 to start
+	time.Sleep(20 * time.Millisecond)
+
+	// Now send query2 on the SAME taskSlot -> should cancel query1
+	res2, err := cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-slot-A", container, query2, startTime, endTime, provider2)
+	if err != nil {
+		t.Fatalf("query2 EstimateWithTaskSlot() error = %v", err)
+	}
+	if res2.EstimatedCount != 300 {
+		t.Errorf("res2.EstimatedCount = %d, want 300", res2.EstimatedCount)
+	}
+
+	// Verify query1's context was cancelled
+	select {
+	case <-query1Cancelled:
+		// Success: query1 was cancelled
+	case <-time.After(200 * time.Millisecond):
+		t.Errorf("expected query1 to be cancelled when query2 was sent to the same task slot")
+	}
+}
+
+func TestCachedStructuredLogEstimator_IdenticalQueryDoesNotCancel(t *testing.T) {
+	cachedEstimator := NewCachedStructuredLogEstimator()
+	defer cachedEstimator.Close()
+
+	var providerCalls int64
+	provider := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
+		atomic.AddInt64(&providerCalls, 1)
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
+			delay: 50 * time.Millisecond,
+			count: 150,
+		}, nil), nil
+	}
+
+	query := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+		Filters:       []LoggingMonitoringMatcher{ResourceLabel("cluster_name", Exact("cluster-1"))},
+	}
+	container := googlecloud.Project("test-project")
+	now := time.Now()
+	startTime := now.Add(-time.Hour)
+	endTime := now
+
+	var wg sync.WaitGroup
+	var res1, res2 *EstimateResult
+	var err1, err2 error
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		res1, err1 = cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-slot-B", container, query, startTime, endTime, provider)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	go func() {
+		defer wg.Done()
+		// Same query on same slot -> joins flight, should NOT cancel
+		res2, err2 = cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-slot-B", container, query, startTime, endTime, provider)
+	}()
+
+	wg.Wait()
+
+	if err1 != nil {
+		t.Errorf("call 1 returned unexpected error: %v", err1)
+	}
+	if err2 != nil {
+		t.Errorf("call 2 returned unexpected error: %v", err2)
+	}
+	if res1 == nil || res1.EstimatedCount != 150 {
+		t.Errorf("res1 = %v, want EstimatedCount=150", res1)
+	}
+	if res2 == nil || res2.EstimatedCount != 150 {
+		t.Errorf("res2 = %v, want EstimatedCount=150", res2)
+	}
+	if calls := atomic.LoadInt64(&providerCalls); calls != 1 {
+		t.Errorf("providerCalls = %d, want 1", calls)
+	}
+}
+
+func TestCachedStructuredLogEstimator_ErrorNotCached(t *testing.T) {
+	cachedEstimator := NewCachedStructuredLogEstimator()
+	defer cachedEstimator.Close()
+
+	var attempts int64
+	provider := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
+		current := atomic.AddInt64(&attempts, 1)
+		if current == 1 {
+			return nil, errors.New("network failure")
+		}
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{count: 500}, nil), nil
+	}
+
+	query := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+	}
+	container := googlecloud.Project("test-project")
+	now := time.Now()
+
+	// Attempt 1 fails
+	_, err := cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-err", container, query, now.Add(-time.Hour), now, provider)
+	if err == nil {
+		t.Fatalf("first attempt expected error, got nil")
+	}
+
+	// Attempt 2 succeeds (retry is allowed)
+	res, err := cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-err", container, query, now.Add(-time.Hour), now, provider)
+	if err != nil {
+		t.Fatalf("second attempt error = %v", err)
+	}
+	if res.EstimatedCount != 500 {
+		t.Errorf("res.EstimatedCount = %d, want 500", res.EstimatedCount)
+	}
+}
+
+func TestCachedStructuredLogEstimator_Close(t *testing.T) {
+	cachedEstimator := NewCachedStructuredLogEstimator()
+
+	cancelled := make(chan struct{})
+	provider := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
+			delay: 500 * time.Millisecond,
+			callHook: func(queryCtx context.Context) {
+				go func() {
+					<-queryCtx.Done()
+					close(cancelled)
+				}()
+			},
+			count: 100,
+		}, nil), nil
+	}
+
+	query := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+	}
+	container := googlecloud.Project("test-project")
+	now := time.Now()
+
+	go func() {
+		_, _ = cachedEstimator.EstimateWithTaskSlot(context.Background(), "task-close", container, query, now.Add(-time.Hour), now, provider)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Closing estimator should cancel in-flight tasks and clear cache
+	cachedEstimator.Close()
+
+	select {
+	case <-cancelled:
+		// Successfully cancelled
+	case <-time.After(200 * time.Millisecond):
+		t.Errorf("expected in-flight task to be cancelled on Close()")
+	}
+}

--- a/pkg/api/googlecloud/logestimator/estimator.go
+++ b/pkg/api/googlecloud/logestimator/estimator.go
@@ -1,0 +1,268 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logestimator
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync/atomic"
+	"time"
+
+	logging "cloud.google.com/go/logging/apiv2"
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// MetricLogCountFetcher is a function or client capable of querying Cloud Monitoring for log entry counts.
+type MetricLogCountFetcher interface {
+	QueryMetricCount(ctx context.Context, container googlecloud.ResourceContainer, metricFilter string, startTime, endTime time.Time) (int64, error)
+}
+
+// MonitoringClientFetcher implements MetricLogCountFetcher using *monitoring.MetricClient.
+type MonitoringClientFetcher struct {
+	Client *monitoring.MetricClient
+}
+
+// QueryMetricCount queries Cloud Monitoring for logging.googleapis.com/log_entry_count.
+func (f *MonitoringClientFetcher) QueryMetricCount(ctx context.Context, container googlecloud.ResourceContainer, metricFilter string, startTime, endTime time.Time) (int64, error) {
+	req := &monitoringpb.ListTimeSeriesRequest{
+		Name:   container.Identifier(),
+		Filter: metricFilter,
+		Interval: &monitoringpb.TimeInterval{
+			StartTime: timestamppb.New(startTime),
+			EndTime:   timestamppb.New(endTime),
+		},
+		View: monitoringpb.ListTimeSeriesRequest_FULL,
+		Aggregation: &monitoringpb.Aggregation{
+			CrossSeriesReducer: monitoringpb.Aggregation_REDUCE_SUM,
+			PerSeriesAligner:   monitoringpb.Aggregation_ALIGN_SUM,
+			AlignmentPeriod:    durationpb.New(60 * time.Second),
+		},
+	}
+
+	it := f.Client.ListTimeSeries(ctx, req)
+	var totalCount int64
+
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return 0, fmt.Errorf("failed to query time series: %w", err)
+		}
+		for _, pt := range resp.GetPoints() {
+			totalCount += pt.GetValue().GetInt64Value()
+		}
+	}
+
+	return totalCount, nil
+}
+
+// LogSamplingProbeFetcher is an interface for probing Cloud Logging sample logs.
+type LogSamplingProbeFetcher interface {
+	// ProbeLogTimestamps returns timestamps of matching log entries (up to maxEntries, ordered by timestamp desc).
+	ProbeLogTimestamps(ctx context.Context, container googlecloud.ResourceContainer, filter string, maxEntries int32) ([]time.Time, error)
+}
+
+// LoggingClientProbeFetcher implements LogSamplingProbeFetcher using *logging.Client.
+type LoggingClientProbeFetcher struct {
+	Client *logging.Client
+}
+
+// ProbeLogTimestamps queries recent matching log entries from Cloud Logging to extract timestamps.
+func (f *LoggingClientProbeFetcher) ProbeLogTimestamps(ctx context.Context, container googlecloud.ResourceContainer, filter string, maxEntries int32) ([]time.Time, error) {
+	req := &loggingpb.ListLogEntriesRequest{
+		ResourceNames: []string{container.Identifier()},
+		Filter:        filter,
+		OrderBy:       "timestamp desc",
+		PageSize:      maxEntries,
+	}
+	it := f.Client.ListLogEntries(ctx, req)
+	var timestamps []time.Time
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to probe log entries: %w", err)
+		}
+		timestamps = append(timestamps, resp.GetTimestamp().AsTime())
+		if int32(len(timestamps)) >= maxEntries {
+			break
+		}
+	}
+	return timestamps, nil
+}
+
+// StructuredLogEstimator estimates log volume for StructuredLogQuery.
+type StructuredLogEstimator struct {
+	MetricFetcher MetricLogCountFetcher
+	ProbeFetcher  LogSamplingProbeFetcher
+	TargetSamples int32
+}
+
+// NewStructuredLogEstimator creates a StructuredLogEstimator with defaults.
+func NewStructuredLogEstimator(metricFetcher MetricLogCountFetcher, probeFetcher LogSamplingProbeFetcher) *StructuredLogEstimator {
+	return &StructuredLogEstimator{
+		MetricFetcher: metricFetcher,
+		ProbeFetcher:  probeFetcher,
+		TargetSamples: 50,
+	}
+}
+
+// NewStructuredLogEstimatorFromClients constructs a StructuredLogEstimator directly from Google Cloud SDK clients.
+func NewStructuredLogEstimatorFromClients(loggingClient *logging.Client, metricClient *monitoring.MetricClient) *StructuredLogEstimator {
+	var metricFetcher MetricLogCountFetcher
+	if metricClient != nil {
+		metricFetcher = &MonitoringClientFetcher{Client: metricClient}
+	}
+	var probeFetcher LogSamplingProbeFetcher
+	if loggingClient != nil {
+		probeFetcher = &LoggingClientProbeFetcher{Client: loggingClient}
+	}
+	return NewStructuredLogEstimator(metricFetcher, probeFetcher)
+}
+
+// Estimate estimates the total log volume for the given StructuredLogQuery over the time interval.
+// Cloud Monitoring queries for all resource types are executed concurrently.
+// If custom filters require sampling, a time-window bounded sampling probe is executed.
+func (e *StructuredLogEstimator) Estimate(ctx context.Context, container googlecloud.ResourceContainer, query *StructuredLogQuery, startTime, endTime time.Time) (*EstimateResult, error) {
+	allSupported := query.AllFiltersSupportMetrics()
+	metricFilters := query.GenerateMonitoringMetricFilters()
+
+	sampleSize := e.TargetSamples
+	if sampleSize <= 0 {
+		sampleSize = 50
+	}
+
+	timeFilter := fmt.Sprintf("timestamp >= \"%s\"\ntimestamp <= \"%s\"", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
+
+	g, groupCtx := errgroup.WithContext(ctx)
+
+	// 1. Fetch Cloud Monitoring metrics concurrently for all resource types.
+	var metricCount int64
+	for _, filter := range metricFilters {
+		f := filter
+		g.Go(func() error {
+			cnt, err := e.MetricFetcher.QueryMetricCount(groupCtx, container, f, startTime, endTime)
+			if err != nil {
+				return fmt.Errorf("failed to query metric count for filter %s: %w", f, err)
+			}
+			atomic.AddInt64(&metricCount, cnt)
+			return nil
+		})
+	}
+
+	// 2. If sampling is needed, concurrently fetch base probe logs (up to sampleSize).
+	var baseTimestamps []time.Time
+	if !allSupported && e.ProbeFetcher != nil {
+		baseQuery := query.GenerateBaseLoggingQuery()
+		baseFilter := fmt.Sprintf("%s\n%s", baseQuery, timeFilter)
+		g.Go(func() error {
+			ts, err := e.ProbeFetcher.ProbeLogTimestamps(groupCtx, container, baseFilter, sampleSize)
+			if err != nil {
+				return fmt.Errorf("failed to fetch base sample probe: %w", err)
+			}
+			baseTimestamps = ts
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	// 3. Pure metric query (no custom filter, all matchers natively supported in Cloud Monitoring)
+	if allSupported {
+		return &EstimateResult{
+			MetricCount:       metricCount,
+			EstimatedCount:    metricCount,
+			CustomFilterRatio: 1.0,
+			IsExact:           true,
+		}, nil
+	}
+
+	// 4. Custom filter query but probe fetcher is not configured
+	if e.ProbeFetcher == nil {
+		return &EstimateResult{
+			MetricCount:       metricCount,
+			EstimatedCount:    metricCount,
+			CustomFilterRatio: 1.0,
+			IsExact:           false,
+		}, nil
+	}
+
+	// 5. If base probe returned 0 logs in the whole interval
+	if len(baseTimestamps) == 0 {
+		// Probe custom query over the full interval to check if logs exist (e.g. retention > 42 days).
+		customQuery := query.GenerateCloudLoggingQuery()
+		customFilter := fmt.Sprintf("%s\n%s", customQuery, timeFilter)
+		customTimestamps, err := e.ProbeFetcher.ProbeLogTimestamps(ctx, container, customFilter, sampleSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to probe custom log count: %w", err)
+		}
+		if len(customTimestamps) > 0 {
+			return &EstimateResult{
+				MetricCount:       0,
+				EstimatedCount:    int64(len(customTimestamps)),
+				CustomFilterRatio: 1.0,
+				IsExact:           false,
+			}, nil
+		}
+		return &EstimateResult{
+			MetricCount:       0,
+			EstimatedCount:    0,
+			CustomFilterRatio: 1.0,
+			IsExact:           true,
+		}, nil
+	}
+
+	// 6. Time-window bounded sampling: query custom logs in the exact window [cutoffTime, endTime].
+	cutoffTime := baseTimestamps[len(baseTimestamps)-1]
+	customQuery := query.GenerateCloudLoggingQuery()
+	customWindowFilter := fmt.Sprintf("%s\ntimestamp >= \"%s\"\ntimestamp <= \"%s\"",
+		customQuery, cutoffTime.Format(time.RFC3339Nano), endTime.Format(time.RFC3339Nano))
+
+	customTimestamps, err := e.ProbeFetcher.ProbeLogTimestamps(ctx, container, customWindowFilter, sampleSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to probe custom window logs: %w", err)
+	}
+
+	ratio := float64(len(customTimestamps)) / float64(len(baseTimestamps))
+	if ratio > 1.0 {
+		ratio = 1.0
+	}
+
+	estimatedCount := int64(math.Round(float64(metricCount) * ratio))
+	if metricCount == 0 && len(customTimestamps) > 0 {
+		estimatedCount = int64(len(customTimestamps))
+	}
+
+	return &EstimateResult{
+		MetricCount:       metricCount,
+		EstimatedCount:    estimatedCount,
+		CustomFilterRatio: ratio,
+		IsExact:           false,
+	}, nil
+}

--- a/pkg/api/googlecloud/logestimator/estimator.go
+++ b/pkg/api/googlecloud/logestimator/estimator.go
@@ -71,6 +71,9 @@ func (f *MonitoringClientFetcher) QueryMetricCount(ctx context.Context, containe
 			return 0, fmt.Errorf("failed to query time series: %w", err)
 		}
 		for _, pt := range resp.GetPoints() {
+			if pt == nil || pt.GetValue() == nil {
+				continue
+			}
 			totalCount += pt.GetValue().GetInt64Value()
 		}
 	}

--- a/pkg/api/googlecloud/logestimator/estimator_test.go
+++ b/pkg/api/googlecloud/logestimator/estimator_test.go
@@ -1,0 +1,851 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logestimator
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	logging "cloud.google.com/go/logging/apiv2"
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"github.com/GoogleCloudPlatform/khi/internal/testflags"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/iterator"
+)
+
+func TestStructuredLogQuery_Generation(t *testing.T) {
+	tests := []struct {
+		name                    string
+		query                   *StructuredLogQuery
+		wantLoggingQuery        string
+		wantMetricFilters       []string
+		wantAllFiltersSupported bool
+	}{
+		{
+			name: "k8s_container query with pod substring and namespace exclusion",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("my-cluster")),
+					ResourceLabel("location", Exact("us-central1")),
+					ResourceLabel("namespace_name", FromSetFilter(&gcpqueryutil.SetFilterParseResult{
+						SubtractMode: true,
+						Subtractives: []string{"kube-system", "istio-system"},
+					}, false)),
+					ResourceLabel("pod_name", FromSetFilter(&gcpqueryutil.SetFilterParseResult{
+						Additives: []string{"nginx", "redis"},
+					}, true)),
+					ResourceLabel("project_id", Exact("my-project")),
+					LogID(NoneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")),
+				},
+			},
+			wantLoggingQuery: `resource.type="k8s_container"
+resource.labels.cluster_name="my-cluster"
+resource.labels.location="us-central1"
+-resource.labels.namespace_name=("kube-system" OR "istio-system")
+resource.labels.pod_name:("nginx" OR "redis")
+resource.labels.project_id="my-project"
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_container" AND resource.labels.cluster_name = "my-cluster" AND resource.labels.location = "us-central1" AND resource.labels.namespace_name != "kube-system" AND resource.labels.namespace_name != "istio-system" AND (resource.labels.pod_name = has_substring("nginx") OR resource.labels.pod_name = has_substring("redis")) AND resource.labels.project_id = "my-project" AND metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver"`,
+			},
+			wantAllFiltersSupported: true,
+		},
+		{
+			name: "gke_audit query with multiple resource types and log IDs",
+			query: &StructuredLogQuery{
+				ResourceTypes:             []string{"gke_cluster", "gke_nodepool"},
+				IgnoreMetricsResourceType: []string{"gke_cluster", "gke_nodepool"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("my-cluster")),
+					ResourceLabel("location", Exact("us-central1")),
+					ResourceLabel("project_id", Exact("my-project")),
+					LogID(OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+					CustomFilter(`protoPayload.serviceName="container.googleapis.com"`),
+				},
+			},
+			wantLoggingQuery: `resource.type=("gke_cluster" OR "gke_nodepool")
+resource.labels.cluster_name="my-cluster"
+resource.labels.location="us-central1"
+resource.labels.project_id="my-project"
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.serviceName="container.googleapis.com"`,
+			wantMetricFilters:       nil,
+			wantAllFiltersSupported: false, // CustomFilter and IgnoreMetricsResourceType trigger probe
+		},
+		{
+			name: "k8s_event query with log ID inclusion (100% pure metric)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("my-cluster")),
+					ResourceLabel("location", Exact("us-central1")),
+					ResourceLabel("project_id", Exact("my-project")),
+					LogID(Exact("events")),
+				},
+			},
+			wantLoggingQuery: `resource.type="k8s_cluster"
+resource.labels.cluster_name="my-cluster"
+resource.labels.location="us-central1"
+resource.labels.project_id="my-project"
+LOG_ID("events")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.cluster_name = "my-cluster" AND resource.labels.location = "us-central1" AND resource.labels.project_id = "my-project" AND metric.labels.log = "events"`,
+			},
+			wantAllFiltersSupported: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLogging := tt.query.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tt.wantLoggingQuery, gotLogging); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			if got := tt.query.AllFiltersSupportMetrics(); got != tt.wantAllFiltersSupported {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", got, tt.wantAllFiltersSupported)
+			}
+
+			gotMetrics := tt.query.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tt.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type mockMetricFetcher struct {
+	count int64
+	err   error
+}
+
+func (m *mockMetricFetcher) QueryMetricCount(ctx context.Context, container googlecloud.ResourceContainer, metricFilter string, startTime, endTime time.Time) (int64, error) {
+	return m.count, m.err
+}
+
+type mockProbeFetcher struct {
+	baseCount   int32
+	customCount int32
+	err         error
+}
+
+func (m *mockProbeFetcher) ProbeLogTimestamps(ctx context.Context, container googlecloud.ResourceContainer, filter string, maxEntries int32) ([]time.Time, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	count := m.baseCount
+	if strings.Contains(filter, "jsonPayload") || strings.Contains(filter, "protoPayload") {
+		count = m.customCount
+	}
+	if count <= 0 {
+		return nil, nil
+	}
+	now := time.Now()
+	res := make([]time.Time, count)
+	for i := int32(0); i < count; i++ {
+		res[i] = now.Add(-time.Duration(i) * time.Second)
+	}
+	return res, nil
+}
+
+func TestStructuredLogEstimator_Estimate(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         *StructuredLogQuery
+		metricFetcher MetricLogCountFetcher
+		probeFetcher  LogSamplingProbeFetcher
+		wantResult    *EstimateResult
+		wantErr       bool
+	}{
+		{
+			name: "exact count when metric has 0 logs",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("cluster-1")),
+				},
+			},
+			metricFetcher: &mockMetricFetcher{count: 0},
+			wantResult: &EstimateResult{
+				MetricCount:       0,
+				EstimatedCount:    0,
+				CustomFilterRatio: 1.0,
+				IsExact:           true,
+			},
+		},
+		{
+			name: "exact count when no custom filter and no exclusions",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("cluster-1")),
+					LogID(Exact("stdout")),
+				},
+			},
+			metricFetcher: &mockMetricFetcher{count: 500000},
+			wantResult: &EstimateResult{
+				MetricCount:       500000,
+				EstimatedCount:    500000,
+				CustomFilterRatio: 1.0,
+				IsExact:           true,
+			},
+		},
+		{
+			name: "concurrent multi-resource metric summation",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_node", "k8s_pod"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("cluster-1")),
+					LogID(Exact("events")),
+				},
+			},
+			metricFetcher: &mockMetricFetcher{count: 3000}, // 2 resource types * 3000 = 6000
+			wantResult: &EstimateResult{
+				MetricCount:       6000,
+				EstimatedCount:    6000,
+				CustomFilterRatio: 1.0,
+				IsExact:           true,
+			},
+		},
+		{
+			name: "sampled estimation with custom filter ratio",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("cluster-1")),
+					LogID(Exact("events")),
+					CustomFilter(`jsonPayload.involvedObject.namespace="default"`),
+				},
+			},
+			metricFetcher: &mockMetricFetcher{count: 100000},
+			probeFetcher: &mockProbeFetcher{
+				baseCount:   50,
+				customCount: 10, // ratio 10/50 = 0.20 -> 20000
+			},
+			wantResult: &EstimateResult{
+				MetricCount:       100000,
+				EstimatedCount:    20000,
+				CustomFilterRatio: 0.2,
+				IsExact:           false,
+			},
+		},
+		{
+			name: "fallback when metric is 0 but custom probe finds logs",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("cluster-1")),
+					LogID(Exact("events")),
+					CustomFilter(`jsonPayload.involvedObject.namespace="default"`),
+				},
+			},
+			metricFetcher: &mockMetricFetcher{count: 0},
+			probeFetcher: &mockProbeFetcher{
+				baseCount:   0,
+				customCount: 42,
+			},
+			wantResult: &EstimateResult{
+				MetricCount:       0,
+				EstimatedCount:    42,
+				CustomFilterRatio: 1.0,
+				IsExact:           false,
+			},
+		},
+		{
+			name: "metric 0 and custom probe 0 returns 0 exact",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("cluster-1")),
+					LogID(Exact("events")),
+					CustomFilter(`jsonPayload.involvedObject.namespace="default"`),
+				},
+			},
+			metricFetcher: &mockMetricFetcher{count: 0},
+			probeFetcher: &mockProbeFetcher{
+				baseCount:   0,
+				customCount: 0,
+			},
+			wantResult: &EstimateResult{
+				MetricCount:       0,
+				EstimatedCount:    0,
+				CustomFilterRatio: 1.0,
+				IsExact:           true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			estimator := NewStructuredLogEstimator(tt.metricFetcher, tt.probeFetcher)
+			got, err := estimator.Estimate(context.Background(), googlecloud.Project("test-project"), tt.query, time.Now().Add(-time.Hour), time.Now())
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Estimate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(tt.wantResult, got); diff != "" {
+				t.Errorf("Estimate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type realLogProbeFetcher struct {
+	client *logging.Client
+}
+
+func (f *realLogProbeFetcher) ProbeLogTimestamps(ctx context.Context, container googlecloud.ResourceContainer, filter string, maxEntries int32) ([]time.Time, error) {
+	req := &loggingpb.ListLogEntriesRequest{
+		ResourceNames: []string{container.Identifier()},
+		Filter:        filter,
+		PageSize:      maxEntries,
+	}
+	it := f.client.ListLogEntries(ctx, req)
+	var timestamps []time.Time
+	for {
+		entry, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if entry.GetTimestamp() != nil {
+			timestamps = append(timestamps, entry.GetTimestamp().AsTime())
+		} else {
+			timestamps = append(timestamps, time.Now())
+		}
+		if int32(len(timestamps)) >= maxEntries {
+			break
+		}
+	}
+	return timestamps, nil
+}
+
+// TestLiveMetricEstimation runs against real GCP when RUN_LIVE_ESTIMATION_TESTS=true.
+func TestLiveMetricEstimation(t *testing.T) {
+	if os.Getenv("RUN_LIVE_ESTIMATION_TESTS") != "true" || *testflags.SkipCloudLogging {
+		t.Skip("skipping live test: set RUN_LIVE_ESTIMATION_TESTS=true to run")
+		return
+	}
+
+	projectID := os.Getenv("GCP_PROJECT_ID")
+	if projectID == "" {
+		projectID = "tse-kakeru"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	metricClient, err := monitoring.NewMetricClient(ctx)
+	if err != nil {
+		t.Skipf("skipping live test: failed to create monitoring client: %v", err)
+	}
+	defer metricClient.Close()
+
+	logClient, err := logging.NewClient(ctx)
+	if err != nil {
+		t.Skipf("skipping live test: failed to create logging client: %v", err)
+	}
+	defer logClient.Close()
+
+	estimator := NewStructuredLogEstimator(
+		&MonitoringClientFetcher{Client: metricClient},
+		&realLogProbeFetcher{client: logClient},
+	)
+
+	now := time.Now()
+	startTime := now.Add(-24 * time.Hour)
+	endTime := now
+
+	scenarios := []struct {
+		name  string
+		query *StructuredLogQuery
+	}{
+		{
+			name: "Scenario 1: K8s Event logs (Pure Metric - 100% exact)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					LogID(Exact("events")),
+				},
+			},
+		},
+		{
+			name: "Scenario 2: Container logs with namespace filter (Pure Metric)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("namespace_name", OneOf("default", "kube-system")),
+				},
+			},
+		},
+		{
+			name: "Scenario 3: GKE Audit logs (Metric + Service Name Custom Filter)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"audited_resource"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("service", Exact("container.googleapis.com")),
+					LogID(OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+				},
+			},
+		},
+		{
+			name: "Scenario 4: Container logs with Custom Filter (Sampling Probe Estimation)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("namespace_name", OneOf("kube-system")),
+					CustomFilter(`jsonPayload.message:""`),
+				},
+			},
+		},
+		{
+			name: "Scenario 5: Container logs with LogID NoneOf (Pure Metric)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					LogID(NoneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")),
+				},
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			mFilters := s.query.GenerateMonitoringMetricFilters()
+			t.Logf("Metric Filters: %v", mFilters)
+			t.Logf("Logging Query:\n%s", s.query.GenerateCloudLoggingQuery())
+
+			start := time.Now()
+			res, err := estimator.Estimate(ctx, googlecloud.Project(projectID), s.query, startTime, endTime)
+			elapsed := time.Since(start)
+
+			if err != nil {
+				t.Fatalf("Estimate failed: %v", err)
+			}
+
+			t.Logf("Result in %v: MetricCount=%d, EstimatedCount=%d, Ratio=%.4f, IsExact=%v",
+				elapsed, res.MetricCount, res.EstimatedCount, res.CustomFilterRatio, res.IsExact)
+		})
+	}
+}
+
+// TestEstimateClusterLogs tests log estimation for a specific project and cluster.
+func TestEstimateClusterLogs(t *testing.T) {
+	if os.Getenv("RUN_LIVE_ESTIMATION_TESTS") != "true" || *testflags.SkipCloudLogging {
+		t.Skip("skipping live test: set RUN_LIVE_ESTIMATION_TESTS=true to run")
+		return
+	}
+
+	projectID := "khi-testing-with-auditlog"
+	clusterName := "p0-gke-basic-1"
+
+	startTime, err := time.Parse(time.RFC3339, "2026-02-18T05:53:08Z")
+	if err != nil {
+		t.Fatalf("failed to parse startTime: %v", err)
+	}
+	endTime, err := time.Parse(time.RFC3339, "2026-02-18T09:53:08Z")
+	if err != nil {
+		t.Fatalf("failed to parse endTime: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	metricClient, err := monitoring.NewMetricClient(ctx)
+	if err != nil {
+		t.Skipf("skipping live test: failed to create monitoring client: %v", err)
+	}
+	defer metricClient.Close()
+
+	logClient, err := logging.NewClient(ctx)
+	if err != nil {
+		t.Skipf("skipping live test: failed to create logging client: %v", err)
+	}
+	defer logClient.Close()
+
+	estimator := NewStructuredLogEstimator(
+		&MonitoringClientFetcher{Client: metricClient},
+		&realLogProbeFetcher{client: logClient},
+	)
+
+	queries := []struct {
+		logType string
+		query   *StructuredLogQuery
+	}{
+		{
+			logType: "1. K8s Event Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(Exact("events")),
+				},
+			},
+		},
+		{
+			logType: "2. K8s Audit Log (mutations on deployments/replicasets/pods/nodes)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+					CustomFilter(`protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+protoPayload.methodName=~"\.(deployments|replicasets|pods|nodes)\."`),
+				},
+			},
+		},
+		{
+			logType: "3. K8s Node Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_node"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(NoneOf("events")),
+				},
+			},
+		},
+		{
+			logType: "4. K8s Container Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(NoneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")),
+				},
+			},
+		},
+	}
+
+	for _, item := range queries {
+		t.Run(item.logType, func(t *testing.T) {
+			mFilters := item.query.GenerateMonitoringMetricFilters()
+			t.Logf("Metric Filter: %v", mFilters)
+			t.Logf("Logging Query:\n%s", item.query.GenerateCloudLoggingQuery())
+
+			start := time.Now()
+			res, err := estimator.Estimate(ctx, googlecloud.Project(projectID), item.query, startTime, endTime)
+			elapsed := time.Since(start)
+
+			if err != nil {
+				t.Fatalf("Estimate failed: %v", err)
+			}
+
+			t.Logf(">>> [%s] Elapsed: %v | Base Metric: %d | Estimated: %d | Ratio: %.4f | IsExact: %v",
+				item.logType, elapsed, res.MetricCount, res.EstimatedCount, res.CustomFilterRatio, res.IsExact)
+		})
+	}
+}
+
+// TestEstimateTseKakeruClusterLogs tests log volume estimation for yesterday on tse-kakeru clusters.
+func TestEstimateTseKakeruClusterLogs(t *testing.T) {
+	if os.Getenv("RUN_LIVE_ESTIMATION_TESTS") != "true" || *testflags.SkipCloudLogging {
+		t.Skip("skipping live test: set RUN_LIVE_ESTIMATION_TESTS=true to run")
+		return
+	}
+
+	projectID := "tse-kakeru"
+	clusterName := "keigof-0804-cluster"
+	location := "asia-northeast1"
+
+	// Yesterday: 2026-08-21 00:00:00 UTC to 2026-08-21 23:59:59 UTC
+	startTime, err := time.Parse(time.RFC3339, "2026-08-21T00:00:00Z")
+	if err != nil {
+		t.Fatalf("failed to parse startTime: %v", err)
+	}
+	endTime, err := time.Parse(time.RFC3339, "2026-08-21T23:59:59Z")
+	if err != nil {
+		t.Fatalf("failed to parse endTime: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	metricClient, err := monitoring.NewMetricClient(ctx)
+	if err != nil {
+		t.Skipf("skipping live test: failed to create monitoring client: %v", err)
+	}
+	defer metricClient.Close()
+
+	logClient, err := logging.NewClient(ctx)
+	if err != nil {
+		t.Skipf("skipping live test: failed to create logging client: %v", err)
+	}
+	defer logClient.Close()
+
+	estimator := NewStructuredLogEstimator(
+		&MonitoringClientFetcher{Client: metricClient},
+		&realLogProbeFetcher{client: logClient},
+	)
+
+	queries := []struct {
+		logType string
+		query   *StructuredLogQuery
+	}{
+		{
+			logType: "1. K8s Event Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(Exact("events")),
+				},
+			},
+		},
+		{
+			logType: "2. K8s Audit Log (mutations on deployments/replicasets/pods/nodes)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+					CustomFilter(`protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+protoPayload.methodName=~"\.(deployments|replicasets|pods|nodes)\."`),
+				},
+			},
+		},
+		{
+			logType: "3. K8s Node Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_node"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(NoneOf("events")),
+				},
+			},
+		},
+		{
+			logType: "4. K8s Container Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(NoneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")),
+				},
+			},
+		},
+		{
+			logType: "5. K8s Control Plane Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_control_plane_component"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					CustomFilter(`-sourceLocation.file="httplog.go"`),
+				},
+			},
+		},
+	}
+
+	for _, item := range queries {
+		t.Run(item.logType, func(t *testing.T) {
+			mFilters := item.query.GenerateMonitoringMetricFilters()
+			t.Logf("Metric Filter: %v", mFilters)
+			t.Logf("Logging Query:\n%s", item.query.GenerateCloudLoggingQuery())
+
+			start := time.Now()
+			res, err := estimator.Estimate(ctx, googlecloud.Project(projectID), item.query, startTime, endTime)
+			elapsed := time.Since(start)
+
+			if err != nil {
+				t.Fatalf("Estimate failed: %v", err)
+			}
+
+			t.Logf(">>> [%s] Elapsed: %v | Base Metric: %d | Estimated: %d | Ratio: %.4f | IsExact: %v",
+				item.logType, elapsed, res.MetricCount, res.EstimatedCount, res.CustomFilterRatio, res.IsExact)
+		})
+	}
+}
+
+// TestAccuracyOneHourComparison tests accuracy by comparing estimated vs actual counts over a time window.
+func TestAccuracyOneHourComparison(t *testing.T) {
+	if os.Getenv("RUN_LIVE_ESTIMATION_TESTS") != "true" || *testflags.SkipCloudLogging {
+		t.Skip("skipping live test: set RUN_LIVE_ESTIMATION_TESTS=true to run")
+		return
+	}
+
+	projectID := "tse-kakeru"
+	clusterName := os.Getenv("TEST_CLUSTER_NAME")
+	if clusterName == "" {
+		clusterName = "csm-cluster"
+	}
+	location := os.Getenv("TEST_CLUSTER_LOCATION")
+	if location == "" {
+		location = "us-central1"
+	}
+
+	// 15-minute window: 2026-08-21 06:00:00 UTC to 2026-08-21 06:15:00 UTC
+	startTime, _ := time.Parse(time.RFC3339, "2026-08-21T06:00:00Z")
+	endTime, _ := time.Parse(time.RFC3339, "2026-08-21T06:15:00Z")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	metricClient, err := monitoring.NewMetricClient(ctx)
+	if err != nil {
+		t.Skipf("skipping live test: failed to create monitoring client: %v", err)
+	}
+	defer metricClient.Close()
+
+	logClient, err := logging.NewClient(ctx)
+	if err != nil {
+		t.Skipf("skipping live test: failed to create logging client: %v", err)
+	}
+	defer logClient.Close()
+
+	estimator := NewStructuredLogEstimator(
+		&MonitoringClientFetcher{Client: metricClient},
+		&realLogProbeFetcher{client: logClient},
+	)
+
+	queries := []struct {
+		logType string
+		query   *StructuredLogQuery
+	}{
+		{
+			logType: "1. K8s Event Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(Exact("events")),
+				},
+			},
+		},
+		{
+			logType: "2. K8s Audit Log (Mutations)",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+					CustomFilter(`protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+protoPayload.methodName=~"\.(deployments|replicasets|pods|nodes)\."`),
+				},
+			},
+		},
+		{
+			logType: "3. K8s Node Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_node"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(NoneOf("events")),
+				},
+			},
+		},
+		{
+			logType: "4. K8s Container Log",
+			query: &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("project_id", Exact(projectID)),
+					ResourceLabel("location", Exact(location)),
+					ResourceLabel("cluster_name", Exact(clusterName)),
+					LogID(NoneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")),
+				},
+			},
+		},
+	}
+
+	for _, item := range queries {
+		t.Run(item.logType, func(t *testing.T) {
+			time.Sleep(5 * time.Second)
+
+			// 1. Estimation
+			estStart := time.Now()
+			res, err := estimator.Estimate(ctx, googlecloud.Project(projectID), item.query, startTime, endTime)
+			estElapsed := time.Since(estStart)
+			if err != nil {
+				t.Fatalf("Estimate failed: %v", err)
+			}
+
+			// 2. Actual Count from Cloud Logging with rate pacing
+			time.Sleep(5 * time.Second)
+			actStart := time.Now()
+			fullQuery := fmt.Sprintf("%s\ntimestamp >= \"%s\"\ntimestamp <= \"%s\"",
+				item.query.GenerateCloudLoggingQuery(),
+				startTime.Format(time.RFC3339),
+				endTime.Format(time.RFC3339),
+			)
+			req := &loggingpb.ListLogEntriesRequest{
+				ResourceNames: []string{"projects/" + projectID},
+				Filter:        fullQuery,
+				PageSize:      1000,
+			}
+			it := logClient.ListLogEntries(ctx, req)
+			var actualCount int64
+			var pageCount int
+			for {
+				_, err := it.Next()
+				if err == iterator.Done {
+					break
+				}
+				if err != nil {
+					t.Fatalf("ListLogEntries error: %v", err)
+				}
+				actualCount++
+				if actualCount%1000 == 0 {
+					pageCount++
+					time.Sleep(600 * time.Millisecond)
+				}
+			}
+			actElapsed := time.Since(actStart)
+
+			diff := res.EstimatedCount - actualCount
+			errPct := 0.0
+			if actualCount > 0 {
+				errPct = math.Abs(float64(diff)) / float64(actualCount) * 100.0
+			}
+
+			t.Logf(">>> [%s]\n    Estimated: %d (in %v, MetricBase: %d, Ratio: %.4f)\n    Actual:    %d (in %v, Pages: %d)\n    Error:     %.2f%% (diff: %d)",
+				item.logType, res.EstimatedCount, estElapsed, res.MetricCount, res.CustomFilterRatio, actualCount, actElapsed, pageCount, errPct, diff)
+		})
+	}
+}

--- a/pkg/api/googlecloud/logestimator/matcher.go
+++ b/pkg/api/googlecloud/logestimator/matcher.go
@@ -1,0 +1,489 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logestimator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+)
+
+// LoggingMonitoringMatcher defines a self-contained filter clause for both
+// Cloud Logging query strings and Cloud Monitoring metric filters.
+type LoggingMonitoringMatcher interface {
+	// SupportMetrics returns true if this filter condition can be natively represented in Cloud Monitoring.
+	SupportMetrics() bool
+
+	// ToLoggingQuery returns the filter fragment for Cloud Logging queries.
+	ToLoggingQuery() string
+
+	// ToMonitoringFilter returns the filter fragment for Cloud Monitoring metric filters.
+	ToMonitoringFilter() string
+}
+
+// ValueMatcher defines how a set of values or patterns expands for both
+// general field names (e.g. resource.labels.key) and LogID macros.
+type ValueMatcher interface {
+	// ToLoggingFieldQuery returns the Cloud Logging query fragment for a named field.
+	ToLoggingFieldQuery(fieldName string) string
+
+	// ToMonitoringFieldFilter returns the Cloud Monitoring metric filter fragment for a named field.
+	ToMonitoringFieldFilter(fieldName string) string
+
+	// ToLoggingLogIDQuery returns the Cloud Logging query fragment for LOG_ID(...).
+	ToLoggingLogIDQuery() string
+
+	// ToMonitoringLogIDFilter returns the Cloud Monitoring metric filter fragment for metric.labels.log.
+	ToMonitoringLogIDFilter() string
+}
+
+// ----------------------------------------------------------------------------
+// ResourceLabel Matcher
+// ----------------------------------------------------------------------------
+
+type resourceLabelMatcher struct {
+	labelKey string
+	vm       ValueMatcher
+}
+
+var _ LoggingMonitoringMatcher = (*resourceLabelMatcher)(nil)
+
+// ResourceLabel creates a LoggingMonitoringMatcher for a resource.labels.<key> field.
+func ResourceLabel(labelKey string, vm ValueMatcher) LoggingMonitoringMatcher {
+	if vm == nil {
+		return nil
+	}
+	return &resourceLabelMatcher{
+		labelKey: labelKey,
+		vm:       vm,
+	}
+}
+
+func (m *resourceLabelMatcher) SupportMetrics() bool {
+	return m.vm.ToMonitoringFieldFilter("resource.labels."+m.labelKey) != ""
+}
+
+func (m *resourceLabelMatcher) ToLoggingQuery() string {
+	return m.vm.ToLoggingFieldQuery("resource.labels." + m.labelKey)
+}
+
+func (m *resourceLabelMatcher) ToMonitoringFilter() string {
+	return m.vm.ToMonitoringFieldFilter("resource.labels." + m.labelKey)
+}
+
+// ----------------------------------------------------------------------------
+// LogID Matcher
+// ----------------------------------------------------------------------------
+
+type logIDMatcher struct {
+	vm ValueMatcher
+}
+
+var _ LoggingMonitoringMatcher = (*logIDMatcher)(nil)
+
+// LogID creates a LoggingMonitoringMatcher for log IDs (LOG_ID macro in Logging, metric.labels.log in Monitoring).
+func LogID(vm ValueMatcher) LoggingMonitoringMatcher {
+	if vm == nil {
+		return nil
+	}
+	return &logIDMatcher{
+		vm: vm,
+	}
+}
+
+func (m *logIDMatcher) SupportMetrics() bool {
+	return m.vm.ToMonitoringLogIDFilter() != ""
+}
+
+func (m *logIDMatcher) ToLoggingQuery() string {
+	return m.vm.ToLoggingLogIDQuery()
+}
+
+func (m *logIDMatcher) ToMonitoringFilter() string {
+	return m.vm.ToMonitoringLogIDFilter()
+}
+
+// ----------------------------------------------------------------------------
+// CustomFilter Matcher
+// ----------------------------------------------------------------------------
+
+type customFilterMatcher struct {
+	rawQuery string
+}
+
+var _ LoggingMonitoringMatcher = (*customFilterMatcher)(nil)
+
+// CustomFilter creates a LoggingMonitoringMatcher for payload/custom filters.
+// Cloud Monitoring does not support payload filters natively, so SupportMetrics returns false.
+func CustomFilter(rawQuery string) LoggingMonitoringMatcher {
+	trimmed := strings.TrimSpace(rawQuery)
+	if trimmed == "" {
+		return nil
+	}
+	return &customFilterMatcher{
+		rawQuery: trimmed,
+	}
+}
+
+func (m *customFilterMatcher) SupportMetrics() bool {
+	return false
+}
+
+func (m *customFilterMatcher) ToLoggingQuery() string {
+	return m.rawQuery
+}
+
+func (m *customFilterMatcher) ToMonitoringFilter() string {
+	return ""
+}
+
+// ----------------------------------------------------------------------------
+// Comment Matcher
+// ----------------------------------------------------------------------------
+
+type commentMatcher struct {
+	comment string
+}
+
+var _ LoggingMonitoringMatcher = (*commentMatcher)(nil)
+
+// Comment creates a LoggingMonitoringMatcher for a standalone comment-only line.
+// The comment text is formatted as "-- <comment>".
+// Since comments do not filter log entries, SupportMetrics returns true and ToMonitoringFilter returns an empty string.
+func Comment(comment string) LoggingMonitoringMatcher {
+	trimmed := strings.TrimSpace(comment)
+	if trimmed == "" {
+		return nil
+	}
+	return &commentMatcher{
+		comment: trimmed,
+	}
+}
+
+func (m *commentMatcher) SupportMetrics() bool {
+	return true
+}
+
+func (m *commentMatcher) ToLoggingQuery() string {
+	return fmt.Sprintf("-- %s", m.comment)
+}
+
+func (m *commentMatcher) ToMonitoringFilter() string {
+	return ""
+}
+
+// ----------------------------------------------------------------------------
+// WithComment Matcher Wrapper
+// ----------------------------------------------------------------------------
+
+type withCommentMatcher struct {
+	inner   LoggingMonitoringMatcher
+	comment string
+}
+
+var _ LoggingMonitoringMatcher = (*withCommentMatcher)(nil)
+
+// WithComment wraps an existing LoggingMonitoringMatcher to append a trailing comment (" -- <comment>")
+// to its Cloud Logging query representation.
+// Cloud Monitoring metric evaluation is delegated to the wrapped matcher without appending the comment.
+func WithComment(matcher LoggingMonitoringMatcher, comment string) LoggingMonitoringMatcher {
+	if matcher == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(comment)
+	if trimmed == "" {
+		return matcher
+	}
+	return &withCommentMatcher{
+		inner:   matcher,
+		comment: trimmed,
+	}
+}
+
+func (m *withCommentMatcher) SupportMetrics() bool {
+	return m.inner.SupportMetrics()
+}
+
+func (m *withCommentMatcher) ToLoggingQuery() string {
+	innerQuery := m.inner.ToLoggingQuery()
+	if innerQuery == "" {
+		return fmt.Sprintf("-- %s", m.comment)
+	}
+	return fmt.Sprintf("%s -- %s", innerQuery, m.comment)
+}
+
+func (m *withCommentMatcher) ToMonitoringFilter() string {
+	return m.inner.ToMonitoringFilter()
+}
+
+// ----------------------------------------------------------------------------
+// ValueMatcher Implementations
+// ----------------------------------------------------------------------------
+
+// exactMatcher matches an exact value.
+type exactMatcher struct {
+	val string
+}
+
+var _ ValueMatcher = (*exactMatcher)(nil)
+
+// Exact creates a ValueMatcher for an exact single value.
+func Exact(val string) ValueMatcher {
+	return &exactMatcher{val: val}
+}
+
+func (m *exactMatcher) ToLoggingFieldQuery(fieldName string) string {
+	return fmt.Sprintf(`%s="%s"`, fieldName, m.val)
+}
+
+func (m *exactMatcher) ToMonitoringFieldFilter(fieldName string) string {
+	return fmt.Sprintf(`%s = "%s"`, fieldName, m.val)
+}
+
+func (m *exactMatcher) ToLoggingLogIDQuery() string {
+	return fmt.Sprintf(`LOG_ID("%s")`, m.val)
+}
+
+func (m *exactMatcher) ToMonitoringLogIDFilter() string {
+	return fmt.Sprintf(`metric.labels.log = "%s"`, m.val)
+}
+
+// oneOfMatcher matches any value in a set (OR).
+type oneOfMatcher struct {
+	vals []string
+}
+
+var _ ValueMatcher = (*oneOfMatcher)(nil)
+
+// OneOf creates a ValueMatcher that matches any of the provided values (OR).
+func OneOf(vals ...string) ValueMatcher {
+	filtered := filterNonEmpty(vals)
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &oneOfMatcher{vals: filtered}
+}
+
+func (m *oneOfMatcher) ToLoggingFieldQuery(fieldName string) string {
+	if len(m.vals) == 1 {
+		return fmt.Sprintf(`%s="%s"`, fieldName, m.vals[0])
+	}
+	quoted := quoteStrings(m.vals)
+	return fmt.Sprintf(`%s=(%s)`, fieldName, strings.Join(quoted, " OR "))
+}
+
+func (m *oneOfMatcher) ToMonitoringFieldFilter(fieldName string) string {
+	if len(m.vals) == 1 {
+		return fmt.Sprintf(`%s = "%s"`, fieldName, m.vals[0])
+	}
+	quoted := quoteStrings(m.vals)
+	return fmt.Sprintf(`%s = one_of(%s)`, fieldName, strings.Join(quoted, ", "))
+}
+
+func (m *oneOfMatcher) ToLoggingLogIDQuery() string {
+	if len(m.vals) == 1 {
+		return fmt.Sprintf(`LOG_ID("%s")`, m.vals[0])
+	}
+	parts := make([]string, len(m.vals))
+	for i, v := range m.vals {
+		parts[i] = fmt.Sprintf(`LOG_ID("%s")`, v)
+	}
+	return "(" + strings.Join(parts, " OR ") + ")"
+}
+
+func (m *oneOfMatcher) ToMonitoringLogIDFilter() string {
+	if len(m.vals) == 1 {
+		return fmt.Sprintf(`metric.labels.log = "%s"`, m.vals[0])
+	}
+	quoted := quoteStrings(m.vals)
+	return fmt.Sprintf(`metric.labels.log = one_of(%s)`, strings.Join(quoted, ", "))
+}
+
+// noneOfMatcher excludes all values in a set (NOT).
+type noneOfMatcher struct {
+	vals []string
+}
+
+var _ ValueMatcher = (*noneOfMatcher)(nil)
+
+// NoneOf creates a ValueMatcher that excludes all provided values (NOT).
+func NoneOf(vals ...string) ValueMatcher {
+	filtered := filterNonEmpty(vals)
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &noneOfMatcher{vals: filtered}
+}
+
+func (m *noneOfMatcher) ToLoggingFieldQuery(fieldName string) string {
+	if len(m.vals) == 1 {
+		return fmt.Sprintf(`-%s="%s"`, fieldName, m.vals[0])
+	}
+	quoted := quoteStrings(m.vals)
+	return fmt.Sprintf(`-%s=(%s)`, fieldName, strings.Join(quoted, " OR "))
+}
+
+func (m *noneOfMatcher) ToMonitoringFieldFilter(fieldName string) string {
+	parts := make([]string, len(m.vals))
+	for i, v := range m.vals {
+		parts[i] = fmt.Sprintf(`%s != "%s"`, fieldName, v)
+	}
+	return strings.Join(parts, " AND ")
+}
+
+func (m *noneOfMatcher) ToLoggingLogIDQuery() string {
+	lines := make([]string, len(m.vals))
+	for i, v := range m.vals {
+		lines[i] = fmt.Sprintf(`-LOG_ID("%s")`, v)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m *noneOfMatcher) ToMonitoringLogIDFilter() string {
+	parts := make([]string, len(m.vals))
+	for i, v := range m.vals {
+		parts[i] = fmt.Sprintf(`metric.labels.log != "%s"`, v)
+	}
+	return strings.Join(parts, " AND ")
+}
+
+// containsAnyMatcher matches any substring in a set.
+type containsAnyMatcher struct {
+	subs []string
+}
+
+var _ ValueMatcher = (*containsAnyMatcher)(nil)
+
+// ContainsAny creates a ValueMatcher matching any of the substrings.
+func ContainsAny(subs ...string) ValueMatcher {
+	filtered := filterNonEmpty(subs)
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &containsAnyMatcher{subs: filtered}
+}
+
+func (m *containsAnyMatcher) ToLoggingFieldQuery(fieldName string) string {
+	if len(m.subs) == 1 {
+		return fmt.Sprintf(`%s:"%s"`, fieldName, m.subs[0])
+	}
+	quoted := quoteStrings(m.subs)
+	return fmt.Sprintf(`%s:(%s)`, fieldName, strings.Join(quoted, " OR "))
+}
+
+func (m *containsAnyMatcher) ToMonitoringFieldFilter(fieldName string) string {
+	if len(m.subs) == 1 {
+		return fmt.Sprintf(`%s = has_substring("%s")`, fieldName, m.subs[0])
+	}
+	parts := make([]string, len(m.subs))
+	for i, s := range m.subs {
+		parts[i] = fmt.Sprintf(`%s = has_substring("%s")`, fieldName, s)
+	}
+	return "(" + strings.Join(parts, " OR ") + ")"
+}
+
+func (m *containsAnyMatcher) ToLoggingLogIDQuery() string {
+	return ""
+}
+
+func (m *containsAnyMatcher) ToMonitoringLogIDFilter() string {
+	return ""
+}
+
+// notContainsAnyMatcher excludes all substrings in a set.
+type notContainsAnyMatcher struct {
+	subs []string
+}
+
+var _ ValueMatcher = (*notContainsAnyMatcher)(nil)
+
+// NotContainsAny creates a ValueMatcher excluding all of the substrings.
+func NotContainsAny(subs ...string) ValueMatcher {
+	filtered := filterNonEmpty(subs)
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &notContainsAnyMatcher{subs: filtered}
+}
+
+func (m *notContainsAnyMatcher) ToLoggingFieldQuery(fieldName string) string {
+	if len(m.subs) == 1 {
+		return fmt.Sprintf(`-%s:"%s"`, fieldName, m.subs[0])
+	}
+	quoted := quoteStrings(m.subs)
+	return fmt.Sprintf(`-%s:(%s)`, fieldName, strings.Join(quoted, " OR "))
+}
+
+func (m *notContainsAnyMatcher) ToMonitoringFieldFilter(fieldName string) string {
+	parts := make([]string, len(m.subs))
+	for i, s := range m.subs {
+		parts[i] = fmt.Sprintf(`%s != has_substring("%s")`, fieldName, s)
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return "(" + strings.Join(parts, " AND ") + ")"
+}
+
+func (m *notContainsAnyMatcher) ToLoggingLogIDQuery() string {
+	return ""
+}
+
+func (m *notContainsAnyMatcher) ToMonitoringLogIDFilter() string {
+	return ""
+}
+
+// FromSetFilter converts a KHI SetFilterParseResult into a ValueMatcher.
+func FromSetFilter(filter *gcpqueryutil.SetFilterParseResult, isSubstring bool) ValueMatcher {
+	if filter == nil || filter.ValidationError != "" {
+		return nil
+	}
+	if filter.SubtractMode {
+		if len(filter.Subtractives) == 0 {
+			return nil
+		}
+		if isSubstring {
+			return NotContainsAny(filter.Subtractives...)
+		}
+		return NoneOf(filter.Subtractives...)
+	}
+	if len(filter.Additives) == 0 {
+		return nil
+	}
+	if isSubstring {
+		return ContainsAny(filter.Additives...)
+	}
+	return OneOf(filter.Additives...)
+}
+
+func quoteStrings(vals []string) []string {
+	quoted := make([]string, len(vals))
+	for i, v := range vals {
+		quoted[i] = fmt.Sprintf(`"%s"`, v)
+	}
+	return quoted
+}
+
+func filterNonEmpty(vals []string) []string {
+	var res []string
+	for _, v := range vals {
+		trimmed := strings.TrimSpace(v)
+		if trimmed != "" {
+			res = append(res, trimmed)
+		}
+	}
+	return res
+}

--- a/pkg/api/googlecloud/logestimator/matcher_test.go
+++ b/pkg/api/googlecloud/logestimator/matcher_test.go
@@ -1,0 +1,413 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logestimator
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestResourceLabelMatchers(t *testing.T) {
+	tests := []struct {
+		name               string
+		matcher            LoggingMonitoringMatcher
+		wantLoggingQuery   string
+		wantMonitoring     string
+		wantSupportMetrics bool
+	}{
+		{
+			name:               "ResourceLabel with Exact",
+			matcher:            ResourceLabel("cluster_name", Exact("my-cluster")),
+			wantLoggingQuery:   `resource.labels.cluster_name="my-cluster"`,
+			wantMonitoring:     `resource.labels.cluster_name = "my-cluster"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "ResourceLabel with OneOf multiple",
+			matcher:            ResourceLabel("namespace_name", OneOf("default", "kube-system")),
+			wantLoggingQuery:   `resource.labels.namespace_name=("default" OR "kube-system")`,
+			wantMonitoring:     `resource.labels.namespace_name = one_of("default", "kube-system")`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "ResourceLabel with OneOf single",
+			matcher:            ResourceLabel("namespace_name", OneOf("default")),
+			wantLoggingQuery:   `resource.labels.namespace_name="default"`,
+			wantMonitoring:     `resource.labels.namespace_name = "default"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "ResourceLabel with NoneOf multiple",
+			matcher:            ResourceLabel("namespace_name", NoneOf("kube-system", "istio-system")),
+			wantLoggingQuery:   `-resource.labels.namespace_name=("kube-system" OR "istio-system")`,
+			wantMonitoring:     `resource.labels.namespace_name != "kube-system" AND resource.labels.namespace_name != "istio-system"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "ResourceLabel with NoneOf single",
+			matcher:            ResourceLabel("namespace_name", NoneOf("kube-system")),
+			wantLoggingQuery:   `-resource.labels.namespace_name="kube-system"`,
+			wantMonitoring:     `resource.labels.namespace_name != "kube-system"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "ResourceLabel with ContainsAny multiple",
+			matcher:            ResourceLabel("pod_name", ContainsAny("nginx", "redis")),
+			wantLoggingQuery:   `resource.labels.pod_name:("nginx" OR "redis")`,
+			wantMonitoring:     `(resource.labels.pod_name = has_substring("nginx") OR resource.labels.pod_name = has_substring("redis"))`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "ResourceLabel with ContainsAny single",
+			matcher:            ResourceLabel("pod_name", ContainsAny("nginx")),
+			wantLoggingQuery:   `resource.labels.pod_name:"nginx"`,
+			wantMonitoring:     `resource.labels.pod_name = has_substring("nginx")`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "ResourceLabel with NotContainsAny multiple",
+			matcher:            ResourceLabel("pod_name", NotContainsAny("nginx", "redis")),
+			wantLoggingQuery:   `-resource.labels.pod_name:("nginx" OR "redis")`,
+			wantMonitoring:     `(resource.labels.pod_name != has_substring("nginx") AND resource.labels.pod_name != has_substring("redis"))`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "ResourceLabel with NotContainsAny single",
+			matcher:            ResourceLabel("pod_name", NotContainsAny("nginx")),
+			wantLoggingQuery:   `-resource.labels.pod_name:"nginx"`,
+			wantMonitoring:     `resource.labels.pod_name != has_substring("nginx")`,
+			wantSupportMetrics: true,
+		},
+		{
+			name: "ResourceLabel with FromSetFilter additive exact",
+			matcher: ResourceLabel("namespace_name", FromSetFilter(&gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"prod", "staging"},
+			}, false)),
+			wantLoggingQuery:   `resource.labels.namespace_name=("prod" OR "staging")`,
+			wantMonitoring:     `resource.labels.namespace_name = one_of("prod", "staging")`,
+			wantSupportMetrics: true,
+		},
+		{
+			name: "ResourceLabel with FromSetFilter subtractive substring",
+			matcher: ResourceLabel("pod_name", FromSetFilter(&gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{"canary", "test"},
+			}, true)),
+			wantLoggingQuery:   `-resource.labels.pod_name:("canary" OR "test")`,
+			wantMonitoring:     `(resource.labels.pod_name != has_substring("canary") AND resource.labels.pod_name != has_substring("test"))`,
+			wantSupportMetrics: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.matcher.SupportMetrics(); got != tt.wantSupportMetrics {
+				t.Errorf("SupportMetrics() = %v, want %v", got, tt.wantSupportMetrics)
+			}
+
+			gotLogging := tt.matcher.ToLoggingQuery()
+			if diff := cmp.Diff(tt.wantLoggingQuery, gotLogging); diff != "" {
+				t.Errorf("ToLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMonitoring := tt.matcher.ToMonitoringFilter()
+			if diff := cmp.Diff(tt.wantMonitoring, gotMonitoring); diff != "" {
+				t.Errorf("ToMonitoringFilter() filter mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLogIDMatchers(t *testing.T) {
+	tests := []struct {
+		name               string
+		matcher            LoggingMonitoringMatcher
+		wantLoggingQuery   string
+		wantMonitoring     string
+		wantSupportMetrics bool
+	}{
+		{
+			name:               "LogID with Exact",
+			matcher:            LogID(Exact("events")),
+			wantLoggingQuery:   `LOG_ID("events")`,
+			wantMonitoring:     `metric.labels.log = "events"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "LogID with OneOf multiple",
+			matcher:            LogID(OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+			wantLoggingQuery:   `(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))`,
+			wantMonitoring:     `metric.labels.log = one_of("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "LogID with OneOf single",
+			matcher:            LogID(OneOf("events")),
+			wantLoggingQuery:   `LOG_ID("events")`,
+			wantMonitoring:     `metric.labels.log = "events"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "LogID with NoneOf multiple",
+			matcher:            LogID(NoneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")),
+			wantLoggingQuery:   `-LOG_ID("server-accesslog-stackdriver")` + "\n" + `-LOG_ID("client-accesslog-stackdriver")`,
+			wantMonitoring:     `metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "LogID with NoneOf single",
+			matcher:            LogID(NoneOf("events")),
+			wantLoggingQuery:   `-LOG_ID("events")`,
+			wantMonitoring:     `metric.labels.log != "events"`,
+			wantSupportMetrics: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.matcher.SupportMetrics(); got != tt.wantSupportMetrics {
+				t.Errorf("SupportMetrics() = %v, want %v", got, tt.wantSupportMetrics)
+			}
+
+			gotLogging := tt.matcher.ToLoggingQuery()
+			if diff := cmp.Diff(tt.wantLoggingQuery, gotLogging); diff != "" {
+				t.Errorf("ToLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMonitoring := tt.matcher.ToMonitoringFilter()
+			if diff := cmp.Diff(tt.wantMonitoring, gotMonitoring); diff != "" {
+				t.Errorf("ToMonitoringFilter() filter mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCustomFilterMatcher(t *testing.T) {
+	customQuery := `protoPayload.methodName: ("create" OR "update")`
+	m := CustomFilter(customQuery)
+
+	if m.SupportMetrics() {
+		t.Errorf("SupportMetrics() = true, want false")
+	}
+
+	if diff := cmp.Diff(customQuery, m.ToLoggingQuery()); diff != "" {
+		t.Errorf("ToLoggingQuery() mismatch (-want +got):\n%s", diff)
+	}
+
+	filter := m.ToMonitoringFilter()
+	if filter != "" {
+		t.Errorf("ToMonitoringFilter() filter = %q, want empty", filter)
+	}
+
+	// Empty custom filter returns nil
+	if nilMatcher := CustomFilter("   "); nilMatcher != nil {
+		t.Errorf("CustomFilter(\"   \") = %v, want nil", nilMatcher)
+	}
+}
+
+func TestCommentMatcher(t *testing.T) {
+	testCases := []struct {
+		name               string
+		comment            string
+		wantNil            bool
+		wantLoggingQuery   string
+		wantMonitoring     string
+		wantSupportMetrics bool
+	}{
+		{
+			name:               "standard comment",
+			comment:            "this is a comment",
+			wantNil:            false,
+			wantLoggingQuery:   "-- this is a comment",
+			wantMonitoring:     "",
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "comment with leading and trailing spaces",
+			comment:            "   trimmed comment   ",
+			wantNil:            false,
+			wantLoggingQuery:   "-- trimmed comment",
+			wantMonitoring:     "",
+			wantSupportMetrics: true,
+		},
+		{
+			name:    "empty comment returns nil",
+			comment: "",
+			wantNil: true,
+		},
+		{
+			name:    "whitespace-only comment returns nil",
+			comment: "     ",
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Comment(tc.comment)
+			if tc.wantNil {
+				if m != nil {
+					t.Errorf("Comment(%q) = %v, want nil", tc.comment, m)
+				}
+				return
+			}
+
+			if m == nil {
+				t.Fatalf("Comment(%q) = nil, want non-nil", tc.comment)
+			}
+
+			if got := m.SupportMetrics(); got != tc.wantSupportMetrics {
+				t.Errorf("SupportMetrics() = %v, want %v", got, tc.wantSupportMetrics)
+			}
+
+			if diff := cmp.Diff(tc.wantLoggingQuery, m.ToLoggingQuery()); diff != "" {
+				t.Errorf("ToLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantMonitoring, m.ToMonitoringFilter()); diff != "" {
+				t.Errorf("ToMonitoringFilter() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWithCommentMatcher(t *testing.T) {
+	testCases := []struct {
+		name               string
+		inner              LoggingMonitoringMatcher
+		comment            string
+		wantNil            bool
+		wantLoggingQuery   string
+		wantMonitoring     string
+		wantSupportMetrics bool
+	}{
+		{
+			name:               "ResourceLabel with comment",
+			inner:              ResourceLabel("cluster_name", Exact("my-cluster")),
+			comment:            "target cluster identity",
+			wantNil:            false,
+			wantLoggingQuery:   `resource.labels.cluster_name="my-cluster" -- target cluster identity`,
+			wantMonitoring:     `resource.labels.cluster_name = "my-cluster"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "LogID with comment",
+			inner:              LogID(Exact("events")),
+			comment:            "k8s events only",
+			wantNil:            false,
+			wantLoggingQuery:   `LOG_ID("events") -- k8s events only`,
+			wantMonitoring:     `metric.labels.log = "events"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "CustomFilter with comment",
+			inner:              CustomFilter(`protoPayload.methodName="delete"`),
+			comment:            "ignore deletion actions",
+			wantNil:            false,
+			wantLoggingQuery:   `protoPayload.methodName="delete" -- ignore deletion actions`,
+			wantMonitoring:     "",
+			wantSupportMetrics: false,
+		},
+		{
+			name:               "nil inner matcher returns nil",
+			inner:              nil,
+			comment:            "should be nil",
+			wantNil:            true,
+			wantLoggingQuery:   "",
+			wantMonitoring:     "",
+			wantSupportMetrics: false,
+		},
+		{
+			name:               "empty comment returns original inner matcher",
+			inner:              ResourceLabel("project_id", Exact("test-project")),
+			comment:            "",
+			wantNil:            false,
+			wantLoggingQuery:   `resource.labels.project_id="test-project"`,
+			wantMonitoring:     `resource.labels.project_id = "test-project"`,
+			wantSupportMetrics: true,
+		},
+		{
+			name:               "whitespace-only comment returns original inner matcher",
+			inner:              ResourceLabel("project_id", Exact("test-project")),
+			comment:            "   ",
+			wantNil:            false,
+			wantLoggingQuery:   `resource.labels.project_id="test-project"`,
+			wantMonitoring:     `resource.labels.project_id = "test-project"`,
+			wantSupportMetrics: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := WithComment(tc.inner, tc.comment)
+			if tc.wantNil {
+				if m != nil {
+					t.Errorf("WithComment() = %v, want nil", m)
+				}
+				return
+			}
+
+			if m == nil {
+				t.Fatalf("WithComment() = nil, want non-nil")
+			}
+
+			if got := m.SupportMetrics(); got != tc.wantSupportMetrics {
+				t.Errorf("SupportMetrics() = %v, want %v", got, tc.wantSupportMetrics)
+			}
+
+			if diff := cmp.Diff(tc.wantLoggingQuery, m.ToLoggingQuery()); diff != "" {
+				t.Errorf("ToLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantMonitoring, m.ToMonitoringFilter()); diff != "" {
+				t.Errorf("ToMonitoringFilter() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStructuredLogQueryWithComments(t *testing.T) {
+	sq := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+		Filters: []LoggingMonitoringMatcher{
+			WithComment(ResourceLabel("project_id", Exact("my-project")), "the main project"),
+			Comment("following filter ignores noisy events"),
+			WithComment(CustomFilter(`-sourceLocation.file="httplog.go"`), "scheduler spam"),
+		},
+	}
+
+	wantLoggingQuery := `resource.type="k8s_cluster"
+resource.labels.project_id="my-project" -- the main project
+-- following filter ignores noisy events
+-sourceLocation.file="httplog.go" -- scheduler spam`
+
+	if diff := cmp.Diff(wantLoggingQuery, sq.GenerateCloudLoggingQuery()); diff != "" {
+		t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+	}
+
+	if sq.AllFiltersSupportMetrics() {
+		t.Errorf("AllFiltersSupportMetrics() = true, want false due to CustomFilter")
+	}
+
+	wantMetricFilters := []string{
+		`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "my-project"`,
+	}
+
+	if diff := cmp.Diff(wantMetricFilters, sq.GenerateMonitoringMetricFilters()); diff != "" {
+		t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/api/googlecloud/logestimator/types.go
+++ b/pkg/api/googlecloud/logestimator/types.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logestimator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+)
+
+// StructuredLogQuery represents a decomposed Cloud Logging and Cloud Monitoring query.
+type StructuredLogQuery struct {
+	// ResourceTypes specifies the resource.type strings (e.g. ["k8s_container"] or ["gke_cluster", "gke_nodepool"]).
+	ResourceTypes []string
+
+	// IgnoreMetricsResourceType specifies the resource.type strings that should NOT be queried via Cloud Monitoring metrics
+	// (e.g. resource types like "gke_nodepool" that are valid in Cloud Logging but do not exist as MonitoredResourceDescriptors in Cloud Monitoring).
+	IgnoreMetricsResourceType []string
+
+	// Filters are the individual filter matchers for this query.
+	Filters []LoggingMonitoringMatcher
+
+	// Incomplete indicates that the query is missing required parameters (e.g. ProjectID or ClusterName)
+	// and should not trigger log volume estimation.
+	Incomplete bool
+}
+
+// GenerateCloudLoggingQuery generates the Cloud Logging filter string.
+func (q *StructuredLogQuery) GenerateCloudLoggingQuery() string {
+	var parts []string
+
+	// Resource type
+	if len(q.ResourceTypes) == 1 {
+		parts = append(parts, fmt.Sprintf(`resource.type="%s"`, q.ResourceTypes[0]))
+	} else if len(q.ResourceTypes) > 1 {
+		quoted := quoteStrings(q.ResourceTypes)
+		parts = append(parts, fmt.Sprintf(`resource.type=(%s)`, strings.Join(quoted, " OR ")))
+	}
+
+	for _, matcher := range q.Filters {
+		if matcher != nil {
+			snippet := matcher.ToLoggingQuery()
+			if snippet != "" {
+				parts = append(parts, snippet)
+			}
+		}
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+// AllFiltersSupportMetrics returns true if all matchers in Filters can be natively evaluated in Cloud Monitoring
+// and no resource types are excluded from metrics querying.
+func (q *StructuredLogQuery) AllFiltersSupportMetrics() bool {
+	if len(q.IgnoreMetricsResourceType) > 0 {
+		return false
+	}
+	for _, matcher := range q.Filters {
+		if matcher != nil && !matcher.SupportMetrics() {
+			return false
+		}
+	}
+	return true
+}
+
+// GenerateBaseLoggingQuery generates the Cloud Logging filter string containing only matchers supported by Cloud Monitoring.
+func (q *StructuredLogQuery) GenerateBaseLoggingQuery() string {
+	var parts []string
+
+	ignoreSet := make(map[string]struct{}, len(q.IgnoreMetricsResourceType))
+	for _, ignore := range q.IgnoreMetricsResourceType {
+		ignoreSet[ignore] = struct{}{}
+	}
+	var metricTypes []string
+	for _, resType := range q.ResourceTypes {
+		if _, ignored := ignoreSet[resType]; !ignored {
+			metricTypes = append(metricTypes, resType)
+		}
+	}
+
+	// Resource type
+	if len(metricTypes) == 1 {
+		parts = append(parts, fmt.Sprintf(`resource.type="%s"`, metricTypes[0]))
+	} else if len(metricTypes) > 1 {
+		quoted := quoteStrings(metricTypes)
+		parts = append(parts, fmt.Sprintf(`resource.type=(%s)`, strings.Join(quoted, " OR ")))
+	}
+
+	for _, matcher := range q.Filters {
+		if matcher != nil && matcher.SupportMetrics() {
+			snippet := matcher.ToLoggingQuery()
+			if snippet != "" {
+				parts = append(parts, snippet)
+			}
+		}
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+// GenerateMonitoringMetricFilters generates the filter strings for logging.googleapis.com/log_entry_count in Cloud Monitoring (one per resource type).
+func (q *StructuredLogQuery) GenerateMonitoringMetricFilters() []string {
+	ignoreSet := make(map[string]struct{}, len(q.IgnoreMetricsResourceType))
+	for _, ignore := range q.IgnoreMetricsResourceType {
+		ignoreSet[ignore] = struct{}{}
+	}
+
+	var types []string
+	for _, resType := range q.ResourceTypes {
+		if _, ignored := ignoreSet[resType]; !ignored {
+			types = append(types, resType)
+		}
+	}
+	if len(types) == 0 {
+		if len(q.ResourceTypes) == 0 {
+			types = []string{""}
+		} else {
+			return nil
+		}
+	}
+
+	var metricFilterParts []string
+	for _, matcher := range q.Filters {
+		if matcher != nil && matcher.SupportMetrics() {
+			snippet := matcher.ToMonitoringFilter()
+			if snippet != "" {
+				metricFilterParts = append(metricFilterParts, snippet)
+			}
+		}
+	}
+
+	var filters []string
+	for _, resType := range types {
+		parts := []string{`metric.type = "logging.googleapis.com/log_entry_count"`}
+		if resType != "" {
+			parts = append(parts, fmt.Sprintf(`resource.type = "%s"`, resType))
+		}
+		parts = append(parts, metricFilterParts...)
+		filters = append(filters, strings.Join(parts, " AND "))
+	}
+
+	return filters
+}
+
+// LogProbeClient is an interface for probing Cloud Logging.
+type LogProbeClient interface {
+	FetchProbe(ctx context.Context, filter string, pageSize int32) ([]*loggingpb.LogEntry, error)
+}
+
+// EstimateResult represents the volume estimate.
+type EstimateResult struct {
+	// MetricCount is the base count obtained from Cloud Monitoring metric.
+	MetricCount int64 `json:"metricCount"`
+
+	// EstimatedCount is the estimated total count after applying custom filters.
+	EstimatedCount int64 `json:"estimatedCount"`
+
+	// CustomFilterRatio is the ratio r (0.0 to 1.0) applied to MetricCount.
+	CustomFilterRatio float64 `json:"customFilterRatio"`
+
+	// IsExact is true if no custom filter ratio estimation was required.
+	IsExact bool `json:"isExact"`
+}

--- a/pkg/core/inspection/metadata/query_metadata.go
+++ b/pkg/core/inspection/metadata/query_metadata.go
@@ -23,9 +23,11 @@ import (
 )
 
 type QueryItem struct {
-	Id    string `json:"id"`
-	Name  string `json:"name"`
-	Query string `json:"query"`
+	Id             string `json:"id"`
+	Name           string `json:"name"`
+	Query          string `json:"query"`
+	EstimatedCount *int64 `json:"estimatedCount,omitempty"`
+	Incomplete     bool   `json:"incomplete,omitempty"`
 }
 
 type QueryMetadata struct {
@@ -46,20 +48,39 @@ func (q *QueryMetadata) ToSerializable() interface{} {
 	return q.Queries
 }
 
+// SetQuery sets or updates the query item with no estimated count (nil).
 func (q *QueryMetadata) SetQuery(id string, name string, queryString string) {
+	q.setQueryInternal(id, name, queryString, nil, false)
+}
+
+// SetIncompleteQuery sets or updates the query item marked as incomplete without an estimated count.
+func (q *QueryMetadata) SetIncompleteQuery(id string, name string, queryString string) {
+	q.setQueryInternal(id, name, queryString, nil, true)
+}
+
+// SetQueryWithEstimate sets or updates the query item along with its estimated log count.
+func (q *QueryMetadata) SetQueryWithEstimate(id string, name string, queryString string, estimatedCount int64) {
+	q.setQueryInternal(id, name, queryString, &estimatedCount, false)
+}
+
+func (q *QueryMetadata) setQueryInternal(id string, name string, queryString string, estimatedCount *int64, incomplete bool) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	for _, qi := range q.Queries {
 		if qi.Id == id {
 			qi.Name = name
 			qi.Query = queryString
+			qi.EstimatedCount = estimatedCount
+			qi.Incomplete = incomplete
 			return
 		}
 	}
 	q.Queries = append(q.Queries, &QueryItem{
-		Id:    id,
-		Name:  name,
-		Query: queryString,
+		Id:             id,
+		Name:           name,
+		Query:          queryString,
+		EstimatedCount: estimatedCount,
+		Incomplete:     incomplete,
 	})
 }
 

--- a/pkg/core/inspection/metadata/query_metadata_test.go
+++ b/pkg/core/inspection/metadata/query_metadata_test.go
@@ -42,3 +42,25 @@ func TestQuerySerializeInSortedOrder(t *testing.T) {
 		t.Errorf("Query info serialization result was not in the sorted order\n%s", diff)
 	}
 }
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestQueryMetadata_SetQueryWithEstimate(t *testing.T) {
+	qm := NewQueryMetadata()
+	qm.SetQuery("q1", "Query 1", "resource.type=k8s_container")
+	qm.SetQueryWithEstimate("q2", "Query 2", "resource.type=k8s_node", 1500)
+
+	// Update existing query q1 with estimate
+	qm.SetQueryWithEstimate("q1", "Query 1 Updated", "resource.type=k8s_container updated", 3200)
+
+	expected := []*QueryItem{
+		{Id: "q1", Name: "Query 1 Updated", Query: "resource.type=k8s_container updated", EstimatedCount: ptr(int64(3200))},
+		{Id: "q2", Name: "Query 2", Query: "resource.type=k8s_node", EstimatedCount: ptr(int64(1500))},
+	}
+
+	if diff := cmp.Diff(expected, qm.ToSerializable()); diff != "" {
+		t.Errorf("SetQueryWithEstimate mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/query_task.go
@@ -18,28 +18,53 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
+
+// GenerateComposerLogsStructuredQuery generates a structured query for Composer environment logs.
+func GenerateComposerLogsStructuredQuery(projectID, location, environmentName string, selectedComponents []string) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(projectID)),
+		logestimator.ResourceLabel("location", logestimator.Exact(location)),
+		logestimator.ResourceLabel("environment_name", logestimator.Exact(environmentName)),
+	}
+
+	if !slices.Contains(selectedComponents, "@any") && len(selectedComponents) > 0 {
+		filters = append(filters, logestimator.LogID(logestimator.OneOf(selectedComponents...)))
+	}
+
+	filters = append(filters, logestimator.LogID(logestimator.NoneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")))
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    projectID == "" || location == "" || environmentName == "",
+		ResourceTypes: []string{"cloud_composer_environment"},
+		Filters:       filters,
+	}
+}
+
+// GenerateComposerLogsQuery generates a query for Composer environment logs.
+func GenerateComposerLogsQuery(projectID, location, environmentName string, selectedComponents []string) string {
+	return GenerateComposerLogsStructuredQuery(projectID, location, environmentName, selectedComponents).GenerateCloudLoggingQuery()
+}
 
 type composerListLogEntriesTaskSetting struct {
 	taskId    taskid.TaskImplementationID[[]*log.Log]
 	queryName string
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *composerListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudclustercomposer_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", clusterIdentity.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *composerListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudclustercomposer_contract.ClusterIdentityTaskID.Ref(),
@@ -48,71 +73,34 @@ func (c *composerListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskR
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *composerListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName:    c.queryName,
-		ExampleQuery: generateExampleQuery("test-project", "sample-composer-environment"),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *composerListLogEntriesTaskSetting) QueryName() string {
+	return c.queryName
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *composerListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *composerListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudclustercomposer_contract.ClusterIdentityTaskID.Ref())
 	environmentName := coretask.GetTaskResult(ctx, googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref())
 	selectedComponents := coretask.GetTaskResult(ctx, googlecloudclustercomposer_contract.InputComposerComponentsTaskID.Ref())
 
-	logIds := []string{}
-	logIDSelector := "-- no component filter specified. fetching all logs."
-	if !slices.Contains(selectedComponents, "@any") {
-		logIds = append(logIds, selectedComponents...)
-		for i := range logIds {
-			logIds[i] = fmt.Sprintf(`LOG_ID("%s")`, logIds[i])
-		}
-		logIDSelector = fmt.Sprintf("(%s)", strings.Join(logIds, " OR "))
-	}
-
-	return []string{fmt.Sprintf(`%s
-resource.type="cloud_composer_environment"
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.environment_name="%s"
-
--LOG_ID("cloudaudit.googleapis.com/activity")
--LOG_ID("cloudaudit.googleapis.com/data_access")
-`, logIDSelector, clusterIdentity.ProjectID, clusterIdentity.Location, environmentName)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateComposerLogsStructuredQuery(clusterIdentity.ProjectID, clusterIdentity.Location, environmentName, selectedComponents)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *composerListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return c.taskId
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *composerListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*composerListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*composerListLogEntriesTaskSetting)(nil)
 
 // ComposerLogsQueryTask defines a task that gathers logs from Cloud Logging for multiple Composer components.
-var ComposerLogsQueryTask = googlecloudcommon_contract.NewListLogEntriesTask(&composerListLogEntriesTaskSetting{
+var ComposerLogsQueryTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&composerListLogEntriesTaskSetting{
 	taskId:    googlecloudclustercomposer_contract.ComposerLogsQueryTaskID,
 	queryName: "Composer Environment Logs",
 })
-
-func generateExampleQuery(projectId string, environmentName string) string {
-	composerFilter := composerEnvironmentLog(projectId, environmentName)
-	return fmt.Sprintf(`(LOG_ID("airflow-worker") OR LOG_ID("worker") OR LOG_ID("airflow-scheduler") OR LOG_ID("scheduler"))
-%s
-
--LOG_ID("cloudaudit.googleapis.com/activity")
--LOG_ID("cloudaudit.googleapis.com/data_access")`, composerFilter)
-}
-
-func composerEnvironmentLog(projectId string, environmentName string) string {
-	return fmt.Sprintf(`resource.type="cloud_composer_environment"
-resource.labels.project_id="%s"
-resource.labels.environment_name="%s"`, projectId, environmentName)
-}

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/query_task_test.go
@@ -15,124 +15,231 @@
 package googlecloudclustercomposer_impl
 
 import (
-	"context"
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
-	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestLogFiltersGeneratesComposerQuery(t *testing.T) {
+func TestGenerateComposerLogsStructuredQuery(t *testing.T) {
 	testCases := []struct {
-		name               string
-		selectedComponents []string
-		wantQuery          string
+		name                   string
+		projectID              string
+		location               string
+		environmentName        string
+		selectedComponents     []string
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
 			name:               "specific component selected",
+			projectID:          "test-project",
+			location:           "test-location",
+			environmentName:    "test-environment",
 			selectedComponents: []string{"scheduler"},
-			wantQuery: `(LOG_ID("scheduler"))
-resource.type="cloud_composer_environment"
+			wantQuery: `resource.type="cloud_composer_environment"
 resource.labels.project_id="test-project"
 resource.labels.location="test-location"
 resource.labels.environment_name="test-environment"
-
+LOG_ID("scheduler")
 -LOG_ID("cloudaudit.googleapis.com/activity")
--LOG_ID("cloudaudit.googleapis.com/data_access")
-`,
+-LOG_ID("cloudaudit.googleapis.com/data_access")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "cloud_composer_environment" AND resource.labels.project_id = "test-project" AND resource.labels.location = "test-location" AND resource.labels.environment_name = "test-environment" AND metric.labels.log = "scheduler" AND metric.labels.log != "cloudaudit.googleapis.com/activity" AND metric.labels.log != "cloudaudit.googleapis.com/data_access"`,
+			},
+			wantSupportMetricsFlag: true,
+		},
+		{
+			name:               "multiple components selected",
+			projectID:          "test-project",
+			location:           "test-location",
+			environmentName:    "test-environment",
+			selectedComponents: []string{"worker", "scheduler"},
+			wantQuery: `resource.type="cloud_composer_environment"
+resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.environment_name="test-environment"
+(LOG_ID("worker") OR LOG_ID("scheduler"))
+-LOG_ID("cloudaudit.googleapis.com/activity")
+-LOG_ID("cloudaudit.googleapis.com/data_access")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "cloud_composer_environment" AND resource.labels.project_id = "test-project" AND resource.labels.location = "test-location" AND resource.labels.environment_name = "test-environment" AND metric.labels.log = one_of("worker", "scheduler") AND metric.labels.log != "cloudaudit.googleapis.com/activity" AND metric.labels.log != "cloudaudit.googleapis.com/data_access"`,
+			},
+			wantSupportMetricsFlag: true,
 		},
 		{
 			name:               "any component selected",
+			projectID:          "test-project",
+			location:           "test-location",
+			environmentName:    "test-environment",
 			selectedComponents: []string{"@any"},
-			wantQuery: `-- no component filter specified. fetching all logs.
-resource.type="cloud_composer_environment"
+			wantQuery: `resource.type="cloud_composer_environment"
 resource.labels.project_id="test-project"
 resource.labels.location="test-location"
 resource.labels.environment_name="test-environment"
-
 -LOG_ID("cloudaudit.googleapis.com/activity")
--LOG_ID("cloudaudit.googleapis.com/data_access")
-`,
+-LOG_ID("cloudaudit.googleapis.com/data_access")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "cloud_composer_environment" AND resource.labels.project_id = "test-project" AND resource.labels.location = "test-location" AND resource.labels.environment_name = "test-environment" AND metric.labels.log != "cloudaudit.googleapis.com/activity" AND metric.labels.log != "cloudaudit.googleapis.com/data_access"`,
+			},
+			wantSupportMetricsFlag: true,
+		},
+		{
+			name:               "empty components (treated like any)",
+			projectID:          "test-project",
+			location:           "test-location",
+			environmentName:    "test-environment",
+			selectedComponents: []string{},
+			wantQuery: `resource.type="cloud_composer_environment"
+resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.environment_name="test-environment"
+-LOG_ID("cloudaudit.googleapis.com/activity")
+-LOG_ID("cloudaudit.googleapis.com/data_access")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "cloud_composer_environment" AND resource.labels.project_id = "test-project" AND resource.labels.location = "test-location" AND resource.labels.environment_name = "test-environment" AND metric.labels.log != "cloudaudit.googleapis.com/activity" AND metric.labels.log != "cloudaudit.googleapis.com/data_access"`,
+			},
+			wantSupportMetricsFlag: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			projectId := "test-project"
-			environmentName := "test-environment"
-			taskDependentValues := typedmap.NewTypedMap()
-			typedmap.Set(taskDependentValues, typedmap.NewTypedKey[googlecloudk8scommon_contract.GoogleCloudClusterIdentity](googlecloudclustercomposer_contract.ClusterIdentityTaskID.ReferenceIDString()), googlecloudk8scommon_contract.GoogleCloudClusterIdentity{ProjectID: projectId, Location: "test-location"})
-			typedmap.Set(taskDependentValues, typedmap.NewTypedKey[string](googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.ReferenceIDString()), environmentName)
-			typedmap.Set(taskDependentValues, typedmap.NewTypedKey[[]string](googlecloudclustercomposer_contract.InputComposerComponentsTaskID.ReferenceIDString()), tc.selectedComponents)
-			ctx = khictx.WithValue(ctx, core_contract.TaskResultMapContextKey, taskDependentValues)
-
-			setting := &composerListLogEntriesTaskSetting{
-				taskId:    googlecloudclustercomposer_contract.ComposerLogsQueryTaskID,
-				queryName: "Composer Logs",
+			sq := GenerateComposerLogsStructuredQuery(tc.projectID, tc.location, tc.environmentName, tc.selectedComponents)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
 			}
 
-			taskMode := inspectioncore_contract.TaskModeDryRun
-			actual, err := setting.LogFilters(ctx, taskMode)
-			if err != nil {
-				t.Fatalf("LogFilters() returned unexpected error: %v", err)
+			legacyQuery := GenerateComposerLogsQuery(tc.projectID, tc.location, tc.environmentName, tc.selectedComponents)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("GenerateComposerLogsQuery() mismatch (-want +got):\n%s", diff)
 			}
-			if len(actual) != 1 {
-				t.Fatalf("LogFilters() returned unexpected query count %d", len(actual))
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantQuery, actual[0]); diff != "" {
-				t.Errorf("LogFilters() mismatch (-want +got):\n%s", diff)
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
 			}
 		})
 	}
 }
 
-func TestDependenciesAndDefaultResourceNames(t *testing.T) {
-	ctx := context.Background()
-	projectId := "test-project"
-	taskDependentValues := typedmap.NewTypedMap()
-	typedmap.Set(taskDependentValues, typedmap.NewTypedKey[googlecloudk8scommon_contract.GoogleCloudClusterIdentity](googlecloudclustercomposer_contract.ClusterIdentityTaskID.ReferenceIDString()), googlecloudk8scommon_contract.GoogleCloudClusterIdentity{ProjectID: projectId})
-	ctx = khictx.WithValue(ctx, core_contract.TaskResultMapContextKey, taskDependentValues)
-
-	setting := &composerListLogEntriesTaskSetting{}
-
-	deps := setting.Dependencies()
-	if len(deps) != 3 {
-		t.Errorf("Unexpected dependencies count %d", len(deps))
+func TestGenerateComposerLogsQueryIsValid(t *testing.T) {
+	testCases := []struct {
+		name               string
+		projectID          string
+		location           string
+		environmentName    string
+		selectedComponents []string
+	}{
+		{
+			name:               "Valid Query with single component",
+			projectID:          "test-project",
+			location:           "test-location",
+			environmentName:    "test-environment",
+			selectedComponents: []string{"scheduler"},
+		},
+		{
+			name:               "Valid Query with multiple components",
+			projectID:          "test-project",
+			location:           "test-location",
+			environmentName:    "test-environment",
+			selectedComponents: []string{"scheduler", "worker"},
+		},
+		{
+			name:               "Valid Query with any",
+			projectID:          "test-project",
+			location:           "test-location",
+			environmentName:    "test-environment",
+			selectedComponents: []string{"@any"},
+		},
 	}
-
-	resourceNames, err := setting.DefaultResourceNames(ctx)
-	if err != nil {
-		t.Fatalf("DefaultResourceNames: %v", err)
-	}
-	if len(resourceNames) != 1 || resourceNames[0] != "projects/test-project" {
-		t.Errorf("Unexpected resource names: %v", resourceNames)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			query := GenerateComposerLogsQuery(tc.projectID, tc.location, tc.environmentName, tc.selectedComponents)
+			err := gcp_test.IsValidLogQuery(t, query)
+			if err != nil {
+				t.Errorf("IsValidLogQuery error: %s", err.Error())
+			}
+		})
 	}
 }
 
-func TestDescription(t *testing.T) {
-	setting := &composerListLogEntriesTaskSetting{
-		queryName: "Test Query",
-	}
-	desc := setting.Description()
-	if desc.QueryName != "Test Query" {
-		t.Errorf("Description().QueryName mismatch (-want +got): -%s +%s", "Test Query", desc.QueryName)
+func TestComposerLogsQueryTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1",
 	}
 
-	wantExampleQuery := `(LOG_ID("airflow-worker") OR LOG_ID("worker") OR LOG_ID("airflow-scheduler") OR LOG_ID("scheduler"))
-resource.type="cloud_composer_environment"
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ComposerLogsQueryTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudclustercomposer_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref(), "test-env"),
+		tasktest.NewTaskDependencyValuePair(googlecloudclustercomposer_contract.InputComposerComponentsTaskID.Ref(), []string{"scheduler"}),
+	)
+	if err != nil {
+		t.Fatalf("DryRun returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("DryRun should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="cloud_composer_environment"
 resource.labels.project_id="test-project"
-resource.labels.environment_name="sample-composer-environment"
-
+resource.labels.location="us-central1"
+resource.labels.environment_name="test-env"
+LOG_ID("scheduler")
 -LOG_ID("cloudaudit.googleapis.com/activity")
--LOG_ID("cloudaudit.googleapis.com/data_access")`
+-LOG_ID("cloudaudit.googleapis.com/data_access")
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
 
-	if diff := cmp.Diff(wantExampleQuery, desc.ExampleQuery); diff != "" {
-		t.Errorf("Description().ExampleQuery mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("Query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "Composer Environment Logs" {
+		t.Errorf("Query Name mismatch: got %q, want %q", serialized[0].Name, "Composer Environment Logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
@@ -1,0 +1,317 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// StructuredListLogEntriesTaskSetting defines the settings for a Cloud Logging task driven by StructuredLogQuery.
+type StructuredListLogEntriesTaskSetting interface {
+	// TaskID returns the task ID for the structured list log entries task.
+	TaskID() taskid.TaskImplementationID[[]*log.Log]
+
+	// Dependencies returns the list of dependencies for the task.
+	Dependencies() []taskid.UntypedTaskReference
+
+	// DefaultResourceNames returns default resource names (e.g. ["projects/<project-id>"]).
+	DefaultResourceNames(ctx context.Context) ([]string, error)
+
+	// Queries returns the list of structured log queries for estimation and execution.
+	Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error)
+
+	// TimePartitionCount returns the number of time partitions to gather logs in parallel.
+	TimePartitionCount(ctx context.Context) (int, error)
+
+	// QueryName returns human-readable name of the query.
+	QueryName() string
+}
+
+// NewStructuredListLogEntriesTask creates a new task that queries logs from Cloud Logging using StructuredLogQuery.
+// In DryRun mode, it estimates log volumes and populates QueryMetadata with estimated counts.
+func NewStructuredListLogEntriesTask(taskSetting StructuredListLogEntriesTaskSetting) coretask.Task[[]*log.Log] {
+	taskID := taskSetting.TaskID()
+	dependencies := taskSetting.Dependencies()
+	dependencies = append(dependencies,
+		InputStartTimeTaskID.Ref(),
+		InputEndTimeTaskID.Ref(),
+		InputLoggingFilterResourceNameTaskID.Ref(),
+		LoggingFetcherTaskID.Ref(),
+		APIClientFactoryTaskID.Ref(),
+	)
+	queryName := taskSetting.QueryName()
+
+	return inspectiontaskbase.NewProgressReportableInspectionTask(
+		taskID,
+		dependencies,
+		func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*log.Log, error) {
+			startTime := coretask.GetTaskResult(ctx, InputStartTimeTaskID.Ref())
+			endTime := coretask.GetTaskResult(ctx, InputEndTimeTaskID.Ref())
+			resourceNames, err := handleResourceNames(ctx, taskID, &resourceNamesSettingAdapter{taskSetting: taskSetting})
+			if err != nil {
+				return nil, fmt.Errorf("failed to determine resource names list for structured log query: %w", err)
+			}
+
+			queries, err := taskSetting.Queries(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("Queries returned an error: %w", err)
+			}
+			if len(queries) == 0 {
+				slog.DebugContext(ctx, "Queries returned an empty list. Skipping fetching logs for this task.")
+				return []*log.Log{}, nil
+			}
+
+			groups, err := groupResourceNamesByContainer(resourceNames)
+			if err != nil {
+				return nil, err
+			}
+
+			// In DryRun: perform volume estimation across all container groups and record query metadata.
+			if taskMode != inspectioncore_contract.TaskModeRun {
+				clientFactory := coretask.GetTaskResult(ctx, APIClientFactoryTaskID.Ref())
+				return nil, estimateAndRecordQueries(ctx, taskID.String(), clientFactory, groups, queries, startTime, endTime, queryName)
+			}
+
+			// In Run mode: fetch logs across partitions.
+			timePartitionCount, err := taskSetting.TimePartitionCount(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("TimePartitionCount returned an error: %w", err)
+			}
+			if timePartitionCount < 1 {
+				return nil, fmt.Errorf("TimePartitionCount returned an invalid value %d, it must be bigger than 0", timePartitionCount)
+			}
+
+			logFetcher := coretask.GetTaskResult(ctx, LoggingFetcherTaskID.Ref())
+			return fetchLogsForStructuredQueries(ctx, taskID.String(), logFetcher, groups, queries, startTime, endTime, queryName, timePartitionCount, progress)
+		},
+		coretask.WithLabelValue(RequestOptionalInputResourceNameTaskLabel, taskID.ReferenceIDString()),
+	)
+}
+
+// resourceNamesSettingAdapter adapts StructuredListLogEntriesTaskSetting to ListLogEntriesTaskSetting for resource name handling.
+type resourceNamesSettingAdapter struct {
+	taskSetting StructuredListLogEntriesTaskSetting
+}
+
+func (a *resourceNamesSettingAdapter) TaskID() taskid.TaskImplementationID[[]*log.Log] {
+	return a.taskSetting.TaskID()
+}
+
+func (a *resourceNamesSettingAdapter) Dependencies() []taskid.UntypedTaskReference {
+	return a.taskSetting.Dependencies()
+}
+
+func (a *resourceNamesSettingAdapter) DefaultResourceNames(ctx context.Context) ([]string, error) {
+	return a.taskSetting.DefaultResourceNames(ctx)
+}
+
+func (a *resourceNamesSettingAdapter) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+	return nil, nil
+}
+
+func (a *resourceNamesSettingAdapter) TimePartitionCount(ctx context.Context) (int, error) {
+	return a.taskSetting.TimePartitionCount(ctx)
+}
+
+func (a *resourceNamesSettingAdapter) Description() *ListLogEntriesTaskDescription {
+	return &ListLogEntriesTaskDescription{
+		QueryName: a.taskSetting.QueryName(),
+	}
+}
+
+var _ ListLogEntriesTaskSetting = (*resourceNamesSettingAdapter)(nil)
+
+// LogEstimatorCacheKey is the key to retrieve or store CachedStructuredLogEstimator in the InspectionSharedMap.
+var LogEstimatorCacheKey = typedmap.NewTypedKey[*logestimator.CachedStructuredLogEstimator]("googlecloud.logestimator.cache")
+
+// getOrInitLogEstimatorCache gets the cached estimator from InspectionSharedMap or initializes a new one.
+func getOrInitLogEstimatorCache(ctx context.Context) *logestimator.CachedStructuredLogEstimator {
+	sharedMap, err := khictx.GetValue(ctx, inspectioncore_contract.InspectionSharedMap)
+	if err != nil || sharedMap == nil {
+		return logestimator.NewCachedStructuredLogEstimator()
+	}
+
+	cachedEstimator, found := typedmap.Get(sharedMap, LogEstimatorCacheKey)
+	if found && cachedEstimator != nil {
+		return cachedEstimator
+	}
+
+	newEstimator := logestimator.NewCachedStructuredLogEstimator()
+	typedmap.Set(sharedMap, LogEstimatorCacheKey, newEstimator)
+
+	inspectionContext, err := khictx.GetValue(ctx, inspectioncore_contract.InspectionContext)
+	if err == nil && inspectionContext != nil {
+		context.AfterFunc(inspectionContext, func() {
+			newEstimator.Close()
+		})
+	}
+	return newEstimator
+}
+
+// estimateAndRecordQueries performs volume estimation across container groups and writes query metadata during dryrun.
+func estimateAndRecordQueries(
+	ctx context.Context,
+	taskID string,
+	clientFactory *googlecloud.ClientFactory,
+	groups []*resourceContainerLogQueryGroup,
+	queries []*logestimator.StructuredLogQuery,
+	startTime, endTime time.Time,
+	queryName string,
+) error {
+	estimatorCache := getOrInitLogEstimatorCache(ctx)
+
+	for queryIndex, q := range queries {
+		if q.Incomplete {
+			filterString := q.GenerateCloudLoggingQuery()
+			if err := setStructuredQueryInfo(ctx, taskID, filterString, queryIndex, len(queries), startTime, endTime, queryName, nil, true); err != nil {
+				return err
+			}
+			continue
+		}
+
+		var totalEstimatedCount int64
+		var estimated *int64
+		for _, group := range groups {
+			taskSlotKey := fmt.Sprintf("%s/%s/%d", taskID, group.container.Identifier(), queryIndex)
+			res, estErr := estimatorCache.EstimateWithTaskSlot(
+				ctx,
+				taskSlotKey,
+				group.container,
+				q,
+				startTime,
+				endTime,
+				func(queryCtx context.Context, container googlecloud.ResourceContainer) (*logestimator.StructuredLogEstimator, error) {
+					loggingClient, logErr := clientFactory.LoggingClient(queryCtx, container)
+					metricClient, monErr := clientFactory.MonitoringMetricClient(queryCtx, container)
+					if logErr != nil || monErr != nil {
+						return nil, fmt.Errorf("failed to initialize clients for container %s: loggingErr=%v, metricErr=%v", container.Identifier(), logErr, monErr)
+					}
+					return logestimator.NewStructuredLogEstimatorFromClients(loggingClient, metricClient), nil
+				},
+			)
+			if estErr != nil {
+				slog.WarnContext(ctx, fmt.Sprintf("log estimation failed for query %s in %s: %v", queryName, group.container.Identifier(), estErr))
+			} else {
+				totalEstimatedCount += res.EstimatedCount
+				estimated = &totalEstimatedCount
+			}
+		}
+		filterString := q.GenerateCloudLoggingQuery()
+		if err := setStructuredQueryInfo(ctx, taskID, filterString, queryIndex, len(queries), startTime, endTime, queryName, estimated, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// fetchLogsForStructuredQueries retrieves logs in parallel across time partitions and container groups.
+func fetchLogsForStructuredQueries(
+	ctx context.Context,
+	taskID string,
+	logFetcher LogFetcher,
+	groups []*resourceContainerLogQueryGroup,
+	queries []*logestimator.StructuredLogQuery,
+	startTime, endTime time.Time,
+	queryName string,
+	timePartitionCount int,
+	progress *inspectionmetadata.TaskProgressMetadata,
+) ([]*log.Log, error) {
+	groups = divideGroupByMaximumResourceName(groups, maxResourceNameCountPerRequest)
+	progressReportableLogFetcher := NewTimePartitioningProgressReportableLogFetcher(logFetcher, 500*time.Millisecond, timePartitionCount, runtime.GOMAXPROCS(0))
+
+	allLogs := make([]*log.Log, 0)
+	for queryIndex, q := range queries {
+		filterString := q.GenerateCloudLoggingQuery()
+		if err := setStructuredQueryInfo(ctx, taskID, filterString, queryIndex, len(queries), startTime, endTime, queryName, nil, false); err != nil {
+			return nil, err
+		}
+
+		for groupIndex, group := range groups {
+			var wg sync.WaitGroup
+			var logChan = make(chan *loggingpb.LogEntry)
+			var progressChan = make(chan LogFetchProgress)
+			listCallIndex := queryIndex*len(groups) + groupIndex
+			allListCalls := len(queries) * len(groups)
+			monitorProgress(ctx, &wg, progressChan, progress, listCallIndex, allListCalls)
+			convertLogsArray(ctx, &wg, logChan, &allLogs)
+			err := progressReportableLogFetcher.FetchLogsWithProgress(logChan, progressChan, ctx, startTime, endTime, filterString, group.container, group.resourceNames)
+			wg.Wait()
+
+			if err != nil {
+				return nil, setErrorMetadataForFetchLogError(ctx, err)
+			}
+		}
+	}
+
+	for _, l := range allLogs {
+		l.SetFieldSetReader(&gcpqueryutil.GCPCommonFieldSetReader{})
+	}
+
+	tracingActive, _ := khictx.GetValue(ctx, inspectioncore_contract.TracingActive)
+	if tracingActive {
+		trace.SpanFromContext(ctx).SetAttributes(
+			attribute.String("log_count", fmt.Sprintf("%d", len(allLogs))),
+		)
+	}
+
+	return allLogs, nil
+}
+
+// setStructuredQueryInfo records the generated Cloud Logging query details and estimated count into the inspection run metadata.
+func setStructuredQueryInfo(ctx context.Context, taskID, baseLogFilter string, logFilterIndex, totalLogFilterCount int, startTime, endTime time.Time, queryName string, estimatedCount *int64, incomplete bool) error {
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryInfo, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		return fmt.Errorf("query metadata was not found")
+	}
+
+	logFilterName := queryName
+	if totalLogFilterCount > 1 {
+		logFilterName = fmt.Sprintf("%s-%d", queryName, logFilterIndex)
+	}
+	finalFilter := fmt.Sprintf("%s\n%s", baseLogFilter, gcpqueryutil.TimeRangeQuerySection(startTime, endTime, true))
+	if len(finalFilter) > 20000 {
+		slog.WarnContext(ctx, fmt.Sprintf("Logging filter is exceeding Cloud Logging limitation 20000 characters\n%s", finalFilter))
+	}
+	switch {
+	case incomplete:
+		queryInfo.SetIncompleteQuery(taskID, logFilterName, finalFilter)
+	case estimatedCount != nil:
+		queryInfo.SetQueryWithEstimate(taskID, logFilterName, finalFilter, *estimatedCount)
+	default:
+		queryInfo.SetQuery(taskID, logFilterName, finalFilter)
+	}
+	return nil
+}

--- a/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task_test.go
@@ -1,0 +1,527 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudcommon_contract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/logging/apiv2/loggingpb"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/google/go-cmp/cmp"
+)
+
+type mockStructuredListLogEntriesTaskSetting struct {
+	dependencies       []taskid.UntypedTaskReference
+	resourceNames      []string
+	queries            []*logestimator.StructuredLogQuery
+	timePartitionCount int
+	queryName          string
+}
+
+func (s *mockStructuredListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+	return s.dependencies
+}
+
+func (s *mockStructuredListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
+	return s.resourceNames, nil
+}
+
+func (s *mockStructuredListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
+	return s.queries, nil
+}
+
+func (s *mockStructuredListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
+	return taskid.NewDefaultImplementationID[[]*log.Log]("structured-test")
+}
+
+func (s *mockStructuredListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
+	return s.timePartitionCount, nil
+}
+
+func (s *mockStructuredListLogEntriesTaskSetting) QueryName() string {
+	return s.queryName
+}
+
+var _ StructuredListLogEntriesTaskSetting = (*mockStructuredListLogEntriesTaskSetting)(nil)
+
+func TestStructuredListLogEntriesTask_DryRun_FallbackWhenNoClient(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	setting := &mockStructuredListLogEntriesTaskSetting{
+		queryName:     "container-logs",
+		resourceNames: []string{"projects/test-project"},
+		queries: []*logestimator.StructuredLogQuery{
+			{
+				ResourceTypes: []string{"k8s_container"},
+				Filters: []logestimator.LoggingMonitoringMatcher{
+					logestimator.ResourceLabel("project_id", logestimator.Exact("test-project")),
+					logestimator.LogID(logestimator.Exact("events")),
+				},
+			},
+		},
+		timePartitionCount: 1,
+	}
+
+	task := NewStructuredListLogEntriesTask(setting)
+	resourceNamesInput := NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, task, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+	)
+	if err != nil {
+		t.Fatalf("DryRun returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("DryRun should return empty logs, got %d", len(gotLogs))
+	}
+
+	// Verify QueryMetadata
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in run metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="k8s_container"
+resource.labels.project_id="test-project"
+LOG_ID("events")
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("Query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "container-logs" {
+		t.Errorf("Query Name mismatch: got %q, want %q", serialized[0].Name, "container-logs")
+	}
+}
+
+func TestStructuredListLogEntriesTask_Run_FetchLogs(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+	testErr := fmt.Errorf("fetch error")
+
+	testCases := []struct {
+		desc           string
+		setting        *mockStructuredListLogEntriesTaskSetting
+		fetcherFactory func(t *testing.T) *mockLogFetcher
+		wantLogsString []string
+		wantError      error
+	}{
+		{
+			desc: "successful log fetch with single query",
+			setting: &mockStructuredListLogEntriesTaskSetting{
+				queryName:     "container-logs",
+				resourceNames: []string{"projects/test-project"},
+				queries: []*logestimator.StructuredLogQuery{
+					{
+						ResourceTypes: []string{"k8s_container"},
+						Filters: []logestimator.LoggingMonitoringMatcher{
+							logestimator.ResourceLabel("project_id", logestimator.Exact("test-project")),
+						},
+					},
+				},
+				timePartitionCount: 1,
+			},
+			fetcherFactory: func(t *testing.T) *mockLogFetcher {
+				return getMockFetcherFromFakeLogUpstreamPairs(t, []fakeLogUpstreamPair{
+					newFakeLogUpstreamPair(`resource.type="k8s_container"
+resource.labels.project_id="test-project"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp < "2025-01-01T01:01:00+0000"`, func(logSource chan<- *loggingpb.LogEntry, errSource chan<- error) {
+						logSource <- &loggingpb.LogEntry{InsertId: "log-1", LogName: "container-log"}
+						logSource <- &loggingpb.LogEntry{InsertId: "log-2", LogName: "container-log"}
+					}),
+				})
+			},
+			wantLogsString: []string{
+				"insertId: log-1\nlogName: container-log\n",
+				"insertId: log-2\nlogName: container-log\n",
+			},
+		},
+		{
+			desc: "fetch error propagation",
+			setting: &mockStructuredListLogEntriesTaskSetting{
+				queryName:     "container-logs",
+				resourceNames: []string{"projects/test-project"},
+				queries: []*logestimator.StructuredLogQuery{
+					{
+						ResourceTypes: []string{"k8s_container"},
+						Filters: []logestimator.LoggingMonitoringMatcher{
+							logestimator.ResourceLabel("project_id", logestimator.Exact("test-project")),
+						},
+					},
+				},
+				timePartitionCount: 1,
+			},
+			fetcherFactory: func(t *testing.T) *mockLogFetcher {
+				return getMockFetcherFromFakeLogUpstreamPairs(t, []fakeLogUpstreamPair{
+					newFakeLogUpstreamPair(`resource.type="k8s_container"
+resource.labels.project_id="test-project"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp < "2025-01-01T01:01:00+0000"`, func(logSource chan<- *loggingpb.LogEntry, errSource chan<- error) {
+						errSource <- testErr
+					}),
+				})
+			},
+			wantError: testErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			task := NewStructuredListLogEntriesTask(tc.setting)
+			fetcher := tc.fetcherFactory(t)
+			resourceNamesInput := NewResourceNamesInput()
+			clientFactory, err := googlecloud.NewClientFactory()
+			if err != nil {
+				t.Fatalf("failed to create ClientFactory: %v", err)
+			}
+
+			firstCtx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+			_, _, err = inspectiontest.RunInspectionTask(firstCtx, task, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+				tasktest.NewTaskDependencyValuePair(InputStartTimeTaskID.Ref(), startTime),
+				tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
+				tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
+				tasktest.NewTaskDependencyValuePair[LogFetcher](LoggingFetcherTaskID.Ref(), fetcher),
+				tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+			)
+			if err != nil {
+				t.Fatalf("dry run failed: %v", err)
+			}
+
+			nextCtx := inspectiontest.NextRunTaskContext(t.Context(), firstCtx)
+			gotLogs, _, err := inspectiontest.RunInspectionTask(nextCtx, task, inspectioncore_contract.TaskModeRun, map[string]any{},
+				tasktest.NewTaskDependencyValuePair(InputStartTimeTaskID.Ref(), startTime),
+				tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
+				tasktest.NewTaskDependencyValuePair[LogFetcher](LoggingFetcherTaskID.Ref(), fetcher),
+				tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
+				tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+			)
+
+			if tc.wantError != nil {
+				if !errors.Is(err, tc.wantError) {
+					t.Errorf("error mismatch: got %v, want %v", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotLogsString := []string{}
+			for _, l := range gotLogs {
+				yaml, err := l.Serialize("", &structured.YAMLNodeSerializer{})
+				if err != nil {
+					t.Fatalf("failed to serialize to yaml: %v", err)
+				}
+				gotLogsString = append(gotLogsString, string(yaml))
+				_, err = log.GetFieldSet(l, &log.CommonFieldSet{})
+				if err != nil {
+					t.Errorf("CommonFieldSet not found on log: %v", err)
+				}
+			}
+
+			if diff := cmp.Diff(tc.wantLogsString, gotLogsString); diff != "" {
+				t.Errorf("Logs mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestSetStructuredQueryInfo(t *testing.T) {
+	t.Parallel()
+	taskID := "task-structured"
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+	queryName := "k8s-logs"
+	baseFilter := "resource.type=k8s_container"
+
+	testCases := []struct {
+		desc            string
+		queryIndex      int
+		totalQueryCount int
+		estimatedCount  *int64
+		incomplete      bool
+		wantQuery       *inspectionmetadata.QueryItem
+	}{
+		{
+			desc:            "single query with estimate",
+			queryIndex:      0,
+			totalQueryCount: 1,
+			estimatedCount:  ptr(int64(12500)),
+			wantQuery: &inspectionmetadata.QueryItem{
+				Id:   taskID,
+				Name: "k8s-logs",
+				Query: `resource.type=k8s_container
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`,
+				EstimatedCount: ptr(int64(12500)),
+			},
+		},
+		{
+			desc:            "multi query index 1 with estimate",
+			queryIndex:      1,
+			totalQueryCount: 2,
+			estimatedCount:  ptr(int64(450)),
+			wantQuery: &inspectionmetadata.QueryItem{
+				Id:   taskID,
+				Name: "k8s-logs-1",
+				Query: `resource.type=k8s_container
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`,
+				EstimatedCount: ptr(int64(450)),
+			},
+		},
+		{
+			desc:            "query with 0 estimate is preserved as 0",
+			queryIndex:      0,
+			totalQueryCount: 1,
+			estimatedCount:  ptr(int64(0)),
+			wantQuery: &inspectionmetadata.QueryItem{
+				Id:   taskID,
+				Name: "k8s-logs",
+				Query: `resource.type=k8s_container
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`,
+				EstimatedCount: ptr(int64(0)),
+			},
+		},
+		{
+			desc:            "query with nil estimate has nil EstimatedCount",
+			queryIndex:      0,
+			totalQueryCount: 1,
+			estimatedCount:  nil,
+			incomplete:      false,
+			wantQuery: &inspectionmetadata.QueryItem{
+				Id:   taskID,
+				Name: "k8s-logs",
+				Query: `resource.type=k8s_container
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`,
+				EstimatedCount: nil,
+				Incomplete:     false,
+			},
+		},
+		{
+			desc:            "query marked as incomplete",
+			queryIndex:      0,
+			totalQueryCount: 1,
+			estimatedCount:  nil,
+			incomplete:      true,
+			wantQuery: &inspectionmetadata.QueryItem{
+				Id:   taskID,
+				Name: "k8s-logs",
+				Query: `resource.type=k8s_container
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`,
+				EstimatedCount: nil,
+				Incomplete:     true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+			err := setStructuredQueryInfo(ctx, taskID, baseFilter, tc.queryIndex, tc.totalQueryCount, startTime, endTime, queryName, tc.estimatedCount, tc.incomplete)
+			if err != nil {
+				t.Fatalf("setStructuredQueryInfo returned error: %v", err)
+			}
+
+			metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+			queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+			if !found {
+				t.Fatalf("QueryMetadata not found")
+			}
+
+			serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+			if len(serialized) != 1 {
+				t.Fatalf("expected 1 query item, got %d", len(serialized))
+			}
+
+			if diff := cmp.Diff(tc.wantQuery, serialized[0]); diff != "" {
+				t.Errorf("QueryItem mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStructuredListLogEntriesTask_DryRun_EstimationCache(t *testing.T) {
+	taskSetting := &mockStructuredListLogEntriesTaskSetting{
+		queryName:     "test-cache-query",
+		resourceNames: []string{"projects/test-project"},
+		queries: []*logestimator.StructuredLogQuery{
+			{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters:       []logestimator.LoggingMonitoringMatcher{logestimator.ResourceLabel("cluster_name", logestimator.Exact("test-cluster"))},
+			},
+		},
+	}
+	task := NewStructuredListLogEntriesTask(taskSetting)
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create clientFactory: %v", err)
+	}
+
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+	resourceNamesInput := NewResourceNamesInput()
+
+	// Run DryRun 1
+	firstCtx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	_, _, err = inspectiontest.RunInspectionTask(firstCtx, task, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+	)
+	if err != nil {
+		t.Fatalf("first dryrun failed: %v", err)
+	}
+
+	sharedMap := khictx.MustGetValue(firstCtx, inspectioncore_contract.InspectionSharedMap)
+	cachedEstimator, found := typedmap.Get(sharedMap, LogEstimatorCacheKey)
+	if !found || cachedEstimator == nil {
+		t.Fatalf("expected CachedStructuredLogEstimator to be stored in InspectionSharedMap")
+	}
+
+	// Run DryRun 2 in the same inspection session
+	nextCtx := inspectiontest.NextRunTaskContext(t.Context(), firstCtx)
+	_, _, err = inspectiontest.RunInspectionTask(nextCtx, task, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+	)
+	if err != nil {
+		t.Fatalf("second dryrun failed: %v", err)
+	}
+
+	// Verify that the cached estimator instance was reused
+	nextSharedMap := khictx.MustGetValue(nextCtx, inspectioncore_contract.InspectionSharedMap)
+	reusedEstimator, found := typedmap.Get(nextSharedMap, LogEstimatorCacheKey)
+	if !found || reusedEstimator != cachedEstimator {
+		t.Errorf("expected same CachedStructuredLogEstimator instance to be reused across dryruns")
+	}
+}
+
+func TestStructuredListLogEntriesTask_DryRun_Incomplete(t *testing.T) {
+	testCases := []struct {
+		name          string
+		resourceNames []string
+		queries       []*logestimator.StructuredLogQuery
+		want          *inspectionmetadata.QueryItem
+	}{
+		{
+			name:          "query explicitly marked as incomplete",
+			resourceNames: []string{"projects/test-project"},
+			queries: []*logestimator.StructuredLogQuery{
+				{
+					Incomplete:    true,
+					ResourceTypes: []string{"k8s_cluster"},
+					Filters:       []logestimator.LoggingMonitoringMatcher{logestimator.ResourceLabel("cluster_name", logestimator.Exact(""))},
+				},
+			},
+			want: &inspectionmetadata.QueryItem{
+				Id:             "structured-test#default",
+				Name:           "test-query",
+				Query:          "resource.type=\"k8s_cluster\"\nresource.labels.cluster_name=\"\"\ntimestamp >= \"2025-01-01T01:00:00+0000\"\ntimestamp <= \"2025-01-01T01:01:00+0000\"",
+				EstimatedCount: nil,
+				Incomplete:     true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			taskSetting := &mockStructuredListLogEntriesTaskSetting{
+				queryName:     "test-query",
+				resourceNames: tc.resourceNames,
+				queries:       tc.queries,
+			}
+			task := NewStructuredListLogEntriesTask(taskSetting)
+			clientFactory, err := googlecloud.NewClientFactory()
+			if err != nil {
+				t.Fatalf("failed to create clientFactory: %v", err)
+			}
+
+			startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+			endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+			resourceNamesInput := NewResourceNamesInput()
+			resourceNamesInput.UpdateDefaultResourceNamesForQuery("structured-test", tc.resourceNames)
+
+			ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+			_, _, err = inspectiontest.RunInspectionTask(ctx, task, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+				tasktest.NewTaskDependencyValuePair(InputStartTimeTaskID.Ref(), startTime),
+				tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
+				tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
+				tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+			)
+			if err != nil {
+				t.Fatalf("dryrun failed: %v", err)
+			}
+
+			metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+			queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+			if !found {
+				t.Fatalf("QueryMetadata not found")
+			}
+
+			serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+			if len(serialized) != 1 {
+				t.Fatalf("expected 1 query item, got %d", len(serialized))
+			}
+
+			if diff := cmp.Diff(tc.want, serialized[0]); diff != "" {
+				t.Errorf("QueryItem mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudk8scommon/contract/cluster.go
+++ b/pkg/task/inspection/googlecloudk8scommon/contract/cluster.go
@@ -77,3 +77,8 @@ func (g *GoogleCloudClusterIdentity) PrefixFor(usage ClusterNameUsage) string {
 func (g *GoogleCloudClusterIdentity) UniqueDigest() string {
 	return fmt.Sprintf("%s|%s|%s|%s", g.ProjectID, g.PrefixPolicy.Prefix, g.ClusterName, g.Location)
 }
+
+// IsComplete returns true if ProjectID, ClusterName, and Location are all non-empty.
+func (g *GoogleCloudClusterIdentity) IsComplete() bool {
+	return g.ProjectID != "" && g.ClusterName != "" && g.Location != ""
+}

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/query_task.go
@@ -18,31 +18,41 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogcomposerapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
+
+// GenerateComposerAuditStructuredQuery generates a structured query for Cloud Composer audit logs.
+func GenerateComposerAuditStructuredQuery(projectID, location, environmentName string) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(projectID)),
+	}
+	if location != "" && location != "all" {
+		filters = append(filters, logestimator.ResourceLabel("location", logestimator.Exact(location)))
+	}
+	if environmentName != "" {
+		filters = append(filters, logestimator.ResourceLabel("environment_name", logestimator.Exact(environmentName)))
+	}
+	filters = append(filters,
+		logestimator.LogID(logestimator.OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+		logestimator.CustomFilter(`protoPayload.serviceName="composer.googleapis.com"`),
+	)
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    projectID == "" || environmentName == "",
+		ResourceTypes: []string{"cloud_composer_environment"},
+		Filters:       filters,
+	}
+}
 
 // GenerateComposerAuditQuery generates a Cloud Logging filter string for Cloud Composer audit logs.
 func GenerateComposerAuditQuery(projectID, location, environmentName string) string {
-	locationFilter := ""
-	if location != "" && location != "all" {
-		locationFilter = fmt.Sprintf("resource.labels.location=\"%s\"\n", location)
-	}
-	environmentFilter := ""
-	if environmentName != "" {
-		environmentFilter = fmt.Sprintf("resource.labels.environment_name=\"%s\"\n", environmentName)
-	}
-
-	return fmt.Sprintf(`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-resource.type="cloud_composer_environment"
-resource.labels.project_id="%s"
-%s%sprotoPayload.serviceName="composer.googleapis.com"
-`, projectID, locationFilter, environmentFilter)
+	return GenerateComposerAuditStructuredQuery(projectID, location, environmentName).GenerateCloudLoggingQuery()
 }
 
 type composerAPIListLogEntriesTaskSetting struct{}
@@ -61,19 +71,16 @@ func (s *composerAPIListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTa
 	}
 }
 
-// Description returns user-facing task metadata and example query.
-func (s *composerAPIListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-		QueryName:    "Composer API Audit logs",
-		ExampleQuery: GenerateComposerAuditQuery("test-project", "us-central1", "test-environment"),
-	}
+// QueryName returns human-readable name of the query.
+func (s *composerAPIListLogEntriesTaskSetting) QueryName() string {
+	return "Composer API Audit logs"
 }
 
-// LogFilters returns the Cloud Logging query string.
-func (s *composerAPIListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries returns the list of structured log queries for estimation and execution.
+func (s *composerAPIListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogcomposerapiaudit_contract.ClusterIdentityTaskID.Ref())
 	environmentName := coretask.GetTaskResult(ctx, googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref())
-	return []string{GenerateComposerAuditQuery(clusterIdentity.ProjectID, clusterIdentity.Location, environmentName)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateComposerAuditStructuredQuery(clusterIdentity.ProjectID, clusterIdentity.Location, environmentName)}, nil
 }
 
 // TaskID returns the implementation ID of this query task.
@@ -86,7 +93,7 @@ func (s *composerAPIListLogEntriesTaskSetting) TimePartitionCount(ctx context.Co
 	return 1, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*composerAPIListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*composerAPIListLogEntriesTaskSetting)(nil)
 
 // ListLogEntriesTask is the task that queries Cloud Composer audit logs from Cloud Logging.
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&composerAPIListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&composerAPIListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/query_task_test.go
@@ -16,62 +16,193 @@ package googlecloudlogcomposerapiaudit_impl
 
 import (
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudclustercomposer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustercomposer/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogcomposerapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateComposerAuditQuery(t *testing.T) {
+func TestGenerateComposerAuditStructuredQuery(t *testing.T) {
 	testCases := []struct {
-		name            string
-		projectID       string
-		location        string
-		environmentName string
-		want            string
+		name                   string
+		projectID              string
+		location               string
+		environmentName        string
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
 			name:            "with location and environment name",
 			projectID:       "my-project",
 			location:        "us-central1",
 			environmentName: "env-1",
-			want: `(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-resource.type="cloud_composer_environment"
+			wantQuery: `resource.type="cloud_composer_environment"
 resource.labels.project_id="my-project"
 resource.labels.location="us-central1"
 resource.labels.environment_name="env-1"
-protoPayload.serviceName="composer.googleapis.com"
-`,
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.serviceName="composer.googleapis.com"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "cloud_composer_environment" AND resource.labels.project_id = "my-project" AND resource.labels.location = "us-central1" AND resource.labels.environment_name = "env-1" AND metric.labels.log = one_of("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
 			name:            "empty location and environment name",
 			projectID:       "my-project",
 			location:        "",
 			environmentName: "",
-			want: `(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-resource.type="cloud_composer_environment"
+			wantQuery: `resource.type="cloud_composer_environment"
 resource.labels.project_id="my-project"
-protoPayload.serviceName="composer.googleapis.com"
-`,
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.serviceName="composer.googleapis.com"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "cloud_composer_environment" AND resource.labels.project_id = "my-project" AND metric.labels.log = one_of("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
 			name:            "location all",
 			projectID:       "my-project",
 			location:        "all",
 			environmentName: "env-1",
-			want: `(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-resource.type="cloud_composer_environment"
+			wantQuery: `resource.type="cloud_composer_environment"
 resource.labels.project_id="my-project"
 resource.labels.environment_name="env-1"
-protoPayload.serviceName="composer.googleapis.com"
-`,
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.serviceName="composer.googleapis.com"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "cloud_composer_environment" AND resource.labels.project_id = "my-project" AND resource.labels.environment_name = "env-1" AND metric.labels.log = one_of("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := GenerateComposerAuditQuery(tc.projectID, tc.location, tc.environmentName)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			sq := GenerateComposerAuditStructuredQuery(tc.projectID, tc.location, tc.environmentName)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := GenerateComposerAuditQuery(tc.projectID, tc.location, tc.environmentName)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
 				t.Errorf("GenerateComposerAuditQuery() mismatch (-want +got):\n%s", diff)
 			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
+			}
 		})
+	}
+}
+
+func TestGenerateComposerAuditQueryIsValid(t *testing.T) {
+	testCases := []struct {
+		name            string
+		projectID       string
+		location        string
+		environmentName string
+	}{
+		{
+			name:            "Valid Query with location and env",
+			projectID:       "my-project",
+			location:        "us-central1",
+			environmentName: "env-1",
+		},
+		{
+			name:            "Valid Query with empty location",
+			projectID:       "my-project",
+			location:        "",
+			environmentName: "env-1",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			query := GenerateComposerAuditQuery(tc.projectID, tc.location, tc.environmentName)
+			err := gcp_test.IsValidLogQuery(t, query)
+			if err != nil {
+				t.Errorf("IsValidLogQuery error: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogcomposerapiaudit_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudclustercomposer_contract.InputComposerEnvironmentNameTaskID.Ref(), "test-env"),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="cloud_composer_environment"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1"
+resource.labels.environment_name="test-env"
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.serviceName="composer.googleapis.com"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "Composer API Audit logs" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "Composer API Audit logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/query_task.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -30,45 +32,59 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-// GenerateComputeAPIQuery generates a query for compute API logs.
-func GenerateComputeAPIQuery(taskMode inspectioncore_contract.InspectionTaskModeType, nodeNames []string) []string {
+// GenerateComputeAPIStructuredQuery generates a structured query slice for compute API logs.
+func GenerateComputeAPIStructuredQuery(taskMode inspectioncore_contract.InspectionTaskModeType, nodeNames []string) []*logestimator.StructuredLogQuery {
 	if taskMode == inspectioncore_contract.TaskModeDryRun {
-		return []string{
-			generateComputeAPIQueryWithInstanceNameFilter("-- instance name filters to be determined after node name discovery"),
+		return []*logestimator.StructuredLogQuery{
+			{
+				ResourceTypes: []string{"gce_instance"},
+				Filters: []logestimator.LoggingMonitoringMatcher{
+					logestimator.CustomFilter(`-protoPayload.methodName:("list" OR "get" OR "watch")`),
+					logestimator.Comment("instance name filters to be determined after node name discovery"),
+				},
+			},
 		}
-	} else {
-		result := []string{}
-		instanceNameGroups := gcpqueryutil.SplitToChildGroups(nodeNames, 30)
-		for _, group := range instanceNameGroups {
-			nodeNamesWithInstance := []string{}
-			for _, nodeName := range group {
-				nodeNamesWithInstance = append(nodeNamesWithInstance, fmt.Sprintf("instances/%s", nodeName))
-			}
-			instanceNameFilter := fmt.Sprintf("protoPayload.resourceName:(%s)", strings.Join(nodeNamesWithInstance, " OR "))
-			result = append(result, generateComputeAPIQueryWithInstanceNameFilter(instanceNameFilter))
-		}
-		return result
 	}
+
+	result := []*logestimator.StructuredLogQuery{}
+	instanceNameGroups := gcpqueryutil.SplitToChildGroups(nodeNames, 30)
+	for _, group := range instanceNameGroups {
+		nodeNamesWithInstance := []string{}
+		for _, nodeName := range group {
+			nodeNamesWithInstance = append(nodeNamesWithInstance, fmt.Sprintf("instances/%s", nodeName))
+		}
+		instanceNameFilter := fmt.Sprintf("protoPayload.resourceName:(%s)", strings.Join(nodeNamesWithInstance, " OR "))
+		result = append(result, &logestimator.StructuredLogQuery{
+			ResourceTypes: []string{"gce_instance"},
+			Filters: []logestimator.LoggingMonitoringMatcher{
+				logestimator.CustomFilter(`-protoPayload.methodName:("list" OR "get" OR "watch")`),
+				logestimator.CustomFilter(instanceNameFilter),
+			},
+		})
+	}
+	return result
 }
 
-func generateComputeAPIQueryWithInstanceNameFilter(instanceNameFilter string) string {
-	return fmt.Sprintf(`resource.type="gce_instance"
--protoPayload.methodName:("list" OR "get" OR "watch")
-%s
-`, instanceNameFilter)
+// GenerateComputeAPIQuery generates a query for compute API logs.
+func GenerateComputeAPIQuery(taskMode inspectioncore_contract.InspectionTaskModeType, nodeNames []string) []string {
+	structuredQueries := GenerateComputeAPIStructuredQuery(taskMode, nodeNames)
+	result := make([]string, 0, len(structuredQueries))
+	for _, sq := range structuredQueries {
+		result = append(result, sq.GenerateCloudLoggingQuery())
+	}
+	return result
 }
 
 type computeAPIListLogEntriesTaskSetting struct {
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *computeAPIListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogcomputeapiaudit_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", clusterIdentity.ProjectID)}, nil
-
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *computeAPIListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		commonlogk8saudit_contract.NodeNameInventoryTaskID.Ref(),
@@ -76,34 +92,41 @@ func (c *computeAPIListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTas
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *computeAPIListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *computeAPIListLogEntriesTaskSetting) QueryName() string {
+	return "Compute API Audit log"
+}
 
-		QueryName: "Compute API Audit log",
-		ExampleQuery: GenerateComputeAPIQuery(inspectioncore_contract.TaskModeRun, []string{
-			"gke-test-cluster-node-1",
-			"gke-test-cluster-node-2",
-		})[0],
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *computeAPIListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
+	taskMode, err := khictx.GetValue(ctx, inspectioncore_contract.InspectionTaskMode)
+	if err != nil {
+		taskMode = inspectioncore_contract.TaskModeRun
 	}
+	var nodeNames []string
+	if taskMode == inspectioncore_contract.TaskModeRun {
+		nodeNames = coretask.GetTaskResult(ctx, commonlogk8saudit_contract.NodeNameInventoryTaskID.Ref())
+	}
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogcomputeapiaudit_contract.ClusterIdentityTaskID.Ref())
+	queries := GenerateComputeAPIStructuredQuery(taskMode, nodeNames)
+	if !clusterIdentity.IsComplete() {
+		for _, q := range queries {
+			q.Incomplete = true
+		}
+	}
+	return queries, nil
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *computeAPIListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
-	nodeNames := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.NodeNameInventoryTaskID.Ref())
-	return GenerateComputeAPIQuery(taskMode, nodeNames), nil
-}
-
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *computeAPIListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogcomputeapiaudit_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *computeAPIListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
-	return 1, nil
+	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*computeAPIListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*computeAPIListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&computeAPIListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&computeAPIListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/query_task_test.go
@@ -15,45 +15,109 @@
 package googlecloudlogcomputeapiaudit_impl
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogcomputeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateComputeAPIQuery(t *testing.T) {
+func TestGenerateComputeAPIStructuredQuery(t *testing.T) {
+	generateNodes := func(count int) []string {
+		nodes := make([]string, count)
+		for i := 0; i < count; i++ {
+			nodes[i] = fmt.Sprintf("node-%d", i+1)
+		}
+		return nodes
+	}
+
 	testCases := []struct {
-		Name      string
-		TaskMode  inspectioncore_contract.InspectionTaskModeType
-		NodeNames []string
-		Expected  []string
+		name                   string
+		taskMode               inspectioncore_contract.InspectionTaskModeType
+		nodeNames              []string
+		wantQueries            []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			Name:      "DryRun mode",
-			TaskMode:  inspectioncore_contract.TaskModeDryRun,
-			NodeNames: []string{}, // No nodes specified for dry run
-			Expected: []string{`resource.type="gce_instance"
+			name:      "DryRun mode",
+			taskMode:  inspectioncore_contract.TaskModeDryRun,
+			nodeNames: []string{},
+			wantQueries: []string{
+				`resource.type="gce_instance"
 -protoPayload.methodName:("list" OR "get" OR "watch")
--- instance name filters to be determined after node name discovery
-`},
+-- instance name filters to be determined after node name discovery`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
-			Name:      "Run mode with a few nodes",
-			TaskMode:  inspectioncore_contract.TaskModeRun,
-			NodeNames: []string{"node1", "node2"},
-			Expected: []string{`resource.type="gce_instance"
+			name:                   "Run mode with empty nodes",
+			taskMode:               inspectioncore_contract.TaskModeRun,
+			nodeNames:              []string{},
+			wantQueries:            []string{},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:      "Run mode with a few nodes",
+			taskMode:  inspectioncore_contract.TaskModeRun,
+			nodeNames: []string{"node1", "node2"},
+			wantQueries: []string{
+				`resource.type="gce_instance"
 -protoPayload.methodName:("list" OR "get" OR "watch")
-protoPayload.resourceName:(instances/node1 OR instances/node2)
-`},
+protoPayload.resourceName:(instances/node1 OR instances/node2)`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:      "Run mode with >30 nodes chunked into multiple queries",
+			taskMode:  inspectioncore_contract.TaskModeRun,
+			nodeNames: generateNodes(32),
+			wantQueries: []string{
+				func() string {
+					parts := []string{}
+					for i := 1; i <= 30; i++ {
+						parts = append(parts, fmt.Sprintf("instances/node-%d", i))
+					}
+					return fmt.Sprintf("resource.type=\"gce_instance\"\n-protoPayload.methodName:(\"list\" OR \"get\" OR \"watch\")\nprotoPayload.resourceName:(%s)", strings.Join(parts, " OR "))
+				}(),
+				`resource.type="gce_instance"
+-protoPayload.methodName:("list" OR "get" OR "watch")
+protoPayload.resourceName:(instances/node-31 OR instances/node-32)`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			act := GenerateComputeAPIQuery(tc.TaskMode, tc.NodeNames)
-			if diff := cmp.Diff(tc.Expected, act); diff != "" {
-				t.Errorf("The generated result is not matching with the expected\n%s", diff)
+		t.Run(tc.name, func(t *testing.T) {
+			sqs := GenerateComputeAPIStructuredQuery(tc.taskMode, tc.nodeNames)
+			gotQueries := make([]string, len(sqs))
+			for i, sq := range sqs {
+				gotQueries[i] = sq.GenerateCloudLoggingQuery()
+				if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+					t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
+				}
+			}
+
+			if diff := cmp.Diff(tc.wantQueries, gotQueries); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQueries := GenerateComputeAPIQuery(tc.taskMode, tc.nodeNames)
+			if diff := cmp.Diff(gotQueries, legacyQueries); diff != "" {
+				t.Errorf("GenerateComputeAPIQuery() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -61,30 +125,88 @@ protoPayload.resourceName:(instances/node1 OR instances/node2)
 
 func TestGenerateComputeAPIQueryIsValid(t *testing.T) {
 	testCases := []struct {
-		Name      string
-		TaskMode  inspectioncore_contract.InspectionTaskModeType
-		NodeNames []string
+		name      string
+		taskMode  inspectioncore_contract.InspectionTaskModeType
+		nodeNames []string
 	}{
 		{
-			Name:      "Valid Query in DryRun mode",
-			TaskMode:  inspectioncore_contract.TaskModeDryRun,
-			NodeNames: []string{}, // No nodes specified for dry run
+			name:      "Valid Query in DryRun mode",
+			taskMode:  inspectioncore_contract.TaskModeDryRun,
+			nodeNames: []string{},
 		},
 		{
-			Name:      "Valid Query in Run mode",
-			TaskMode:  inspectioncore_contract.TaskModeRun,
-			NodeNames: []string{"gke-test-cluster-node-1"},
+			name:      "Valid Query in Run mode",
+			taskMode:  inspectioncore_contract.TaskModeRun,
+			nodeNames: []string{"gke-test-cluster-node-1"},
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			queries := GenerateComputeAPIQuery(tc.TaskMode, tc.NodeNames)
+		t.Run(tc.name, func(t *testing.T) {
+			queries := GenerateComputeAPIQuery(tc.taskMode, tc.nodeNames)
 			for _, query := range queries {
 				err := gcp_test.IsValidLogQuery(t, query)
 				if err != nil {
-					t.Errorf("%s", err.Error())
+					t.Errorf("IsValidLogQuery error: %s", err.Error())
 				}
 			}
 		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1-a",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogcomputeapiaudit_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(commonlogk8saudit_contract.NodeNameInventoryTaskID.Ref(), []string{}),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="gce_instance"
+-protoPayload.methodName:("list" OR "get" OR "watch")
+-- instance name filters to be determined after node name discovery
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "Compute API Audit log" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "Compute API Audit log")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -26,70 +27,92 @@ import (
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-func csmTrafficLogsFilter(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, responseFlagsSetFilter *gcpqueryutil.SetFilterParseResult, namespaceSetFilter *gcpqueryutil.SetFilterParseResult) string {
-	responseFlagsFilterStr := responseFlagsFilter(responseFlagsSetFilter)
-	namespaceFilterStr := namespaceFilter(namespaceSetFilter)
-	return fmt.Sprintf(`LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-%s
-%s
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"`, responseFlagsFilterStr, namespaceFilterStr, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageCSM))
+// GenerateCSMTrafficLogsStructuredQuery generates a structured query for CSM Traffic logs.
+func GenerateCSMTrafficLogsStructuredQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, responseFlagsSetFilter *gcpqueryutil.SetFilterParseResult, namespaceSetFilter *gcpqueryutil.SetFilterParseResult) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(cluster.ProjectID)),
+		logestimator.ResourceLabel("location", logestimator.Exact(cluster.Location)),
+		logestimator.ResourceLabel("cluster_name", logestimator.Exact(cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageCSM))),
+	}
+
+	if nsFilter := namespaceStructuredMatcher(namespaceSetFilter); nsFilter != nil {
+		filters = append(filters, nsFilter)
+	}
+
+	filters = append(filters, logestimator.LogID(logestimator.OneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")))
+
+	if responseFlagsFilter := responseFlagsStructuredMatcher(responseFlagsSetFilter); responseFlagsFilter != nil {
+		filters = append(filters, responseFlagsFilter)
+	}
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete: !cluster.IsComplete(),
+		Filters:    filters,
+	}
 }
 
-func responseFlagsFilter(responseFlagsFilter *gcpqueryutil.SetFilterParseResult) string {
+// GenerateCSMTrafficLogsQuery generates a query for CSM Traffic logs.
+func GenerateCSMTrafficLogsQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, responseFlagsSetFilter *gcpqueryutil.SetFilterParseResult, namespaceSetFilter *gcpqueryutil.SetFilterParseResult) string {
+	return GenerateCSMTrafficLogsStructuredQuery(cluster, responseFlagsSetFilter, namespaceSetFilter).GenerateCloudLoggingQuery()
+}
+
+func responseFlagsStructuredMatcher(responseFlagsFilter *gcpqueryutil.SetFilterParseResult) logestimator.LoggingMonitoringMatcher {
+	if responseFlagsFilter == nil {
+		return nil
+	}
 	if responseFlagsFilter.ValidationError != "" {
-		return fmt.Sprintf(`-- Failed to generate response flags filter due to the validation error "%s"`, responseFlagsFilter.ValidationError)
+		return logestimator.Comment(fmt.Sprintf(`Failed to generate response flags filter due to the validation error "%s"`, responseFlagsFilter.ValidationError))
 	}
 	if responseFlagsFilter.SubtractMode {
 		if len(responseFlagsFilter.Subtractives) == 0 {
-			return "-- No response flags filter"
+			return nil
 		}
-		return fmt.Sprintf(`-labels.response_flag:(%s)`, strings.Join(responseFlagsFilter.SubtractivesWithQuotes(), " OR "))
+		return logestimator.CustomFilter(fmt.Sprintf(`-labels.response_flag:(%s)`, strings.Join(responseFlagsFilter.SubtractivesWithQuotes(), " OR ")))
 	}
 
 	if len(responseFlagsFilter.Additives) == 0 {
-		return `-- Invalid: none of the resources will be selected. Ignoring response flag filter.`
+		return logestimator.Comment(`Invalid: none of the resources will be selected. Ignoring response flag filter.`)
 	}
-	return fmt.Sprintf(`labels.response_flag:(%s)`, strings.Join(responseFlagsFilter.AdditivesWithQuotes(), " OR "))
+	return logestimator.CustomFilter(fmt.Sprintf(`labels.response_flag:(%s)`, strings.Join(responseFlagsFilter.AdditivesWithQuotes(), " OR ")))
 }
 
-func namespaceFilter(filter *gcpqueryutil.SetFilterParseResult) string {
+func namespaceStructuredMatcher(filter *gcpqueryutil.SetFilterParseResult) logestimator.LoggingMonitoringMatcher {
+	if filter == nil {
+		return nil
+	}
 	if filter.ValidationError != "" {
-		return fmt.Sprintf(`-- Failed to generate namespace filter due to the validation error "%s"`, filter.ValidationError)
+		return logestimator.CustomFilter(fmt.Sprintf(`-- Failed to generate namespace filter due to the validation error "%s"`, filter.ValidationError))
 	}
 	if filter.SubtractMode {
-		return "-- Unsupported operation"
-	} else {
-		selectedNamespaces := []string{}
-		for _, additive := range filter.Additives {
-			if strings.HasPrefix(additive, "#") {
-				if additive == "#namespaced" {
-					return "-- No namespace filter"
-				}
-				continue
-			}
-			selectedNamespaces = append(selectedNamespaces, fmt.Sprintf(`"%s"`, additive))
-		}
-		if len(selectedNamespaces) == 0 {
-			return `resource.labels.namespace_name="" -- Invalid: No namespaces remain to filter for CSM traffic logs.`
-		}
-		return fmt.Sprintf(`resource.labels.namespace_name:(%s)`, strings.Join(selectedNamespaces, " OR "))
+		return logestimator.CustomFilter("-- Unsupported operation")
 	}
+	selectedNamespaces := []string{}
+	for _, additive := range filter.Additives {
+		if strings.HasPrefix(additive, "#") {
+			if additive == "#namespaced" {
+				return nil
+			}
+			continue
+		}
+		selectedNamespaces = append(selectedNamespaces, additive)
+	}
+	if len(selectedNamespaces) == 0 {
+		return logestimator.CustomFilter(`resource.labels.namespace_name="" -- Invalid: No namespaces remain to filter for CSM traffic logs.`)
+	}
+	return logestimator.ResourceLabel("namespace_name", logestimator.ContainsAny(selectedNamespaces...))
 }
 
 type CSMTrafficLogListLogEntryTaskSetting struct{}
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *CSMTrafficLogListLogEntryTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *CSMTrafficLogListLogEntryTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(),
@@ -98,37 +121,29 @@ func (c *CSMTrafficLogListLogEntryTaskSetting) Dependencies() []taskid.UntypedTa
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *CSMTrafficLogListLogEntryTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "CSM Traffic logs",
-		ExampleQuery: csmTrafficLogsFilter(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:   "test-project",
-			Location:    "test-location",
-			ClusterName: "test-cluster",
-		}, &gcpqueryutil.SetFilterParseResult{Subtractives: []string{"-"}, SubtractMode: true}, &gcpqueryutil.SetFilterParseResult{SubtractMode: true}),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *CSMTrafficLogListLogEntryTaskSetting) QueryName() string {
+	return "CSM Traffic logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *CSMTrafficLogListLogEntryTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *CSMTrafficLogListLogEntryTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref())
 	namespaceFilter := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputNamespaceFilterTaskID.Ref())
 	responseFlagsFilter := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.InputCSMResponseFlagsTaskID.Ref())
-	return []string{csmTrafficLogsFilter(cluster, responseFlagsFilter, namespaceFilter)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateCSMTrafficLogsStructuredQuery(cluster, responseFlagsFilter, namespaceFilter)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *CSMTrafficLogListLogEntryTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogcsm_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *CSMTrafficLogListLogEntryTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*CSMTrafficLogListLogEntryTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*CSMTrafficLogListLogEntryTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&CSMTrafficLogListLogEntryTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&CSMTrafficLogListLogEntryTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task.go
@@ -83,10 +83,10 @@ func namespaceStructuredMatcher(filter *gcpqueryutil.SetFilterParseResult) loges
 		return nil
 	}
 	if filter.ValidationError != "" {
-		return logestimator.CustomFilter(fmt.Sprintf(`-- Failed to generate namespace filter due to the validation error "%s"`, filter.ValidationError))
+		return logestimator.Comment(fmt.Sprintf(`Failed to generate namespace filter due to the validation error "%s"`, filter.ValidationError))
 	}
 	if filter.SubtractMode {
-		return logestimator.CustomFilter("-- Unsupported operation")
+		return logestimator.Comment("Unsupported operation")
 	}
 	selectedNamespaces := []string{}
 	for _, additive := range filter.Additives {
@@ -99,7 +99,7 @@ func namespaceStructuredMatcher(filter *gcpqueryutil.SetFilterParseResult) loges
 		selectedNamespaces = append(selectedNamespaces, additive)
 	}
 	if len(selectedNamespaces) == 0 {
-		return logestimator.CustomFilter(`resource.labels.namespace_name="" -- Invalid: No namespaces remain to filter for CSM traffic logs.`)
+		return logestimator.WithComment(logestimator.ResourceLabel("namespace_name", logestimator.Exact("")), "Invalid: No namespaces remain to filter for CSM traffic logs.")
 	}
 	return logestimator.ResourceLabel("namespace_name", logestimator.ContainsAny(selectedNamespaces...))
 }

--- a/pkg/task/inspection/googlecloudlogcsm/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/query_task_test.go
@@ -17,10 +17,14 @@ package googlecloudlogcsm_impl
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
-
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
 	googlecloudclustergdcbaremetal_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudclustergdcbaremetal/impl"
@@ -30,45 +34,46 @@ import (
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudk8scommon_impl "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/impl"
+	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestCsmTrafficLogsFilter(t *testing.T) {
+func TestGenerateCSMTrafficLogsStructuredQuery(t *testing.T) {
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ProjectID:   "test-project",
+		Location:    "test-location",
+		ClusterName: "test-cluster",
+	}
+
 	testCases := []struct {
-		desc                string
-		cluster             googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		responseFlagsFilter *gcpqueryutil.SetFilterParseResult
-		namespaceFilter     *gcpqueryutil.SetFilterParseResult
-		want                string
+		desc                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		responseFlagsFilter    *gcpqueryutil.SetFilterParseResult
+		namespaceFilter        *gcpqueryutil.SetFilterParseResult
+		wantQuery              string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			desc: "basic filter",
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				Location:    "test-location",
-				ClusterName: "test-cluster",
-			},
+			desc:    "basic filter with additives",
+			cluster: cluster,
 			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"UH", "UT"},
 			},
 			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"default"},
 			},
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH" OR "UT")
-resource.labels.namespace_name:("default")
-resource.labels.project_id="test-project"
+			wantQuery: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="test-cluster"`,
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH" OR "UT")`,
+			wantSupportMetricsFlag: false,
 		},
 		{
-			desc: "response flags subtractive filter",
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				Location:    "test-location",
-				ClusterName: "test-cluster",
-			},
+			desc:    "response flags subtractive filter",
+			cluster: cluster,
 			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
 				Subtractives: []string{"-"},
 				SubtractMode: true,
@@ -76,99 +81,208 @@ resource.labels.cluster_name="test-cluster"`,
 			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"default"},
 			},
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
--labels.response_flag:("-")
-resource.labels.namespace_name:("default")
-resource.labels.project_id="test-project"
+			wantQuery: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="test-cluster"`,
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+-labels.response_flag:("-")`,
+			wantSupportMetricsFlag: false,
 		},
 		{
-			desc: "namespace cluster-scoped filter",
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				Location:    "test-location",
-				ClusterName: "test-cluster",
+			desc:    "response flags subtractive filter with empty subtractives",
+			cluster: cluster,
+			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
+				Subtractives: []string{},
+				SubtractMode: true,
 			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"default"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))`,
+			wantSupportMetricsFlag: true,
+		},
+		{
+			desc:    "response flags empty additives",
+			cluster: cluster,
+			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"default"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+-- Invalid: none of the resources will be selected. Ignoring response flag filter.`,
+			wantSupportMetricsFlag: true,
+		},
+		{
+			desc:    "response flags validation error",
+			cluster: cluster,
+			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
+				ValidationError: "invalid response flag format",
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"default"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+-- Failed to generate response flags filter due to the validation error "invalid response flag format"`,
+			wantSupportMetricsFlag: true,
+		},
+		{
+			desc:    "nil response flags filter and nil namespace filter",
+			cluster: cluster,
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))`,
+			wantSupportMetricsFlag: true,
+		},
+		{
+			desc:    "namespace validation error",
+			cluster: cluster,
+			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"UH"},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				ValidationError: "invalid namespace syntax",
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"
+-- Failed to generate namespace filter due to the validation error "invalid namespace syntax"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
+			wantSupportMetricsFlag: false,
+		},
+		{
+			desc:    "namespace subtractive mode unsupported",
+			cluster: cluster,
+			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"UH"},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{"kube-system"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"
+-- Unsupported operation
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
+			wantSupportMetricsFlag: false,
+		},
+		{
+			desc:    "namespace cluster-scoped filter",
+			cluster: cluster,
 			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"UH"},
 			},
 			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"#cluster-scoped"},
 			},
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH")
-resource.labels.namespace_name="" -- Invalid: No namespaces remain to filter for CSM traffic logs.
-resource.labels.project_id="test-project"
+			wantQuery: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="test-cluster"`,
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name="" -- Invalid: No namespaces remain to filter for CSM traffic logs.
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
+			wantSupportMetricsFlag: false,
 		},
 		{
-			desc: "namespace cluster-scoped and specific namespaces filter",
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				Location:    "test-location",
-				ClusterName: "test-cluster",
-			},
+			desc:    "namespace cluster-scoped and specific namespaces filter",
+			cluster: cluster,
 			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"UH"},
 			},
 			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"#cluster-scoped", "kube-system"},
 			},
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH")
-resource.labels.namespace_name:("kube-system")
-resource.labels.project_id="test-project"
+			wantQuery: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="test-cluster"`,
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:"kube-system"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
+			wantSupportMetricsFlag: false,
 		},
 		{
-			desc: "namespace namespaced-scoped filter",
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				Location:    "test-location",
-				ClusterName: "test-cluster",
-			},
+			desc:    "namespace namespaced-scoped filter",
+			cluster: cluster,
 			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"UH"},
 			},
 			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"#namespaced"},
 			},
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH")
--- No namespace filter
-resource.labels.project_id="test-project"
+			wantQuery: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="test-cluster"`,
+resource.labels.cluster_name="test-cluster"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
+			wantSupportMetricsFlag: false,
 		},
 		{
-			desc: "namespace cluster-scoped and namespaced-scoped filter",
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				Location:    "test-location",
-				ClusterName: "test-cluster",
-			},
+			desc:    "namespace cluster-scoped and namespaced-scoped filter",
+			cluster: cluster,
 			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"UH"},
 			},
 			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"#cluster-scoped", "#namespaced"},
 			},
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH")
--- No namespace filter
-resource.labels.project_id="test-project"
+			wantQuery: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="test-cluster"`,
+resource.labels.cluster_name="test-cluster"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
+			wantSupportMetricsFlag: false,
+		},
+		{
+			desc:    "multiple namespaces filter",
+			cluster: cluster,
+			responseFlagsFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"UH"},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"default", "istio-system"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:("default" OR "istio-system")
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
+			wantSupportMetricsFlag: false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := csmTrafficLogsFilter(tc.cluster, tc.responseFlagsFilter, tc.namespaceFilter)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("csmTrafficLogsFilter() mismatch (-want +got):\n%s", diff)
+			sq := GenerateCSMTrafficLogsStructuredQuery(tc.cluster, tc.responseFlagsFilter, tc.namespaceFilter)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := GenerateCSMTrafficLogsQuery(tc.cluster, tc.responseFlagsFilter, tc.namespaceFilter)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("GenerateCSMTrafficLogsQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
 			}
 		})
 	}
@@ -183,42 +297,42 @@ func TestCSMQueryTaskPrefixResolution(t *testing.T) {
 		{
 			name:       "GKE side task generates no prefix",
 			prefixTask: googlecloudclustergke_impl.GKEClusterNamePrefixTask,
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH")
-resource.labels.namespace_name:("default")
-resource.labels.project_id="test-project"
+			want: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="test-cluster"`,
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
 		},
 		{
 			name:       "baremetal side task adds prefix",
 			prefixTask: googlecloudclustergdcbaremetal_impl.GDCVForBaremetalClusterNamePrefixTask,
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH")
-resource.labels.namespace_name:("default")
-resource.labels.project_id="test-project"
+			want: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="baremetalClusters/test-cluster"`,
+resource.labels.cluster_name="baremetalClusters/test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
 		},
 		{
 			name:       "aws side task adds prefix",
 			prefixTask: googlecloudclustergkeonaws_impl.AnthosOnAWSClusterNamePrefixTask,
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH")
-resource.labels.namespace_name:("default")
-resource.labels.project_id="test-project"
+			want: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="awsClusters/test-cluster"`,
+resource.labels.cluster_name="awsClusters/test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
 		},
 		{
 			name:       "azure side task adds prefix",
 			prefixTask: googlecloudclustergkeonazure_impl.AnthosOnAzureClusterNamePrefixTask,
-			want: `LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver") 
-labels.response_flag:("UH")
-resource.labels.namespace_name:("default")
-resource.labels.project_id="test-project"
+			want: `resource.labels.project_id="test-project"
 resource.labels.location="test-location"
-resource.labels.cluster_name="azureClusters/test-cluster"`,
+resource.labels.cluster_name="azureClusters/test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")`,
 		},
 	}
 
@@ -241,11 +355,73 @@ resource.labels.cluster_name="azureClusters/test-cluster"`,
 				t.Fatalf("unexpected error running cluster identity task: %v", err)
 			}
 
-			got := csmTrafficLogsFilter(idRes, &gcpqueryutil.SetFilterParseResult{Additives: []string{"UH"}}, &gcpqueryutil.SetFilterParseResult{Additives: []string{"default"}})
+			got := GenerateCSMTrafficLogsQuery(idRes, &gcpqueryutil.SetFilterParseResult{Additives: []string{"UH"}}, &gcpqueryutil.SetFilterParseResult{Additives: []string{"default"}})
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("csmTrafficLogsFilter() mismatch (-want +got):\n%s", diff)
+				t.Errorf("GenerateCSMTrafficLogsQuery() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "test-location",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.InputNamespaceFilterTaskID.Ref(), &gcpqueryutil.SetFilterParseResult{Additives: []string{"default"}}),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogcsm_contract.InputCSMResponseFlagsTaskID.Ref(), &gcpqueryutil.SetFilterParseResult{Additives: []string{"UH"}}),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.labels.project_id="test-project"
+resource.labels.location="test-location"
+resource.labels.cluster_name="test-cluster"
+resource.labels.namespace_name:"default"
+(LOG_ID("server-accesslog-stackdriver") OR LOG_ID("client-accesslog-stackdriver"))
+labels.response_flag:("UH")
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "CSM Traffic logs" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "CSM Traffic logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_query_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_query_task.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -28,15 +30,57 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
+// GenerateCSMTrafficDirectorStructuredQuery generates a structured query for CSM Traffic Director logs.
+func GenerateCSMTrafficDirectorStructuredQuery(fleetProjectID string, clusterIdentifiers []string, isDryRun bool) *logestimator.StructuredLogQuery {
+	if isDryRun {
+		clusterIdentifiers = []string{"dummy"}
+	}
+	if len(clusterIdentifiers) == 0 {
+		return nil
+	}
+
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(fleetProjectID)),
+		logestimator.LogID(logestimator.OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+	}
+
+	switch {
+	case isDryRun:
+		filters = append(filters, logestimator.CustomFilter(`protoPayload.resourceName:"gsmrsvd-dummy" -- The actual resource name selector will be generated from other logs in the middle of the pipeline.`))
+	case len(clusterIdentifiers) == 1:
+		filters = append(filters, logestimator.CustomFilter(fmt.Sprintf(`protoPayload.resourceName:"gsmrsvd-%s"`, clusterIdentifiers[0])))
+	default:
+		quotedIdentifiers := make([]string, len(clusterIdentifiers))
+		for i, id := range clusterIdentifiers {
+			quotedIdentifiers[i] = fmt.Sprintf(`"gsmrsvd-%s"`, id)
+		}
+		filters = append(filters, logestimator.CustomFilter(fmt.Sprintf(`protoPayload.resourceName:(%s)`, strings.Join(quotedIdentifiers, " OR "))))
+	}
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete: fleetProjectID == "",
+		Filters:    filters,
+	}
+}
+
+// GenerateCSMTrafficDirectorQuery generates a query for CSM Traffic Director logs.
+func GenerateCSMTrafficDirectorQuery(fleetProjectID string, clusterIdentifiers []string, isDryRun bool) string {
+	sq := GenerateCSMTrafficDirectorStructuredQuery(fleetProjectID, clusterIdentifiers, isDryRun)
+	if sq == nil {
+		return ""
+	}
+	return sq.GenerateCloudLoggingQuery()
+}
+
 type CSMTrafficDirectorListLogEntryTaskSetting struct{}
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (s *CSMTrafficDirectorListLogEntryTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	fleetProjectID := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", fleetProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (s *CSMTrafficDirectorListLogEntryTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref(),
@@ -44,59 +88,42 @@ func (s *CSMTrafficDirectorListLogEntryTaskSetting) Dependencies() []taskid.Unty
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (s *CSMTrafficDirectorListLogEntryTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "CSM Traffic Director logs",
-		ExampleQuery: `(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-  protoPayload.resourceName: "gsmrsvd-XXXX" -- XXXX part will be generated from other log parsing result
-  resource.labels.project_id="fleet-project"`,
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (s *CSMTrafficDirectorListLogEntryTaskSetting) QueryName() string {
+	return "CSM Traffic Director logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (s *CSMTrafficDirectorListLogEntryTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (s *CSMTrafficDirectorListLogEntryTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	fleetProjectID := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref())
 	clusterIdentifiers := coretask.GetTaskResult(ctx, googlecloudlogcsm_contract.CSMClusterIdentifierTaskID.Ref())
+	taskMode := inspectioncore_contract.TaskModeRun
+	if val, err := khictx.GetValue(ctx, inspectioncore_contract.InspectionTaskMode); err == nil {
+		taskMode = val
+	}
+	isDryRun := taskMode == inspectioncore_contract.TaskModeDryRun
 
-	dryRunComment := ""
-	if taskMode == inspectioncore_contract.TaskModeDryRun {
-		clusterIdentifiers = []string{"dummy"}
-		dryRunComment = " -- The actual resource name selector will be generated from other logs in the middle of the pipeline."
-	} else if len(clusterIdentifiers) == 0 {
-		slog.InfoContext(ctx, "No CSM BackendServices found in inventory. Skipping Traffic Director log query.")
+	sq := GenerateCSMTrafficDirectorStructuredQuery(fleetProjectID, clusterIdentifiers, isDryRun)
+	if sq == nil {
+		if !isDryRun {
+			slog.InfoContext(ctx, "No CSM BackendServices found in inventory. Skipping Traffic Director log query.")
+		}
 		return nil, nil
 	}
 
-	resourceNameFilter := ""
-	if len(clusterIdentifiers) == 1 {
-		resourceNameFilter = fmt.Sprintf(`protoPayload.resourceName:"gsmrsvd-%s"`, clusterIdentifiers[0])
-	} else {
-		quotedIdentifiers := make([]string, len(clusterIdentifiers))
-		for i, id := range clusterIdentifiers {
-			quotedIdentifiers[i] = fmt.Sprintf(`"gsmrsvd-%s"`, id)
-		}
-		resourceNameFilter = fmt.Sprintf(`protoPayload.resourceName:(%s)`, strings.Join(quotedIdentifiers, " OR "))
-	}
-
-	query := fmt.Sprintf(`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-%s%s
-resource.labels.project_id="%s"`, resourceNameFilter, dryRunComment, fleetProjectID)
-
-	return []string{query}, nil
+	return []*logestimator.StructuredLogQuery{sq}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (s *CSMTrafficDirectorListLogEntryTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogcsm_contract.ListCSMTrafficDirectorLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (s *CSMTrafficDirectorListLogEntryTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 1, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*CSMTrafficDirectorListLogEntryTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*CSMTrafficDirectorListLogEntryTaskSetting)(nil)
 
-var ListCSMTrafficDirectorLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&CSMTrafficDirectorListLogEntryTaskSetting{})
+var ListCSMTrafficDirectorLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&CSMTrafficDirectorListLogEntryTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_query_task_test.go
@@ -15,82 +15,158 @@
 package googlecloudlogcsm_impl
 
 import (
-	"context"
 	"testing"
+	"time"
 
-	"github.com/google/go-cmp/cmp"
-
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudlogcsm_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogcsm/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestCSMTrafficDirectorListLogEntryTaskSetting_LogFilters(t *testing.T) {
+func TestGenerateCSMTrafficDirectorStructuredQuery(t *testing.T) {
 	tests := []struct {
-		name               string
-		fleetProjectID     string
-		clusterIdentifiers []string
-		taskMode           inspectioncore_contract.InspectionTaskModeType
-		want               []string
+		name                   string
+		fleetProjectID         string
+		clusterIdentifiers     []string
+		isDryRun               bool
+		wantQuery              string
+		wantSupportMetricsFlag bool
 	}{
 		{
 			name:               "single identifier",
 			fleetProjectID:     "fleet-project",
 			clusterIdentifiers: []string{"cluster1"},
-			taskMode:           inspectioncore_contract.TaskModeRun,
-			want: []string{
-				`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-protoPayload.resourceName:"gsmrsvd-cluster1"
-resource.labels.project_id="fleet-project"`,
-			},
+			isDryRun:           false,
+			wantQuery: `resource.labels.project_id="fleet-project"
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"gsmrsvd-cluster1"`,
+			wantSupportMetricsFlag: false,
 		},
 		{
 			name:               "multiple identifiers",
 			fleetProjectID:     "fleet-project",
 			clusterIdentifiers: []string{"cluster1", "cluster2"},
-			taskMode:           inspectioncore_contract.TaskModeRun,
-			want: []string{
-				`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-protoPayload.resourceName:("gsmrsvd-cluster1" OR "gsmrsvd-cluster2")
-resource.labels.project_id="fleet-project"`,
-			},
+			isDryRun:           false,
+			wantQuery: `resource.labels.project_id="fleet-project"
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:("gsmrsvd-cluster1" OR "gsmrsvd-cluster2")`,
+			wantSupportMetricsFlag: false,
 		},
 		{
-			name:               "no identifiers",
-			fleetProjectID:     "fleet-project",
-			clusterIdentifiers: []string{},
-			taskMode:           inspectioncore_contract.TaskModeRun,
-			want:               nil,
+			name:                   "no identifiers",
+			fleetProjectID:         "fleet-project",
+			clusterIdentifiers:     []string{},
+			isDryRun:               false,
+			wantQuery:              "",
+			wantSupportMetricsFlag: false,
 		},
 		{
 			name:               "dry run",
 			fleetProjectID:     "fleet-project",
-			clusterIdentifiers: []string{"cluster1"}, // Should be ignored in dry run
-			taskMode:           inspectioncore_contract.TaskModeDryRun,
-			want: []string{
-				`(log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access"))
-protoPayload.resourceName:"gsmrsvd-dummy" -- The actual resource name selector will be generated from other logs in the middle of the pipeline.
-resource.labels.project_id="fleet-project"`,
-			},
+			clusterIdentifiers: []string{"cluster1"}, // Ignored in dry run
+			isDryRun:           true,
+			wantQuery: `resource.labels.project_id="fleet-project"
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"gsmrsvd-dummy" -- The actual resource name selector will be generated from other logs in the middle of the pipeline.`,
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:               "dry run with empty identifiers",
+			fleetProjectID:     "fleet-project",
+			clusterIdentifiers: []string{},
+			isDryRun:           true,
+			wantQuery: `resource.labels.project_id="fleet-project"
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"gsmrsvd-dummy" -- The actual resource name selector will be generated from other logs in the middle of the pipeline.`,
+			wantSupportMetricsFlag: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			setting := &CSMTrafficDirectorListLogEntryTaskSetting{}
-
-			// Mocking dependencies by providing them in the context
-			ctx = tasktest.WithTaskResult(ctx, googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref(), tc.fleetProjectID)
-			ctx = tasktest.WithTaskResult(ctx, googlecloudlogcsm_contract.CSMClusterIdentifierTaskID.Ref(), tc.clusterIdentifiers)
-
-			got, err := setting.LogFilters(ctx, tc.taskMode)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			sq := GenerateCSMTrafficDirectorStructuredQuery(tc.fleetProjectID, tc.clusterIdentifiers, tc.isDryRun)
+			if sq == nil {
+				if tc.wantQuery != "" {
+					t.Errorf("GenerateCSMTrafficDirectorStructuredQuery() = nil, want %q", tc.wantQuery)
+				}
+				legacyQuery := GenerateCSMTrafficDirectorQuery(tc.fleetProjectID, tc.clusterIdentifiers, tc.isDryRun)
+				if diff := cmp.Diff(tc.wantQuery, legacyQuery); diff != "" {
+					t.Errorf("GenerateCSMTrafficDirectorQuery() mismatch (-want +got):\n%s", diff)
+				}
+				return
 			}
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("LogFilters() mismatch (-want +got):\n%s", diff)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := GenerateCSMTrafficDirectorQuery(tc.fleetProjectID, tc.clusterIdentifiers, tc.isDryRun)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("GenerateCSMTrafficDirectorQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
 			}
 		})
+	}
+}
+
+func TestListCSMTrafficDirectorLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListCSMTrafficDirectorLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogcsm_contract.InputFleetProjectIDTaskID.Ref(), "fleet-project"),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogcsm_contract.CSMClusterIdentifierTaskID.Ref(), []string{}),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.labels.project_id="fleet-project"
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"gsmrsvd-dummy" -- The actual resource name selector will be generated from other logs in the middle of the pipeline.
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "CSM Traffic Director logs" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "CSM Traffic Director logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/impl/query_task.go
@@ -18,66 +18,73 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudloggkeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudloggkeapiaudit/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
+// GenerateGKEAuditStructuredQuery generates a structured query for GKE API audit logs.
+func GenerateGKEAuditStructuredQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity) *logestimator.StructuredLogQuery {
+	return &logestimator.StructuredLogQuery{
+		Incomplete:                !cluster.IsComplete(),
+		ResourceTypes:             []string{"gke_cluster", "gke_nodepool"},
+		IgnoreMetricsResourceType: []string{"gke_cluster", "gke_nodepool"},
+		Filters: []logestimator.LoggingMonitoringMatcher{
+			logestimator.ResourceLabel("project_id", logestimator.Exact(cluster.ProjectID)),
+			logestimator.ResourceLabel("location", logestimator.Exact(cluster.Location)),
+			logestimator.ResourceLabel("cluster_name", logestimator.Exact(cluster.ClusterName)),
+			logestimator.LogID(logestimator.OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+			logestimator.CustomFilter(`protoPayload.serviceName="container.googleapis.com"`),
+		},
+	}
+}
+
+// GenerateGKEAuditQuery generates a query for GKE API audit logs.
 func GenerateGKEAuditQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity) string {
-	return fmt.Sprintf(`log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access")
-resource.type=("gke_cluster" OR "gke_nodepool")
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"
-protoPayload.serviceName="container.googleapis.com"
-`, cluster.ProjectID, cluster.Location, cluster.ClusterName)
+	return GenerateGKEAuditStructuredQuery(cluster).GenerateCloudLoggingQuery()
 }
 
 type gkeAPIListLogEntriesTaskSetting struct {
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (g *gkeAPIListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudloggkeapiaudit_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", clusterIdentity.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (g *gkeAPIListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudloggkeapiaudit_contract.ClusterIdentityTaskID.Ref(),
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (g *gkeAPIListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName:    "GKE Audit logs",
-		ExampleQuery: GenerateGKEAuditQuery(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{ProjectID: "gcp-project-id", Location: "gcp-location", ClusterName: "gcp-cluster-name"}),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (g *gkeAPIListLogEntriesTaskSetting) QueryName() string {
+	return "GKE Audit logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (g *gkeAPIListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (g *gkeAPIListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudloggkeapiaudit_contract.ClusterIdentityTaskID.Ref())
-	return []string{GenerateGKEAuditQuery(cluster)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateGKEAuditStructuredQuery(cluster)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (g *gkeAPIListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudloggkeapiaudit_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (g *gkeAPIListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 1, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*gkeAPIListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*gkeAPIListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&gkeAPIListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&gkeAPIListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/impl/query_task_test.go
@@ -16,38 +16,72 @@ package googlecloudloggkeapiaudit_impl
 
 import (
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudloggkeapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudloggkeapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateGKEAuditQuery(t *testing.T) {
+func TestGenerateGKEAuditStructuredQuery(t *testing.T) {
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ProjectID:   "test-project",
+		ClusterName: "test-cluster",
+		Location:    "asia-northeast1",
+	}
+
 	testCases := []struct {
-		clusterIdentity googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		expected        string
+		name                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			clusterIdentity: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				ClusterName: "test-cluster",
-				Location:    "asia-northeast1",
-			},
-			expected: `log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access")
-resource.type=("gke_cluster" OR "gke_nodepool")
+			name:    "standard GKE audit query",
+			cluster: cluster,
+			wantQuery: `resource.type=("gke_cluster" OR "gke_nodepool")
 resource.labels.project_id="test-project"
 resource.labels.location="asia-northeast1"
 resource.labels.cluster_name="test-cluster"
-protoPayload.serviceName="container.googleapis.com"
-`,
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.serviceName="container.googleapis.com"`,
+			wantMetricFilters:      nil,
+			wantSupportMetricsFlag: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		result := GenerateGKEAuditQuery(tc.clusterIdentity)
-		if diff := cmp.Diff(result, tc.expected); diff != "" {
-			t.Errorf("GenerateGKEAuditQuery() mismatch (-want +got):\n%s", diff)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			sq := GenerateGKEAuditStructuredQuery(tc.cluster)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := GenerateGKEAuditQuery(tc.cluster)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("GenerateGKEAuditQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
+			}
+		})
 	}
 }
 
@@ -70,8 +104,68 @@ func TestGeneratedGKEAuditQueryIsValid(t *testing.T) {
 			query := GenerateGKEAuditQuery(tc.clusterIdentity)
 			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
-				t.Errorf("%s", err.Error())
+				t.Errorf("IsValidLogQuery error: %s", err.Error())
 			}
 		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "asia-northeast1",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudloggkeapiaudit_contract.ClusterIdentityTaskID.Ref(), cluster),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type=("gke_cluster" OR "gke_nodepool")
+resource.labels.project_id="test-project"
+resource.labels.location="asia-northeast1"
+resource.labels.cluster_name="test-cluster"
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.serviceName="container.googleapis.com"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "GKE Audit logs" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "GKE Audit logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/impl/query.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/impl/query.go
@@ -18,72 +18,79 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudloggkeautoscaler_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudloggkeautoscaler/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-func generateAutoscalerQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, excludeStatus bool) string {
-	excludeStatusQueryFragment := "-- include query for status log"
-	if excludeStatus {
-		excludeStatusQueryFragment = `-jsonPayload.status: ""`
+// GenerateAutoscalerStructuredQuery generates a structured query for GKE cluster autoscaler logs.
+func GenerateAutoscalerStructuredQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, excludeStatus bool) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(cluster.ProjectID)),
+		logestimator.ResourceLabel("location", logestimator.Exact(cluster.Location)),
+		logestimator.ResourceLabel("cluster_name", logestimator.Exact(cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster))),
+		logestimator.LogID(logestimator.Exact("container.googleapis.com/cluster-autoscaler-visibility")),
 	}
-	return fmt.Sprintf(`resource.type="k8s_cluster"
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"
-%s
-logName="projects/%s/logs/container.googleapis.com%%2Fcluster-autoscaler-visibility"`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), excludeStatusQueryFragment, cluster.ProjectID)
+	if excludeStatus {
+		filters = append(filters, logestimator.CustomFilter(`-jsonPayload.status: ""`))
+	}
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    !cluster.IsComplete(),
+		ResourceTypes: []string{"k8s_cluster"},
+		Filters:       filters,
+	}
+}
+
+// GenerateAutoscalerQuery generates a query for GKE cluster autoscaler logs.
+func GenerateAutoscalerQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, excludeStatus bool) string {
+	return GenerateAutoscalerStructuredQuery(cluster, excludeStatus).GenerateCloudLoggingQuery()
+}
+
+func generateAutoscalerQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, excludeStatus bool) string {
+	return GenerateAutoscalerQuery(cluster, excludeStatus)
 }
 
 type autoscalerListLogEntriesTaskSetting struct{}
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (a *autoscalerListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (a *autoscalerListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(),
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (a *autoscalerListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "Cluster autoscaler logs",
-		ExampleQuery: generateAutoscalerQuery(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:   "gcp-project-id",
-			Location:    "gcp-location",
-			ClusterName: "gcp-cluster-name",
-		}, true),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (a *autoscalerListLogEntriesTaskSetting) QueryName() string {
+	return "Cluster autoscaler logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (a *autoscalerListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (a *autoscalerListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref())
-	return []string{generateAutoscalerQuery(cluster, true)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateAutoscalerStructuredQuery(cluster, true)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (a *autoscalerListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudloggkeautoscaler_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (a *autoscalerListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 1, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*autoscalerListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*autoscalerListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&autoscalerListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&autoscalerListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/impl/query_test.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/impl/query_test.go
@@ -16,87 +16,184 @@ package googlecloudloggkeautoscaler_impl
 
 import (
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateAutoscalerQuery(t *testing.T) {
+func TestGenerateAutoscalerStructuredQuery(t *testing.T) {
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ProjectID:   "my-project",
+		Location:    "my-location",
+		ClusterName: "my-cluster",
+	}
+
 	testCases := []struct {
-		cluster       googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		excludeStatus bool
-		expected      string
+		name                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		excludeStatus          bool
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "my-project",
-				Location:    "my-location",
-				ClusterName: "my-cluster",
-			},
+			name:          "include status (pure metric)",
+			cluster:       cluster,
 			excludeStatus: false,
-			expected: `resource.type="k8s_cluster"
+			wantQuery: `resource.type="k8s_cluster"
 resource.labels.project_id="my-project"
 resource.labels.location="my-location"
 resource.labels.cluster_name="my-cluster"
--- include query for status log
-logName="projects/my-project/logs/container.googleapis.com%2Fcluster-autoscaler-visibility"`,
+LOG_ID("container.googleapis.com/cluster-autoscaler-visibility")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "my-project" AND resource.labels.location = "my-location" AND resource.labels.cluster_name = "my-cluster" AND metric.labels.log = "container.googleapis.com/cluster-autoscaler-visibility"`,
+			},
+			wantSupportMetricsFlag: true,
 		},
 		{
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "my-project",
-				Location:    "my-location",
-				ClusterName: "my-cluster",
-			},
+			name:          "exclude status (probe fallback)",
+			cluster:       cluster,
 			excludeStatus: true,
-			expected: `resource.type="k8s_cluster"
+			wantQuery: `resource.type="k8s_cluster"
 resource.labels.project_id="my-project"
 resource.labels.location="my-location"
 resource.labels.cluster_name="my-cluster"
--jsonPayload.status: ""
-logName="projects/my-project/logs/container.googleapis.com%2Fcluster-autoscaler-visibility"`,
+LOG_ID("container.googleapis.com/cluster-autoscaler-visibility")
+-jsonPayload.status: ""`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "my-project" AND resource.labels.location = "my-location" AND resource.labels.cluster_name = "my-cluster" AND metric.labels.log = "container.googleapis.com/cluster-autoscaler-visibility"`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		result := generateAutoscalerQuery(tc.cluster, tc.excludeStatus)
-		if result != tc.expected {
-			t.Errorf("Expected query:\n%s\nGot:\n%s", tc.expected, result)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			sq := GenerateAutoscalerStructuredQuery(tc.cluster, tc.excludeStatus)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := generateAutoscalerQuery(tc.cluster, tc.excludeStatus)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("generateAutoscalerQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
+			}
+		})
 	}
 }
 
 func TestGeneratedAutoscalerQueryIsValid(t *testing.T) {
 	testCases := []struct {
-		Name          string
-		Cluster       googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		ExcludeStatus bool
+		name          string
+		cluster       googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		excludeStatus bool
 	}{
 		{
-			Name: "Valid Query",
-			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+			name: "Valid Query",
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
 				ProjectID:   "gcp-project-id",
 				Location:    "gcp-location",
 				ClusterName: "gcp-cluster-name",
 			},
-			ExcludeStatus: false,
+			excludeStatus: false,
 		},
 		{
-			Name: "Valid Query with Exclude Status",
-			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+			name: "Valid Query with Exclude Status",
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
 				ProjectID:   "gcp-project-id",
 				Location:    "gcp-location",
 				ClusterName: "gcp-cluster-name",
 			},
-			ExcludeStatus: true,
+			excludeStatus: true,
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			query := generateAutoscalerQuery(tc.Cluster, tc.ExcludeStatus)
+		t.Run(tc.name, func(t *testing.T) {
+			query := generateAutoscalerQuery(tc.cluster, tc.excludeStatus)
 			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
-				t.Errorf("%s", err.Error())
+				t.Errorf("IsValidLogQuery error: %s", err.Error())
 			}
 		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1-a",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(), cluster),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="k8s_cluster"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("container.googleapis.com/cluster-autoscaler-visibility")
+-jsonPayload.status: ""
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "Cluster autoscaler logs" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "Cluster autoscaler logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/query.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/query.go
@@ -20,28 +20,27 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8saudit/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
-
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 )
 
-var GCPK8sAuditLogListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&GCPK8sAuditLogListLogEntriesTaskSetting{})
+var GCPK8sAuditLogListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&GCPK8sAuditLogListLogEntriesTaskSetting{})
 
 type GCPK8sAuditLogListLogEntriesTaskSetting struct{}
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *GCPK8sAuditLogListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *GCPK8sAuditLogListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(),
@@ -50,59 +49,67 @@ func (k *GCPK8sAuditLogListLogEntriesTaskSetting) Dependencies() []taskid.Untype
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (k *GCPK8sAuditLogListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-		QueryName: "K8s audit logs",
-
-		ExampleQuery: GenerateK8sAuditQuery(
-			googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				Location:    "test-location",
-				ClusterName: "test-cluster",
-			},
-			&gcpqueryutil.SetFilterParseResult{
-				Additives: []string{"deployments", "replicasets", "pods", "nodes"},
-			},
-			&gcpqueryutil.SetFilterParseResult{
-				Additives: []string{"#cluster-scoped", "#namespaced"},
-			},
-		),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (k *GCPK8sAuditLogListLogEntriesTaskSetting) QueryName() string {
+	return "K8s audit logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (k *GCPK8sAuditLogListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (k *GCPK8sAuditLogListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref())
 	kindFilter := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputKindFilterTaskID.Ref())
 	namespaceFilter := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputNamespaceFilterTaskID.Ref())
 
-	return []string{GenerateK8sAuditQuery(cluster, kindFilter, namespaceFilter)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateK8sAuditStructuredQuery(cluster, kindFilter, namespaceFilter)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *GCPK8sAuditLogListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogk8saudit_contract.GCPK8sAuditLogListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *GCPK8sAuditLogListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*GCPK8sAuditLogListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*GCPK8sAuditLogListLogEntriesTaskSetting)(nil)
+
+// GenerateK8sAuditStructuredQuery constructs a StructuredLogQuery for fetching
+// Kubernetes audit logs based on cluster identity, kind filters, and namespace filters.
+func GenerateK8sAuditStructuredQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, auditKindFilter *gcpqueryutil.SetFilterParseResult, namespaceFilter *gcpqueryutil.SetFilterParseResult) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(cluster.ProjectID)),
+		logestimator.ResourceLabel("location", logestimator.Exact(cluster.Location)),
+		logestimator.ResourceLabel("cluster_name", logestimator.Exact(cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster))),
+		logestimator.CustomFilter(`protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")`),
+	}
+
+	if auditKindFilter != nil {
+		kindSnippet := generateAuditKindFilter(auditKindFilter)
+		if kindSnippet != "" && kindSnippet != "-- No kind filter" {
+			filters = append(filters, logestimator.CustomFilter(kindSnippet))
+		}
+	}
+
+	if namespaceFilter != nil {
+		namespaceSnippet := generateK8sAuditNamespaceFilter(namespaceFilter)
+		if namespaceSnippet != "" && namespaceSnippet != "-- No namespace filter" {
+			filters = append(filters, logestimator.CustomFilter(namespaceSnippet))
+		}
+	}
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    !cluster.IsComplete(),
+		ResourceTypes: []string{"k8s_cluster"},
+		Filters:       filters,
+	}
+}
 
 // GenerateK8sAuditQuery constructs a Google Cloud Logging query string for fetching
 // Kubernetes audit logs based on cluster name, kind filters, and namespace filters.
 func GenerateK8sAuditQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, auditKindFilter *gcpqueryutil.SetFilterParseResult, namespaceFilter *gcpqueryutil.SetFilterParseResult) string {
-	return fmt.Sprintf(`resource.type="k8s_cluster"
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"
-protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
-%s
-%s
-`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateAuditKindFilter(auditKindFilter), generateK8sAuditNamespaceFilter(namespaceFilter))
+	return GenerateK8sAuditStructuredQuery(cluster, auditKindFilter, namespaceFilter).GenerateCloudLoggingQuery()
 }
 
 // generateAuditKindFilter creates a log filter snippet for Kubernetes resource kinds

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/query.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/query.go
@@ -85,18 +85,12 @@ func GenerateK8sAuditStructuredQuery(cluster googlecloudk8scommon_contract.Googl
 		logestimator.CustomFilter(`protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")`),
 	}
 
-	if auditKindFilter != nil {
-		kindSnippet := generateAuditKindFilter(auditKindFilter)
-		if kindSnippet != "" && kindSnippet != "-- No kind filter" {
-			filters = append(filters, logestimator.CustomFilter(kindSnippet))
-		}
+	if kindFilterMatcher := generateAuditKindFilter(auditKindFilter); kindFilterMatcher != nil {
+		filters = append(filters, kindFilterMatcher)
 	}
 
-	if namespaceFilter != nil {
-		namespaceSnippet := generateK8sAuditNamespaceFilter(namespaceFilter)
-		if namespaceSnippet != "" && namespaceSnippet != "-- No namespace filter" {
-			filters = append(filters, logestimator.CustomFilter(namespaceSnippet))
-		}
+	if namespaceFilterMatcher := generateK8sAuditNamespaceFilter(namespaceFilter); namespaceFilterMatcher != nil {
+		filters = append(filters, namespaceFilterMatcher)
 	}
 
 	return &logestimator.StructuredLogQuery{
@@ -114,60 +108,64 @@ func GenerateK8sAuditQuery(cluster googlecloudk8scommon_contract.GoogleCloudClus
 
 // generateAuditKindFilter creates a log filter snippet for Kubernetes resource kinds
 // based on the parsed filter result.
-func generateAuditKindFilter(filter *gcpqueryutil.SetFilterParseResult) string {
+func generateAuditKindFilter(filter *gcpqueryutil.SetFilterParseResult) logestimator.LoggingMonitoringMatcher {
+	if filter == nil {
+		return nil
+	}
 	if filter.ValidationError != "" {
-		return fmt.Sprintf(`-- Failed to generate kind filter due to the validation error "%s"`, filter.ValidationError)
+		return logestimator.Comment(fmt.Sprintf(`Failed to generate kind filter due to the validation error "%s"`, filter.ValidationError))
 	}
 	if filter.SubtractMode {
 		if len(filter.Subtractives) == 0 {
-			return "-- No kind filter"
+			return nil
 		}
-		return fmt.Sprintf(`-protoPayload.methodName=~"\.(%s)\."`, strings.Join(filter.Subtractives, "|"))
-	} else {
-		if len(filter.Additives) == 0 {
-			return `-- Invalid: none of the resources will be selected. Ignoring kind filter.`
-		}
-		return fmt.Sprintf(`protoPayload.methodName=~"\.(%s)\."`, strings.Join(filter.Additives, "|"))
+		return logestimator.CustomFilter(fmt.Sprintf(`-protoPayload.methodName=~"\.(%s)\."`, strings.Join(filter.Subtractives, "|")))
 	}
+	if len(filter.Additives) == 0 {
+		return logestimator.Comment("Invalid: none of the resources will be selected. Ignoring kind filter.")
+	}
+	return logestimator.CustomFilter(fmt.Sprintf(`protoPayload.methodName=~"\.(%s)\."`, strings.Join(filter.Additives, "|")))
 }
 
 // generateK8sAuditNamespaceFilter creates a log filter snippet for Kubernetes namespaces
 // based on the parsed filter result.
-func generateK8sAuditNamespaceFilter(filter *gcpqueryutil.SetFilterParseResult) string {
+func generateK8sAuditNamespaceFilter(filter *gcpqueryutil.SetFilterParseResult) logestimator.LoggingMonitoringMatcher {
+	if filter == nil {
+		return nil
+	}
 	if filter.ValidationError != "" {
-		return fmt.Sprintf(`-- Failed to generate namespace filter due to the validation error "%s"`, filter.ValidationError)
+		return logestimator.Comment(fmt.Sprintf(`Failed to generate namespace filter due to the validation error "%s"`, filter.ValidationError))
 	}
 	if filter.SubtractMode {
-		return "-- Unsupported operation"
-	} else {
-		hasClusterScope := slices.Contains(filter.Additives, "#cluster-scoped")
-		hasNamespacedScope := slices.Contains(filter.Additives, "#namespaced")
-		if hasClusterScope && hasNamespacedScope {
-			return "-- No namespace filter"
-		}
-		if !hasClusterScope && hasNamespacedScope {
-			return `protoPayload.resourceName:"namespaces/"`
-		}
-		if hasClusterScope && !hasNamespacedScope {
-			if len(filter.Additives) == 1 { // 1 is used for #cluster-scope
-				return `-protoPayload.resourceName:"/namespaces/"`
-			}
-			resourceNameContains := []string{}
-			for _, additive := range filter.Additives {
-				if strings.HasPrefix(additive, "#") {
-					continue
-				}
-				resourceNameContains = append(resourceNameContains, fmt.Sprintf(`"/namespaces/%s"`, additive))
-			}
-			return fmt.Sprintf(`(protoPayload.resourceName:(%s) OR NOT (protoPayload.resourceName:"/namespaces/"))`, strings.Join(resourceNameContains, " OR "))
-		}
-		if len(filter.Additives) == 0 {
-			return `-- Invalid: none of the resources will be selected. Ignoring namespace filter.`
+		return logestimator.Comment("Unsupported operation")
+	}
+	hasClusterScope := slices.Contains(filter.Additives, "#cluster-scoped")
+	hasNamespacedScope := slices.Contains(filter.Additives, "#namespaced")
+	if hasClusterScope && hasNamespacedScope {
+		return nil
+	}
+	if !hasClusterScope && hasNamespacedScope {
+		return logestimator.CustomFilter(`protoPayload.resourceName:"namespaces/"`)
+	}
+	if hasClusterScope && !hasNamespacedScope {
+		if len(filter.Additives) == 1 { // 1 is used for #cluster-scope
+			return logestimator.CustomFilter(`-protoPayload.resourceName:"/namespaces/"`)
 		}
 		resourceNameContains := []string{}
 		for _, additive := range filter.Additives {
+			if strings.HasPrefix(additive, "#") {
+				continue
+			}
 			resourceNameContains = append(resourceNameContains, fmt.Sprintf(`"/namespaces/%s"`, additive))
 		}
-		return fmt.Sprintf(`protoPayload.resourceName:(%s)`, strings.Join(resourceNameContains, " OR "))
+		return logestimator.CustomFilter(fmt.Sprintf(`(protoPayload.resourceName:(%s) OR NOT (protoPayload.resourceName:"/namespaces/"))`, strings.Join(resourceNameContains, " OR ")))
 	}
+	if len(filter.Additives) == 0 {
+		return logestimator.Comment("Invalid: none of the resources will be selected. Ignoring namespace filter.")
+	}
+	resourceNameContains := []string{}
+	for _, additive := range filter.Additives {
+		resourceNameContains = append(resourceNameContains, fmt.Sprintf(`"/namespaces/%s"`, additive))
+	}
+	return logestimator.CustomFilter(fmt.Sprintf(`protoPayload.resourceName:(%s)`, strings.Join(resourceNameContains, " OR ")))
 }

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/query_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/query_test.go
@@ -15,54 +15,244 @@
 package googlecloudlogk8saudit_impl
 
 import (
-	"fmt"
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateK8sAuditQuery(t *testing.T) {
+func TestGenerateK8sAuditStructuredQuery(t *testing.T) {
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "foo-cluster",
+		ProjectID:   "foo-project",
+		Location:    "foo-location",
+	}
+
 	testCases := []struct {
-		ExpectedQuery        string
-		Cluster              googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		InputKindFilter      *gcpqueryutil.SetFilterParseResult
-		InputNamespaceFilter *gcpqueryutil.SetFilterParseResult
+		name                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		kindFilter             *gcpqueryutil.SetFilterParseResult
+		namespaceFilter        *gcpqueryutil.SetFilterParseResult
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			ExpectedQuery: `resource.type="k8s_cluster"
+			name:    "kind additive and namespaced scope",
+			cluster: cluster,
+			kindFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"pods", "deployments", "jobs"},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"#namespaced"},
+			},
+			wantQuery: `resource.type="k8s_cluster"
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
 protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
 protoPayload.methodName=~"\.(pods|deployments|jobs)\."
-protoPayload.resourceName:"namespaces/"
-`,
-			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ClusterName: "foo-cluster",
-				ProjectID:   "foo-project",
-				Location:    "foo-location",
+protoPayload.resourceName:"namespaces/"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
 			},
-			InputKindFilter: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"pods",
-					"deployments",
-					"jobs",
-				},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "kind subtractive and both scopes",
+			cluster: cluster,
+			kindFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{"pods", "deployments"},
 			},
-			InputNamespaceFilter: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"#namespaced",
-				},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"#cluster-scoped", "#namespaced"},
 			},
+			wantQuery: `resource.type="k8s_cluster"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+-protoPayload.methodName=~"\.(pods|deployments)\."`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "empty kind filter and cluster-scoped with specific namespace",
+			cluster: cluster,
+			kindFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"#cluster-scoped", "kube-system", "default"},
+			},
+			wantQuery: `resource.type="k8s_cluster"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+(protoPayload.resourceName:("/namespaces/kube-system" OR "/namespaces/default") OR NOT (protoPayload.resourceName:"/namespaces/"))`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "cluster-scoped only",
+			cluster: cluster,
+			kindFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"#cluster-scoped"},
+			},
+			wantQuery: `resource.type="k8s_cluster"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+-protoPayload.resourceName:"/namespaces/"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "specific namespaces only",
+			cluster: cluster,
+			kindFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"kube-system", "default"},
+			},
+			wantQuery: `resource.type="k8s_cluster"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+protoPayload.resourceName:("/namespaces/kube-system" OR "/namespaces/default")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "subtractive namespace mode (unsupported)",
+			cluster: cluster,
+			kindFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+			},
+			wantQuery: `resource.type="k8s_cluster"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+-- Unsupported operation`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "validation error on kind and namespace",
+			cluster: cluster,
+			kindFilter: &gcpqueryutil.SetFilterParseResult{
+				ValidationError: "kind error",
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				ValidationError: "namespace error",
+			},
+			wantQuery: `resource.type="k8s_cluster"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+-- Failed to generate kind filter due to the validation error "kind error"
+-- Failed to generate namespace filter due to the validation error "namespace error"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "empty additives for kind and namespace",
+			cluster: cluster,
+			kindFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{},
+			},
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{},
+			},
+			wantQuery: `resource.type="k8s_cluster"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+-- Invalid: none of the resources will be selected. Ignoring kind filter.
+-- Invalid: none of the resources will be selected. Ignoring namespace filter.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:            "nil kind and namespace filters",
+			cluster:         cluster,
+			kindFilter:      nil,
+			namespaceFilter: nil,
+			wantQuery: `resource.type="k8s_cluster"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_cluster" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 	}
-	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("testcase-%d-%s", i, testCase.ExpectedQuery), func(t *testing.T) {
-			result := GenerateK8sAuditQuery(testCase.Cluster, testCase.InputKindFilter, testCase.InputNamespaceFilter)
-			if result != testCase.ExpectedQuery {
-				t.Errorf("the result query is not valid:\nInput:\n%v\nActual:\n%s\nExpected:\n%s", testCase, result, testCase.ExpectedQuery)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sq := GenerateK8sAuditStructuredQuery(tc.cluster, tc.kindFilter, tc.namespaceFilter)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := GenerateK8sAuditQuery(tc.cluster, tc.kindFilter, tc.namespaceFilter)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("GenerateK8sAuditQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
 			}
 		})
 	}
@@ -141,144 +331,71 @@ func TestGenerateK8sAuditQueryIsValid(t *testing.T) {
 			query := GenerateK8sAuditQuery(tc.Cluster, tc.KindFilter, tc.NamespaceFilter)
 			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
-				t.Errorf("%s", err.Error())
+				t.Errorf("IsValidLogQuery error: %s", err.Error())
 			}
 		})
 	}
 }
 
-func TestGenerateNamespaceFilter(t *testing.T) {
-	testCases := []struct {
-		ExpectedQuery string
-		Input         *gcpqueryutil.SetFilterParseResult
-	}{
-		{
-			ExpectedQuery: `-- Invalid: none of the resources will be selected. Ignoring namespace filter.`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{},
-			},
-		},
-		{
-			ExpectedQuery: `-- Failed to generate namespace filter due to the validation error "test error"`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				ValidationError: "test error",
-			},
-		},
-		{
-			ExpectedQuery: `protoPayload.resourceName:("/namespaces/kube-system" OR "/namespaces/default")`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"kube-system",
-					"default",
-				},
-			},
-		},
-		{
-			ExpectedQuery: `protoPayload.resourceName:("/namespaces/kube-system" OR "/namespaces/default")`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"kube-system",
-					"default",
-				},
-			},
-		},
-		{
-			ExpectedQuery: `-- No namespace filter`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"#cluster-scoped",
-					"#namespaced",
-				},
-			},
-		},
-		{
-			ExpectedQuery: `protoPayload.resourceName:"namespaces/"`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"#namespaced",
-				},
-			},
-		},
-		{
-			ExpectedQuery: `(protoPayload.resourceName:("/namespaces/kube-system" OR "/namespaces/default") OR NOT (protoPayload.resourceName:"/namespaces/"))`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"#cluster-scoped",
-					"kube-system",
-					"default",
-				},
-			},
-		},
-		{
-			ExpectedQuery: `-protoPayload.resourceName:"/namespaces/"`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"#cluster-scoped",
-				},
-			},
-		},
-	}
-	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("testcase-%d-%s", i, testCase.ExpectedQuery), func(t *testing.T) {
-			result := generateK8sAuditNamespaceFilter(testCase.Input)
-			if result != testCase.ExpectedQuery {
-				t.Errorf("the result query is not valid:\nInput:\n%v\nActual:\n%s\nExpected:\n%s", testCase.Input, result, testCase.ExpectedQuery)
-			}
-		})
-	}
-}
+func TestGCPK8sAuditLogListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
 
-func TestKindNameFilter(t *testing.T) {
-	testCases := []struct {
-		ExpectedQuery string
-		Input         *gcpqueryutil.SetFilterParseResult
-	}{
-		{
-			ExpectedQuery: `-- Failed to generate kind filter due to the validation error "test error"`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				ValidationError: "test error",
-			},
-		},
-		{
-			ExpectedQuery: `-- Invalid: none of the resources will be selected. Ignoring kind filter.`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{},
-			},
-		},
-		{
-			ExpectedQuery: `protoPayload.methodName=~"\.(pods)\."`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{"pods"},
-			},
-		},
-		{
-			ExpectedQuery: `protoPayload.methodName=~"\.(pods|deployments)\."`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{"pods", "deployments"},
-			},
-		},
-		{
-			ExpectedQuery: `-protoPayload.methodName=~"\.(pods|deployments)\."`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Subtractives: []string{"pods", "deployments"},
-				SubtractMode: true,
-			},
-		},
-		{
-			ExpectedQuery: `-- No kind filter`,
-			Input: &gcpqueryutil.SetFilterParseResult{
-				Subtractives: []string{},
-				SubtractMode: true,
-			},
-		},
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1-a",
 	}
 
-	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("testcase-%d-%s", i, testCase.ExpectedQuery), func(t *testing.T) {
-			result := generateAuditKindFilter(testCase.Input)
-			if result != testCase.ExpectedQuery {
-				t.Errorf("the result query is not valid:\nInput:\n%v\nActual:\n%s\nExpected:\n%s", testCase.Input, result, testCase.ExpectedQuery)
-			}
-		})
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, GCPK8sAuditLogListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.InputKindFilterTaskID.Ref(), &gcpqueryutil.SetFilterParseResult{Additives: []string{"pods"}}),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.InputNamespaceFilterTaskID.Ref(), &gcpqueryutil.SetFilterParseResult{Additives: []string{"#namespaced"}}),
+	)
+	if err != nil {
+		t.Fatalf("DryRun returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("DryRun should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="k8s_cluster"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+protoPayload.methodName: ("create" OR "update" OR "patch" OR "delete")
+protoPayload.methodName=~"\.(pods)\."
+protoPayload.resourceName:"namespaces/"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("Query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "K8s audit logs" {
+		t.Errorf("Query Name mismatch: got %q, want %q", serialized[0].Name, "K8s audit logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -26,19 +27,59 @@ import (
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogk8scontainer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontainer/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
+
+// GenerateK8sContainerStructuredQuery constructs a StructuredLogQuery for Kubernetes container logs.
+func GenerateK8sContainerStructuredQuery(
+	cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity,
+	namespacesFilter *gcpqueryutil.SetFilterParseResult,
+	podNamesFilter *gcpqueryutil.SetFilterParseResult,
+) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(cluster.ProjectID)),
+		logestimator.ResourceLabel("location", logestimator.Exact(cluster.Location)),
+		logestimator.ResourceLabel("cluster_name", logestimator.Exact(cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster))),
+		logestimator.LogID(logestimator.NoneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")),
+	}
+
+	if namespacesFilter != nil {
+		switch {
+		case namespacesFilter.ValidationError != "":
+			filters = append(filters, logestimator.CustomFilter(generateNamespacesFilter(namespacesFilter)))
+		case namespacesFilter.SubtractMode:
+			if len(namespacesFilter.Subtractives) > 0 {
+				filters = append(filters, logestimator.ResourceLabel("namespace_name", logestimator.NoneOf(namespacesFilter.Subtractives...)))
+			}
+		case len(namespacesFilter.Additives) == 0:
+			filters = append(filters, logestimator.CustomFilter(generateNamespacesFilter(namespacesFilter)))
+		default:
+			filters = append(filters, logestimator.ResourceLabel("namespace_name", logestimator.OneOf(namespacesFilter.Additives...)))
+		}
+	}
+
+	if podNamesFilter != nil {
+		switch {
+		case podNamesFilter.ValidationError != "":
+			filters = append(filters, logestimator.CustomFilter(generatePodNamesFilter(podNamesFilter)))
+		case podNamesFilter.SubtractMode:
+			if len(podNamesFilter.Subtractives) > 0 {
+				filters = append(filters, logestimator.CustomFilter(generatePodNamesFilter(podNamesFilter)))
+			}
+		default:
+			filters = append(filters, logestimator.CustomFilter(generatePodNamesFilter(podNamesFilter)))
+		}
+	}
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    !cluster.IsComplete(),
+		ResourceTypes: []string{"k8s_container"},
+		Filters:       filters,
+	}
+}
 
 // GenerateK8sContainerQuery generates a Cloud Logging query for Kubernetes container logs.
 func GenerateK8sContainerQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, namespacesFilter *gcpqueryutil.SetFilterParseResult, podNamesFilter *gcpqueryutil.SetFilterParseResult) string {
-	return fmt.Sprintf(`resource.type="k8s_container"
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"
--LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
--LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
-%s
-%s`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateNamespacesFilter(namespacesFilter), generatePodNamesFilter(podNamesFilter))
+	return GenerateK8sContainerStructuredQuery(cluster, namespacesFilter, podNamesFilter).GenerateCloudLoggingQuery()
 }
 
 func generateNamespacesFilter(namespacesFilter *gcpqueryutil.SetFilterParseResult) string {
@@ -96,13 +137,13 @@ func generatePodNamesFilter(podNamesFilter *gcpqueryutil.SetFilterParseResult) s
 type containerListLogEntriesTaskSetting struct {
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *containerListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *containerListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref(),
@@ -111,46 +152,32 @@ func (c *containerListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTask
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *containerListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "K8s container logs",
-		ExampleQuery: GenerateK8sContainerQuery(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:   "test-project",
-			Location:    "test-location",
-			ClusterName: "test-cluster",
-		},
-			&gcpqueryutil.SetFilterParseResult{
-				Additives: []string{"default"},
-			},
-			&gcpqueryutil.SetFilterParseResult{
-				Subtractives: []string{"nginx-", "redis"},
-				SubtractMode: true,
-			},
-		),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *containerListLogEntriesTaskSetting) QueryName() string {
+	return "K8s container logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *containerListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *containerListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref())
 	namespacesFilter := coretask.GetTaskResult(ctx, googlecloudlogk8scontainer_contract.InputContainerQueryNamespacesTaskID.Ref())
 	podNamesFilter := coretask.GetTaskResult(ctx, googlecloudlogk8scontainer_contract.InputContainerQueryPodNamesTaskID.Ref())
 
-	return []string{GenerateK8sContainerQuery(cluster, namespacesFilter, podNamesFilter)}, nil
+	return []*logestimator.StructuredLogQuery{
+		GenerateK8sContainerStructuredQuery(cluster, namespacesFilter, podNamesFilter),
+	}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *containerListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogk8scontainer_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *containerListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*containerListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*containerListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&containerListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&containerListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task.go
@@ -17,7 +17,6 @@ package googlecloudlogk8scontainer_impl
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
@@ -42,32 +41,12 @@ func GenerateK8sContainerStructuredQuery(
 		logestimator.LogID(logestimator.NoneOf("server-accesslog-stackdriver", "client-accesslog-stackdriver")),
 	}
 
-	if namespacesFilter != nil {
-		switch {
-		case namespacesFilter.ValidationError != "":
-			filters = append(filters, logestimator.CustomFilter(generateNamespacesFilter(namespacesFilter)))
-		case namespacesFilter.SubtractMode:
-			if len(namespacesFilter.Subtractives) > 0 {
-				filters = append(filters, logestimator.ResourceLabel("namespace_name", logestimator.NoneOf(namespacesFilter.Subtractives...)))
-			}
-		case len(namespacesFilter.Additives) == 0:
-			filters = append(filters, logestimator.CustomFilter(generateNamespacesFilter(namespacesFilter)))
-		default:
-			filters = append(filters, logestimator.ResourceLabel("namespace_name", logestimator.OneOf(namespacesFilter.Additives...)))
-		}
+	if nsMatcher := generateNamespacesFilter(namespacesFilter); nsMatcher != nil {
+		filters = append(filters, nsMatcher)
 	}
 
-	if podNamesFilter != nil {
-		switch {
-		case podNamesFilter.ValidationError != "":
-			filters = append(filters, logestimator.CustomFilter(generatePodNamesFilter(podNamesFilter)))
-		case podNamesFilter.SubtractMode:
-			if len(podNamesFilter.Subtractives) > 0 {
-				filters = append(filters, logestimator.CustomFilter(generatePodNamesFilter(podNamesFilter)))
-			}
-		default:
-			filters = append(filters, logestimator.CustomFilter(generatePodNamesFilter(podNamesFilter)))
-		}
+	if podMatcher := generatePodNamesFilter(podNamesFilter); podMatcher != nil {
+		filters = append(filters, podMatcher)
 	}
 
 	return &logestimator.StructuredLogQuery{
@@ -82,56 +61,44 @@ func GenerateK8sContainerQuery(cluster googlecloudk8scommon_contract.GoogleCloud
 	return GenerateK8sContainerStructuredQuery(cluster, namespacesFilter, podNamesFilter).GenerateCloudLoggingQuery()
 }
 
-func generateNamespacesFilter(namespacesFilter *gcpqueryutil.SetFilterParseResult) string {
+func generateNamespacesFilter(namespacesFilter *gcpqueryutil.SetFilterParseResult) logestimator.LoggingMonitoringMatcher {
+	if namespacesFilter == nil {
+		return nil
+	}
 	if namespacesFilter.ValidationError != "" {
-		return fmt.Sprintf("-- Failed to generate namespaces filter due to the validation error \"%s\"", namespacesFilter.ValidationError)
+		return logestimator.Comment(fmt.Sprintf(`Failed to generate namespaces filter due to the validation error "%s"`, namespacesFilter.ValidationError))
 	}
 	if namespacesFilter.SubtractMode {
 		if len(namespacesFilter.Subtractives) == 0 {
-			return "-- No namespace filter"
+			return nil
 		}
-		namespacesWithQuotes := []string{}
-		for _, namespace := range namespacesFilter.Subtractives {
-			namespacesWithQuotes = append(namespacesWithQuotes, fmt.Sprintf(`"%s"`, namespace))
-		}
-		return fmt.Sprintf(`-resource.labels.namespace_name=(%s)`, strings.Join(namespacesWithQuotes, " OR "))
+		return logestimator.ResourceLabel("namespace_name", logestimator.NoneOf(namespacesFilter.Subtractives...))
 	}
 
 	if len(namespacesFilter.Additives) == 0 {
-		return `-- Invalid: none of the resources will be selected. Ignoring namespace filter.`
+		return logestimator.Comment("Invalid: none of the resources will be selected. Ignoring namespace filter.")
 	}
-	namespacesWithQuotes := []string{}
-	for _, namespace := range namespacesFilter.Additives {
-		namespacesWithQuotes = append(namespacesWithQuotes, fmt.Sprintf(`"%s"`, namespace))
-	}
-	return fmt.Sprintf(`resource.labels.namespace_name=(%s)`, strings.Join(namespacesWithQuotes, " OR "))
-
+	return logestimator.ResourceLabel("namespace_name", logestimator.OneOf(namespacesFilter.Additives...))
 }
 
-func generatePodNamesFilter(podNamesFilter *gcpqueryutil.SetFilterParseResult) string {
+func generatePodNamesFilter(podNamesFilter *gcpqueryutil.SetFilterParseResult) logestimator.LoggingMonitoringMatcher {
+	if podNamesFilter == nil {
+		return nil
+	}
 	if podNamesFilter.ValidationError != "" {
-		return fmt.Sprintf("-- Failed to generate pod name filter due to the validation error \"%s\"", podNamesFilter.ValidationError)
+		return logestimator.Comment(fmt.Sprintf(`Failed to generate pod name filter due to the validation error "%s"`, podNamesFilter.ValidationError))
 	}
 	if podNamesFilter.SubtractMode {
 		if len(podNamesFilter.Subtractives) == 0 {
-			return "-- No pod name filter"
+			return nil
 		}
-
-		podNamesWithQuotes := []string{}
-		for _, podName := range podNamesFilter.Subtractives {
-			podNamesWithQuotes = append(podNamesWithQuotes, fmt.Sprintf(`"%s"`, podName))
-		}
-		return fmt.Sprintf(`-resource.labels.pod_name:(%s)`, strings.Join(podNamesWithQuotes, " OR "))
+		return logestimator.ResourceLabel("pod_name", logestimator.NotContainsAny(podNamesFilter.Subtractives...))
 	}
 
 	if len(podNamesFilter.Additives) == 0 {
-		return `-- Invalid: none of the resources will be selected. Ignoring pod name filter.`
+		return logestimator.Comment("Invalid: none of the resources will be selected. Ignoring pod name filter.")
 	}
-	podNamesWithQuotes := []string{}
-	for _, podName := range podNamesFilter.Additives {
-		podNamesWithQuotes = append(podNamesWithQuotes, fmt.Sprintf(`"%s"`, podName))
-	}
-	return fmt.Sprintf(`resource.labels.pod_name:(%s)`, strings.Join(podNamesWithQuotes, " OR "))
+	return logestimator.ResourceLabel("pod_name", logestimator.ContainsAny(podNamesFilter.Additives...))
 }
 
 type containerListLogEntriesTaskSetting struct {

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task_test.go
@@ -93,7 +93,7 @@ resource.labels.cluster_name="foo-cluster"
 -LOG_ID("server-accesslog-stackdriver")
 -LOG_ID("client-accesslog-stackdriver")
 -- Invalid: none of the resources will be selected. Ignoring namespace filter.
-resource.labels.pod_name:("nginx-pod")`,
+resource.labels.pod_name:"nginx-pod"`,
 		},
 		{
 			Name: "with both filters",
@@ -111,7 +111,7 @@ resource.labels.cluster_name="foo-cluster"
 -LOG_ID("server-accesslog-stackdriver")
 -LOG_ID("client-accesslog-stackdriver")
 resource.labels.namespace_name="kube-system"
-resource.labels.pod_name:("nginx-pod")`,
+resource.labels.pod_name:"nginx-pod"`,
 		},
 		{
 			Name: "with complex filters",
@@ -287,15 +287,15 @@ func TestGenerateK8sContainerStructuredQuery_MetricSupport(t *testing.T) {
 			wantMonitoringFilterBody: `resource.type = "k8s_container" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver" AND resource.labels.namespace_name != "kube-system"`,
 		},
 		{
-			desc: "not all supported when custom pod name filter is present",
+			desc: "all supported when pod name filter is present with has_substring",
 			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"kube-system"},
 			},
 			podNameFilter: &gcpqueryutil.SetFilterParseResult{
 				Additives: []string{"nginx-pod"},
 			},
-			wantAllSupported:         false,
-			wantMonitoringFilterBody: `resource.type = "k8s_container" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver" AND resource.labels.namespace_name = "kube-system"`,
+			wantAllSupported:         true,
+			wantMonitoringFilterBody: `resource.type = "k8s_container" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver" AND resource.labels.namespace_name = "kube-system" AND resource.labels.pod_name = has_substring("nginx-pod")`,
 		},
 	}
 

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/query_task_test.go
@@ -16,10 +16,21 @@ package googlecloudlogk8scontainer_impl
 
 import (
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogk8scontainer_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontainer/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGenerateK8sContainerQueryIsValid(t *testing.T) {
@@ -43,8 +54,8 @@ func TestGenerateK8sContainerQueryIsValid(t *testing.T) {
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
--LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
 -- Invalid: none of the resources will be selected. Ignoring namespace filter.
 -- Invalid: none of the resources will be selected. Ignoring pod name filter.`,
 		},
@@ -61,9 +72,9 @@ resource.labels.cluster_name="foo-cluster"
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
--LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
-resource.labels.namespace_name=("kube-system")
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
+resource.labels.namespace_name="kube-system"
 -- Invalid: none of the resources will be selected. Ignoring pod name filter.`,
 		},
 		{
@@ -79,8 +90,8 @@ resource.labels.namespace_name=("kube-system")
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
--LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
 -- Invalid: none of the resources will be selected. Ignoring namespace filter.
 resource.labels.pod_name:("nginx-pod")`,
 		},
@@ -97,9 +108,9 @@ resource.labels.pod_name:("nginx-pod")`,
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
--LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
-resource.labels.namespace_name=("kube-system")
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
+resource.labels.namespace_name="kube-system"
 resource.labels.pod_name:("nginx-pod")`,
 		},
 		{
@@ -115,22 +126,256 @@ resource.labels.pod_name:("nginx-pod")`,
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--LOG_ID("server-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
--LOG_ID("client-accesslog-stackdriver") -- Use CSM Traffic log parser for CSM traffic log
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
 resource.labels.namespace_name=("kube-system" OR "istio-system")
 resource.labels.pod_name:("nginx-pod" OR "apache-pod")`,
+		},
+		{
+			Name: "with subtractive namespace filter",
+			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "foo-cluster",
+				ProjectID:   "foo-project",
+				Location:    "foo-location",
+			},
+			PodNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{}},
+			NamespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{"kube-system", "istio-system"},
+			},
+			ExpectedQuery: `resource.type="k8s_container"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
+-resource.labels.namespace_name=("kube-system" OR "istio-system")`,
+		},
+		{
+			Name: "with subtractive pod name filter",
+			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "foo-cluster",
+				ProjectID:   "foo-project",
+				Location:    "foo-location",
+			},
+			PodNameFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{"nginx-", "redis"},
+			},
+			NamespaceFilter: &gcpqueryutil.SetFilterParseResult{Additives: []string{"default"}},
+			ExpectedQuery: `resource.type="k8s_container"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
+resource.labels.namespace_name="default"
+-resource.labels.pod_name:("nginx-" OR "redis")`,
+		},
+		{
+			Name: "with empty subtractive namespace filter",
+			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "foo-cluster",
+				ProjectID:   "foo-project",
+				Location:    "foo-location",
+			},
+			PodNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{}},
+			NamespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{},
+			},
+			ExpectedQuery: `resource.type="k8s_container"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")`,
+		},
+		{
+			Name: "with validation error on namespace and pod name",
+			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "foo-cluster",
+				ProjectID:   "foo-project",
+				Location:    "foo-location",
+			},
+			PodNameFilter: &gcpqueryutil.SetFilterParseResult{
+				ValidationError: "invalid pod regex",
+			},
+			NamespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				ValidationError: "invalid namespace regex",
+			},
+			ExpectedQuery: `resource.type="k8s_container"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
+-- Failed to generate namespaces filter due to the validation error "invalid namespace regex"
+-- Failed to generate pod name filter due to the validation error "invalid pod regex"`,
+		},
+		{
+			Name: "with nil namespace and pod name filters",
+			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "foo-cluster",
+				ProjectID:   "foo-project",
+				Location:    "foo-location",
+			},
+			PodNameFilter:   nil,
+			NamespaceFilter: nil,
+			ExpectedQuery: `resource.type="k8s_container"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")`,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			query := GenerateK8sContainerQuery(tc.Cluster, tc.NamespaceFilter, tc.PodNameFilter)
-			if query != tc.ExpectedQuery {
-				t.Errorf("GenerateK8sContainerQuery() = %v, want %v", query, tc.ExpectedQuery)
+			if diff := cmp.Diff(tc.ExpectedQuery, query); diff != "" {
+				t.Errorf("GenerateK8sContainerQuery() mismatch (-want +got):\n%s", diff)
 			}
 			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
 				t.Errorf("%s", err.Error())
 			}
 		})
+	}
+}
+
+func TestGenerateK8sContainerStructuredQuery_MetricSupport(t *testing.T) {
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "foo-cluster",
+		ProjectID:   "foo-project",
+		Location:    "foo-location",
+	}
+
+	testCases := []struct {
+		desc                     string
+		namespaceFilter          *gcpqueryutil.SetFilterParseResult
+		podNameFilter            *gcpqueryutil.SetFilterParseResult
+		wantAllSupported         bool
+		wantMonitoringFilterBody string
+	}{
+		{
+			desc: "all supported when single namespace and no pod name filter",
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"kube-system"},
+			},
+			podNameFilter:            &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{}},
+			wantAllSupported:         true,
+			wantMonitoringFilterBody: `resource.type = "k8s_container" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver" AND resource.labels.namespace_name = "kube-system"`,
+		},
+		{
+			desc: "all supported when multiple namespaces with one_of",
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"kube-system", "istio-system"},
+			},
+			podNameFilter:            &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{}},
+			wantAllSupported:         true,
+			wantMonitoringFilterBody: `resource.type = "k8s_container" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver" AND resource.labels.namespace_name = one_of("kube-system", "istio-system")`,
+		},
+		{
+			desc: "all supported when subtractive namespace filter",
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+				Subtractives: []string{"kube-system"},
+			},
+			podNameFilter:            &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{}},
+			wantAllSupported:         true,
+			wantMonitoringFilterBody: `resource.type = "k8s_container" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver" AND resource.labels.namespace_name != "kube-system"`,
+		},
+		{
+			desc: "not all supported when custom pod name filter is present",
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"kube-system"},
+			},
+			podNameFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"nginx-pod"},
+			},
+			wantAllSupported:         false,
+			wantMonitoringFilterBody: `resource.type = "k8s_container" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND metric.labels.log != "server-accesslog-stackdriver" AND metric.labels.log != "client-accesslog-stackdriver" AND resource.labels.namespace_name = "kube-system"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sq := GenerateK8sContainerStructuredQuery(cluster, tc.namespaceFilter, tc.podNameFilter)
+			if got := sq.AllFiltersSupportMetrics(); got != tc.wantAllSupported {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", got, tc.wantAllSupported)
+			}
+			filters := sq.GenerateMonitoringMetricFilters()
+			if len(filters) != 1 {
+				t.Fatalf("expected 1 metric filter, got %d", len(filters))
+			}
+			wantFilter := "metric.type = \"logging.googleapis.com/log_entry_count\" AND " + tc.wantMonitoringFilterBody
+			if diff := cmp.Diff(wantFilter, filters[0]); diff != "" {
+				t.Errorf("Monitoring metric filter mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1-a",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogk8scontainer_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogk8scontainer_contract.InputContainerQueryNamespacesTaskID.Ref(), &gcpqueryutil.SetFilterParseResult{Additives: []string{"default"}}),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogk8scontainer_contract.InputContainerQueryPodNamesTaskID.Ref(), &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{}}),
+	)
+	if err != nil {
+		t.Fatalf("DryRun returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("DryRun should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="k8s_container"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+-LOG_ID("server-accesslog-stackdriver")
+-LOG_ID("client-accesslog-stackdriver")
+resource.labels.namespace_name="default"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("Query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "K8s container logs" {
+		t.Errorf("Query Name mismatch: got %q, want %q", serialized[0].Name, "K8s container logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task.go
@@ -17,8 +17,8 @@ package googlecloudlogk8scontrolplane_impl
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -26,39 +26,49 @@ import (
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-func GenerateK8sControlPlaneQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, controlplaneComponentFilter *gcpqueryutil.SetFilterParseResult) string {
-	return fmt.Sprintf(`resource.type="k8s_control_plane_component"
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"
--sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
-%s`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateK8sControlPlaneComponentFilter(controlplaneComponentFilter))
+// GenerateK8sControlPlaneStructuredQuery generates a structured query for Kubernetes control plane logs.
+func GenerateK8sControlPlaneStructuredQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, controlplaneComponentFilter *gcpqueryutil.SetFilterParseResult) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(cluster.ProjectID)),
+		logestimator.ResourceLabel("location", logestimator.Exact(cluster.Location)),
+		logestimator.ResourceLabel("cluster_name", logestimator.Exact(cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster))),
+	}
+
+	if controlplaneComponentFilter != nil {
+		switch {
+		case controlplaneComponentFilter.ValidationError != "":
+			filters = append(filters, logestimator.Comment(fmt.Sprintf(`Failed to generate component name filter due to the validation error "%s"`, controlplaneComponentFilter.ValidationError)))
+		case controlplaneComponentFilter.SubtractMode:
+			if len(controlplaneComponentFilter.Subtractives) > 0 {
+				filters = append(filters, logestimator.ResourceLabel("component_name", logestimator.NotContainsAny(controlplaneComponentFilter.Subtractives...)))
+			}
+		case len(controlplaneComponentFilter.Additives) == 0:
+			filters = append(filters, logestimator.Comment(`Invalid: none of the controlplane components will be selected. Ignoring component name filter.`))
+		default:
+			filters = append(filters, logestimator.ResourceLabel("component_name", logestimator.ContainsAny(controlplaneComponentFilter.Additives...)))
+		}
+	}
+
+	filters = append(filters, logestimator.CustomFilter(`-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`))
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    !cluster.IsComplete(),
+		ResourceTypes: []string{"k8s_control_plane_component"},
+		Filters:       filters,
+	}
 }
 
-func generateK8sControlPlaneComponentFilter(filter *gcpqueryutil.SetFilterParseResult) string {
-	if filter.ValidationError != "" {
-		return fmt.Sprintf(`-- Failed to generate component name filter due to the validation error "%s"`, filter.ValidationError)
-	}
-	if filter.SubtractMode {
-		if len(filter.Subtractives) == 0 {
-			return "-- No component name filter"
-		}
-		return fmt.Sprintf(`-resource.labels.component_name:(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(filter.Subtractives), " OR "))
-	} else {
-		if len(filter.Additives) == 0 {
-			return `-- Invalid: none of the controlplane components will be selected. Ignoring component name filter.`
-		}
-		return fmt.Sprintf(`resource.labels.component_name:(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(filter.Additives), " OR "))
-	}
+// GenerateK8sControlPlaneQuery generates a query for Kubernetes control plane logs.
+func GenerateK8sControlPlaneQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, controlplaneComponentFilter *gcpqueryutil.SetFilterParseResult) string {
+	return GenerateK8sControlPlaneStructuredQuery(cluster, controlplaneComponentFilter).GenerateCloudLoggingQuery()
 }
 
 type controlPlaneListLogEntriesTaskSetting struct {
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *controlPlaneListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogk8scontrolplane_contract.ClusterIdentityTaskID.Ref(),
@@ -66,45 +76,34 @@ func (c *controlPlaneListLogEntriesTaskSetting) Dependencies() []taskid.UntypedT
 	}
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *controlPlaneListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogk8scontrolplane_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *controlPlaneListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "K8s control plane logs",
-		ExampleQuery: GenerateK8sControlPlaneQuery(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:   "test-project",
-			ClusterName: "test-cluster",
-			Location:    "asia-northeast1",
-		}, &gcpqueryutil.SetFilterParseResult{
-			SubtractMode: true,
-		}),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *controlPlaneListLogEntriesTaskSetting) QueryName() string {
+	return "K8s control plane logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *controlPlaneListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *controlPlaneListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogk8scontrolplane_contract.ClusterIdentityTaskID.Ref())
 	controlplaneComponentNameFilter := coretask.GetTaskResult(ctx, googlecloudlogk8scontrolplane_contract.InputControlPlaneComponentNameFilterTaskID.Ref())
-
-	return []string{GenerateK8sControlPlaneQuery(cluster, controlplaneComponentNameFilter)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateK8sControlPlaneStructuredQuery(cluster, controlplaneComponentNameFilter)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *controlPlaneListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogk8scontrolplane_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *controlPlaneListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*controlPlaneListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*controlPlaneListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&controlPlaneListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&controlPlaneListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/query_task_test.go
@@ -15,104 +15,285 @@
 package googlecloudlogk8scontrolplane_impl
 
 import (
-	"fmt"
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateK8sControlPlaneQuery(t *testing.T) {
+func TestGenerateK8sControlPlaneStructuredQuery(t *testing.T) {
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "foo-cluster",
+		ProjectID:   "foo-project",
+		Location:    "foo-location",
+	}
+
 	testCases := []struct {
-		ExpectedQuery                        string
-		Cluster                              googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		InputControlplaneComponentNameFilter *gcpqueryutil.SetFilterParseResult
+		name                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		componentFilter        *gcpqueryutil.SetFilterParseResult
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ClusterName: "foo-cluster",
-				ProjectID:   "foo-project",
-				Location:    "foo-location",
-			},
-			InputControlplaneComponentNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true},
-			ExpectedQuery: `resource.type="k8s_control_plane_component"
+			name:            "no component name filter (subtract mode empty)",
+			cluster:         cluster,
+			componentFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true},
+			wantQuery: `resource.type="k8s_control_plane_component"
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
--- No component name filter`,
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_control_plane_component" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
-			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ClusterName: "foo-cluster",
-				ProjectID:   "foo-project",
-				Location:    "foo-location",
-			},
-			InputControlplaneComponentNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{"apiserver", "autoscaler"}},
-			ExpectedQuery: `resource.type="k8s_control_plane_component"
+			name:            "subtract mode with multiple subtractives",
+			cluster:         cluster,
+			componentFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{"apiserver", "autoscaler"}},
+			wantQuery: `resource.type="k8s_control_plane_component"
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
--resource.labels.component_name:("apiserver" OR "autoscaler")`,
+-resource.labels.component_name:("apiserver" OR "autoscaler")
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_control_plane_component" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND (resource.labels.component_name != has_substring("apiserver") AND resource.labels.component_name != has_substring("autoscaler"))`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
-			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ClusterName: "foo-cluster",
-				ProjectID:   "foo-project",
-				Location:    "foo-location",
-			},
-			InputControlplaneComponentNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: false, Additives: []string{"apiserver"}},
-			ExpectedQuery: `resource.type="k8s_control_plane_component"
+			name:            "additive mode with single component",
+			cluster:         cluster,
+			componentFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: false, Additives: []string{"apiserver"}},
+			wantQuery: `resource.type="k8s_control_plane_component"
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
-resource.labels.component_name:("apiserver")`,
+resource.labels.component_name:"apiserver"
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_control_plane_component" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND resource.labels.component_name = has_substring("apiserver")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
-			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ClusterName: "foo-cluster",
-				ProjectID:   "foo-project",
-				Location:    "foo-location",
-			},
-			InputControlplaneComponentNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: false, Additives: []string{}},
-			ExpectedQuery: `resource.type="k8s_control_plane_component"
+			name:            "additive mode with multiple components",
+			cluster:         cluster,
+			componentFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: false, Additives: []string{"apiserver", "autoscaler"}},
+			wantQuery: `resource.type="k8s_control_plane_component"
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
--- Invalid: none of the controlplane components will be selected. Ignoring component name filter.`,
+resource.labels.component_name:("apiserver" OR "autoscaler")
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_control_plane_component" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND (resource.labels.component_name = has_substring("apiserver") OR resource.labels.component_name = has_substring("autoscaler"))`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
-			Cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ClusterName: "foo-cluster",
-				ProjectID:   "foo-project",
-				Location:    "foo-location",
-			},
-			InputControlplaneComponentNameFilter: &gcpqueryutil.SetFilterParseResult{ValidationError: "test error"},
-			ExpectedQuery: `resource.type="k8s_control_plane_component"
+			name:            "additive mode with empty additives",
+			cluster:         cluster,
+			componentFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: false, Additives: []string{}},
+			wantQuery: `resource.type="k8s_control_plane_component"
 resource.labels.project_id="foo-project"
 resource.labels.location="foo-location"
 resource.labels.cluster_name="foo-cluster"
--sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
--- Failed to generate component name filter due to the validation error "test error"`,
+-- Invalid: none of the controlplane components will be selected. Ignoring component name filter.
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_control_plane_component" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:            "subtract mode with single subtractive",
+			cluster:         cluster,
+			componentFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{"apiserver"}},
+			wantQuery: `resource.type="k8s_control_plane_component"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+-resource.labels.component_name:"apiserver"
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_control_plane_component" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster" AND resource.labels.component_name != has_substring("apiserver")`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:            "validation error",
+			cluster:         cluster,
+			componentFilter: &gcpqueryutil.SetFilterParseResult{ValidationError: "test error"},
+			wantQuery: `resource.type="k8s_control_plane_component"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+-- Failed to generate component name filter due to the validation error "test error"
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_control_plane_component" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:            "nil component filter",
+			cluster:         cluster,
+			componentFilter: nil,
+			wantQuery: `resource.type="k8s_control_plane_component"
+resource.labels.project_id="foo-project"
+resource.labels.location="foo-location"
+resource.labels.cluster_name="foo-cluster"
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_control_plane_component" AND resource.labels.project_id = "foo-project" AND resource.labels.location = "foo-location" AND resource.labels.cluster_name = "foo-cluster"`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 	}
 
-	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("testcase-%d-%s", i, testCase.ExpectedQuery), func(t *testing.T) {
-			result := GenerateK8sControlPlaneQuery(testCase.Cluster, testCase.InputControlplaneComponentNameFilter)
-			if result != testCase.ExpectedQuery {
-				t.Errorf("the result query is not valid:\nInput:\n%v\nActual:\n%s\nExpected:\n%s", testCase, result, testCase.ExpectedQuery)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sq := GenerateK8sControlPlaneStructuredQuery(tc.cluster, tc.componentFilter)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
 			}
-			t.Run("generated query must be valid in Cloud Logging", func(t *testing.T) {
-				err := gcp_test.IsValidLogQuery(t, result)
-				if err != nil {
-					t.Errorf("%s", err.Error())
-				}
-			})
+
+			legacyQuery := GenerateK8sControlPlaneQuery(tc.cluster, tc.componentFilter)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("GenerateK8sControlPlaneQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
+			}
 		})
+	}
+}
+
+func TestGenerateK8sControlPlaneQueryIsValid(t *testing.T) {
+	testCases := []struct {
+		name                                 string
+		cluster                              googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		inputControlplaneComponentNameFilter *gcpqueryutil.SetFilterParseResult
+	}{
+		{
+			name: "All components",
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "foo-cluster",
+				ProjectID:   "foo-project",
+				Location:    "foo-location",
+			},
+			inputControlplaneComponentNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true},
+		},
+		{
+			name: "Specific components (inclusive)",
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "foo-cluster",
+				ProjectID:   "foo-project",
+				Location:    "foo-location",
+			},
+			inputControlplaneComponentNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: false, Additives: []string{"apiserver", "autoscaler"}},
+		},
+		{
+			name: "Specific components (exclusive)",
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ClusterName: "foo-cluster",
+				ProjectID:   "foo-project",
+				Location:    "foo-location",
+			},
+			inputControlplaneComponentNameFilter: &gcpqueryutil.SetFilterParseResult{SubtractMode: true, Subtractives: []string{"apiserver", "autoscaler"}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			query := GenerateK8sControlPlaneQuery(tc.cluster, tc.inputControlplaneComponentNameFilter)
+			err := gcp_test.IsValidLogQuery(t, query)
+			if err != nil {
+				t.Errorf("IsValidLogQuery error: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1-a",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogk8scontrolplane_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogk8scontrolplane_contract.InputControlPlaneComponentNameFilterTaskID.Ref(), &gcpqueryutil.SetFilterParseResult{SubtractMode: true}),
+	)
+	if err != nil {
+		t.Fatalf("DryRun returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("DryRun should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="k8s_control_plane_component"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+-sourceLocation.file="httplog.go" -- Ignoring the noisy log from scheduler. TODO: Support toggling this feature.
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("Query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "K8s control plane logs" {
+		t.Errorf("Query Name mismatch: got %q, want %q", serialized[0].Name, "K8s control plane logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/query_task.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -27,16 +28,34 @@ import (
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogk8sevent_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8sevent/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-// GenerateK8sEventQuery generates a query for Kubernetes Event logs.
+// GenerateK8sEventStructuredQuery generates a structured query for Kubernetes Event logs.
+func GenerateK8sEventStructuredQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, namespaceFilter *gcpqueryutil.SetFilterParseResult) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(cluster.ProjectID)),
+		logestimator.ResourceLabel("location", logestimator.Exact(cluster.Location)),
+		logestimator.ResourceLabel("cluster_name", logestimator.Exact(cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster))),
+		logestimator.LogID(logestimator.Exact("events")),
+	}
+
+	if namespaceFilter != nil {
+		nsSnippet := generateK8sEventNamespaceFilter(namespaceFilter)
+		if nsSnippet != "" && nsSnippet != "-- No namespace filter" {
+			filters = append(filters, logestimator.CustomFilter(nsSnippet))
+		}
+	}
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    !cluster.IsComplete(),
+		ResourceTypes: []string{},
+		Filters:       filters,
+	}
+}
+
+// GenerateK8sEventQuery generates a query string for Kubernetes Event logs.
 func GenerateK8sEventQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, namespaceFilter *gcpqueryutil.SetFilterParseResult) string {
-	return fmt.Sprintf(`log_id("events")
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"
-%s`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateK8sEventNamespaceFilter(namespaceFilter))
+	return GenerateK8sEventStructuredQuery(cluster, namespaceFilter).GenerateCloudLoggingQuery()
 }
 
 func generateK8sEventNamespaceFilter(filter *gcpqueryutil.SetFilterParseResult) string {
@@ -77,13 +96,13 @@ func generateK8sEventNamespaceFilter(filter *gcpqueryutil.SetFilterParseResult) 
 type K8sEventListLogEntriesTaskSetting struct {
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *K8sEventListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogk8sevent_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *K8sEventListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogk8sevent_contract.ClusterIdentityTaskID.Ref(),
@@ -91,41 +110,28 @@ func (k *K8sEventListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskR
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (k *K8sEventListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "Kubernetes Event Logs",
-		ExampleQuery: GenerateK8sEventQuery(
-			googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ProjectID:   "test-project",
-				Location:    "test-location",
-				ClusterName: "test-cluster",
-			},
-			&gcpqueryutil.SetFilterParseResult{
-				Additives: []string{"#cluster-scoped", "#namespaced"},
-			},
-		),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (k *K8sEventListLogEntriesTaskSetting) QueryName() string {
+	return "Kubernetes Event Logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (k *K8sEventListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (k *K8sEventListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogk8sevent_contract.ClusterIdentityTaskID.Ref())
 	namespaceFilter := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputNamespaceFilterTaskID.Ref())
-	return []string{GenerateK8sEventQuery(cluster, namespaceFilter)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateK8sEventStructuredQuery(cluster, namespaceFilter)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *K8sEventListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogk8sevent_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *K8sEventListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*K8sEventListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*K8sEventListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&K8sEventListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&K8sEventListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/query_task_test.go
@@ -15,54 +15,228 @@
 package googlecloudlogk8sevent_impl
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogk8sevent_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8sevent/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateK8sEventQuery(t *testing.T) {
+func TestGenerateK8sEventStructuredQuery(t *testing.T) {
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		Location:    "us-central1-a",
+		ProjectID:   "test-project",
+	}
+
 	testCases := []struct {
-		wantQuery       string
-		cluster         googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		namespaceFilter *gcpqueryutil.SetFilterParseResult
-		startTime       time.Time
-		endTime         time.Time
+		name                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		namespaceFilter        *gcpqueryutil.SetFilterParseResult
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-				ClusterName: "foo-cluster",
-				Location:    "foo-location",
-				ProjectID:   "foo-project",
-			},
+			name:    "both cluster scoped and namespaced scopes (pure metric)",
+			cluster: cluster,
 			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
-				Additives: []string{
-					"#namespaced",
-				},
+				Additives: []string{"#cluster-scoped", "#namespaced"},
 			},
-			wantQuery: `log_id("events")
-resource.labels.project_id="foo-project"
-resource.labels.location="foo-location"
-resource.labels.cluster_name="foo-cluster"
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: true,
+		},
+		{
+			name:    "namespaced scope only",
+			cluster: cluster,
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"#namespaced"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
 jsonPayload.involvedObject.namespace:"" -- ignore events in k8s object with namespace`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "cluster-scoped only",
+			cluster: cluster,
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"#cluster-scoped"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
+-jsonPayload.involvedObject.namespace:"" -- ignore events in k8s object with namespace`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "cluster-scoped with specific namespaces",
+			cluster: cluster,
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"#cluster-scoped", "default", "kube-system"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
+(jsonPayload.involvedObject.namespace=(default OR kube-system) OR NOT (jsonPayload.involvedObject.namespace:""))`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "single specific namespace",
+			cluster: cluster,
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"default"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
+jsonPayload.involvedObject.namespace=(default)`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "multiple specific namespaces",
+			cluster: cluster,
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{"default", "kube-system"},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
+jsonPayload.involvedObject.namespace=(default OR kube-system)`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "subtractive mode",
+			cluster: cluster,
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				SubtractMode: true,
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
+-- Unsupported operation`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "validation error",
+			cluster: cluster,
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				ValidationError: "invalid syntax",
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
+-- Failed to generate namespace filter due to the validation error "invalid syntax"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:    "empty additives",
+			cluster: cluster,
+			namespaceFilter: &gcpqueryutil.SetFilterParseResult{
+				Additives: []string{},
+			},
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
+-- Invalid: none of the resources will be selected. Ignoring namespace filter.`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:            "nil namespace filter",
+			cluster:         cluster,
+			namespaceFilter: nil,
+			wantQuery: `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log = "events"`,
+			},
+			wantSupportMetricsFlag: true,
 		},
 	}
 
-	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("testcase-%d-%s", i, testCase.wantQuery), func(t *testing.T) {
-			result := GenerateK8sEventQuery(testCase.cluster, testCase.namespaceFilter)
-			if result != testCase.wantQuery {
-				t.Errorf("the result query is not valid:\nInput:\n%v\nActual:\n%s\nExpected:\n%s", testCase, result, testCase.wantQuery)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sq := GenerateK8sEventStructuredQuery(tc.cluster, tc.namespaceFilter)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := GenerateK8sEventQuery(tc.cluster, tc.namespaceFilter)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("GenerateK8sEventQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
 			}
 		})
 	}
 }
 
 func TestGenerateK8sEventQueryIsValid(t *testing.T) {
-	testCluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{}
+	testCluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		Location:    "us-central1-a",
+		ProjectID:   "test-project",
+	}
 	testCases := []struct {
 		name            string
 		cluster         googlecloudk8scommon_contract.GoogleCloudClusterIdentity
@@ -104,9 +278,67 @@ func TestGenerateK8sEventQueryIsValid(t *testing.T) {
 			query := GenerateK8sEventQuery(tc.cluster, tc.namespaceFilter)
 			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
-				t.Errorf("%s", err.Error())
+				t.Errorf("IsValidLogQuery error: %s", err.Error())
 			}
 		})
 	}
+}
 
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1-a",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogk8sevent_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.InputNamespaceFilterTaskID.Ref(), &gcpqueryutil.SetFilterParseResult{Additives: []string{"#cluster-scoped", "#namespaced"}}),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+LOG_ID("events")
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "Kubernetes Event Logs" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "Kubernetes Event Logs")
+	}
 }

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/query_task.go
@@ -17,46 +17,50 @@ package googlecloudlogk8snode_impl
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogk8snode_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8snode/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
+
+// GenerateK8sNodeStructuredQuery generates a structured query for GKE node logs.
+func GenerateK8sNodeStructuredQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, nodeNameSubstrings []string) *logestimator.StructuredLogQuery {
+	filters := []logestimator.LoggingMonitoringMatcher{
+		logestimator.ResourceLabel("project_id", logestimator.Exact(cluster.ProjectID)),
+		logestimator.ResourceLabel("location", logestimator.Exact(cluster.Location)),
+		logestimator.ResourceLabel("cluster_name", logestimator.Exact(cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster))),
+		logestimator.LogID(logestimator.NoneOf("events")),
+	}
+
+	if len(nodeNameSubstrings) > 0 {
+		filters = append(filters, logestimator.ResourceLabel("node_name", logestimator.ContainsAny(nodeNameSubstrings...)))
+	}
+
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    !cluster.IsComplete(),
+		ResourceTypes: []string{"k8s_node"},
+		Filters:       filters,
+	}
+}
 
 // GenerateK8sNodeLogQuery generates a query for GKE node logs.
 func GenerateK8sNodeLogQuery(cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity, nodeNameSubstrings []string) string {
-	return fmt.Sprintf(`resource.type="k8s_node"
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"
--log_id("events") -- ignore node related events because it's captured in k8s event log parsers
-%s
-`, cluster.ProjectID, cluster.Location, cluster.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sCluster), generateNodeNameSubstringLogFilter(nodeNameSubstrings))
-}
-
-func generateNodeNameSubstringLogFilter(nodeNameSubstrings []string) string {
-	if len(nodeNameSubstrings) == 0 {
-		return "-- No node name substring filters are specified."
-	} else {
-		return fmt.Sprintf("resource.labels.node_name:(%s)", strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(nodeNameSubstrings), " OR "))
-	}
+	return GenerateK8sNodeStructuredQuery(cluster, nodeNameSubstrings).GenerateCloudLoggingQuery()
 }
 
 type k8snodeListLogEntriesTaskSetting struct{}
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *k8snodeListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *k8snodeListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref(),
@@ -64,36 +68,28 @@ func (c *k8snodeListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskRe
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *k8snodeListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "Kubernetes node logs",
-		ExampleQuery: GenerateK8sNodeLogQuery(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:   "gcp-project-id",
-			Location:    "gcp-location",
-			ClusterName: "gcp-cluster-name",
-		}, []string{"gke-test-cluster-node-1", "gke-test-cluster-node-2"}),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *k8snodeListLogEntriesTaskSetting) QueryName() string {
+	return "Kubernetes node logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (c *k8snodeListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (c *k8snodeListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref())
 	nodeNameSubstrings := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputNodeNameFilterTaskID.Ref())
-	return []string{GenerateK8sNodeLogQuery(cluster, nodeNameSubstrings)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateK8sNodeStructuredQuery(cluster, nodeNameSubstrings)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (c *k8snodeListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogk8snode_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (k *k8snodeListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*k8snodeListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*k8snodeListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&k8snodeListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&k8snodeListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/query_task_test.go
@@ -16,11 +16,107 @@ package googlecloudlogk8snode_impl
 
 import (
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogk8snode_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8snode/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestGenerateK8sNodeStructuredQuery(t *testing.T) {
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		Location:    "us-central1-a",
+		ProjectID:   "test-project",
+	}
+
+	testCases := []struct {
+		name                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		nodeNameSubstrings     []string
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
+	}{
+		{
+			name:               "empty node name substrings",
+			cluster:            cluster,
+			nodeNameSubstrings: []string{},
+			wantQuery: `resource.type="k8s_node"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+-LOG_ID("events")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_node" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log != "events"`,
+			},
+			wantSupportMetricsFlag: true,
+		},
+		{
+			name:               "single node name substring",
+			cluster:            cluster,
+			nodeNameSubstrings: []string{"node-1"},
+			wantQuery: `resource.type="k8s_node"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+-LOG_ID("events")
+resource.labels.node_name:"node-1"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_node" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log != "events" AND resource.labels.node_name = has_substring("node-1")`,
+			},
+			wantSupportMetricsFlag: true,
+		},
+		{
+			name:               "multiple node name substrings",
+			cluster:            cluster,
+			nodeNameSubstrings: []string{"node-1", "node-2"},
+			wantQuery: `resource.type="k8s_node"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+-LOG_ID("events")
+resource.labels.node_name:("node-1" OR "node-2")`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "k8s_node" AND resource.labels.project_id = "test-project" AND resource.labels.location = "us-central1-a" AND resource.labels.cluster_name = "test-cluster" AND metric.labels.log != "events" AND (resource.labels.node_name = has_substring("node-1") OR resource.labels.node_name = has_substring("node-2"))`,
+			},
+			wantSupportMetricsFlag: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sq := GenerateK8sNodeStructuredQuery(tc.cluster, tc.nodeNameSubstrings)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := GenerateK8sNodeLogQuery(tc.cluster, tc.nodeNameSubstrings)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("GenerateK8sNodeLogQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
+			}
+		})
+	}
+}
 
 func TestGenerateK8sNodeQueryIsValid(t *testing.T) {
 	testCases := []struct {
@@ -61,40 +157,69 @@ func TestGenerateK8sNodeQueryIsValid(t *testing.T) {
 			query := GenerateK8sNodeLogQuery(tc.cluster, tc.nodeNameSubstrings)
 			err := gcp_test.IsValidLogQuery(t, query)
 			if err != nil {
-				t.Errorf("%s", err.Error())
+				t.Errorf("IsValidLogQuery error: %s", err.Error())
 			}
 		})
 	}
 }
 
-func TestGenerateNodeNameSubstringLogFilter(t *testing.T) {
-	tests := []struct {
-		name               string
-		nodeNameSubstrings []string
-		want               string
-	}{
-		{
-			name:               "empty",
-			nodeNameSubstrings: []string{},
-			want:               "-- No node name substring filters are specified.",
-		},
-		{
-			name:               "single",
-			nodeNameSubstrings: []string{"substring1"},
-			want:               "resource.labels.node_name:(\"substring1\")",
-		},
-		{
-			name:               "multiple",
-			nodeNameSubstrings: []string{"substring1", "substring2", "substring3"},
-			want:               "resource.labels.node_name:(\"substring1\" OR \"substring2\" OR \"substring3\")",
-		},
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1-a",
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := generateNodeNameSubstringLogFilter(tt.nodeNameSubstrings)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("generateNodeNameSubstringLogFilter() mismatch (-want +got):\n%s", diff)
-			}
-		})
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogk8snode_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.InputNodeNameFilterTaskID.Ref(), []string{"node-1"}),
+	)
+	if err != nil {
+		t.Fatalf("DryRun returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("DryRun should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="k8s_node"
+resource.labels.project_id="test-project"
+resource.labels.location="us-central1-a"
+resource.labels.cluster_name="test-cluster"
+-LOG_ID("events")
+resource.labels.node_name:"node-1"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("Query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "Kubernetes node logs" {
+		t.Errorf("Query Name mismatch: got %q, want %q", serialized[0].Name, "Kubernetes node logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/query_task.go
@@ -18,78 +18,76 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogmulticloudapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-// generateQuery generates a query for multicloud API logs.
+// GenerateMultiCloudAPIStructuredQuery generates a structured query for multicloud API logs.
+func GenerateMultiCloudAPIStructuredQuery(clusterIdentity googlecloudk8scommon_contract.GoogleCloudClusterIdentity) *logestimator.StructuredLogQuery {
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    !clusterIdentity.IsComplete(),
+		ResourceTypes: []string{"audited_resource"},
+		Filters: []logestimator.LoggingMonitoringMatcher{
+			logestimator.ResourceLabel("service", logestimator.Exact("gkemulticloud.googleapis.com")),
+			logestimator.ResourceLabel("method", logestimator.ContainsAny("Update", "Create", "Delete")),
+			logestimator.LogID(logestimator.OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+			logestimator.CustomFilter(fmt.Sprintf(`protoPayload.resourceName:"projects/%s/locations/%s/"`, clusterIdentity.ProjectID, clusterIdentity.Location)),
+			logestimator.CustomFilter(fmt.Sprintf(`protoPayload.resourceName:"%s"`, clusterIdentity.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit))),
+		},
+	}
+}
+
+// GenerateMultiCloudAPIQuery generates a query for multicloud API logs.
+func GenerateMultiCloudAPIQuery(clusterIdentity googlecloudk8scommon_contract.GoogleCloudClusterIdentity) string {
+	return GenerateMultiCloudAPIStructuredQuery(clusterIdentity).GenerateCloudLoggingQuery()
+}
+
 func generateQuery(clusterIdentity googlecloudk8scommon_contract.GoogleCloudClusterIdentity) string {
-	return fmt.Sprintf(`
-log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access")
-resource.type="audited_resource"
-resource.labels.service="gkemulticloud.googleapis.com"
-resource.labels.method:("Update" OR "Create" OR "Delete")
-protoPayload.resourceName:"projects/%s/locations/%s/"
-protoPayload.resourceName:"%s"
-`, clusterIdentity.ProjectID, clusterIdentity.Location, clusterIdentity.NameFor(googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit))
+	return GenerateMultiCloudAPIQuery(clusterIdentity)
 }
 
 type multicloudAPIListLogEntriesTaskSetting struct {
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (g *multicloudAPIListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogmulticloudapiaudit_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (g *multicloudAPIListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogmulticloudapiaudit_contract.ClusterIdentityTaskID.Ref(),
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (g *multicloudAPIListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-		QueryName: "Multicloud API Logs",
-		ExampleQuery: generateQuery(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:   "example-project-id",
-			Location:    "example-location",
-			ClusterName: "example-cluster-name",
-			PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
-				Prefix: "awsClusters/",
-				RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
-					googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
-				},
-			},
-		}),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (g *multicloudAPIListLogEntriesTaskSetting) QueryName() string {
+	return "Multicloud API Logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (g *multicloudAPIListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (g *multicloudAPIListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogmulticloudapiaudit_contract.ClusterIdentityTaskID.Ref())
-
-	return []string{generateQuery(clusterIdentity)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateMultiCloudAPIStructuredQuery(clusterIdentity)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (g *multicloudAPIListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogmulticloudapiaudit_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (g *multicloudAPIListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 1, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*multicloudAPIListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*multicloudAPIListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&multicloudAPIListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&multicloudAPIListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/query_task_test.go
@@ -16,20 +16,32 @@ package googlecloudlogmulticloudapiaudit_impl
 
 import (
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogmulticloudapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateMultiCloudAPIQuery(t *testing.T) {
+func TestGenerateMultiCloudAPIStructuredQuery(t *testing.T) {
 	testCases := []struct {
-		name    string
-		cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		want    string
+		name                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			name: "standard input",
+			name: "AWS cluster",
 			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
 				ProjectID:   "test-project",
 				ClusterName: "test-cluster",
@@ -41,22 +53,63 @@ func TestGenerateMultiCloudAPIQuery(t *testing.T) {
 				},
 				Location: "asia-northeast1",
 			},
-			want: `
-log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access")
-resource.type="audited_resource"
+			wantQuery: `resource.type="audited_resource"
 resource.labels.service="gkemulticloud.googleapis.com"
 resource.labels.method:("Update" OR "Create" OR "Delete")
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
 protoPayload.resourceName:"projects/test-project/locations/asia-northeast1/"
-protoPayload.resourceName:"awsClusters/test-cluster"
-`,
+protoPayload.resourceName:"awsClusters/test-cluster"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "audited_resource" AND resource.labels.service = "gkemulticloud.googleapis.com" AND (resource.labels.method = has_substring("Update") OR resource.labels.method = has_substring("Create") OR resource.labels.method = has_substring("Delete")) AND metric.labels.log = one_of("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name: "Azure cluster",
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ProjectID:   "test-project",
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "azureClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+					},
+				},
+				Location: "us-east4",
+			},
+			wantQuery: `resource.type="audited_resource"
+resource.labels.service="gkemulticloud.googleapis.com"
+resource.labels.method:("Update" OR "Create" OR "Delete")
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"projects/test-project/locations/us-east4/"
+protoPayload.resourceName:"azureClusters/test-cluster"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "audited_resource" AND resource.labels.service = "gkemulticloud.googleapis.com" AND (resource.labels.method = has_substring("Update") OR resource.labels.method = has_substring("Create") OR resource.labels.method = has_substring("Delete")) AND metric.labels.log = one_of("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			actual := generateQuery(testCase.cluster)
-			if diff := cmp.Diff(testCase.want, actual); diff != "" {
-				t.Errorf("The generated result is not matching with the expected\n%s", diff)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sq := GenerateMultiCloudAPIStructuredQuery(tc.cluster)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := generateQuery(tc.cluster)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("generateQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
 			}
 		})
 	}
@@ -90,5 +143,71 @@ func TestGenerateMultiCloudAPIQueryIsValid(t *testing.T) {
 				t.Errorf("%s", err.Error())
 			}
 		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "asia-northeast1",
+		PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+			Prefix: "awsClusters/",
+			RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+				googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+			},
+		},
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogmulticloudapiaudit_contract.ClusterIdentityTaskID.Ref(), cluster),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="audited_resource"
+resource.labels.service="gkemulticloud.googleapis.com"
+resource.labels.method:("Update" OR "Create" OR "Delete")
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"projects/test-project/locations/asia-northeast1/"
+protoPayload.resourceName:"awsClusters/test-cluster"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "Multicloud API Logs" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "Multicloud API Logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/query_task.go
@@ -39,7 +39,7 @@ func GenerateGCPNetworkAPIStructuredQuery(taskMode inspectioncore_contract.Inspe
 				ResourceTypes: []string{"gce_network"},
 				Filters: []logestimator.LoggingMonitoringMatcher{
 					logestimator.CustomFilter(`-protoPayload.methodName:("list" OR "get" OR "watch")`),
-					logestimator.CustomFilter("-- neg name filters to be determined after audit log query"),
+					logestimator.Comment("neg name filters to be determined after audit log query"),
 				},
 			},
 		}

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/query_task.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -29,77 +31,103 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-// generateGCPNetworkAPIQuery generates a query for network API logs.
-func generateGCPNetworkAPIQuery(taskMode inspectioncore_contract.InspectionTaskModeType, negNames []string) []string {
+// GenerateGCPNetworkAPIStructuredQuery generates a structured query slice for network API logs.
+func GenerateGCPNetworkAPIStructuredQuery(taskMode inspectioncore_contract.InspectionTaskModeType, negNames []string) []*logestimator.StructuredLogQuery {
+	if taskMode == inspectioncore_contract.TaskModeDryRun {
+		return []*logestimator.StructuredLogQuery{
+			{
+				ResourceTypes: []string{"gce_network"},
+				Filters: []logestimator.LoggingMonitoringMatcher{
+					logestimator.CustomFilter(`-protoPayload.methodName:("list" OR "get" OR "watch")`),
+					logestimator.CustomFilter("-- neg name filters to be determined after audit log query"),
+				},
+			},
+		}
+	}
+
 	nodeNamesWithNetworkEndpointGroups := []string{}
 	for _, negName := range negNames {
 		nodeNamesWithNetworkEndpointGroups = append(nodeNamesWithNetworkEndpointGroups, fmt.Sprintf("networkEndpointGroups/%s", negName))
 	}
-	if taskMode == inspectioncore_contract.TaskModeDryRun {
-		return []string{queryFromNegNameFilter("-- neg name filters to be determined after audit log query")}
-	} else {
-		result := []string{}
-		groups := gcpqueryutil.SplitToChildGroups(nodeNamesWithNetworkEndpointGroups, 10)
-		for _, group := range groups {
-			negNameFilter := fmt.Sprintf("protoPayload.resourceName:(%s)", strings.Join(group, " OR "))
-			result = append(result, queryFromNegNameFilter(negNameFilter))
-		}
-		return result
+	result := []*logestimator.StructuredLogQuery{}
+	groups := gcpqueryutil.SplitToChildGroups(nodeNamesWithNetworkEndpointGroups, 10)
+	for _, group := range groups {
+		negNameFilter := fmt.Sprintf("protoPayload.resourceName:(%s)", strings.Join(group, " OR "))
+		result = append(result, &logestimator.StructuredLogQuery{
+			ResourceTypes: []string{"gce_network"},
+			Filters: []logestimator.LoggingMonitoringMatcher{
+				logestimator.CustomFilter(`-protoPayload.methodName:("list" OR "get" OR "watch")`),
+				logestimator.CustomFilter(negNameFilter),
+			},
+		})
 	}
+	return result
 }
 
-func queryFromNegNameFilter(negNameFilter string) string {
-	return fmt.Sprintf(`resource.type="gce_network"
--protoPayload.methodName:("list" OR "get" OR "watch")
-%s
-`, negNameFilter)
+// GenerateGCPNetworkAPIQuery generates a query for network API logs.
+func GenerateGCPNetworkAPIQuery(taskMode inspectioncore_contract.InspectionTaskModeType, negNames []string) []string {
+	structuredQueries := GenerateGCPNetworkAPIStructuredQuery(taskMode, negNames)
+	result := make([]string, 0, len(structuredQueries))
+	for _, sq := range structuredQueries {
+		result = append(result, sq.GenerateCloudLoggingQuery())
+	}
+	return result
 }
 
-type networkAPIListLogEntiesTaskSetting struct{}
+type networkAPIListLogEntriesTaskSetting struct{}
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (n *networkAPIListLogEntiesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (n *networkAPIListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlognetworkapiaudit_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", clusterIdentity.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (n *networkAPIListLogEntiesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (n *networkAPIListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlognetworkapiaudit_contract.ClusterIdentityTaskID.Ref(),
 		googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(),
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (n *networkAPIListLogEntiesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName:    "GCP network log",
-		ExampleQuery: generateGCPNetworkAPIQuery(inspectioncore_contract.TaskModeRun, []string{"neg-id-1", "neg-id-2"})[0],
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (n *networkAPIListLogEntriesTaskSetting) QueryName() string {
+	return "GCP network log"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (n *networkAPIListLogEntiesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
-	negs := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref())
-	negNames := []string{}
-	for negName := range negs {
-		negNames = append(negNames, negName)
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (n *networkAPIListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
+	taskMode, err := khictx.GetValue(ctx, inspectioncore_contract.InspectionTaskMode)
+	if err != nil {
+		taskMode = inspectioncore_contract.TaskModeRun
 	}
-	return generateGCPNetworkAPIQuery(taskMode, negNames), nil
+	var negNames []string
+	if taskMode == inspectioncore_contract.TaskModeRun {
+		negs := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref())
+		for negName := range negs {
+			negNames = append(negNames, negName)
+		}
+	}
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlognetworkapiaudit_contract.ClusterIdentityTaskID.Ref())
+	queries := GenerateGCPNetworkAPIStructuredQuery(taskMode, negNames)
+	if clusterIdentity.ProjectID == "" {
+		for _, q := range queries {
+			q.Incomplete = true
+		}
+	}
+	return queries, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (n *networkAPIListLogEntiesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (n *networkAPIListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlognetworkapiaudit_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (n *networkAPIListLogEntiesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (n *networkAPIListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 1, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*networkAPIListLogEntiesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*networkAPIListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&networkAPIListLogEntiesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&networkAPIListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/query_task_test.go
@@ -15,29 +15,208 @@
 package googlecloudlognetworkapiaudit_impl
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlognetworkapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlognetworkapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateGenerateGCPNetworkAPIQueryIsValid(t *testing.T) {
+func TestGenerateGCPNetworkAPIStructuredQuery(t *testing.T) {
+	generateNEGs := func(count int) []string {
+		negs := make([]string, count)
+		for i := 0; i < count; i++ {
+			negs[i] = fmt.Sprintf("neg-%d", i+1)
+		}
+		return negs
+	}
 
 	testCases := []struct {
-		Name string
-		NEGs []string
+		name                   string
+		taskMode               inspectioncore_contract.InspectionTaskModeType
+		negNames               []string
+		wantQueries            []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			Name: "Valid Query",
-			NEGs: []string{"neg-1", "neg-2"},
+			name:     "DryRun mode",
+			taskMode: inspectioncore_contract.TaskModeDryRun,
+			negNames: []string{},
+			wantQueries: []string{
+				`resource.type="gce_network"
+-protoPayload.methodName:("list" OR "get" OR "watch")
+-- neg name filters to be determined after audit log query`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:                   "Run mode with empty NEGs",
+			taskMode:               inspectioncore_contract.TaskModeRun,
+			negNames:               []string{},
+			wantQueries:            []string{},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:     "Run mode with single NEG",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			negNames: []string{"neg-1"},
+			wantQueries: []string{
+				`resource.type="gce_network"
+-protoPayload.methodName:("list" OR "get" OR "watch")
+protoPayload.resourceName:(networkEndpointGroups/neg-1)`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:     "Run mode with a few NEGs",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			negNames: []string{"neg-1", "neg-2"},
+			wantQueries: []string{
+				`resource.type="gce_network"
+-protoPayload.methodName:("list" OR "get" OR "watch")
+protoPayload.resourceName:(networkEndpointGroups/neg-1 OR networkEndpointGroups/neg-2)`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:     "Run mode with >10 NEGs chunked into multiple queries",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			negNames: generateNEGs(12),
+			wantQueries: []string{
+				func() string {
+					parts := []string{}
+					for i := 1; i <= 10; i++ {
+						parts = append(parts, fmt.Sprintf("networkEndpointGroups/neg-%d", i))
+					}
+					return fmt.Sprintf("resource.type=\"gce_network\"\n-protoPayload.methodName:(\"list\" OR \"get\" OR \"watch\")\nprotoPayload.resourceName:(%s)", strings.Join(parts, " OR "))
+				}(),
+				`resource.type="gce_network"
+-protoPayload.methodName:("list" OR "get" OR "watch")
+protoPayload.resourceName:(networkEndpointGroups/neg-11 OR networkEndpointGroups/neg-12)`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sqs := GenerateGCPNetworkAPIStructuredQuery(tc.taskMode, tc.negNames)
+			gotQueries := make([]string, len(sqs))
+			for i, sq := range sqs {
+				gotQueries[i] = sq.GenerateCloudLoggingQuery()
+				if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+					t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
+				}
+			}
+
+			if diff := cmp.Diff(tc.wantQueries, gotQueries); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQueries := GenerateGCPNetworkAPIQuery(tc.taskMode, tc.negNames)
+			if diff := cmp.Diff(gotQueries, legacyQueries); diff != "" {
+				t.Errorf("GenerateGCPNetworkAPIQuery() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateGCPNetworkAPIQueryIsValid(t *testing.T) {
+	testCases := []struct {
+		name     string
+		taskMode inspectioncore_contract.InspectionTaskModeType
+		negs     []string
+	}{
+		{
+			name:     "Valid Query in DryRun mode",
+			taskMode: inspectioncore_contract.TaskModeDryRun,
+			negs:     []string{},
+		},
+		{
+			name:     "Valid Query in Run mode",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			negs:     []string{"neg-1", "neg-2"},
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			query := generateGCPNetworkAPIQuery(0, tc.NEGs)
-			err := gcp_test.IsValidLogQuery(t, query[0])
-			if err != nil {
-				t.Errorf("Query is not valid: %v", err)
+		t.Run(tc.name, func(t *testing.T) {
+			queries := GenerateGCPNetworkAPIQuery(tc.taskMode, tc.negs)
+			for _, query := range queries {
+				err := gcp_test.IsValidLogQuery(t, query)
+				if err != nil {
+					t.Errorf("IsValidLogQuery error: %v", err)
+				}
 			}
 		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1-a",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlognetworkapiaudit_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{}),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="gce_network"
+-protoPayload.methodName:("list" OR "get" OR "watch")
+-- neg name filters to be determined after audit log query
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "GCP network log" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "GCP network log")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task.go
@@ -18,71 +18,76 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogonpremapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogonpremapiaudit/contract"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
 
-func generateQuery(clusterIdentiy googlecloudk8scommon_contract.GoogleCloudClusterIdentity) string {
-	return fmt.Sprintf(`
-log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access")
-resource.type="audited_resource"
-resource.labels.service="gkeonprem.googleapis.com"
-resource.labels.method:("Update" OR "Create" OR "Delete" OR "Enroll" OR "Unenroll")
-protoPayload.resourceName:"projects/%s/locations/%s/"
-protoPayload.resourceName:"%s"
-`, clusterIdentiy.ProjectID, clusterIdentiy.Location, clusterIdentiy.ClusterName)
+// GenerateOnPremAPIStructuredQuery generates a structured query for OnPrem API audit logs.
+func GenerateOnPremAPIStructuredQuery(clusterIdentity googlecloudk8scommon_contract.GoogleCloudClusterIdentity) *logestimator.StructuredLogQuery {
+	return &logestimator.StructuredLogQuery{
+		Incomplete:    !clusterIdentity.IsComplete(),
+		ResourceTypes: []string{"audited_resource"},
+		Filters: []logestimator.LoggingMonitoringMatcher{
+			logestimator.ResourceLabel("service", logestimator.Exact("gkeonprem.googleapis.com")),
+			logestimator.ResourceLabel("method", logestimator.ContainsAny("Update", "Create", "Delete", "Enroll", "Unenroll")),
+			logestimator.LogID(logestimator.OneOf("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")),
+			logestimator.CustomFilter(fmt.Sprintf(`protoPayload.resourceName:"projects/%s/locations/%s/"`, clusterIdentity.ProjectID, clusterIdentity.Location)),
+			logestimator.CustomFilter(fmt.Sprintf(`protoPayload.resourceName:"%s"`, clusterIdentity.ClusterName)),
+		},
+	}
+}
+
+// GenerateOnPremAPIQuery generates a query for OnPrem API audit logs.
+func GenerateOnPremAPIQuery(clusterIdentity googlecloudk8scommon_contract.GoogleCloudClusterIdentity) string {
+	return GenerateOnPremAPIStructuredQuery(clusterIdentity).GenerateCloudLoggingQuery()
+}
+
+func generateQuery(clusterIdentity googlecloudk8scommon_contract.GoogleCloudClusterIdentity) string {
+	return GenerateOnPremAPIQuery(clusterIdentity)
 }
 
 type onpremAPIListLogEntriesTaskSetting struct {
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (o *onpremAPIListLogEntriesTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	cluster := coretask.GetTaskResult(ctx, googlecloudlogonpremapiaudit_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", cluster.ProjectID)}, nil
 }
 
-// Dependencies implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (o *onpremAPIListLogEntriesTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogonpremapiaudit_contract.ClusterIdentityTaskID.Ref(),
 	}
 }
 
-// Description implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (o *onpremAPIListLogEntriesTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "OnPrem API Logs",
-		ExampleQuery: generateQuery(googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
-			ProjectID:   "example-project-id",
-			Location:    "example-location",
-			ClusterName: "example-cluster-name",
-		}),
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (o *onpremAPIListLogEntriesTaskSetting) QueryName() string {
+	return "OnPrem API Logs"
 }
 
-// LogFilters implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
-func (o *onpremAPIListLogEntriesTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (o *onpremAPIListLogEntriesTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogonpremapiaudit_contract.ClusterIdentityTaskID.Ref())
-	return []string{generateQuery(clusterIdentity)}, nil
+	return []*logestimator.StructuredLogQuery{GenerateOnPremAPIStructuredQuery(clusterIdentity)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (o *onpremAPIListLogEntriesTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogonpremapiaudit_contract.ListLogEntriesTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.ListLogEntriesTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (o *onpremAPIListLogEntriesTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 1, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*onpremAPIListLogEntriesTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*onpremAPIListLogEntriesTaskSetting)(nil)
 
-var ListLogEntriesTask = googlecloudcommon_contract.NewListLogEntriesTask(&onpremAPIListLogEntriesTaskSetting{})
+var ListLogEntriesTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&onpremAPIListLogEntriesTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/query_task_test.go
@@ -16,17 +16,29 @@ package googlecloudlogonpremapiaudit_impl
 
 import (
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
 	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogonpremapiaudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogonpremapiaudit/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateOnPremAPIQuery(t *testing.T) {
+func TestGenerateOnPremAPIStructuredQuery(t *testing.T) {
 	testCases := []struct {
-		name    string
-		cluster googlecloudk8scommon_contract.GoogleCloudClusterIdentity
-		want    string
+		name                   string
+		cluster                googlecloudk8scommon_contract.GoogleCloudClusterIdentity
+		wantQuery              string
+		wantMetricFilters      []string
+		wantSupportMetricsFlag bool
 	}{
 		{
 			name: "BaremetalCluster",
@@ -41,22 +53,63 @@ func TestGenerateOnPremAPIQuery(t *testing.T) {
 				},
 				Location: "asia-northeast1",
 			},
-			want: `
-log_id("cloudaudit.googleapis.com/activity") OR log_id("cloudaudit.googleapis.com/data_access")
-resource.type="audited_resource"
+			wantQuery: `resource.type="audited_resource"
 resource.labels.service="gkeonprem.googleapis.com"
 resource.labels.method:("Update" OR "Create" OR "Delete" OR "Enroll" OR "Unenroll")
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
 protoPayload.resourceName:"projects/test-project/locations/asia-northeast1/"
-protoPayload.resourceName:"test-cluster"
-`,
+protoPayload.resourceName:"test-cluster"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "audited_resource" AND resource.labels.service = "gkeonprem.googleapis.com" AND (resource.labels.method = has_substring("Update") OR resource.labels.method = has_substring("Create") OR resource.labels.method = has_substring("Delete") OR resource.labels.method = has_substring("Enroll") OR resource.labels.method = has_substring("Unenroll")) AND metric.labels.log = one_of("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name: "VMwareCluster",
+			cluster: googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+				ProjectID:   "test-project",
+				ClusterName: "test-cluster",
+				PrefixPolicy: googlecloudk8scommon_contract.ClusterPrefixPolicy{
+					Prefix: "vmwareClusters/",
+					RequiredUsages: []googlecloudk8scommon_contract.ClusterNameUsage{
+						googlecloudk8scommon_contract.ClusterNameUsageK8sPlatformAudit,
+					},
+				},
+				Location: "us-west1",
+			},
+			wantQuery: `resource.type="audited_resource"
+resource.labels.service="gkeonprem.googleapis.com"
+resource.labels.method:("Update" OR "Create" OR "Delete" OR "Enroll" OR "Unenroll")
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"projects/test-project/locations/us-west1/"
+protoPayload.resourceName:"test-cluster"`,
+			wantMetricFilters: []string{
+				`metric.type = "logging.googleapis.com/log_entry_count" AND resource.type = "audited_resource" AND resource.labels.service = "gkeonprem.googleapis.com" AND (resource.labels.method = has_substring("Update") OR resource.labels.method = has_substring("Create") OR resource.labels.method = has_substring("Delete") OR resource.labels.method = has_substring("Enroll") OR resource.labels.method = has_substring("Unenroll")) AND metric.labels.log = one_of("cloudaudit.googleapis.com/activity", "cloudaudit.googleapis.com/data_access")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			actual := generateQuery(testCase.cluster)
-			if diff := cmp.Diff(testCase.want, actual); diff != "" {
-				t.Errorf("The generated result is not matching with the expected\n%s", diff)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sq := GenerateOnPremAPIStructuredQuery(tc.cluster)
+			gotQuery := sq.GenerateCloudLoggingQuery()
+			if diff := cmp.Diff(tc.wantQuery, gotQuery); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQuery := generateQuery(tc.cluster)
+			if diff := cmp.Diff(gotQuery, legacyQuery); diff != "" {
+				t.Errorf("generateQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			gotMetrics := sq.GenerateMonitoringMetricFilters()
+			if diff := cmp.Diff(tc.wantMetricFilters, gotMetrics); diff != "" {
+				t.Errorf("GenerateMonitoringMetricFilters() mismatch (-want +got):\n%s", diff)
+			}
+
+			if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+				t.Errorf("AllFiltersSupportMetrics() = %v, want %v", sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
 			}
 		})
 	}
@@ -90,5 +143,65 @@ func TestGenerateOnPremAPIQueryIsValid(t *testing.T) {
 				t.Errorf("%s", err.Error())
 			}
 		})
+	}
+}
+
+func TestListLogEntriesTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "asia-northeast1",
+	}
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, ListLogEntriesTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogonpremapiaudit_contract.ClusterIdentityTaskID.Ref(), cluster),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `resource.type="audited_resource"
+resource.labels.service="gkeonprem.googleapis.com"
+resource.labels.method:("Update" OR "Create" OR "Delete" OR "Enroll" OR "Unenroll")
+(LOG_ID("cloudaudit.googleapis.com/activity") OR LOG_ID("cloudaudit.googleapis.com/data_access"))
+protoPayload.resourceName:"projects/test-project/locations/asia-northeast1/"
+protoPayload.resourceName:"test-cluster"
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "OnPrem API Logs" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "OnPrem API Logs")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogserialport/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/query_task.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
@@ -32,47 +34,67 @@ import (
 
 const MaxNodesPerQuery = 30
 
-func GenerateSerialPortQuery(taskMode inspectioncore_contract.InspectionTaskModeType, foundNodeNames []string, nodeNameSubstrings []string) []string {
+// GenerateSerialPortStructuredQuery generates structured log queries for serial port logs.
+func GenerateSerialPortStructuredQuery(taskMode inspectioncore_contract.InspectionTaskModeType, foundNodeNames []string, nodeNameSubstrings []string) []*logestimator.StructuredLogQuery {
+	logIDFilter := logestimator.LogID(logestimator.OneOf(
+		"serialconsole.googleapis.com/serial_port_1_output",
+		"serialconsole.googleapis.com/serial_port_2_output",
+		"serialconsole.googleapis.com/serial_port_3_output",
+		"serialconsole.googleapis.com/serial_port_debug_output",
+	))
+
+	var subFilter logestimator.LoggingMonitoringMatcher
+	if len(nodeNameSubstrings) > 0 {
+		subFilter = logestimator.CustomFilter(fmt.Sprintf(`labels."compute.googleapis.com/resource_name":(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(nodeNameSubstrings), " OR ")))
+	}
+
 	if taskMode == inspectioncore_contract.TaskModeDryRun {
-		return []string{
-			generateSerialPortQueryWithInstanceNameFilter("-- instance name filters to be determined after node name discovery", generateNodeNameSubstringLogFilter(nodeNameSubstrings)),
+		filters := []logestimator.LoggingMonitoringMatcher{
+			logIDFilter,
+			logestimator.CustomFilter("-- instance name filters to be determined after node name discovery"),
 		}
-	} else {
-		result := []string{}
-		instanceNameGroups := gcpqueryutil.SplitToChildGroups(foundNodeNames, MaxNodesPerQuery)
-		for _, group := range instanceNameGroups {
-			instanceNameFilter := fmt.Sprintf(`labels."compute.googleapis.com/resource_name"=(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(group), " OR "))
-			result = append(result, generateSerialPortQueryWithInstanceNameFilter(instanceNameFilter, generateNodeNameSubstringLogFilter(nodeNameSubstrings)))
+		if subFilter != nil {
+			filters = append(filters, subFilter)
 		}
-		return result
+		return []*logestimator.StructuredLogQuery{
+			{
+				Filters: filters,
+			},
+		}
 	}
-}
 
-func generateNodeNameSubstringLogFilter(nodeNameSubstrings []string) string {
-	if len(nodeNameSubstrings) == 0 {
-		return "-- No node name substring filters are specified."
-	} else {
-		return fmt.Sprintf(`labels."compute.googleapis.com/resource_name":(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(nodeNameSubstrings), " OR "))
+	result := []*logestimator.StructuredLogQuery{}
+	instanceNameGroups := gcpqueryutil.SplitToChildGroups(foundNodeNames, MaxNodesPerQuery)
+	for _, group := range instanceNameGroups {
+		instanceNameFilter := logestimator.CustomFilter(fmt.Sprintf(`labels."compute.googleapis.com/resource_name"=(%s)`, strings.Join(gcpqueryutil.WrapDoubleQuoteForStringArray(group), " OR ")))
+		filters := []logestimator.LoggingMonitoringMatcher{
+			logIDFilter,
+			instanceNameFilter,
+		}
+		if subFilter != nil {
+			filters = append(filters, subFilter)
+		}
+		result = append(result, &logestimator.StructuredLogQuery{
+			Filters: filters,
+		})
 	}
+	return result
 }
 
-func generateSerialPortQueryWithInstanceNameFilter(instanceNameFilter string, nodeNameSubstringFilter string) string {
-	return fmt.Sprintf(`LOG_ID("serialconsole.googleapis.com%%2Fserial_port_1_output") OR
-LOG_ID("serialconsole.googleapis.com%%2Fserial_port_2_output") OR
-LOG_ID("serialconsole.googleapis.com%%2Fserial_port_3_output") OR
-LOG_ID("serialconsole.googleapis.com%%2Fserial_port_debug_output")
-
-%s
-
-%s`, instanceNameFilter, nodeNameSubstringFilter)
+// GenerateSerialPortQuery generates query strings for serial port logs.
+func GenerateSerialPortQuery(taskMode inspectioncore_contract.InspectionTaskModeType, foundNodeNames []string, nodeNameSubstrings []string) []string {
+	sqs := GenerateSerialPortStructuredQuery(taskMode, foundNodeNames, nodeNameSubstrings)
+	res := make([]string, len(sqs))
+	for i, sq := range sqs {
+		res[i] = sq.GenerateCloudLoggingQuery()
+	}
+	return res
 }
-
-var LogQueryTask = googlecloudcommon_contract.NewListLogEntriesTask(&serialPortLoggingFilterTaskSetting{})
 
 type serialPortLoggingFilterTaskSetting struct {
 }
 
-// Dependencies implements googlecloudcommon_contract.CloudLoggingFilterTaskSetting.
+// Dependencies implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (s *serialPortLoggingFilterTaskSetting) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
 		googlecloudlogserialport_contract.ClusterIdentityTaskID.Ref(),
@@ -81,39 +103,45 @@ func (s *serialPortLoggingFilterTaskSetting) Dependencies() []taskid.UntypedTask
 	}
 }
 
-// Description implements googlecloudcommon_contract.CloudLoggingFilterTaskSetting.
-func (s *serialPortLoggingFilterTaskSetting) Description() *googlecloudcommon_contract.ListLogEntriesTaskDescription {
-	return &googlecloudcommon_contract.ListLogEntriesTaskDescription{
-
-		QueryName: "Serial port log",
-		ExampleQuery: GenerateSerialPortQuery(inspectioncore_contract.TaskModeRun, []string{
-			"gke-test-cluster-node-1",
-			"gke-test-cluster-node-2",
-		}, []string{})[0],
-	}
+// QueryName implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (s *serialPortLoggingFilterTaskSetting) QueryName() string {
+	return "Serial port log"
 }
 
-// LogFilters implements googlecloudcommon_contract.CloudLoggingFilterTaskSetting.
-func (s *serialPortLoggingFilterTaskSetting) LogFilters(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+// Queries implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
+func (s *serialPortLoggingFilterTaskSetting) Queries(ctx context.Context) ([]*logestimator.StructuredLogQuery, error) {
 	nodeNames := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.NodeNameInventoryTaskID.Ref())
 	nodeNameSubstrings := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.InputNodeNameFilterTaskID.Ref())
-	return GenerateSerialPortQuery(taskMode, nodeNames, nodeNameSubstrings), nil
+	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogserialport_contract.ClusterIdentityTaskID.Ref())
+	taskMode := inspectioncore_contract.TaskModeRun
+	if val, err := khictx.GetValue(ctx, inspectioncore_contract.InspectionTaskMode); err == nil {
+		taskMode = val
+	}
+	queries := GenerateSerialPortStructuredQuery(taskMode, nodeNames, nodeNameSubstrings)
+	if clusterIdentity.ProjectID == "" {
+		for _, q := range queries {
+			q.Incomplete = true
+		}
+	}
+	return queries, nil
 }
 
-// DefaultResourceNames implements googlecloudcommon_contract.CloudLoggingFilterTaskSetting.
+// DefaultResourceNames implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (s *serialPortLoggingFilterTaskSetting) DefaultResourceNames(ctx context.Context) ([]string, error) {
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudlogserialport_contract.ClusterIdentityTaskID.Ref())
 	return []string{fmt.Sprintf("projects/%s", clusterIdentity.ProjectID)}, nil
 }
 
-// TaskID implements googlecloudcommon_contract.CloudLoggingFilterTaskSetting.
+// TaskID implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (s *serialPortLoggingFilterTaskSetting) TaskID() taskid.TaskImplementationID[[]*log.Log] {
 	return googlecloudlogserialport_contract.LogQueryTaskID
 }
 
-// TimePartitionCount implements googlecloudcommon_contract.CloudLoggingFilterTaskSetting.
+// TimePartitionCount implements googlecloudcommon_contract.StructuredListLogEntriesTaskSetting.
 func (s *serialPortLoggingFilterTaskSetting) TimePartitionCount(ctx context.Context) (int, error) {
 	return 10, nil
 }
 
-var _ googlecloudcommon_contract.ListLogEntriesTaskSetting = (*serialPortLoggingFilterTaskSetting)(nil)
+var _ googlecloudcommon_contract.StructuredListLogEntriesTaskSetting = (*serialPortLoggingFilterTaskSetting)(nil)
+
+var LogQueryTask = googlecloudcommon_contract.NewStructuredListLogEntriesTask(&serialPortLoggingFilterTaskSetting{})

--- a/pkg/task/inspection/googlecloudlogserialport/impl/query_task.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/query_task.go
@@ -51,7 +51,7 @@ func GenerateSerialPortStructuredQuery(taskMode inspectioncore_contract.Inspecti
 	if taskMode == inspectioncore_contract.TaskModeDryRun {
 		filters := []logestimator.LoggingMonitoringMatcher{
 			logIDFilter,
-			logestimator.CustomFilter("-- instance name filters to be determined after node name discovery"),
+			logestimator.Comment("instance name filters to be determined after node name discovery"),
 		}
 		if subFilter != nil {
 			filters = append(filters, subFilter)

--- a/pkg/task/inspection/googlecloudlogserialport/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/query_task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,88 +17,134 @@ package googlecloudlogserialport_impl
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/idgenerator"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
+	googlecloudlogserialport_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogserialport/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	gcp_test "github.com/GoogleCloudPlatform/khi/pkg/testutil/gcp"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateSerialPortQuery(t *testing.T) {
+func TestGenerateSerialPortStructuredQuery(t *testing.T) {
 	testCases := []struct {
-		name               string
-		taskMode           inspectioncore_contract.InspectionTaskModeType
-		nodeNames          []string
-		nodeNameSubstrings []string
-		wantQuery          string
+		name                   string
+		taskMode               inspectioncore_contract.InspectionTaskModeType
+		nodeNames              []string
+		nodeNameSubstrings     []string
+		wantQueries            []string
+		wantSupportMetricsFlag bool
 	}{
 		{
-			name:               "dryrun",
+			name:               "dryrun with no substrings",
 			taskMode:           inspectioncore_contract.TaskModeDryRun,
 			nodeNames:          []string{"node-1", "node-2"},
 			nodeNameSubstrings: []string{},
-			wantQuery: `LOG_ID("serialconsole.googleapis.com%2Fserial_port_1_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_2_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_3_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_debug_output")
-
--- instance name filters to be determined after node name discovery
-
--- No node name substring filters are specified.`,
+			wantQueries: []string{
+				`(LOG_ID("serialconsole.googleapis.com/serial_port_1_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_2_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_3_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_debug_output"))
+-- instance name filters to be determined after node name discovery`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
-			name:               "with single node",
+			name:               "dryrun with substrings",
+			taskMode:           inspectioncore_contract.TaskModeDryRun,
+			nodeNames:          []string{"node-1"},
+			nodeNameSubstrings: []string{"sub-a", "sub-b"},
+			wantQueries: []string{
+				`(LOG_ID("serialconsole.googleapis.com/serial_port_1_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_2_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_3_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_debug_output"))
+-- instance name filters to be determined after node name discovery
+labels."compute.googleapis.com/resource_name":("sub-a" OR "sub-b")`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:                   "run mode with 0 nodes",
+			taskMode:               inspectioncore_contract.TaskModeRun,
+			nodeNames:              []string{},
+			nodeNameSubstrings:     []string{},
+			wantQueries:            []string{},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:               "run mode with single node",
 			taskMode:           inspectioncore_contract.TaskModeRun,
 			nodeNames:          []string{"node-1"},
 			nodeNameSubstrings: []string{},
-			wantQuery: `LOG_ID("serialconsole.googleapis.com%2Fserial_port_1_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_2_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_3_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_debug_output")
-
-labels."compute.googleapis.com/resource_name"=("node-1")
-
--- No node name substring filters are specified.`,
+			wantQueries: []string{
+				`(LOG_ID("serialconsole.googleapis.com/serial_port_1_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_2_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_3_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_debug_output"))
+labels."compute.googleapis.com/resource_name"=("node-1")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
-			name:               "with multiple nodes",
+			name:               "run mode with multiple nodes",
 			taskMode:           inspectioncore_contract.TaskModeRun,
 			nodeNames:          []string{"node-1", "node-2", "node-3"},
 			nodeNameSubstrings: []string{},
-			wantQuery: `LOG_ID("serialconsole.googleapis.com%2Fserial_port_1_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_2_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_3_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_debug_output")
-
-labels."compute.googleapis.com/resource_name"=("node-1" OR "node-2" OR "node-3")
-
--- No node name substring filters are specified.`,
+			wantQueries: []string{
+				`(LOG_ID("serialconsole.googleapis.com/serial_port_1_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_2_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_3_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_debug_output"))
+labels."compute.googleapis.com/resource_name"=("node-1" OR "node-2" OR "node-3")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 		{
-			name:               "with node name substring",
+			name:               "run mode with multiple nodes and substring",
 			taskMode:           inspectioncore_contract.TaskModeRun,
 			nodeNames:          []string{"node-1", "node-2", "node-3"},
 			nodeNameSubstrings: []string{"node-1"},
-			wantQuery: `LOG_ID("serialconsole.googleapis.com%2Fserial_port_1_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_2_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_3_output") OR
-LOG_ID("serialconsole.googleapis.com%2Fserial_port_debug_output")
-
+			wantQueries: []string{
+				`(LOG_ID("serialconsole.googleapis.com/serial_port_1_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_2_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_3_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_debug_output"))
 labels."compute.googleapis.com/resource_name"=("node-1" OR "node-2" OR "node-3")
-
 labels."compute.googleapis.com/resource_name":("node-1")`,
+			},
+			wantSupportMetricsFlag: false,
+		},
+		{
+			name:               "run mode with multiple nodes and multiple substrings",
+			taskMode:           inspectioncore_contract.TaskModeRun,
+			nodeNames:          []string{"node-1", "node-2"},
+			nodeNameSubstrings: []string{"sub-1", "sub-2"},
+			wantQueries: []string{
+				`(LOG_ID("serialconsole.googleapis.com/serial_port_1_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_2_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_3_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_debug_output"))
+labels."compute.googleapis.com/resource_name"=("node-1" OR "node-2")
+labels."compute.googleapis.com/resource_name":("sub-1" OR "sub-2")`,
+			},
+			wantSupportMetricsFlag: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			query := GenerateSerialPortQuery(tc.taskMode, tc.nodeNames, tc.nodeNameSubstrings)
-			if diff := cmp.Diff(tc.wantQuery, query[0]); diff != "" {
-				t.Errorf("the generated query is not matching with the expected query\n%s", diff)
+			sqs := GenerateSerialPortStructuredQuery(tc.taskMode, tc.nodeNames, tc.nodeNameSubstrings)
+			gotQueries := make([]string, len(sqs))
+			for i, sq := range sqs {
+				gotQueries[i] = sq.GenerateCloudLoggingQuery()
+				if sq.AllFiltersSupportMetrics() != tc.wantSupportMetricsFlag {
+					t.Errorf("AllFiltersSupportMetrics()[%d] = %v, want %v", i, sq.AllFiltersSupportMetrics(), tc.wantSupportMetricsFlag)
+				}
+				err := gcp_test.IsValidLogQuery(t, gotQueries[i])
+				if err != nil {
+					t.Errorf("the generated query is invalid: %v", err)
+				}
 			}
-			err := gcp_test.IsValidLogQuery(t, query[0])
-			if err != nil {
-				t.Errorf("the generated query is invalid. error:%v", err)
+
+			if diff := cmp.Diff(tc.wantQueries, gotQueries); diff != "" {
+				t.Errorf("GenerateCloudLoggingQuery() mismatch (-want +got):\n%s", diff)
+			}
+
+			legacyQueries := GenerateSerialPortQuery(tc.taskMode, tc.nodeNames, tc.nodeNameSubstrings)
+			if diff := cmp.Diff(gotQueries, legacyQueries); diff != "" {
+				t.Errorf("GenerateSerialPortQuery() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -109,7 +155,7 @@ func TestMaximumNodeCountNotHittingQueryLengthLimit(t *testing.T) {
 	idg8 := idgenerator.NewFixedLengthIDGenerator(8)
 	idg4 := idgenerator.NewFixedLengthIDGenerator(4)
 	nodeNames := []string{}
-	for i := 0; i < MaxNodesPerQuery*2+1; i++ { // This query must be splitted with 3 sub groups.
+	for i := 0; i < MaxNodesPerQuery*2+1; i++ { // This query must be split into 3 sub groups.
 		nodeNames = append(nodeNames, fmt.Sprintf(`gke-%s-%s-%s`, idg46.Generate(), idg8.Generate(), idg4.Generate()))
 	}
 	query := GenerateSerialPortQuery(inspectioncore_contract.TaskModeRun, nodeNames, []string{})
@@ -124,34 +170,60 @@ func TestMaximumNodeCountNotHittingQueryLengthLimit(t *testing.T) {
 	}
 }
 
-func Test_generateNodeNameSubstringLogFilter(t *testing.T) {
-	tests := []struct {
-		name               string
-		nodeNameSubstrings []string
-		want               string
-	}{
-		{
-			name:               "empty",
-			nodeNameSubstrings: []string{},
-			want:               "-- No node name substring filters are specified.",
-		},
-		{
-			name:               "single",
-			nodeNameSubstrings: []string{"substring1"},
-			want:               `labels."compute.googleapis.com/resource_name":("substring1")`,
-		},
-		{
-			name:               "multiple",
-			nodeNameSubstrings: []string{"substring1", "substring2", "substring3"},
-			want:               `labels."compute.googleapis.com/resource_name":("substring1" OR "substring2" OR "substring3")`,
-		},
+func TestLogQueryTask_DryRun(t *testing.T) {
+	t.Parallel()
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+
+	cluster := googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
+		ClusterName: "test-cluster",
+		ProjectID:   "test-project",
+		Location:    "us-central1",
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := generateNodeNameSubstringLogFilter(tt.nodeNameSubstrings)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("generateNodeNameSubstringLogFilter() mismatch (-want +got):\n%s", diff)
-			}
-		})
+
+	resourceNamesInput := googlecloudcommon_contract.NewResourceNamesInput()
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create ClientFactory: %v", err)
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	gotLogs, _, err := inspectiontest.RunInspectionTask(ctx, LogQueryTask, inspectioncore_contract.TaskModeDryRun, map[string]any{},
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(googlecloudcommon_contract.InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(googlecloudlogserialport_contract.ClusterIdentityTaskID.Ref(), cluster),
+		tasktest.NewTaskDependencyValuePair(googlecloudk8scommon_contract.InputNodeNameFilterTaskID.Ref(), []string{}),
+		tasktest.NewTaskDependencyValuePair(commonlogk8saudit_contract.NodeNameInventoryTaskID.Ref(), []string{}),
+	)
+	if err != nil {
+		t.Fatalf("dry run returned unexpected error: %v", err)
+	}
+	if len(gotLogs) != 0 {
+		t.Errorf("dry run should return 0 logs, got %d", len(gotLogs))
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	queryMetadata, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found in metadata")
+	}
+
+	serialized := queryMetadata.ToSerializable().([]*inspectionmetadata.QueryItem)
+	if len(serialized) != 1 {
+		t.Fatalf("expected 1 QueryItem, got %d", len(serialized))
+	}
+
+	wantQuery := `(LOG_ID("serialconsole.googleapis.com/serial_port_1_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_2_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_3_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_debug_output"))
+-- instance name filters to be determined after node name discovery
+timestamp >= "2025-01-01T01:00:00+0000"
+timestamp <= "2025-01-01T01:01:00+0000"`
+
+	if diff := cmp.Diff(wantQuery, serialized[0].Query); diff != "" {
+		t.Errorf("query mismatch (-want +got):\n%s", diff)
+	}
+	if serialized[0].Name != "Serial port log" {
+		t.Errorf("query name mismatch: got %q, want %q", serialized[0].Name, "Serial port log")
 	}
 }

--- a/pkg/task/inspection/googlecloudlogserialport/impl/query_task_test.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/query_task_test.go
@@ -53,7 +53,7 @@ func TestGenerateSerialPortStructuredQuery(t *testing.T) {
 				`(LOG_ID("serialconsole.googleapis.com/serial_port_1_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_2_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_3_output") OR LOG_ID("serialconsole.googleapis.com/serial_port_debug_output"))
 -- instance name filters to be determined after node name discovery`,
 			},
-			wantSupportMetricsFlag: false,
+			wantSupportMetricsFlag: true,
 		},
 		{
 			name:               "dryrun with substrings",

--- a/web/src/app/common/schema/metadata-types.ts
+++ b/web/src/app/common/schema/metadata-types.ts
@@ -27,9 +27,11 @@ export type InspectionMetadataPlan = {
 };
 
 export type InspectionMetadataQuery = {
-  id: string;
-  name: string;
-  query: string;
+  readonly id: string;
+  readonly name: string;
+  readonly query: string;
+  readonly estimatedCount?: number;
+  readonly incomplete?: boolean;
 };
 
 export type InspectionMetadataErrorSet = {

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.html
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.html
@@ -115,10 +115,46 @@ limitations under the License.
                 <mat-card-title>Query</mat-card-title>
               </mat-card-header>
               <mat-card-content>
+                @if (parameterViewModel.totalEstimatedSummary; as summary) {
+                  <div
+                    class="total-estimated-callout"
+                    [class.normal]="summary.severity === 'normal'"
+                    [class.warning]="summary.severity === 'warning'"
+                    [class.danger]="summary.severity === 'danger'"
+                  >
+                    @if (summary.isEstimating) {
+                      <mat-spinner diameter="16"></mat-spinner>
+                    } @else if (summary.severity === "danger") {
+                      <mat-icon>error</mat-icon>
+                    } @else if (summary.severity === "warning") {
+                      <mat-icon>warning</mat-icon>
+                    } @else {
+                      <mat-icon>info</mat-icon>
+                    }
+                    <span class="callout-text">{{ summary.displayText }}</span>
+                  </div>
+                }
                 @for (query of parameterViewModel.queries; track query.name) {
                   <mat-card class="query-card">
                     <mat-card-header>
                       <mat-card-title>{{ query.name }}</mat-card-title>
+                      <mat-card-subtitle class="query-status-subtitle">
+                        @if (query.incomplete) {
+                          <span class="query-incomplete"
+                            >Incomplete parameters</span
+                          >
+                        } @else if (query.estimatedCount !== undefined) {
+                          <span class="query-estimated-count"
+                            >~{{ query.estimatedCount | number }} logs
+                            estimated</span
+                          >
+                        } @else {
+                          <div class="query-estimating">
+                            <mat-spinner diameter="14"></mat-spinner>
+                            <span>Estimating...</span>
+                          </div>
+                        }
+                      </mat-card-subtitle>
                     </mat-card-header>
                     <mat-card-content>
                       <pre class="query-section-query-pre">{{

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.scss
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.scss
@@ -19,6 +19,17 @@
 $inspection-type-icon-size: 80px;
 $selected-color: #283593;
 $query-accent: #283593;
+$total-count-warning-color: #f57c00;
+$total-count-danger-color: #d32f2f;
+$callout-normal-bg: #e8eaf6;
+$callout-normal-border: #c5cae9;
+$callout-normal-text: #283593;
+$callout-warning-bg: #fff3e0;
+$callout-warning-border: #ffe0b2;
+$callout-warning-text: #e65100;
+$callout-danger-bg: #ffebee;
+$callout-danger-border: #ffcdd2;
+$callout-danger-text: #c62828;
 
 mat-dialog-content {
   overflow: hidden;
@@ -229,8 +240,102 @@ mat-step {
   margin: 0 0 5px;
 }
 
+.total-estimated-callout {
+  display: grid;
+  grid-template:
+    'icon text' auto
+    / auto 1fr;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  margin: 0 0 10px;
+  border-radius: 4px;
+  font-size: 0.88em;
+  line-height: 1.4;
+
+  mat-icon {
+    grid-area: icon;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  mat-spinner {
+    grid-area: icon;
+  }
+
+  .callout-text {
+    grid-area: text;
+    font-weight: 500;
+  }
+
+  &.normal {
+    background-color: $callout-normal-bg;
+    border: 1px solid $callout-normal-border;
+    color: $callout-normal-text;
+
+    mat-icon {
+      color: $callout-normal-text;
+    }
+  }
+
+  &.warning {
+    background-color: $callout-warning-bg;
+    border: 1px solid $callout-warning-border;
+    color: $callout-warning-text;
+
+    mat-icon {
+      color: $callout-warning-text;
+    }
+  }
+
+  &.danger {
+    background-color: $callout-danger-bg;
+    border: 1px solid $callout-danger-border;
+    color: $callout-danger-text;
+
+    mat-icon {
+      color: $callout-danger-text;
+    }
+  }
+}
+
 .query-card {
   margin: 0 0 5px;
+
+  .query-status-subtitle {
+    display: block;
+    margin: 2px 0 4px;
+    font-size: 0.85em;
+    line-height: 1.2;
+
+    .query-estimated-count {
+      opacity: 0.85;
+    }
+
+    .query-incomplete {
+      font-style: italic;
+      opacity: 0.7;
+    }
+
+    .query-estimating {
+      display: grid;
+      grid-template:
+        'spinner text' auto
+        / auto 1fr;
+      align-items: center;
+      gap: 6px;
+      opacity: 0.85;
+
+      mat-spinner {
+        grid-area: spinner;
+      }
+
+      span {
+        grid-area: text;
+      }
+    }
+  }
 }
 
 .query-section-query-pre {

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
@@ -19,9 +19,14 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { signal } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { NewInspectionDialogComponent } from './new-inspection.component';
+import {
+  NewInspectionDialogComponent,
+  computeTotalEstimatedLogs,
+  TotalEstimatedLogsSeverity,
+} from './new-inspection.component';
 import { BACKEND_API } from 'src/app/services/api/backend-api-interface';
 import { BACKEND_SYNC } from 'src/app/services/api/backend-sync.service';
+import { InspectionMetadataQuery } from 'src/app/common/schema/metadata-types';
 
 import {
   EXTENSION_STORE,
@@ -66,5 +71,154 @@ describe('NewInspectionDialogTest', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('computeTotalEstimatedLogs', () => {
+    it('should return undefined for empty or undefined query list', () => {
+      expect(computeTotalEstimatedLogs(undefined)).toBeUndefined();
+      expect(computeTotalEstimatedLogs([])).toBeUndefined();
+    });
+
+    it('should calculate complete total with Normal severity when < 1,000,000', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 500 },
+        { id: 'q2', name: 'q2', query: 'query2', estimatedCount: 1500 },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 2000,
+        isComplete: true,
+        isEstimating: false,
+        isIncomplete: false,
+        displayText: '~2,000 total logs estimated',
+        severity: TotalEstimatedLogsSeverity.Normal,
+      });
+    });
+
+    it('should calculate complete total with 0 logs', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 0 },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 0,
+        isComplete: true,
+        isEstimating: false,
+        isIncomplete: false,
+        displayText: '~0 total logs estimated',
+        severity: TotalEstimatedLogsSeverity.Normal,
+      });
+    });
+
+    it('should format partial estimate with > prefix when some queries are in-flight', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 1250 },
+        { id: 'q2', name: 'q2', query: 'query2' },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 1250,
+        isComplete: false,
+        isEstimating: true,
+        isIncomplete: false,
+        displayText: '>1,250 logs estimated so far',
+        severity: TotalEstimatedLogsSeverity.Normal,
+      });
+    });
+
+    it('should display Estimating total logs... when all queries are unestimated', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1' },
+        { id: 'q2', name: 'q2', query: 'query2' },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 0,
+        isComplete: false,
+        isEstimating: true,
+        isIncomplete: false,
+        displayText: 'Estimating total logs...',
+        severity: TotalEstimatedLogsSeverity.Normal,
+      });
+    });
+
+    it('should assign Warning severity for counts between 1,000,000 and 4,999,999', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 1200000 },
+        { id: 'q2', name: 'q2', query: 'query2', estimatedCount: 300000 },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 1500000,
+        isComplete: true,
+        isEstimating: false,
+        isIncomplete: false,
+        displayText: '~1,500,000 total logs estimated',
+        severity: TotalEstimatedLogsSeverity.Warning,
+      });
+    });
+
+    it('should assign Danger severity for counts >= 5,000,000', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 5000000 },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 5000000,
+        isComplete: true,
+        isEstimating: false,
+        isIncomplete: false,
+        displayText: '~5,000,000 total logs estimated',
+        severity: TotalEstimatedLogsSeverity.Danger,
+      });
+    });
+
+    it('should assign Danger severity for partial estimates >= 5,000,000', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 6500000 },
+        { id: 'q2', name: 'q2', query: 'query2' },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 6500000,
+        isComplete: false,
+        isEstimating: true,
+        isIncomplete: false,
+        displayText: '>6,500,000 logs estimated so far',
+        severity: TotalEstimatedLogsSeverity.Danger,
+      });
+    });
+
+    it('should display Incomplete parameters when all queries are incomplete with no counts', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', incomplete: true },
+        { id: 'q2', name: 'q2', query: 'query2', incomplete: true },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 0,
+        isComplete: false,
+        isEstimating: false,
+        isIncomplete: true,
+        displayText: 'Incomplete parameters',
+        severity: TotalEstimatedLogsSeverity.Normal,
+      });
+    });
+
+    it('should display >N logs estimated (some parameters incomplete) when some queries are estimated and others are incomplete', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 2500 },
+        { id: 'q2', name: 'q2', query: 'query2', incomplete: true },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 2500,
+        isComplete: false,
+        isEstimating: false,
+        isIncomplete: true,
+        displayText: '>2,500 logs estimated (some parameters incomplete)',
+        severity: TotalEstimatedLogsSeverity.Normal,
+      });
+    });
   });
 });

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
@@ -220,5 +220,22 @@ describe('NewInspectionDialogTest', () => {
         severity: TotalEstimatedLogsSeverity.Normal,
       });
     });
+
+    it('should set isEstimating to true when some queries are incomplete and others are still estimating', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 1000 },
+        { id: 'q2', name: 'q2', query: 'query2' },
+        { id: 'q3', name: 'q3', query: 'query3', incomplete: true },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 1000,
+        isComplete: false,
+        isEstimating: true,
+        isIncomplete: true,
+        displayText: '>1,000 logs estimated (some parameters incomplete)',
+        severity: TotalEstimatedLogsSeverity.Normal,
+      });
+    });
   });
 });

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.ts
@@ -48,6 +48,7 @@ import { BackendSyncService } from 'src/app/services/api/backend-sync-interface'
 import { MatCardModule } from '@angular/material/card';
 import { CommonModule } from '@angular/common';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { KHICommonModule } from 'src/app/common/common.module';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -77,16 +78,115 @@ import {
 } from 'src/app/extensions/extension-common/extension-store';
 
 export interface NewInspectionDialogResult {
-  inspectionTaskStarted: boolean;
+  readonly inspectionTaskStarted: boolean;
+}
+
+/**
+ * Severity level based on estimated log volume.
+ */
+export enum TotalEstimatedLogsSeverity {
+  Normal = 'normal',
+  Warning = 'warning',
+  Danger = 'danger',
+}
+
+/**
+ * Summary of total estimated log count across all queries.
+ */
+export interface TotalEstimatedLogsSummary {
+  readonly knownCount: number;
+  readonly isComplete: boolean;
+  readonly isEstimating: boolean;
+  readonly isIncomplete: boolean;
+  readonly displayText: string;
+  readonly severity: TotalEstimatedLogsSeverity;
+}
+
+/**
+ * Computes the aggregate estimated log count summary across all queries.
+ */
+export function computeTotalEstimatedLogs(
+  queries?: InspectionMetadataQuery[],
+): TotalEstimatedLogsSummary | undefined {
+  if (!queries || queries.length === 0) {
+    return undefined;
+  }
+  const hasIncomplete = queries.some((q) => q.incomplete);
+  const hasUnestimated = queries.some(
+    (q) => q.estimatedCount === undefined && !q.incomplete,
+  );
+  const knownCount = queries
+    .filter((q) => q.estimatedCount !== undefined)
+    .reduce((sum, q) => sum + (q.estimatedCount ?? 0), 0);
+
+  let severity = TotalEstimatedLogsSeverity.Normal;
+  if (knownCount >= 5_000_000) {
+    severity = TotalEstimatedLogsSeverity.Danger;
+  } else if (knownCount >= 1_000_000) {
+    severity = TotalEstimatedLogsSeverity.Warning;
+  }
+
+  const formattedCount = knownCount.toLocaleString('en-US');
+  if (hasIncomplete) {
+    if (knownCount > 0) {
+      return {
+        knownCount,
+        isComplete: false,
+        isEstimating: false,
+        isIncomplete: true,
+        displayText: `>${formattedCount} logs estimated (some parameters incomplete)`,
+        severity,
+      };
+    }
+    return {
+      knownCount: 0,
+      isComplete: false,
+      isEstimating: false,
+      isIncomplete: true,
+      displayText: 'Incomplete parameters',
+      severity: TotalEstimatedLogsSeverity.Normal,
+    };
+  }
+
+  if (hasUnestimated) {
+    if (knownCount > 0) {
+      return {
+        knownCount,
+        isComplete: false,
+        isEstimating: true,
+        isIncomplete: false,
+        displayText: `>${formattedCount} logs estimated so far`,
+        severity,
+      };
+    }
+    return {
+      knownCount: 0,
+      isComplete: false,
+      isEstimating: true,
+      isIncomplete: false,
+      displayText: 'Estimating total logs...',
+      severity: TotalEstimatedLogsSeverity.Normal,
+    };
+  }
+
+  return {
+    knownCount,
+    isComplete: true,
+    isEstimating: false,
+    isIncomplete: false,
+    displayText: `~${formattedCount} total logs estimated`,
+    severity,
+  };
 }
 
 export interface ParameterPageViewModel {
-  rootGroupForm: GroupParameterFormField;
-  queries: InspectionMetadataQuery[];
-  plan: InspectionMetadataPlan;
-  job?: InspectionMetadataJobModeCommand;
-  errorFieldCount: number;
-  fieldCount: number;
+  readonly rootGroupForm: GroupParameterFormField;
+  readonly queries: InspectionMetadataQuery[];
+  readonly plan: InspectionMetadataPlan;
+  readonly job?: InspectionMetadataJobModeCommand;
+  readonly errorFieldCount: number;
+  readonly fieldCount: number;
+  readonly totalEstimatedSummary?: TotalEstimatedLogsSummary;
 }
 
 export function openNewInspectionDialog(dialog: MatDialog) {
@@ -109,6 +209,7 @@ export function openNewInspectionDialog(dialog: MatDialog) {
     MatStepperModule,
     MatCardModule,
     MatProgressBarModule,
+    MatProgressSpinnerModule,
     MatIconModule,
     ReactiveFormsModule,
     MatFormFieldModule,
@@ -267,6 +368,7 @@ export class NewInspectionDialogComponent implements OnDestroy {
           job: metadata.jobCommand,
           errorFieldCount: errorFieldCount,
           fieldCount: fieldCount,
+          totalEstimatedSummary: computeTotalEstimatedLogs(metadata.query),
         } as ParameterPageViewModel;
       }),
     ),

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.ts
@@ -132,7 +132,7 @@ export function computeTotalEstimatedLogs(
       return {
         knownCount,
         isComplete: false,
-        isEstimating: false,
+        isEstimating: hasUnestimated,
         isIncomplete: true,
         displayText: `>${formattedCount} logs estimated (some parameters incomplete)`,
         severity,
@@ -141,7 +141,7 @@ export function computeTotalEstimatedLogs(
     return {
       knownCount: 0,
       isComplete: false,
-      isEstimating: false,
+      isEstimating: hasUnestimated,
       isIncomplete: true,
       displayText: 'Incomplete parameters',
       severity: TotalEstimatedLogsSeverity.Normal,


### PR DESCRIPTION
## Summary

This PR implements structured log query estimation for Google Cloud Logging queries, introduces caching & metric-based volume estimation, migrates all 14 Google Cloud query tasks to `StructuredLogQuery`, and improves the New Inspection dialog UI to display live log count estimates and progress indicators.

### Key Changes

1. **Structured Log Query Estimator (`pkg/api/googlecloud/logestimator`)**:
   - Implemented `StructuredLogQuery` with structured matchers (`ResourceLabel`, `LogID`, `CustomFilter`, `Comment`).
   - Mapped structured query filters directly to Cloud Monitoring log entry metrics (`logging.googleapis.com/log_entry_count`) with fallback to probe sampling.
   - Built `CachedStructuredLogEstimator` with singleflight request deduplication, LRU caching, and cancellation of outdated in-flight queries.

2. **Inspection Framework Extensions (`pkg/core/inspection/metadata`, `pkg/task/inspection/googlecloudcommon/contract`)**:
   - Added `StructuredListLogEntriesTask` capable of generating structured queries and estimating log volumes during dry-run mode.
   - Added `Incomplete` and `EstimatedCount` metadata fields to `InspectionMetadataQuery`.
   - Added `IsComplete()` method to `GoogleCloudClusterIdentity` to skip estimation when required parameters are missing.

3. **Query Task Migrations (`pkg/task/inspection/googlecloud*`)**:
   - Migrated all 14 Google Cloud query tasks to `StructuredLogQuery` (`k8scontainer`, `k8sevent`, `k8snode`, `k8scontrolplane`, `k8saudit`, `gkeautoscaler`, `gkeapiaudit`, `computeapiaudit`, `networkapiaudit`, `onpremapiaudit`, `multicloudapiaudit`, `composerapiaudit`, `clustercomposer`, `csm`, `csm traffic director`, `serialport`).
   - Added comprehensive table-driven tests verifying query generation equivalence, filter order, and metric compatibility.

4. **Frontend UI Redesign (`web/src/app/dialogs/new-inspection`)**:
   - Added a dedicated total estimated logs callout banner under the Query section with spinner and color-coded severity (`normal`, `warning` for >= 1M, `danger` for >= 5M).
   - Moved estimated log counts to individual query card subtitles with loading spinners.
   - Refined status text (`~N total logs estimated`, `>N logs estimated so far`, `Incomplete parameters`).

---

## Verification

- `make test-go`: All backend tests passed.
- `make test-web`: All 736 frontend tests passed.
- `make pre-commit`: All formatters and linters passed with 0 issues.
