### PR TITLE
perf(web): pool and reuse layout components across layout transitions

### DIFF
--- a/web/src/app/services/layout/layout.service.spec.ts
+++ b/web/src/app/services/layout/layout.service.spec.ts
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Component,
+  ComponentRef,
+  ElementRef,
+  inject,
+  Type,
+  viewChild,
+  ViewContainerRef,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { LayoutService } from './layout.service';
+import { MenuManager } from 'src/app/services/menu/menu-manager.service';
+import { TimelineSmartComponent } from 'src/app/timeline/timeline-smart.component';
+import { LogSmartComponent } from 'src/app/log/log-smart.component';
+import { DiffSmartComponent } from 'src/app/diff/diff-smart.component';
+import { GraphSmartComponent } from 'src/app/graph/graph-smart.component';
+
+@Component({
+  template: `<div
+    #layoutContainer
+    style="width: 1000px; height: 800px;"
+  ></div>`,
+  standalone: true,
+})
+class TestHostComponent {
+  readonly layoutContainer =
+    viewChild.required<ElementRef<HTMLElement>>('layoutContainer');
+  readonly viewContainerRef = inject(ViewContainerRef);
+}
+
+describe('LayoutService', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let layoutService: LayoutService;
+  let menuManager: MenuManager;
+  let dialogSpy: jasmine.SpyObj<MatDialog>;
+
+  beforeEach(async () => {
+    dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        LayoutService,
+        MenuManager,
+        { provide: MatDialog, useValue: dialogSpy },
+      ],
+    })
+      .overrideComponent(TimelineSmartComponent, {
+        set: { template: '<div>Timeline</div>', imports: [] },
+      })
+      .overrideComponent(LogSmartComponent, {
+        set: { template: '<div>Log</div>', imports: [] },
+      })
+      .overrideComponent(DiffSmartComponent, {
+        set: { template: '<div>Diff</div>', imports: [] },
+      })
+      .overrideComponent(GraphSmartComponent, {
+        set: { template: '<div>Graph</div>', imports: [] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    layoutService = TestBed.inject(LayoutService);
+    menuManager = TestBed.inject(MenuManager);
+  });
+
+  afterEach(() => {
+    layoutService.ngOnDestroy();
+    fixture.destroy();
+  });
+
+  it('should reuse TimelineSmartComponent when switching layouts', () => {
+    const hostEl = hostComponent.layoutContainer().nativeElement;
+    document.body.appendChild(hostEl);
+
+    let timelineCreatedCount = 0;
+    const originalCreateComponent =
+      hostComponent.viewContainerRef.createComponent.bind(
+        hostComponent.viewContainerRef,
+      );
+    spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
+      (componentType: unknown) => {
+        if (componentType === TimelineSmartComponent) {
+          timelineCreatedCount++;
+        }
+        return originalCreateComponent(componentType as Type<unknown>);
+      },
+    );
+
+    layoutService.init(hostEl, hostComponent.viewContainerRef);
+    layoutService.loadDefaultLayout();
+
+    expect(timelineCreatedCount).toBe(1);
+
+    // Switch to State View Layout (contains Timeline and History)
+    layoutService.loadStateAnalysisLayout();
+    expect(timelineCreatedCount).toBe(1);
+
+    // Switch to Topology View Layout (contains Timeline and Graph)
+    layoutService.loadTopologyAnalysisLayout();
+    expect(timelineCreatedCount).toBe(1);
+
+    // Switch back to Default Layout (contains Timeline, Log, History)
+    layoutService.loadDefaultLayout();
+    expect(timelineCreatedCount).toBe(1);
+
+    hostEl.remove();
+  });
+
+  it('should reuse pooled LogSmartComponent when returning to a layout containing logs', () => {
+    const hostEl = hostComponent.layoutContainer().nativeElement;
+    document.body.appendChild(hostEl);
+
+    let logCreatedCount = 0;
+    const originalCreateComponent =
+      hostComponent.viewContainerRef.createComponent.bind(
+        hostComponent.viewContainerRef,
+      );
+    spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
+      (componentType: unknown) => {
+        if (componentType === LogSmartComponent) {
+          logCreatedCount++;
+        }
+        return originalCreateComponent(componentType as Type<unknown>);
+      },
+    );
+
+    layoutService.init(hostEl, hostComponent.viewContainerRef);
+    layoutService.loadDefaultLayout();
+
+    expect(logCreatedCount).toBe(1);
+
+    // Switch to State View Layout (which does NOT include Log)
+    layoutService.loadStateAnalysisLayout();
+
+    // Switch back to Default Layout (which includes Log)
+    layoutService.loadDefaultLayout();
+
+    // Log component should have been preserved in the pool and reused
+    expect(logCreatedCount).toBe(1);
+
+    hostEl.remove();
+  });
+
+  it('should destroy surplus timeline instances when switching layouts with multiple timelines open', () => {
+    const hostEl = hostComponent.layoutContainer().nativeElement;
+    document.body.appendChild(hostEl);
+
+    const createdRefs: ComponentRef<unknown>[] = [];
+    const originalCreateComponent =
+      hostComponent.viewContainerRef.createComponent.bind(
+        hostComponent.viewContainerRef,
+      );
+    spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
+      (componentType: unknown) => {
+        const ref = originalCreateComponent(componentType as Type<unknown>);
+        if (componentType === TimelineSmartComponent) {
+          createdRefs.push(ref);
+          spyOn(ref, 'destroy').and.callThrough();
+        }
+        return ref;
+      },
+    );
+
+    layoutService.init(hostEl, hostComponent.viewContainerRef);
+    layoutService.loadDefaultLayout();
+
+    expect(createdRefs.length).toBe(1);
+
+    // Open a second timeline via menu action
+    const viewGroup = menuManager.groups().find((g) => g.id === 'view');
+    const openTimelineItem = viewGroup?.items.find(
+      (item) => item.id === 'open-timeline',
+    );
+    expect(openTimelineItem).toBeDefined();
+    openTimelineItem?.action();
+
+    expect(createdRefs.length).toBe(2);
+    const [t1, t2] = createdRefs;
+
+    // Switch to State View Layout (which only needs 1 timeline)
+    layoutService.loadStateAnalysisLayout();
+
+    // Exactly one surplus timeline should have been destroyed
+    const destroyedCount =
+      (t1.destroy as jasmine.Spy).calls.count() +
+      (t2.destroy as jasmine.Spy).calls.count();
+    expect(destroyedCount).toBe(1);
+
+    hostEl.remove();
+  });
+
+  it('should destroy all active and pooled components on ngOnDestroy', () => {
+    const hostEl = hostComponent.layoutContainer().nativeElement;
+    document.body.appendChild(hostEl);
+
+    const createdRefs: ComponentRef<unknown>[] = [];
+    const originalCreateComponent =
+      hostComponent.viewContainerRef.createComponent.bind(
+        hostComponent.viewContainerRef,
+      );
+    spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
+      (componentType: unknown) => {
+        const ref = originalCreateComponent(componentType as Type<unknown>);
+        createdRefs.push(ref);
+        spyOn(ref, 'destroy').and.callThrough();
+        return ref;
+      },
+    );
+
+    layoutService.init(hostEl, hostComponent.viewContainerRef);
+    layoutService.loadDefaultLayout();
+
+    // Switch to State View Layout so that LogSmartComponent is pooled (inactive)
+    layoutService.loadStateAnalysisLayout();
+
+    expect(createdRefs.length).toBeGreaterThan(0);
+
+    // Call ngOnDestroy
+    layoutService.ngOnDestroy();
+
+    // Verify all created component references were destroyed
+    for (const ref of createdRefs) {
+      expect((ref.destroy as jasmine.Spy).calls.count()).toBeGreaterThan(0);
+    }
+
+    hostEl.remove();
+  });
+});

--- a/web/src/app/services/layout/layout.service.spec.ts
+++ b/web/src/app/services/layout/layout.service.spec.ts
@@ -92,157 +92,165 @@ describe('LayoutService', () => {
     const hostEl = hostComponent.layoutContainer().nativeElement;
     document.body.appendChild(hostEl);
 
-    let timelineCreatedCount = 0;
-    const originalCreateComponent =
-      hostComponent.viewContainerRef.createComponent.bind(
-        hostComponent.viewContainerRef,
+    try {
+      let timelineCreatedCount = 0;
+      const originalCreateComponent =
+        hostComponent.viewContainerRef.createComponent.bind(
+          hostComponent.viewContainerRef,
+        );
+      spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
+        (componentType: unknown) => {
+          if (componentType === TimelineSmartComponent) {
+            timelineCreatedCount++;
+          }
+          return originalCreateComponent(componentType as Type<unknown>);
+        },
       );
-    spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
-      (componentType: unknown) => {
-        if (componentType === TimelineSmartComponent) {
-          timelineCreatedCount++;
-        }
-        return originalCreateComponent(componentType as Type<unknown>);
-      },
-    );
 
-    layoutService.init(hostEl, hostComponent.viewContainerRef);
-    layoutService.loadDefaultLayout();
+      layoutService.init(hostEl, hostComponent.viewContainerRef);
+      layoutService.loadDefaultLayout();
 
-    expect(timelineCreatedCount).toBe(1);
+      expect(timelineCreatedCount).toBe(1);
 
-    // Switch to State View Layout (contains Timeline and History)
-    layoutService.loadStateAnalysisLayout();
-    expect(timelineCreatedCount).toBe(1);
+      // Switch to State View Layout (contains Timeline and History)
+      layoutService.loadStateAnalysisLayout();
+      expect(timelineCreatedCount).toBe(1);
 
-    // Switch to Topology View Layout (contains Timeline and Graph)
-    layoutService.loadTopologyAnalysisLayout();
-    expect(timelineCreatedCount).toBe(1);
+      // Switch to Topology View Layout (contains Timeline and Graph)
+      layoutService.loadTopologyAnalysisLayout();
+      expect(timelineCreatedCount).toBe(1);
 
-    // Switch back to Default Layout (contains Timeline, Log, History)
-    layoutService.loadDefaultLayout();
-    expect(timelineCreatedCount).toBe(1);
-
-    hostEl.remove();
+      // Switch back to Default Layout (contains Timeline, Log, History)
+      layoutService.loadDefaultLayout();
+      expect(timelineCreatedCount).toBe(1);
+    } finally {
+      hostEl.remove();
+    }
   });
 
   it('should reuse pooled LogSmartComponent when returning to a layout containing logs', () => {
     const hostEl = hostComponent.layoutContainer().nativeElement;
     document.body.appendChild(hostEl);
 
-    let logCreatedCount = 0;
-    const originalCreateComponent =
-      hostComponent.viewContainerRef.createComponent.bind(
-        hostComponent.viewContainerRef,
+    try {
+      let logCreatedCount = 0;
+      const originalCreateComponent =
+        hostComponent.viewContainerRef.createComponent.bind(
+          hostComponent.viewContainerRef,
+        );
+      spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
+        (componentType: unknown) => {
+          if (componentType === LogSmartComponent) {
+            logCreatedCount++;
+          }
+          return originalCreateComponent(componentType as Type<unknown>);
+        },
       );
-    spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
-      (componentType: unknown) => {
-        if (componentType === LogSmartComponent) {
-          logCreatedCount++;
-        }
-        return originalCreateComponent(componentType as Type<unknown>);
-      },
-    );
 
-    layoutService.init(hostEl, hostComponent.viewContainerRef);
-    layoutService.loadDefaultLayout();
+      layoutService.init(hostEl, hostComponent.viewContainerRef);
+      layoutService.loadDefaultLayout();
 
-    expect(logCreatedCount).toBe(1);
+      expect(logCreatedCount).toBe(1);
 
-    // Switch to State View Layout (which does NOT include Log)
-    layoutService.loadStateAnalysisLayout();
+      // Switch to State View Layout (which does NOT include Log)
+      layoutService.loadStateAnalysisLayout();
 
-    // Switch back to Default Layout (which includes Log)
-    layoutService.loadDefaultLayout();
+      // Switch back to Default Layout (which includes Log)
+      layoutService.loadDefaultLayout();
 
-    // Log component should have been preserved in the pool and reused
-    expect(logCreatedCount).toBe(1);
-
-    hostEl.remove();
+      // Log component should have been preserved in the pool and reused
+      expect(logCreatedCount).toBe(1);
+    } finally {
+      hostEl.remove();
+    }
   });
 
   it('should destroy surplus timeline instances when switching layouts with multiple timelines open', () => {
     const hostEl = hostComponent.layoutContainer().nativeElement;
     document.body.appendChild(hostEl);
 
-    const createdRefs: ComponentRef<unknown>[] = [];
-    const originalCreateComponent =
-      hostComponent.viewContainerRef.createComponent.bind(
-        hostComponent.viewContainerRef,
+    try {
+      const createdRefs: ComponentRef<unknown>[] = [];
+      const originalCreateComponent =
+        hostComponent.viewContainerRef.createComponent.bind(
+          hostComponent.viewContainerRef,
+        );
+      spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
+        (componentType: unknown) => {
+          const ref = originalCreateComponent(componentType as Type<unknown>);
+          if (componentType === TimelineSmartComponent) {
+            createdRefs.push(ref);
+            spyOn(ref, 'destroy').and.callThrough();
+          }
+          return ref;
+        },
       );
-    spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
-      (componentType: unknown) => {
-        const ref = originalCreateComponent(componentType as Type<unknown>);
-        if (componentType === TimelineSmartComponent) {
-          createdRefs.push(ref);
-          spyOn(ref, 'destroy').and.callThrough();
-        }
-        return ref;
-      },
-    );
 
-    layoutService.init(hostEl, hostComponent.viewContainerRef);
-    layoutService.loadDefaultLayout();
+      layoutService.init(hostEl, hostComponent.viewContainerRef);
+      layoutService.loadDefaultLayout();
 
-    expect(createdRefs.length).toBe(1);
+      expect(createdRefs.length).toBe(1);
 
-    // Open a second timeline via menu action
-    const viewGroup = menuManager.groups().find((g) => g.id === 'view');
-    const openTimelineItem = viewGroup?.items.find(
-      (item) => item.id === 'open-timeline',
-    );
-    expect(openTimelineItem).toBeDefined();
-    openTimelineItem?.action();
+      // Open a second timeline via menu action
+      const viewGroup = menuManager.groups().find((g) => g.id === 'view');
+      const openTimelineItem = viewGroup?.items.find(
+        (item) => item.id === 'open-timeline',
+      );
+      expect(openTimelineItem).toBeDefined();
+      openTimelineItem?.action();
 
-    expect(createdRefs.length).toBe(2);
-    const [t1, t2] = createdRefs;
+      expect(createdRefs.length).toBe(2);
+      const [t1, t2] = createdRefs;
 
-    // Switch to State View Layout (which only needs 1 timeline)
-    layoutService.loadStateAnalysisLayout();
+      // Switch to State View Layout (which only needs 1 timeline)
+      layoutService.loadStateAnalysisLayout();
 
-    // Exactly one surplus timeline should have been destroyed
-    const destroyedCount =
-      (t1.destroy as jasmine.Spy).calls.count() +
-      (t2.destroy as jasmine.Spy).calls.count();
-    expect(destroyedCount).toBe(1);
-
-    hostEl.remove();
+      // Exactly one surplus timeline should have been destroyed
+      const destroyedCount =
+        (t1.destroy as jasmine.Spy).calls.count() +
+        (t2.destroy as jasmine.Spy).calls.count();
+      expect(destroyedCount).toBe(1);
+    } finally {
+      hostEl.remove();
+    }
   });
 
   it('should destroy all active and pooled components on ngOnDestroy', () => {
     const hostEl = hostComponent.layoutContainer().nativeElement;
     document.body.appendChild(hostEl);
 
-    const createdRefs: ComponentRef<unknown>[] = [];
-    const originalCreateComponent =
-      hostComponent.viewContainerRef.createComponent.bind(
-        hostComponent.viewContainerRef,
+    try {
+      const createdRefs: ComponentRef<unknown>[] = [];
+      const originalCreateComponent =
+        hostComponent.viewContainerRef.createComponent.bind(
+          hostComponent.viewContainerRef,
+        );
+      spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
+        (componentType: unknown) => {
+          const ref = originalCreateComponent(componentType as Type<unknown>);
+          createdRefs.push(ref);
+          spyOn(ref, 'destroy').and.callThrough();
+          return ref;
+        },
       );
-    spyOn(hostComponent.viewContainerRef, 'createComponent').and.callFake(
-      (componentType: unknown) => {
-        const ref = originalCreateComponent(componentType as Type<unknown>);
-        createdRefs.push(ref);
-        spyOn(ref, 'destroy').and.callThrough();
-        return ref;
-      },
-    );
 
-    layoutService.init(hostEl, hostComponent.viewContainerRef);
-    layoutService.loadDefaultLayout();
+      layoutService.init(hostEl, hostComponent.viewContainerRef);
+      layoutService.loadDefaultLayout();
 
-    // Switch to State View Layout so that LogSmartComponent is pooled (inactive)
-    layoutService.loadStateAnalysisLayout();
+      // Switch to State View Layout so that LogSmartComponent is pooled (inactive)
+      layoutService.loadStateAnalysisLayout();
 
-    expect(createdRefs.length).toBeGreaterThan(0);
+      expect(createdRefs.length).toBeGreaterThan(0);
 
-    // Call ngOnDestroy
-    layoutService.ngOnDestroy();
+      // Call ngOnDestroy
+      layoutService.ngOnDestroy();
 
-    // Verify all created component references were destroyed
-    for (const ref of createdRefs) {
-      expect((ref.destroy as jasmine.Spy).calls.count()).toBeGreaterThan(0);
+      // Verify all created component references were destroyed
+      for (const ref of createdRefs) {
+        expect((ref.destroy as jasmine.Spy).calls.count()).toBeGreaterThan(0);
+      }
+    } finally {
+      hostEl.remove();
     }
-
-    hostEl.remove();
   });
 });

--- a/web/src/app/services/layout/layout.service.ts
+++ b/web/src/app/services/layout/layout.service.ts
@@ -15,11 +15,14 @@
  */
 
 import {
+  ComponentRef,
   inject,
   Injectable,
   OnDestroy,
   signal,
+  Type,
   ViewContainerRef,
+  WritableSignal,
 } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import {
@@ -38,6 +41,26 @@ import {
 } from 'src/app/services/menu/menu-manager.service';
 import { StyleOverrideSmartComponent } from 'src/app/dialogs/style-override/style-override-smart.component';
 import { isEventFromOverlay } from 'src/app/common/dom-util';
+
+/**
+ * Type identifiers for components managed by LayoutService.
+ */
+export enum LayoutComponentType {
+  Timeline = 'timeline',
+  Log = 'log',
+  History = 'history',
+  Graph = 'graph',
+}
+
+/**
+ * Configuration for registering a GoldenLayout component.
+ */
+interface ComponentRegistrationConfig {
+  readonly type: LayoutComponentType;
+  readonly componentClass: Type<unknown>;
+  readonly tabIcon: string;
+  readonly disabledSignal?: WritableSignal<boolean>;
+}
 
 /**
  * LayoutService manages the GoldenLayout instance and component registration.
@@ -63,6 +86,21 @@ export class LayoutService implements OnDestroy {
 
   private readonly disableCreateGraphPane = signal(false);
 
+  /** Flag indicating whether a layout switch is in progress. */
+  private isSwitchingLayout = false;
+
+  /** Pool of detached component instances waiting to be reused. */
+  private readonly componentPool = new Map<
+    LayoutComponentType,
+    ComponentRef<unknown>[]
+  >();
+
+  /** Active component instances mapped by their GoldenLayout container. */
+  private readonly activeComponentRefs = new Map<
+    ComponentContainer,
+    ComponentRef<unknown>
+  >();
+
   /** The default layout configuration used if no saved state is found. */
   private readonly defaultLayout: LayoutConfig = {
     settings: {
@@ -79,19 +117,19 @@ export class LayoutService implements OnDestroy {
           content: [
             {
               type: 'component',
-              componentType: 'timeline',
+              componentType: LayoutComponentType.Timeline,
               title: 'Timeline',
               size: '70%',
             },
             {
               type: 'component',
-              componentType: 'log',
+              componentType: LayoutComponentType.Log,
               title: 'Logs',
               size: '15%',
             },
             {
               type: 'component',
-              componentType: 'history',
+              componentType: LayoutComponentType.History,
               title: 'History',
               size: '15%',
             },
@@ -117,13 +155,13 @@ export class LayoutService implements OnDestroy {
           content: [
             {
               type: 'component',
-              componentType: 'timeline',
+              componentType: LayoutComponentType.Timeline,
               title: 'Timeline',
               size: '60%',
             },
             {
               type: 'component',
-              componentType: 'history',
+              componentType: LayoutComponentType.History,
               title: 'History',
               size: '40%',
             },
@@ -149,13 +187,13 @@ export class LayoutService implements OnDestroy {
           content: [
             {
               type: 'component',
-              componentType: 'timeline',
+              componentType: LayoutComponentType.Timeline,
               title: 'Timeline',
               size: '50%',
             },
             {
               type: 'component',
-              componentType: 'graph',
+              componentType: LayoutComponentType.Graph,
               title: 'Graph',
               size: '50%',
             },
@@ -188,61 +226,68 @@ export class LayoutService implements OnDestroy {
   /**
    * Registers components to GoldenLayout.
    */
-  private registerComponents() {
-    this.goldenLayout.registerComponentFactoryFunction(
-      'timeline',
-      (container: ComponentContainer) => {
-        const componentRef = this.viewContainerRef.createComponent(
-          TimelineSmartComponent,
-        );
-        container.element.appendChild(componentRef.location.nativeElement);
-        this.addIconToTab(container, 'view_timeline');
-        container.on('destroy', () => componentRef.destroy());
-      },
-    );
+  private registerComponents(): void {
+    this.registerComponent({
+      type: LayoutComponentType.Timeline,
+      componentClass: TimelineSmartComponent,
+      tabIcon: 'view_timeline',
+    });
 
-    this.goldenLayout.registerComponentFactoryFunction(
-      'log',
-      (container: ComponentContainer) => {
-        const componentRef =
-          this.viewContainerRef.createComponent(LogSmartComponent);
-        container.element.appendChild(componentRef.location.nativeElement);
-        this.addIconToTab(container, 'cards_stack');
-        container.on('destroy', () => {
-          componentRef.destroy();
-          this.disableCreateLogPane.set(false);
-        });
-        this.disableCreateLogPane.set(true);
-      },
-    );
+    this.registerComponent({
+      type: LayoutComponentType.Log,
+      componentClass: LogSmartComponent,
+      tabIcon: 'cards_stack',
+      disabledSignal: this.disableCreateLogPane,
+    });
 
-    this.goldenLayout.registerComponentFactoryFunction(
-      'history',
-      (container: ComponentContainer) => {
-        const componentRef =
-          this.viewContainerRef.createComponent(DiffSmartComponent);
-        container.element.appendChild(componentRef.location.nativeElement);
-        this.addIconToTab(container, 'deployed_code_history');
-        container.on('destroy', () => {
-          componentRef.destroy();
-          this.disableCreateDiffPane.set(false);
-        });
-        this.disableCreateDiffPane.set(true);
-      },
-    );
+    this.registerComponent({
+      type: LayoutComponentType.History,
+      componentClass: DiffSmartComponent,
+      tabIcon: 'deployed_code_history',
+      disabledSignal: this.disableCreateDiffPane,
+    });
 
+    this.registerComponent({
+      type: LayoutComponentType.Graph,
+      componentClass: GraphSmartComponent,
+      tabIcon: 'family_history',
+      disabledSignal: this.disableCreateGraphPane,
+    });
+  }
+
+  /**
+   * Registers a single component type with pooling and caching support.
+   */
+  private registerComponent(config: ComponentRegistrationConfig): void {
     this.goldenLayout.registerComponentFactoryFunction(
-      'graph',
+      config.type,
       (container: ComponentContainer) => {
+        const pool = this.componentPool.get(config.type);
         const componentRef =
-          this.viewContainerRef.createComponent(GraphSmartComponent);
+          pool && pool.length > 0
+            ? pool.pop()!
+            : this.viewContainerRef.createComponent(config.componentClass);
+
+        this.activeComponentRefs.set(container, componentRef);
         container.element.appendChild(componentRef.location.nativeElement);
-        this.addIconToTab(container, 'family_history');
+        this.addIconToTab(container, config.tabIcon);
+        config.disabledSignal?.set(true);
+
         container.on('destroy', () => {
-          componentRef.destroy();
-          this.disableCreateGraphPane.set(false);
+          this.activeComponentRefs.delete(container);
+          if (this.isSwitchingLayout) {
+            componentRef.location.nativeElement.remove();
+            let currentPool = this.componentPool.get(config.type);
+            if (!currentPool) {
+              currentPool = [];
+              this.componentPool.set(config.type, currentPool);
+            }
+            currentPool.push(componentRef);
+          } else {
+            componentRef.destroy();
+          }
+          config.disabledSignal?.set(false);
         });
-        this.disableCreateGraphPane.set(true);
       },
     );
   }
@@ -250,7 +295,7 @@ export class LayoutService implements OnDestroy {
   /**
    * Adds icon to tab.
    */
-  private addIconToTab(container: ComponentContainer, iconName: string) {
+  private addIconToTab(container: ComponentContainer, iconName: string): void {
     container.on('tab', (tab: Tab) => {
       const iconSpan = document.createElement('span');
       iconSpan.className = 'material-symbols-outlined khi-tab-icon';
@@ -264,24 +309,44 @@ export class LayoutService implements OnDestroy {
   }
 
   /**
+   * Executes a layout switch while preserving cached components.
+   */
+  private executeLayoutSwitch(layoutConfig: LayoutConfig): void {
+    this.isSwitchingLayout = true;
+    try {
+      this.goldenLayout.loadLayout(layoutConfig);
+
+      const timelinePool = this.componentPool.get(LayoutComponentType.Timeline);
+      if (timelinePool) {
+        while (timelinePool.length > 0) {
+          const surplus = timelinePool.pop();
+          surplus?.destroy();
+        }
+      }
+    } finally {
+      this.isSwitchingLayout = false;
+    }
+  }
+
+  /**
    * Loads default layout configuration.
    */
-  public loadDefaultLayout() {
-    this.goldenLayout.loadLayout(this.defaultLayout);
+  public loadDefaultLayout(): void {
+    this.executeLayoutSwitch(this.defaultLayout);
   }
 
   /**
    * Loads state analysis layout configuration.
    */
-  public loadStateAnalysisLayout() {
-    this.goldenLayout.loadLayout(this.stateAnalysisLayout);
+  public loadStateAnalysisLayout(): void {
+    this.executeLayoutSwitch(this.stateAnalysisLayout);
   }
 
   /**
    * Loads topology analysis layout configuration.
    */
-  public loadTopologyAnalysisLayout() {
-    this.goldenLayout.loadLayout(this.topologyAnalysisLayout);
+  public loadTopologyAnalysisLayout(): void {
+    this.executeLayoutSwitch(this.topologyAnalysisLayout);
   }
 
   /**
@@ -314,7 +379,7 @@ export class LayoutService implements OnDestroy {
       icon: 'timeline',
       priority: 1,
       action: () => {
-        this.addPane('timeline', 'Timeline');
+        this.addPane(LayoutComponentType.Timeline, 'Timeline');
       },
     });
     this.menuManager.addItem('view', {
@@ -325,7 +390,7 @@ export class LayoutService implements OnDestroy {
       priority: 2,
       disabled: this.disableCreateLogPane,
       action: () => {
-        this.addPane('log', 'Logs');
+        this.addPane(LayoutComponentType.Log, 'Logs');
       },
     });
     this.menuManager.addItem('view', {
@@ -336,7 +401,7 @@ export class LayoutService implements OnDestroy {
       disabled: this.disableCreateDiffPane,
       priority: 3,
       action: () => {
-        this.addPane('history', 'History');
+        this.addPane(LayoutComponentType.History, 'History');
       },
     });
     this.menuManager.addItem('view', {
@@ -347,7 +412,7 @@ export class LayoutService implements OnDestroy {
       disabled: this.disableCreateGraphPane,
       priority: 4,
       action: () => {
-        this.addPane('graph', 'Graph');
+        this.addPane(LayoutComponentType.Graph, 'Graph');
       },
     });
     this.menuManager.addItem('view', {
@@ -430,7 +495,7 @@ export class LayoutService implements OnDestroy {
   /**
    * Adds a new pane to the layout.
    */
-  private addPane(componentType: string, title: string) {
+  private addPane(componentType: LayoutComponentType, title: string): void {
     try {
       this.goldenLayout.addItem({
         type: 'component',
@@ -445,9 +510,21 @@ export class LayoutService implements OnDestroy {
     }
   }
 
-  ngOnDestroy(): void {
+  public ngOnDestroy(): void {
     window.removeEventListener('keydown', this.handleKeyDown);
     this.resizeObserver?.disconnect();
     this.goldenLayout?.destroy();
+
+    for (const ref of this.activeComponentRefs.values()) {
+      ref.destroy();
+    }
+    this.activeComponentRefs.clear();
+
+    for (const pool of this.componentPool.values()) {
+      for (const ref of pool) {
+        ref.destroy();
+      }
+    }
+    this.componentPool.clear();
   }
 }

--- a/web/src/app/services/layout/layout.service.ts
+++ b/web/src/app/services/layout/layout.service.ts
@@ -268,6 +268,8 @@ export class LayoutService implements OnDestroy {
             ? pool.pop()!
             : this.viewContainerRef.createComponent(config.componentClass);
 
+        componentRef.changeDetectorRef.reattach();
+
         this.activeComponentRefs.set(container, componentRef);
         container.element.appendChild(componentRef.location.nativeElement);
         this.addIconToTab(container, config.tabIcon);
@@ -277,6 +279,7 @@ export class LayoutService implements OnDestroy {
           this.activeComponentRefs.delete(container);
           if (this.isSwitchingLayout) {
             componentRef.location.nativeElement.remove();
+            componentRef.changeDetectorRef.detach();
             let currentPool = this.componentPool.get(config.type);
             if (!currentPool) {
               currentPool = [];


### PR DESCRIPTION
## Summary
Prevent recreation of expensive components (Timeline, Logs, History, Graph) when switching layouts from the header menu or shortcuts (`Ctrl+1`, `Ctrl+2`, `Ctrl+3`).

## Changes
- **LayoutService Pooling**: Detaches and pools Angular `ComponentRef` instances on layout change, cleanly reattaching their DOM elements into new GoldenLayout containers within the same JS execution frame.
- **Resource Retention**: Keeps WebGL context, shaders, and log histogram caches intact for instantaneous layout switching without loading spinner.
- **Tab Close vs Layout Switch**: Preserves pool on layout switch, but cleanly destroys (`ComponentRef.destroy()`) components on explicit tab close ('x').
- **Surplus Management**: Automatically destroys extra timeline instances created by the user if they are not used in the newly selected layout.
- **Testing**: Added `layout.service.spec.ts` unit tests verifying reuse, surplus destruction, and lifecycle disposal on `ngOnDestroy`.

## Verification
- `make test-web` (766/766 passed)
- `make lint-web` (0 errors)
- `make format-web`
- `make build-storybook`
- `make pre-commit`