### PR TITLE
fix(estimator): inject call options in StructuredLogEstimator and document Google API guidelines

### DIFF
--- a/.agents/rules/khi-task-rule.md
+++ b/.agents/rules/khi-task-rule.md
@@ -35,3 +35,8 @@ When developing or modifying task-related files in the KHI project (under `pkg/t
 ## 5. Proposing an implementation plan
 
 - When you propose an implementation plan to user, include the expected task graph in Mermaid format.
+
+## 6. Calling Google Cloud APIs
+
+- When calling Google Cloud APIs (Cloud Logging, Cloud Monitoring, etc.), you **MUST** inject call options into `context.Context` using `CallOptionInjector.InjectToCallContext(ctx, container)` before executing the API call. Refer to the `googlecloud-api` skill for details and patterns.
+- Tasks calling Google Cloud APIs must depend on `googlecloudcommon_contract.APIClientCallOptionsInjectorTaskID.Ref()` and retrieve it via `coretask.GetTaskResult(ctx, ...)` (or `coretask.GetTaskResultOptional` when maintaining compatibility with test fixtures that omit the injector).

--- a/.agents/skills/googlecloud_api/SKILL.md
+++ b/.agents/skills/googlecloud_api/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: googlecloud-api
+description: Guidelines and mandatory rules for calling Google Cloud APIs in KHI, including CallOptionInjector, ClientFactory, and context propagation.
+---
+
+# Calling Google Cloud APIs in KHI
+
+This guide outlines the mandatory patterns and best practices for invoking Google Cloud APIs (such as Cloud Logging, Cloud Monitoring, GKE, and Compute Engine) across KHI tasks and SDK components.
+
+---
+
+## 1. Core Principles
+
+All calls to Google Cloud APIs in KHI must carry proper call options (such as gRPC metadata, routing headers, quota parameters, and credentials) associated with the target Google Cloud resource container (`googlecloud.Project`, `googlecloud.Folder`, or `googlecloud.Organization`).
+
+> [!IMPORTANT]
+> **Mandatory Context Injection:**
+> You **MUST** always apply `CallOptionInjector` to the call's `context.Context` (or HTTP headers) prior to invoking any Google Cloud API.
+> Failing to call `InjectToCallContext` means required metadata and options will not propagate to the RPC, which can cause authentication, quota, or routing failures.
+
+---
+
+## 2. Using CallOptionInjector in Inspection Tasks
+
+Inspection tasks under `pkg/task/` that interact with Google Cloud APIs must retrieve `CallOptionInjector` through the KHI task DAG dependency system.
+
+### Step-by-Step Task Pattern
+
+1. **Add Task Dependency:**
+   Include `googlecloudcommon_contract.APIClientCallOptionsInjectorTaskID.Ref()` in the task's dependency list.
+
+2. **Retrieve Injector:**
+   In the task body, retrieve the injector using `coretask.GetTaskResult` (or `coretask.GetTaskResultOptional` when the injector is optional).
+
+3. **Inject Options Before Calling APIs:**
+   Call `InjectToCallContext` on `ctx` for the target container, and pass the resulting context to client initialization and API calls.
+
+### Code Sample: Task Implementation
+
+```go
+package mylog_impl
+
+import (
+ "context"
+ "fmt"
+
+ "cloud.google.com/go/logging/apiv2/loggingpb"
+ "github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+ coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
+ "github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+ googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+ inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+var MyDiscoveryTask = coretask.NewTask(
+ taskid.NewDefaultImplementationID[[]string]("mylog.khi.google.com/discovery"),
+ []taskid.UntypedTaskReference{
+  googlecloudcommon_contract.APIClientFactoryTaskID.Ref(),
+  googlecloudcommon_contract.APIClientCallOptionsInjectorTaskID.Ref(),
+ },
+ func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) ([]string, error) {
+  clientFactory := coretask.GetTaskResult(ctx, googlecloudcommon_contract.APIClientFactoryTaskID.Ref())
+  callOptionInjector := coretask.GetTaskResult(ctx, googlecloudcommon_contract.APIClientCallOptionsInjectorTaskID.Ref())
+
+  container := googlecloud.Project("my-project-id")
+
+  // 1. Inject call options into context for the container.
+  callCtx := callOptionInjector.InjectToCallContext(ctx, container)
+
+  // 2. Create client and make calls using callCtx.
+  loggingClient, err := clientFactory.NewClient(callCtx, container)
+  if err != nil {
+   return nil, fmt.Errorf("failed to create logging client: %w", err)
+  }
+  defer loggingClient.Close()
+
+  it := loggingClient.ListLogEntries(callCtx, &loggingpb.ListLogEntriesRequest{
+   ResourceNames: []string{"projects/my-project-id"},
+   PageSize:      10,
+  })
+  _ = it
+
+  return []string{}, nil
+ },
+)
+```
+
+---
+
+## 3. Using CallOptionInjector in Reusable Components and Fetchers
+
+When writing reusable helper structs that hold Google Cloud API clients (such as `LogFetcher`, `LocationFetcher`, or `StructuredLogEstimator`):
+
+1. **Accept as Constructor Argument:** Pass `callOptionInjector *googlecloud.CallOptionInjector` into the constructor.
+2. **Store as Struct Field:** Keep `CallOptionInjector *googlecloud.CallOptionInjector` on the struct.
+3. **Inject in Methods:** Right before making the RPC calls (or before passing context to goroutines/`errgroup`), execute:
+
+   ```go
+   if e.CallOptionInjector != nil {
+       ctx = e.CallOptionInjector.InjectToCallContext(ctx, container)
+   }
+   ```
+
+### Code Sample: Component Implementation
+
+```go
+package myfetcher
+
+import (
+ "context"
+
+ "github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+ "golang.org/x/sync/errgroup"
+)
+
+type ResourceFetcher struct {
+ CallOptionInjector *googlecloud.CallOptionInjector
+ // Other client fields...
+}
+
+func NewResourceFetcher(injector *googlecloud.CallOptionInjector) *ResourceFetcher {
+ return &ResourceFetcher{
+  CallOptionInjector: injector,
+ }
+}
+
+func (f *ResourceFetcher) FetchResources(ctx context.Context, container googlecloud.ResourceContainer) error {
+ // Inject options before creating child context or errgroup.
+ if f.CallOptionInjector != nil {
+  ctx = f.CallOptionInjector.InjectToCallContext(ctx, container)
+ }
+
+ g, groupCtx := errgroup.WithContext(ctx)
+ g.Go(func() error {
+  // groupCtx now inherits all injected call options.
+  return f.queryAPI(groupCtx, container)
+ })
+
+ return g.Wait()
+}
+
+func (f *ResourceFetcher) queryAPI(ctx context.Context, container googlecloud.ResourceContainer) error {
+ // API call using ctx...
+ return nil
+}
+```
+
+---
+
+## 4. Raw HTTP Requests
+
+When sending REST/HTTP requests rather than using gRPC client libraries, gRPC context call options do not take effect. Instead, inject the options into the HTTP headers using `ApplyToRawHTTPHeader`:
+
+```go
+req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpointURL, nil)
+if err != nil {
+ return err
+}
+
+if callOptionInjector != nil {
+ callOptionInjector.ApplyToRawHTTPHeader(req.Header, container)
+}
+
+resp, err := httpClient.Do(req)
+// ...
+```
+
+---
+
+## 5. Testing Components with CallOptionInjector
+
+When writing unit tests for tasks or components that use `CallOptionInjector`:
+
+- Verify that `CallOptionInjector` executes and modifies the context using a mock `CallOptionInjectorOption`.
+- Ensure the component functions correctly when `CallOptionInjector` is `nil` (defensive programming).
+
+### Test Example
+
+```go
+type mockCallOptionInjectorOption struct {
+ key   string
+ value string
+}
+
+func (m *mockCallOptionInjectorOption) ApplyToCallContext(ctx context.Context, container googlecloud.ResourceContainer) context.Context {
+ return context.WithValue(ctx, m.key, m.value)
+}
+
+func (m *mockCallOptionInjectorOption) ApplyToRawHTTPHeader(header http.Header, container googlecloud.ResourceContainer) {}
+
+var _ googlecloud.CallOptionInjectorOption = (*mockCallOptionInjectorOption)(nil)
+
+func TestComponent_CallOptionInjector(t *testing.T) {
+ testCases := []struct {
+  name        string
+  injector    *googlecloud.CallOptionInjector
+  wantValue   any
+ }{
+  {
+   name: "injector modifies context",
+   injector: googlecloud.NewCallOptionInjector(&mockCallOptionInjectorOption{
+    key:   "test-key",
+    value: "test-value",
+   }),
+   wantValue: "test-value",
+  },
+  {
+   name:      "nil injector succeeds without error",
+   injector:  nil,
+   wantValue: nil,
+  },
+ }
+
+ for _, tc := range testCases {
+  t.Run(tc.name, func(t *testing.T) {
+   component := NewResourceFetcher(tc.injector)
+   err := component.FetchResources(context.Background(), googlecloud.Project("test-project"))
+   if err != nil {
+    t.Fatalf("unexpected error: %v", err)
+   }
+  })
+ }
+}
+```

--- a/.agents/skills/khi_parser/SKILL.md
+++ b/.agents/skills/khi_parser/SKILL.md
@@ -66,6 +66,7 @@ Exposes interactive input fields (e.g., text boxes, multi-select checkboxes) to 
 Queries logs from the data source (e.g., Google Cloud Logging or local files) using parameters provided by the Form tasks.
 
 - **Utility:** `googlecloudcommon_contract.NewListLogEntriesTask` (for any logs on Cloud Logging) or `inspection_task.NewInspectionTask`.
+- **Google Cloud API Calling:** When calling Google Cloud APIs directly or through fetchers, refer to [googlecloud-api](skill://googlecloud-api) for mandatory `CallOptionInjector` usage and client configuration.
 
 ### Step 3: FieldSet Reading Tasks
 

--- a/pkg/api/googlecloud/logestimator/cached_estimator_test.go
+++ b/pkg/api/googlecloud/logestimator/cached_estimator_test.go
@@ -54,7 +54,7 @@ func TestCachedStructuredLogEstimator_CacheHit(t *testing.T) {
 	var providerCalls int64
 	provider := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
 		atomic.AddInt64(&providerCalls, 1)
-		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{count: 100}, nil), nil
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{count: 100}, nil, nil), nil
 	}
 
 	query := &StructuredLogQuery{
@@ -99,7 +99,7 @@ func TestCachedStructuredLogEstimator_SingleflightDeduplication(t *testing.T) {
 		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
 			delay: 50 * time.Millisecond,
 			count: 200,
-		}, nil), nil
+		}, nil, nil), nil
 	}
 
 	query := &StructuredLogQuery{
@@ -156,14 +156,14 @@ func TestCachedStructuredLogEstimator_OutdatedQueryCancellation(t *testing.T) {
 				}()
 			},
 			count: 100,
-		}, nil), nil
+		}, nil, nil), nil
 	}
 
 	provider2 := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
 		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
 			delay: 10 * time.Millisecond,
 			count: 300,
-		}, nil), nil
+		}, nil, nil), nil
 	}
 
 	query1 := &StructuredLogQuery{
@@ -216,7 +216,7 @@ func TestCachedStructuredLogEstimator_IdenticalQueryDoesNotCancel(t *testing.T) 
 		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
 			delay: 50 * time.Millisecond,
 			count: 150,
-		}, nil), nil
+		}, nil, nil), nil
 	}
 
 	query := &StructuredLogQuery{
@@ -276,7 +276,7 @@ func TestCachedStructuredLogEstimator_ErrorNotCached(t *testing.T) {
 		if current == 1 {
 			return nil, errors.New("network failure")
 		}
-		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{count: 500}, nil), nil
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{count: 500}, nil, nil), nil
 	}
 
 	query := &StructuredLogQuery{
@@ -315,7 +315,7 @@ func TestCachedStructuredLogEstimator_Close(t *testing.T) {
 				}()
 			},
 			count: 100,
-		}, nil), nil
+		}, nil, nil), nil
 	}
 
 	query := &StructuredLogQuery{

--- a/pkg/api/googlecloud/logestimator/estimator.go
+++ b/pkg/api/googlecloud/logestimator/estimator.go
@@ -120,22 +120,24 @@ func (f *LoggingClientProbeFetcher) ProbeLogTimestamps(ctx context.Context, cont
 
 // StructuredLogEstimator estimates log volume for StructuredLogQuery.
 type StructuredLogEstimator struct {
-	MetricFetcher MetricLogCountFetcher
-	ProbeFetcher  LogSamplingProbeFetcher
-	TargetSamples int32
+	MetricFetcher      MetricLogCountFetcher
+	ProbeFetcher       LogSamplingProbeFetcher
+	CallOptionInjector *googlecloud.CallOptionInjector
+	TargetSamples      int32
 }
 
 // NewStructuredLogEstimator creates a StructuredLogEstimator with defaults.
-func NewStructuredLogEstimator(metricFetcher MetricLogCountFetcher, probeFetcher LogSamplingProbeFetcher) *StructuredLogEstimator {
+func NewStructuredLogEstimator(metricFetcher MetricLogCountFetcher, probeFetcher LogSamplingProbeFetcher, callOptionInjector *googlecloud.CallOptionInjector) *StructuredLogEstimator {
 	return &StructuredLogEstimator{
-		MetricFetcher: metricFetcher,
-		ProbeFetcher:  probeFetcher,
-		TargetSamples: 50,
+		MetricFetcher:      metricFetcher,
+		ProbeFetcher:       probeFetcher,
+		CallOptionInjector: callOptionInjector,
+		TargetSamples:      50,
 	}
 }
 
 // NewStructuredLogEstimatorFromClients constructs a StructuredLogEstimator directly from Google Cloud SDK clients.
-func NewStructuredLogEstimatorFromClients(loggingClient *logging.Client, metricClient *monitoring.MetricClient) *StructuredLogEstimator {
+func NewStructuredLogEstimatorFromClients(loggingClient *logging.Client, metricClient *monitoring.MetricClient, callOptionInjector *googlecloud.CallOptionInjector) *StructuredLogEstimator {
 	var metricFetcher MetricLogCountFetcher
 	if metricClient != nil {
 		metricFetcher = &MonitoringClientFetcher{Client: metricClient}
@@ -144,13 +146,17 @@ func NewStructuredLogEstimatorFromClients(loggingClient *logging.Client, metricC
 	if loggingClient != nil {
 		probeFetcher = &LoggingClientProbeFetcher{Client: loggingClient}
 	}
-	return NewStructuredLogEstimator(metricFetcher, probeFetcher)
+	return NewStructuredLogEstimator(metricFetcher, probeFetcher, callOptionInjector)
 }
 
 // Estimate estimates the total log volume for the given StructuredLogQuery over the time interval.
 // Cloud Monitoring queries for all resource types are executed concurrently.
 // If custom filters require sampling, a time-window bounded sampling probe is executed.
 func (e *StructuredLogEstimator) Estimate(ctx context.Context, container googlecloud.ResourceContainer, query *StructuredLogQuery, startTime, endTime time.Time) (*EstimateResult, error) {
+	if e.CallOptionInjector != nil {
+		ctx = e.CallOptionInjector.InjectToCallContext(ctx, container)
+	}
+
 	allSupported := query.AllFiltersSupportMetrics()
 	metricFilters := query.GenerateMonitoringMetricFilters()
 

--- a/pkg/api/googlecloud/logestimator/estimator_test.go
+++ b/pkg/api/googlecloud/logestimator/estimator_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -299,7 +300,7 @@ func TestStructuredLogEstimator_Estimate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			estimator := NewStructuredLogEstimator(tt.metricFetcher, tt.probeFetcher)
+			estimator := NewStructuredLogEstimator(tt.metricFetcher, tt.probeFetcher, nil)
 			got, err := estimator.Estimate(context.Background(), googlecloud.Project("test-project"), tt.query, time.Now().Add(-time.Hour), time.Now())
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Estimate() error = %v, wantErr %v", err, tt.wantErr)
@@ -373,6 +374,7 @@ func TestLiveMetricEstimation(t *testing.T) {
 	estimator := NewStructuredLogEstimator(
 		&MonitoringClientFetcher{Client: metricClient},
 		&realLogProbeFetcher{client: logClient},
+		nil,
 	)
 
 	now := time.Now()
@@ -494,6 +496,7 @@ func TestEstimateClusterLogs(t *testing.T) {
 	estimator := NewStructuredLogEstimator(
 		&MonitoringClientFetcher{Client: metricClient},
 		&realLogProbeFetcher{client: logClient},
+		nil,
 	)
 
 	queries := []struct {
@@ -607,6 +610,7 @@ func TestEstimateTseKakeruClusterLogs(t *testing.T) {
 	estimator := NewStructuredLogEstimator(
 		&MonitoringClientFetcher{Client: metricClient},
 		&realLogProbeFetcher{client: logClient},
+		nil,
 	)
 
 	queries := []struct {
@@ -736,6 +740,7 @@ func TestAccuracyOneHourComparison(t *testing.T) {
 	estimator := NewStructuredLogEstimator(
 		&MonitoringClientFetcher{Client: metricClient},
 		&realLogProbeFetcher{client: logClient},
+		nil,
 	)
 
 	queries := []struct {
@@ -846,6 +851,105 @@ protoPayload.methodName=~"\.(deployments|replicasets|pods|nodes)\."`),
 
 			t.Logf(">>> [%s]\n    Estimated: %d (in %v, MetricBase: %d, Ratio: %.4f)\n    Actual:    %d (in %v, Pages: %d)\n    Error:     %.2f%% (diff: %d)",
 				item.logType, res.EstimatedCount, estElapsed, res.MetricCount, res.CustomFilterRatio, actualCount, actElapsed, pageCount, errPct, diff)
+		})
+	}
+}
+
+type mockCallOptionInjectorOption struct {
+	key   string
+	value string
+}
+
+func (m *mockCallOptionInjectorOption) ApplyToCallContext(ctx context.Context, container googlecloud.ResourceContainer) context.Context {
+	return context.WithValue(ctx, m.key, m.value)
+}
+
+func (m *mockCallOptionInjectorOption) ApplyToRawHTTPHeader(header http.Header, container googlecloud.ResourceContainer) {
+}
+
+var _ googlecloud.CallOptionInjectorOption = (*mockCallOptionInjectorOption)(nil)
+
+type mockContextCapturingMetricFetcher struct {
+	capturedContext context.Context
+	count           int64
+	err             error
+}
+
+func (m *mockContextCapturingMetricFetcher) QueryMetricCount(ctx context.Context, container googlecloud.ResourceContainer, metricFilter string, startTime, endTime time.Time) (int64, error) {
+	m.capturedContext = ctx
+	return m.count, m.err
+}
+
+type mockContextCapturingProbeFetcher struct {
+	capturedContext context.Context
+	timestamps      []time.Time
+	err             error
+}
+
+func (m *mockContextCapturingProbeFetcher) ProbeLogTimestamps(ctx context.Context, container googlecloud.ResourceContainer, filter string, maxEntries int32) ([]time.Time, error) {
+	m.capturedContext = ctx
+	return m.timestamps, m.err
+}
+
+func TestStructuredLogEstimator_CallOptionInjector(t *testing.T) {
+	testCases := []struct {
+		name               string
+		callOptionInjector *googlecloud.CallOptionInjector
+		wantInjectedKey    string
+		wantInjectedVal    string
+		wantPresent        bool
+	}{
+		{
+			name: "callOptionInjector is configured and options are injected into context",
+			callOptionInjector: googlecloud.NewCallOptionInjector(&mockCallOptionInjectorOption{
+				key:   "test-option-key",
+				value: "test-option-value",
+			}),
+			wantInjectedKey: "test-option-key",
+			wantInjectedVal: "test-option-value",
+			wantPresent:     true,
+		},
+		{
+			name:               "callOptionInjector is nil",
+			callOptionInjector: nil,
+			wantInjectedKey:    "test-option-key",
+			wantPresent:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metricFetcher := &mockContextCapturingMetricFetcher{count: 100}
+			probeFetcher := &mockContextCapturingProbeFetcher{timestamps: []time.Time{time.Now()}}
+			estimator := NewStructuredLogEstimator(metricFetcher, probeFetcher, tc.callOptionInjector)
+
+			query := &StructuredLogQuery{
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters: []LoggingMonitoringMatcher{
+					ResourceLabel("cluster_name", Exact("cluster-1")),
+					LogID(Exact("events")),
+				},
+			}
+
+			_, err := estimator.Estimate(context.Background(), googlecloud.Project("test-project"), query, time.Now().Add(-time.Hour), time.Now())
+			if err != nil {
+				t.Fatalf("Estimate() unexpected error = %v", err)
+			}
+
+			if metricFetcher.capturedContext == nil {
+				t.Fatal("metricFetcher.capturedContext is nil")
+			}
+
+			gotVal := metricFetcher.capturedContext.Value(tc.wantInjectedKey)
+			if tc.wantPresent {
+				if diff := cmp.Diff(tc.wantInjectedVal, gotVal); diff != "" {
+					t.Errorf("captured context value mismatch (-want +got):\n%s", diff)
+				}
+			} else {
+				if gotVal != nil {
+					t.Errorf("captured context value = %v, want nil", gotVal)
+				}
+			}
 		})
 	}
 }

--- a/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
@@ -70,6 +70,7 @@ func NewStructuredListLogEntriesTask(taskSetting StructuredListLogEntriesTaskSet
 		InputLoggingFilterResourceNameTaskID.Ref(),
 		LoggingFetcherTaskID.Ref(),
 		APIClientFactoryTaskID.Ref(),
+		APIClientCallOptionsInjectorTaskID.Ref(),
 	)
 	queryName := taskSetting.QueryName()
 
@@ -101,7 +102,8 @@ func NewStructuredListLogEntriesTask(taskSetting StructuredListLogEntriesTaskSet
 			// In DryRun: perform volume estimation across all container groups and record query metadata.
 			if taskMode != inspectioncore_contract.TaskModeRun {
 				clientFactory := coretask.GetTaskResult(ctx, APIClientFactoryTaskID.Ref())
-				return nil, estimateAndRecordQueries(ctx, taskID.String(), clientFactory, groups, queries, startTime, endTime, queryName)
+				callOptionInjector, _ := coretask.GetTaskResultOptional(ctx, APIClientCallOptionsInjectorTaskID.Ref())
+				return nil, estimateAndRecordQueries(ctx, taskID.String(), clientFactory, callOptionInjector, groups, queries, startTime, endTime, queryName)
 			}
 
 			// In Run mode: fetch logs across partitions.
@@ -185,6 +187,7 @@ func estimateAndRecordQueries(
 	ctx context.Context,
 	taskID string,
 	clientFactory *googlecloud.ClientFactory,
+	callOptionInjector *googlecloud.CallOptionInjector,
 	groups []*resourceContainerLogQueryGroup,
 	queries []*logestimator.StructuredLogQuery,
 	startTime, endTime time.Time,
@@ -218,7 +221,7 @@ func estimateAndRecordQueries(
 					if logErr != nil || monErr != nil {
 						return nil, fmt.Errorf("failed to initialize clients for container %s: loggingErr=%v, metricErr=%v", container.Identifier(), logErr, monErr)
 					}
-					return logestimator.NewStructuredLogEstimatorFromClients(loggingClient, metricClient), nil
+					return logestimator.NewStructuredLogEstimatorFromClients(loggingClient, metricClient, callOptionInjector), nil
 				},
 			)
 			if estErr != nil {

--- a/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task_test.go
@@ -103,6 +103,7 @@ func TestStructuredListLogEntriesTask_DryRun_FallbackWhenNoClient(t *testing.T) 
 		tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
 		tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
 		tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(APIClientCallOptionsInjectorTaskID.Ref(), googlecloud.NewCallOptionInjector()),
 	)
 	if err != nil {
 		t.Fatalf("DryRun returned unexpected error: %v", err)
@@ -227,6 +228,7 @@ timestamp < "2025-01-01T01:01:00+0000"`, func(logSource chan<- *loggingpb.LogEnt
 				tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
 				tasktest.NewTaskDependencyValuePair[LogFetcher](LoggingFetcherTaskID.Ref(), fetcher),
 				tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+				tasktest.NewTaskDependencyValuePair(APIClientCallOptionsInjectorTaskID.Ref(), googlecloud.NewCallOptionInjector()),
 			)
 			if err != nil {
 				t.Fatalf("dry run failed: %v", err)
@@ -421,6 +423,7 @@ func TestStructuredListLogEntriesTask_DryRun_EstimationCache(t *testing.T) {
 		tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
 		tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
 		tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(APIClientCallOptionsInjectorTaskID.Ref(), googlecloud.NewCallOptionInjector()),
 	)
 	if err != nil {
 		t.Fatalf("first dryrun failed: %v", err)
@@ -439,6 +442,7 @@ func TestStructuredListLogEntriesTask_DryRun_EstimationCache(t *testing.T) {
 		tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
 		tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
 		tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(APIClientCallOptionsInjectorTaskID.Ref(), googlecloud.NewCallOptionInjector()),
 	)
 	if err != nil {
 		t.Fatalf("second dryrun failed: %v", err)
@@ -503,6 +507,7 @@ func TestStructuredListLogEntriesTask_DryRun_Incomplete(t *testing.T) {
 				tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
 				tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
 				tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+				tasktest.NewTaskDependencyValuePair(APIClientCallOptionsInjectorTaskID.Ref(), googlecloud.NewCallOptionInjector()),
 			)
 			if err != nil {
 				t.Fatalf("dryrun failed: %v", err)
@@ -523,5 +528,49 @@ func TestStructuredListLogEntriesTask_DryRun_Incomplete(t *testing.T) {
 				t.Errorf("QueryItem mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestStructuredListLogEntriesTask_DryRun_CallOptionInjector(t *testing.T) {
+	taskSetting := &mockStructuredListLogEntriesTaskSetting{
+		queryName:     "test-query",
+		resourceNames: []string{"projects/test-project"},
+		queries: []*logestimator.StructuredLogQuery{
+			{
+				Incomplete:    true,
+				ResourceTypes: []string{"k8s_cluster"},
+				Filters:       []logestimator.LoggingMonitoringMatcher{logestimator.ResourceLabel("cluster_name", logestimator.Exact(""))},
+			},
+		},
+	}
+	task := NewStructuredListLogEntriesTask(taskSetting)
+	clientFactory, err := googlecloud.NewClientFactory()
+	if err != nil {
+		t.Fatalf("failed to create clientFactory: %v", err)
+	}
+
+	startTime := time.Date(2025, time.January, 1, 1, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.January, 1, 1, 1, 0, 0, time.UTC)
+	resourceNamesInput := NewResourceNamesInput()
+	resourceNamesInput.UpdateDefaultResourceNamesForQuery("structured-test", []string{"projects/test-project"})
+
+	deps := []tasktest.TaskDependencyValues{
+		tasktest.NewTaskDependencyValuePair(InputStartTimeTaskID.Ref(), startTime),
+		tasktest.NewTaskDependencyValuePair(InputEndTimeTaskID.Ref(), endTime),
+		tasktest.NewTaskDependencyValuePair(APIClientFactoryTaskID.Ref(), clientFactory),
+		tasktest.NewTaskDependencyValuePair(InputLoggingFilterResourceNameTaskID.Ref(), resourceNamesInput),
+		tasktest.NewTaskDependencyValuePair(APIClientCallOptionsInjectorTaskID.Ref(), googlecloud.NewCallOptionInjector()),
+	}
+
+	ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+	_, _, err = inspectiontest.RunInspectionTask(ctx, task, inspectioncore_contract.TaskModeDryRun, map[string]any{}, deps...)
+	if err != nil {
+		t.Fatalf("dryrun failed: %v", err)
+	}
+
+	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
+	_, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
+	if !found {
+		t.Fatalf("QueryMetadata not found")
 	}
 }


### PR DESCRIPTION
## Summary

This PR ensures that Google Cloud API call options are properly injected into the request context before executing volume estimation queries in `StructuredLogEstimator`. It also introduces documentation and repository rules defining the mandatory usage of `CallOptionInjector` whenever calling Google Cloud APIs across KHI.

## Background & Motivation

1. **Missing Call Option Injection in `StructuredLogEstimator`**:
   `StructuredLogEstimator` queries Cloud Monitoring metrics and Cloud Logging probe entries during log volume estimation. Previously, `InjectToCallContext` was not invoked on the context prior to issuing these queries. Consequently, gRPC call options, custom request headers, and quota project parameters were not propagated, which could lead to API call failures or unexpected quota accounting.
2. **Standardizing Call Option Propagation in KHI**:
   In KHI, all calls to Google Cloud APIs must carry options associated with their target resource container (`googlecloud.Project`, `googlecloud.Folder`, or `googlecloud.Organization`). A dedicated skill and rule documentation ensures all current and future tasks/components adhere to this requirement.

## Key Changes

### 1. Go Backend
- **`pkg/api/googlecloud/logestimator/estimator.go`**:
  - Added `CallOptionInjector *googlecloud.CallOptionInjector` field to `StructuredLogEstimator`.
  - Updated constructors `NewStructuredLogEstimator` and `NewStructuredLogEstimatorFromClients` to accept `callOptionInjector`.
  - In `Estimate()`, applied `ctx = e.CallOptionInjector.InjectToCallContext(ctx, container)` before spawning goroutines with `errgroup.WithContext(ctx)`.
- **`pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go`**:
  - Added `APIClientCallOptionsInjectorTaskID.Ref()` to task dependencies.
  - In dry-run mode, retrieved `callOptionInjector` via `coretask.GetTaskResultOptional` and forwarded it to `StructuredLogEstimator`.
- **Unit Tests**:
  - `pkg/api/googlecloud/logestimator/estimator_test.go`: Added `TestStructuredLogEstimator_CallOptionInjector` verifying context injection on Cloud Monitoring and Cloud Logging queries.
  - `pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task_test.go`: Added `TestStructuredListLogEntriesTask_DryRun_CallOptionInjector` testing dependency resolution and call option propagation.
  - Updated existing estimator tests to pass injector or `nil`.

### 2. Developer & Agent Guidelines
- **`.agents/skills/googlecloud_api/SKILL.md`**:
  - Created a new skill defining mandatory patterns and rules for calling Google Cloud APIs in KHI, covering task DAG dependencies, helper structs/fetchers, raw HTTP headers, and unit testing.
- **`.agents/skills/khi_parser/SKILL.md`**:
  - Added reference to `googlecloud-api` skill in Step 2 (Log Query Tasks).
- **`.agents/rules/khi-task-rule.md`**:
  - Added Section 6 requiring `CallOptionInjector.InjectToCallContext` for any task invoking Google Cloud APIs.

## Verification

- **Unit Tests**: `make test-go` passed (all 672 top-level tests, 2,732 subtests).
- **Linters & Formatters**: `make lint-go`, `make lint-md`, `make format-md`, and `make pre-commit` passed with 0 issues.
