### PR TITLE
feat(workbench): persistent background Trigram indexing and search optimization

### DIFF
--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -174,7 +174,7 @@ func (n *NodeReader) getNode(fieldPath string) (Node, error) {
 	if fieldPath == "" {
 		return n.Node, nil
 	}
-	pathSegments := parseFieldPath(fieldPath)
+	pathSegments := ParseFieldPath(fieldPath)
 	currentNode := n.Node
 	for pathCursor := 0; pathCursor < len(pathSegments); pathCursor++ {
 		found := false
@@ -224,9 +224,9 @@ func ReadReflectK8sRuntimeObject[T runtime.Object](r *NodeReader, fieldPath stri
 	return nil
 }
 
-// parseFieldPath splits a field path string according to specified rules.
+// ParseFieldPath splits a field path string according to specified rules.
 // It uses '.' as a delimiter, but '\.' is treated as an escaped literal dot.
-func parseFieldPath(s string) []string {
+func ParseFieldPath(s string) []string {
 	var result []string
 	var currentSegment strings.Builder
 	isEscaped := false

--- a/pkg/common/structured/reader_test.go
+++ b/pkg/common/structured/reader_test.go
@@ -324,7 +324,7 @@ func TestParseFieldPath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := parseFieldPath(tc.input)
+			result := ParseFieldPath(tc.input)
 
 			if len(result) != len(tc.expected) {
 				t.Errorf("Expected %d segments, got %d", len(tc.expected), len(result))

--- a/pkg/core/init/default/import_inspection.go
+++ b/pkg/core/init/default/import_inspection.go
@@ -30,6 +30,7 @@ var ImportInspectionInitializer = &coreinit.Initializer{
 	Dependencies: []coreinit.InitializerID{
 		InitializerIDGinServer,
 		InitializerIDInspectionTaskServer,
+		InitializerIDInspectionIndexManager,
 	},
 	Before: []coreinit.InitializerID{
 		InitializerIDServerRunner,
@@ -41,11 +42,12 @@ var ImportInspectionInitializer = &coreinit.Initializer{
 		}
 
 		inspectionServer := coreinit.MustGet(ctx, InspectionTaskServerKey)
+		indexManager := coreinit.MustGet(ctx, InspectionIndexManagerKey)
 		router := coreinit.MustGet(ctx, GinRouterKey)
 		basePath := coreinit.MustGet(ctx, BasePathKey)
 
 		importSessionManager := importinspection.NewImportSessionManager(inspectionServer, inspectionServer.IOConfig())
-		importInspectionServer := serverapiv1.NewImportInspectionServiceServer(importSessionManager)
+		importInspectionServer := serverapiv1.NewImportInspectionServiceServer(importSessionManager, indexManager)
 		importInspectionPath, importInspectionHandler := apiv1connect.NewImportInspectionServiceHandler(importInspectionServer)
 		coreinit.RegisterConnectServiceHandler(router, basePath, importInspectionPath, importInspectionHandler)
 

--- a/pkg/core/init/default/import_inspection_test.go
+++ b/pkg/core/init/default/import_inspection_test.go
@@ -23,6 +23,7 @@ import (
 	coreinit "github.com/GoogleCloudPlatform/khi/pkg/core/init"
 	coreinspection "github.com/GoogleCloudPlatform/khi/pkg/core/inspection"
 	"github.com/GoogleCloudPlatform/khi/pkg/parameters"
+	"github.com/GoogleCloudPlatform/khi/pkg/server/workbench"
 	"github.com/gin-gonic/gin"
 )
 
@@ -76,6 +77,7 @@ func TestImportInspectionInitializer(t *testing.T) {
 			}
 
 			coreinit.Set(ctx, InspectionTaskServerKey, taskServer)
+			coreinit.Set(ctx, InspectionIndexManagerKey, workbench.NewInspectionIndexManager(taskServer, t.TempDir()))
 			coreinit.Set(ctx, GinRouterKey, router)
 			coreinit.Set(ctx, BasePathKey, tc.basePath)
 

--- a/pkg/core/init/default/server.go
+++ b/pkg/core/init/default/server.go
@@ -45,6 +45,7 @@ var GinServerInitializer = &coreinit.Initializer{
 	Dependencies: []coreinit.InitializerID{
 		InitializerIDGinEngine,
 		InitializerIDInspectionTaskServer,
+		InitializerIDInspectionIndexManager,
 	},
 	Before: []coreinit.InitializerID{
 		InitializerIDServerRunner,
@@ -70,6 +71,7 @@ var GinServerInitializer = &coreinit.Initializer{
 			StaticFolderPath: *serverParams.FrontendAssetFolder,
 			ResourceMonitor:  server.NewResourceMonitorImpl(),
 			ServerBasePath:   *serverParams.BasePath,
+			IndexManager:     coreinit.MustGet(ctx, InspectionIndexManagerKey),
 		}
 		inspectionServer := coreinit.MustGet(ctx, InspectionTaskServerKey)
 

--- a/pkg/core/init/default/workbench.go
+++ b/pkg/core/init/default/workbench.go
@@ -27,7 +27,27 @@ import (
 var (
 	// WorkbenchManagerKey stores the WorkbenchManager instance in the init context.
 	WorkbenchManagerKey = typedmap.NewTypedKey[*workbench.WorkbenchManager]("khi.google.com/init/workbench-manager")
+	// InspectionIndexManagerKey stores the InspectionIndexManager instance in the init context.
+	InspectionIndexManagerKey = typedmap.NewTypedKey[*workbench.InspectionIndexManager]("khi.google.com/init/inspection-index-manager")
 )
+
+// InitializerIDInspectionIndexManager identifies the Initializer that creates the InspectionIndexManager.
+const InitializerIDInspectionIndexManager coreinit.InitializerID = "khi.default/inspection-index-manager"
+
+// InspectionIndexManagerInitializer initializes the persistent InspectionIndexManager.
+var InspectionIndexManagerInitializer = &coreinit.Initializer{
+	ID: InitializerIDInspectionIndexManager,
+	Dependencies: []coreinit.InitializerID{
+		InitializerIDInspectionTaskServer,
+	},
+	Init: func(ctx *coreinit.InitContext) error {
+		inspectionServer := coreinit.MustGet(ctx, InspectionTaskServerKey)
+		dataDir := inspectionServer.IOConfig().DataDestination
+		indexManager := workbench.NewInspectionIndexManager(inspectionServer, dataDir)
+		coreinit.Set(ctx, InspectionIndexManagerKey, indexManager)
+		return nil
+	},
+}
 
 // InitializerIDWorkbenchService identifies the Initializer that mounts the WorkbenchService.
 const InitializerIDWorkbenchService coreinit.InitializerID = "khi.default/workbench-service"
@@ -38,6 +58,7 @@ var WorkbenchServiceInitializer = &coreinit.Initializer{
 	Dependencies: []coreinit.InitializerID{
 		InitializerIDGinServer,
 		InitializerIDInspectionTaskServer,
+		InitializerIDInspectionIndexManager,
 	},
 	Before: []coreinit.InitializerID{
 		InitializerIDServerRunner,
@@ -48,10 +69,11 @@ var WorkbenchServiceInitializer = &coreinit.Initializer{
 			return nil
 		}
 		inspectionServer := coreinit.MustGet(ctx, InspectionTaskServerKey)
+		indexManager := coreinit.MustGet(ctx, InspectionIndexManagerKey)
 		router := coreinit.MustGet(ctx, GinRouterKey)
 		basePath := coreinit.MustGet(ctx, BasePathKey)
 
-		workbenchManager := workbench.NewWorkbenchManager(inspectionServer, 60*time.Second, 15*time.Second)
+		workbenchManager := workbench.NewWorkbenchManager(inspectionServer, indexManager, 15*time.Minute, 15*time.Second)
 		coreinit.Set(ctx, WorkbenchManagerKey, workbenchManager)
 
 		workbenchPath, workbenchHandler := apiv1connect.NewWorkbenchServiceHandler(apiv1impl.NewWorkbenchServiceServer(workbenchManager))
@@ -61,5 +83,6 @@ var WorkbenchServiceInitializer = &coreinit.Initializer{
 }
 
 func init() {
+	coreinit.RegisterInitializer(InspectionIndexManagerInitializer)
 	coreinit.RegisterInitializer(WorkbenchServiceInitializer)
 }

--- a/pkg/generated/api/v1/apiv1connect/workbench.connect.go
+++ b/pkg/generated/api/v1/apiv1connect/workbench.connect.go
@@ -71,7 +71,7 @@ const (
 type WorkbenchServiceClient interface {
 	// Opens or attaches to an in-memory Workbench session with real-time loading progress streaming.
 	OpenWorkbench(context.Context, *connect.Request[v1.OpenWorkbenchRequest]) (*connect.ServerStreamForClient[v1.OpenWorkbenchResponse], error)
-	// Watches the search index construction progress and status for an active Workbench session. The server terminates the stream every 30s to accommodate proxy timeouts, and clients are expected to reconnect.
+	// Watches the search index construction progress and status for an inspection dataset. The server terminates the stream every 30s to accommodate proxy timeouts, and clients are expected to reconnect.
 	WatchIndexProgress(context.Context, *connect.Request[v1.WatchIndexProgressRequest]) (*connect.ServerStreamForClient[v1.WatchIndexProgressResponse], error)
 	// Sends periodic heartbeat to keep the Workbench session alive in memory.
 	HeartbeatWorkbench(context.Context, *connect.Request[v1.HeartbeatWorkbenchRequest]) (*connect.Response[v1.HeartbeatWorkbenchResponse], error)
@@ -177,7 +177,7 @@ func (c *workbenchServiceClient) CloseWorkbench(ctx context.Context, req *connec
 type WorkbenchServiceHandler interface {
 	// Opens or attaches to an in-memory Workbench session with real-time loading progress streaming.
 	OpenWorkbench(context.Context, *connect.Request[v1.OpenWorkbenchRequest], *connect.ServerStream[v1.OpenWorkbenchResponse]) error
-	// Watches the search index construction progress and status for an active Workbench session. The server terminates the stream every 30s to accommodate proxy timeouts, and clients are expected to reconnect.
+	// Watches the search index construction progress and status for an inspection dataset. The server terminates the stream every 30s to accommodate proxy timeouts, and clients are expected to reconnect.
 	WatchIndexProgress(context.Context, *connect.Request[v1.WatchIndexProgressRequest], *connect.ServerStream[v1.WatchIndexProgressResponse]) error
 	// Sends periodic heartbeat to keep the Workbench session alive in memory.
 	HeartbeatWorkbench(context.Context, *connect.Request[v1.HeartbeatWorkbenchRequest]) (*connect.Response[v1.HeartbeatWorkbenchResponse], error)

--- a/pkg/generated/api/v1/workbench.pb.go
+++ b/pkg/generated/api/v1/workbench.pb.go
@@ -332,10 +332,10 @@ func (x *OpenWorkbenchResponse) GetWorkbenchId() string {
 	return ""
 }
 
-// Request to watch the search index construction progress of a Workbench session.
+// Request to watch the search index construction progress of an active Workbench session.
 type WatchIndexProgressRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The active workbench session identifier.
+	// The active workbench session identifier to stream search index construction progress for.
 	WorkbenchId   *string `protobuf:"bytes,1,opt,name=workbench_id,json=workbenchId" json:"workbench_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/model/khifile/v6/direct_yaml.go
+++ b/pkg/model/khifile/v6/direct_yaml.go
@@ -16,6 +16,7 @@ package khifilev6
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -323,11 +324,37 @@ func isSafePlainScalar(str string) bool {
 	return true
 }
 
+// emitQuotedString writes a double-quoted YAML string preserving valid UTF-8 runes.
+func emitQuotedString(targetBuf *bytes.Buffer, str string) {
+	targetBuf.WriteByte('"')
+	for _, r := range str {
+		switch r {
+		case '"':
+			targetBuf.WriteString(`\"`)
+		case '\\':
+			targetBuf.WriteString(`\\`)
+		case '\n':
+			targetBuf.WriteString(`\n`)
+		case '\r':
+			targetBuf.WriteString(`\r`)
+		case '\t':
+			targetBuf.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(targetBuf, `\x%02x`, r)
+			} else {
+				targetBuf.WriteRune(r)
+			}
+		}
+	}
+	targetBuf.WriteByte('"')
+}
+
 // emitString writes a string value to the buffer, using plain scalar for safe identifiers and double-quotes otherwise.
 func (s *DirectYAMLSerializer) emitString(targetBuf *bytes.Buffer, str string) {
 	if isSafePlainScalar(str) {
 		targetBuf.WriteString(str)
 	} else {
-		targetBuf.WriteString(strconv.Quote(str))
+		emitQuotedString(targetBuf, str)
 	}
 }

--- a/pkg/model/khifile/v6/direct_yaml.go
+++ b/pkg/model/khifile/v6/direct_yaml.go
@@ -105,7 +105,7 @@ func compileFieldPathSchema(keys []string) *FieldPathSchema {
 		var prefixBuilder strings.Builder
 		for lvl := common; lvl < len(parts)-1; lvl++ {
 			prefixBuilder.WriteString(strings.Repeat("  ", lvl))
-			prefixBuilder.WriteString(formatKeyName(parts[lvl]))
+			prefixBuilder.WriteString(FormatKeyName(parts[lvl]))
 			prefixBuilder.WriteString(":\n")
 		}
 
@@ -113,7 +113,7 @@ func compileFieldPathSchema(keys []string) *FieldPathSchema {
 		ops[i] = FieldOp{
 			PrefixYAML:  prefixBuilder.String(),
 			Indent:      strings.Repeat("  ", leafLvl),
-			KeyName:     formatKeyName(parts[leafLvl]),
+			KeyName:     FormatKeyName(parts[leafLvl]),
 			IndentLevel: leafLvl,
 		}
 
@@ -123,8 +123,8 @@ func compileFieldPathSchema(keys []string) *FieldPathSchema {
 	return &FieldPathSchema{Ops: ops}
 }
 
-// formatKeyName formats a mapping key safely, applying quotes if the key starts with @ or contains control characters.
-func formatKeyName(key string) string {
+// FormatKeyName formats a mapping key safely, applying quotes if the key starts with @ or contains control characters.
+func FormatKeyName(key string) string {
 	if isSafePlainScalar(key) {
 		return key
 	}

--- a/pkg/model/khifile/v6/direct_yaml_test.go
+++ b/pkg/model/khifile/v6/direct_yaml_test.go
@@ -73,6 +73,8 @@ str_empty: ""
 str_brackets: "[item1, item2]"
 str_braces: "{a: 1}"
 str_special_chars: "foo#bar=baz&qux%quux"
+str_japanese: "設定マップの更新"
+str_unicode_symbols: "🚀 container-started (node-1) ⚡"
 `,
 		},
 		{

--- a/pkg/server/api/v1/import_inspection.go
+++ b/pkg/server/api/v1/import_inspection.go
@@ -23,20 +23,23 @@ import (
 	apiv1 "github.com/GoogleCloudPlatform/khi/pkg/generated/api/v1"
 	"github.com/GoogleCloudPlatform/khi/pkg/generated/api/v1/apiv1connect"
 	"github.com/GoogleCloudPlatform/khi/pkg/server/importinspection"
+	"github.com/GoogleCloudPlatform/khi/pkg/server/workbench"
 	"google.golang.org/protobuf/proto"
 )
 
 // ImportInspectionServiceServer implements the apiv1connect.ImportInspectionServiceHandler interface.
 type ImportInspectionServiceServer struct {
-	manager *importinspection.ImportSessionManager
+	manager      *importinspection.ImportSessionManager
+	indexManager *workbench.InspectionIndexManager
 }
 
 var _ apiv1connect.ImportInspectionServiceHandler = (*ImportInspectionServiceServer)(nil)
 
 // NewImportInspectionServiceServer creates a new ImportInspectionServiceServer backed by the given manager.
-func NewImportInspectionServiceServer(manager *importinspection.ImportSessionManager) *ImportInspectionServiceServer {
+func NewImportInspectionServiceServer(manager *importinspection.ImportSessionManager, indexManager *workbench.InspectionIndexManager) *ImportInspectionServiceServer {
 	return &ImportInspectionServiceServer{
-		manager: manager,
+		manager:      manager,
+		indexManager: indexManager,
 	}
 }
 
@@ -111,6 +114,10 @@ func (s *ImportInspectionServiceServer) CompleteImportInspection(
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to complete import: %w", err))
+	}
+
+	if s.indexManager != nil {
+		s.indexManager.StartAsyncIndexing(context.Background(), finalized.InspectionID)
 	}
 
 	res := &apiv1.CompleteImportInspectionResponse{

--- a/pkg/server/api/v1/import_inspection.go
+++ b/pkg/server/api/v1/import_inspection.go
@@ -117,6 +117,7 @@ func (s *ImportInspectionServiceServer) CompleteImportInspection(
 	}
 
 	if s.indexManager != nil {
+		s.indexManager.InvalidateInspectionIndex(finalized.InspectionID)
 		s.indexManager.StartAsyncIndexing(context.Background(), finalized.InspectionID)
 	}
 

--- a/pkg/server/api/v1/import_inspection_test.go
+++ b/pkg/server/api/v1/import_inspection_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	coreinspection "github.com/GoogleCloudPlatform/khi/pkg/core/inspection"
@@ -28,6 +29,7 @@ import (
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/server/importinspection"
+	"github.com/GoogleCloudPlatform/khi/pkg/server/workbench"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
@@ -73,7 +75,7 @@ func setupTestServer(t *testing.T) (apiv1connect.ImportInspectionServiceClient, 
 	}
 
 	manager := importinspection.NewImportSessionManager(server, ioConfig)
-	serviceServer := NewImportInspectionServiceServer(manager)
+	serviceServer := NewImportInspectionServiceServer(manager, nil)
 	mux := http.NewServeMux()
 	path, handler := apiv1connect.NewImportInspectionServiceHandler(serviceServer)
 	mux.Handle(path, handler)
@@ -352,6 +354,95 @@ func TestImportInspectionService_Errors(t *testing.T) {
 
 			if connect.CodeOf(err) != tc.wantCode {
 				t.Errorf("error code mismatch: got %v, want %v (error: %v)", connect.CodeOf(err), tc.wantCode, err)
+			}
+		})
+	}
+}
+
+func TestImportInspectionService_AsyncIndexingIntegration(t *testing.T) {
+	testCases := []struct {
+		name             string
+		withIndexManager bool
+	}{
+		{
+			name:             "triggers async indexing on complete when indexManager is configured",
+			withIndexManager: true,
+		},
+		{
+			name:             "completes cleanly when indexManager is nil",
+			withIndexManager: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			khiData := createTestBinaryKHIBytes(t, "Cluster-Test")
+			tempDir := t.TempDir()
+			destDir := t.TempDir()
+			ioConfig := &inspectioncore_contract.IOConfig{
+				TemporaryFolder: tempDir,
+				DataDestination: destDir,
+			}
+			server, err := coreinspection.NewServer(ioConfig)
+			if err != nil {
+				t.Fatalf("NewServer failed: %v", err)
+			}
+
+			manager := importinspection.NewImportSessionManager(server, ioConfig)
+			var indexManager *workbench.InspectionIndexManager
+			if tc.withIndexManager {
+				indexManager = workbench.NewInspectionIndexManager(server, destDir)
+			}
+
+			serviceServer := NewImportInspectionServiceServer(manager, indexManager)
+			mux := http.NewServeMux()
+			path, handler := apiv1connect.NewImportInspectionServiceHandler(serviceServer)
+			mux.Handle(path, handler)
+
+			httpServer := httptest.NewServer(mux)
+			defer httpServer.Close()
+			client := apiv1connect.NewImportInspectionServiceClient(httpServer.Client(), httpServer.URL)
+
+			ctx := context.Background()
+			startResp, err := client.StartImportInspection(ctx, connect.NewRequest(&apiv1.StartImportInspectionRequest{
+				FileName:       proto.String("cluster.khi"),
+				TotalSizeBytes: proto.Int64(int64(len(khiData))),
+			}))
+			if err != nil {
+				t.Fatalf("StartImportInspection failed: %v", err)
+			}
+
+			token := startResp.Msg.GetImportToken()
+			_, err = client.UploadInspectionChunk(ctx, connect.NewRequest(&apiv1.UploadInspectionChunkRequest{
+				ImportToken: proto.String(token),
+				OffsetBytes: proto.Int64(0),
+				Data:        khiData,
+			}))
+			if err != nil {
+				t.Fatalf("UploadInspectionChunk failed: %v", err)
+			}
+
+			completeResp, err := client.CompleteImportInspection(ctx, connect.NewRequest(&apiv1.CompleteImportInspectionRequest{
+				ImportToken: proto.String(token),
+			}))
+			if err != nil {
+				t.Fatalf("CompleteImportInspection failed: %v", err)
+			}
+
+			inspectionID := completeResp.Msg.GetInspectionId()
+			if tc.withIndexManager {
+				deadline := time.Now().Add(5 * time.Second)
+				var state workbench.IndexState
+				for time.Now().Before(deadline) {
+					state, _, _, _ = indexManager.IndexStatus(inspectionID)
+					if state == workbench.IndexStateBuilding || state == workbench.IndexStateReady {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				if state != workbench.IndexStateBuilding && state != workbench.IndexStateReady {
+					t.Errorf("expected index state to be building or ready, got %v", state)
+				}
 			}
 		})
 	}

--- a/pkg/server/api/v1/workbench.go
+++ b/pkg/server/api/v1/workbench.go
@@ -103,6 +103,7 @@ func (s *WorkbenchServiceServer) WatchIndexProgress(
 	timer := time.NewTimer(30 * time.Second)
 	defer timer.Stop()
 
+	wb.StartAsyncIndexing(context.Background())
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/server/api/v1/workbench_test.go
+++ b/pkg/server/api/v1/workbench_test.go
@@ -88,7 +88,7 @@ func createTestInspectionServerForWorkbench(t *testing.T) (*coreinspection.Inspe
 func setupTestWorkbenchServer(t *testing.T) (*httptest.Server, apiv1connect.WorkbenchServiceClient, *workbench.WorkbenchManager, string) {
 	inspectionServer, validInspID := createTestInspectionServerForWorkbench(t)
 
-	manager := workbench.NewWorkbenchManager(inspectionServer, 100*time.Millisecond, 0)
+	manager := workbench.NewWorkbenchManager(inspectionServer, nil, 100*time.Millisecond, 0)
 	serverImpl := NewWorkbenchServiceServer(manager)
 	mux := http.NewServeMux()
 	path, handler := apiv1connect.NewWorkbenchServiceHandler(serverImpl)

--- a/pkg/server/api/v1/workbench_test.go
+++ b/pkg/server/api/v1/workbench_test.go
@@ -88,7 +88,8 @@ func createTestInspectionServerForWorkbench(t *testing.T) (*coreinspection.Inspe
 func setupTestWorkbenchServer(t *testing.T) (*httptest.Server, apiv1connect.WorkbenchServiceClient, *workbench.WorkbenchManager, string) {
 	inspectionServer, validInspID := createTestInspectionServerForWorkbench(t)
 
-	manager := workbench.NewWorkbenchManager(inspectionServer, nil, 100*time.Millisecond, 0)
+	indexMgr := workbench.NewInspectionIndexManager(inspectionServer, t.TempDir())
+	manager := workbench.NewWorkbenchManager(inspectionServer, indexMgr, 100*time.Millisecond, 0)
 	serverImpl := NewWorkbenchServiceServer(manager)
 	mux := http.NewServeMux()
 	path, handler := apiv1connect.NewWorkbenchServiceHandler(serverImpl)
@@ -405,27 +406,26 @@ func TestWorkbenchServiceServer_FilterTimeline(t *testing.T) {
 }
 
 func TestWorkbenchServiceServer_WatchIndexProgress(t *testing.T) {
-	ts, client, _, validInspID := setupTestWorkbenchServer(t)
+	ts, client, manager, validInspID := setupTestWorkbenchServer(t)
 	defer ts.Close()
+	defer manager.Stop()
 
-	// Open a workbench first
+	// 1. Open workbench first
 	openStream, err := client.OpenWorkbench(context.Background(), connect.NewRequest(&apiv1.OpenWorkbenchRequest{
-		UserId:       proto.String("user-1"),
-		SessionId:    proto.String("session-1"),
+		UserId:       proto.String("user-watch"),
+		SessionId:    proto.String("session-0"),
 		InspectionId: proto.String(validInspID),
 	}))
 	if err != nil {
 		t.Fatalf("OpenWorkbench() error = %v", err)
 	}
-	var validWBID string
 	for openStream.Receive() {
-		if openStream.Msg().GetWorkbenchId() != "" {
-			validWBID = openStream.Msg().GetWorkbenchId()
-		}
 	}
 	if err := openStream.Err(); err != nil {
 		t.Fatalf("OpenWorkbench() stream error = %v", err)
 	}
+
+	workbenchID := "user-watch-session-0"
 
 	testCases := []struct {
 		name        string
@@ -433,9 +433,9 @@ func TestWorkbenchServiceServer_WatchIndexProgress(t *testing.T) {
 		wantErrCode connect.Code
 	}{
 		{
-			name: "success on active workbench",
+			name: "success on valid workbench id",
 			req: &apiv1.WatchIndexProgressRequest{
-				WorkbenchId: proto.String(validWBID),
+				WorkbenchId: proto.String(workbenchID),
 			},
 			wantErrCode: 0,
 		},
@@ -457,7 +457,9 @@ func TestWorkbenchServiceServer_WatchIndexProgress(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			stream, err := client.WatchIndexProgress(context.Background(), connect.NewRequest(tc.req))
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			stream, err := client.WatchIndexProgress(ctx, connect.NewRequest(tc.req))
 			if err != nil {
 				t.Fatalf("WatchIndexProgress() error = %v", err)
 			}

--- a/pkg/server/importinspection/session.go
+++ b/pkg/server/importinspection/session.go
@@ -138,6 +138,10 @@ func (m *ImportSessionManager) CompleteSession(token string) (*FinalizedImport, 
 		return nil, fmt.Errorf("failed to persist inspection file: %w", err)
 	}
 
+	// Invalidate any stale trigram index from a previous upload of the same ID.
+	_ = os.Remove(filepath.Join(destinationDir, inspectionID+".trigram"))
+	_ = os.Remove(filepath.Join(destinationDir, inspectionID+".trigram.tmp"))
+
 	store := inspectioncore_contract.NewFileSystemInspectionResultRepository(destinationPath)
 	fileSize, err := store.GetInspectionResultSizeInBytes()
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -41,9 +41,10 @@ const embeddedStaticFolderPath = "dist/browser"
 //go:embed dist/browser
 var embeddedStaticFolder embed.FS
 
-// InspectionIndexer defines the contract for asynchronously indexing an inspection.
+// InspectionIndexer defines the contract for asynchronously indexing an inspection and invalidating stale indices.
 type InspectionIndexer interface {
 	StartAsyncIndexing(ctx context.Context, inspectionID string)
+	InvalidateInspectionIndex(inspectionID string)
 }
 
 type ServerConfig struct {
@@ -77,6 +78,9 @@ func coepCoopMiddleware() gin.HandlerFunc {
 // SetupKHIServerRoutes mounts base middlewares, static files, and standard REST routes onto engine.
 // It returns the normalized base path without trailing slash and the created gin.IRouter.
 func SetupKHIServerRoutes(engine *gin.Engine, inspectionServer *coreinspection.InspectionTaskServer, serverConfig *ServerConfig) (string, gin.IRouter) {
+	if serverConfig.IndexManager == nil {
+		panic("serverConfig.IndexManager is required")
+	}
 	engine.Use(coepCoopMiddleware())
 	basePathWithoutTrailingSlash := strings.TrimSuffix(serverConfig.ServerBasePath, "/")
 	engine.Use(redirectMiddleware(basePathWithoutTrailingSlash+"/", basePathWithoutTrailingSlash+"/session/0")) // Request for `/` shouldn't be handled by `static.Serve`, redirect `/session/0` to be handled by patternToString
@@ -291,14 +295,13 @@ func SetupKHIServerRoutes(engine *gin.Engine, inspectionServer *coreinspection.I
 			ctx.String(http.StatusInternalServerError, err.Error())
 			return
 		}
-		if serverConfig.IndexManager != nil {
-			go func() {
-				<-currentTask.Wait()
-				if res, err := currentTask.Result(); err == nil && res != nil {
-					serverConfig.IndexManager.StartAsyncIndexing(context.Background(), inspectionID)
-				}
-			}()
-		}
+		go func() {
+			<-currentTask.Wait()
+			if res, err := currentTask.Result(); err == nil && res != nil {
+				serverConfig.IndexManager.InvalidateInspectionIndex(inspectionID)
+				serverConfig.IndexManager.StartAsyncIndexing(context.Background(), inspectionID)
+			}
+		}()
 		ctx.String(http.StatusAccepted, "ok")
 	})
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"log/slog"
@@ -40,10 +41,16 @@ const embeddedStaticFolderPath = "dist/browser"
 //go:embed dist/browser
 var embeddedStaticFolder embed.FS
 
+// InspectionIndexer defines the contract for asynchronously indexing an inspection.
+type InspectionIndexer interface {
+	StartAsyncIndexing(ctx context.Context, inspectionID string)
+}
+
 type ServerConfig struct {
 	StaticFolderPath string
 	ResourceMonitor  ResourceMonitor
 	ServerBasePath   string
+	IndexManager     InspectionIndexer
 }
 
 func redirectMiddleware(exactPath string, redirectTo string) gin.HandlerFunc {
@@ -283,6 +290,14 @@ func SetupKHIServerRoutes(engine *gin.Engine, inspectionServer *coreinspection.I
 		if err != nil {
 			ctx.String(http.StatusInternalServerError, err.Error())
 			return
+		}
+		if serverConfig.IndexManager != nil {
+			go func() {
+				<-currentTask.Wait()
+				if res, err := currentTask.Result(); err == nil && res != nil {
+					serverConfig.IndexManager.StartAsyncIndexing(context.Background(), inspectionID)
+				}
+			}()
 		}
 		ctx.String(http.StatusAccepted, "ok")
 	})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -217,6 +217,7 @@ func TestApiResponses(t *testing.T) {
 		StaticFolderPath: "dist",
 		ResourceMonitor:  &ResourceMonitorMock{UsedMemory: 1000, TotalMemory: 2000},
 		ServerBasePath:   "/foo",
+		IndexManager:     &mockInspectionIndexer{},
 	}
 	engine := gin.New()
 	engine = CreateKHIServer(engine, inspectionServer, &serverConfig)
@@ -649,6 +650,7 @@ func TestKHIServer_EndpointExistsWithConfigs(t *testing.T) {
 				StaticFolderPath: embeddedStaticFolderPath,
 				ResourceMonitor:  &ResourceMonitorMock{UsedMemory: 1000},
 				ServerBasePath:   tc.serverBasePath,
+				IndexManager:     &mockInspectionIndexer{},
 			}
 			engine := gin.New()
 			engine = CreateKHIServer(engine, inspectionServer, &config)
@@ -698,6 +700,7 @@ func TestKHIServerRedirects(t *testing.T) {
 				StaticFolderPath: "dist",
 				ResourceMonitor:  &ResourceMonitorMock{UsedMemory: 1000},
 				ServerBasePath:   tc.serverBasePath,
+				IndexManager:     &mockInspectionIndexer{},
 			}
 			engine := gin.New()
 			engine = CreateKHIServer(engine, inspectionServer, &config)
@@ -745,6 +748,7 @@ func TestRegisterConnectServiceHandler(t *testing.T) {
 				StaticFolderPath: "dist",
 				ResourceMonitor:  &ResourceMonitorMock{UsedMemory: 1000},
 				ServerBasePath:   tc.basePath,
+				IndexManager:     &mockInspectionIndexer{},
 			}
 			inspectionServer, err := createTestInspectionServer()
 			if err != nil {
@@ -777,14 +781,23 @@ func TestRegisterConnectServiceHandler(t *testing.T) {
 }
 
 type mockInspectionIndexer struct {
-	mu           sync.Mutex
-	indexedCalls []string
+	mu               sync.Mutex
+	indexedCalls     []string
+	invalidatedCalls []string
 }
+
+var _ InspectionIndexer = (*mockInspectionIndexer)(nil)
 
 func (m *mockInspectionIndexer) StartAsyncIndexing(ctx context.Context, inspectionID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.indexedCalls = append(m.indexedCalls, inspectionID)
+}
+
+func (m *mockInspectionIndexer) InvalidateInspectionIndex(inspectionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.invalidatedCalls = append(m.invalidatedCalls, inspectionID)
 }
 
 func (m *mockInspectionIndexer) IndexedCalls() []string {
@@ -795,93 +808,103 @@ func (m *mockInspectionIndexer) IndexedCalls() []string {
 	return res
 }
 
+func (m *mockInspectionIndexer) InvalidatedCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	res := make([]string, len(m.invalidatedCalls))
+	copy(res, m.invalidatedCalls)
+	return res
+}
+
 func TestKHIServerRoutes_RunTriggersAsyncIndexing(t *testing.T) {
-	testCases := []struct {
-		name             string
-		withIndexManager bool
-		wantIndexedCount int
-	}{
-		{
-			name:             "triggers async indexing when index manager is configured",
-			withIndexManager: true,
-			wantIndexedCount: 1,
-		},
-		{
-			name:             "does not panic or fail when index manager is nil",
-			withIndexManager: false,
-			wantIndexedCount: 0,
-		},
-	}
+	t.Run("triggers cache invalidation and async indexing when inspection completes successfully", func(t *testing.T) {
+		logger.InitGlobalKHILogger()
+		inspectionServer, err := createTestInspectionServer()
+		if err != nil {
+			t.Fatalf("createTestInspectionServer failed: %v", err)
+		}
+		taskID, err := inspectionServer.CreateInspection("foo")
+		if err != nil {
+			t.Fatalf("CreateInspection failed: %v", err)
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			logger.InitGlobalKHILogger()
-			inspectionServer, err := createTestInspectionServer()
-			if err != nil {
-				t.Fatalf("createTestInspectionServer failed: %v", err)
-			}
-			taskID, err := inspectionServer.CreateInspection("foo")
-			if err != nil {
-				t.Fatalf("CreateInspection failed: %v", err)
-			}
+		mockIndexer := &mockInspectionIndexer{}
+		serverConfig := ServerConfig{
+			StaticFolderPath: "dist",
+			ResourceMonitor:  &ResourceMonitorMock{UsedMemory: 1000},
+			ServerBasePath:   "",
+			IndexManager:     mockIndexer,
+		}
 
-			mockIndexer := &mockInspectionIndexer{}
-			serverConfig := ServerConfig{
-				StaticFolderPath: "dist",
-				ResourceMonitor:  &ResourceMonitorMock{UsedMemory: 1000},
-				ServerBasePath:   "",
-			}
-			if tc.withIndexManager {
-				serverConfig.IndexManager = mockIndexer
-			}
+		engine := gin.New()
+		SetupKHIServerRoutes(engine, inspectionServer, &serverConfig)
 
-			engine := gin.New()
-			SetupKHIServerRoutes(engine, inspectionServer, &serverConfig)
+		task := inspectionServer.GetInspection(taskID)
+		if err := task.UpdateFeatureMap(map[string]bool{"feature-foo2#default": true}); err != nil {
+			t.Fatalf("UpdateFeatureMap failed: %v", err)
+		}
 
-			task := inspectionServer.GetInspection(taskID)
-			if err := task.UpdateFeatureMap(map[string]bool{"feature-foo2#default": true}); err != nil {
-				t.Fatalf("UpdateFeatureMap failed: %v", err)
-			}
-
-			bodyBytes, err := json.Marshal(map[string]any{
-				"foo-input": "foo-input-value",
-			})
-			if err != nil {
-				t.Fatalf("json.Marshal failed: %v", err)
-			}
-			recorder := httptest.NewRecorder()
-			req, err := http.NewRequest("POST", fmt.Sprintf("/api/v3/inspection/%s/run", taskID), bytes.NewReader(bodyBytes))
-			if err != nil {
-				t.Fatalf("http.NewRequest failed: %v", err)
-			}
-			req.Header.Set("Content-Type", "application/json")
-			engine.ServeHTTP(recorder, req)
-
-			if recorder.Code != http.StatusAccepted {
-				t.Fatalf("POST /run returned code %d, want %d", recorder.Code, http.StatusAccepted)
-			}
-
-			<-task.Wait()
-
-			if tc.withIndexManager {
-				deadline := time.Now().Add(2 * time.Second)
-				for time.Now().Before(deadline) {
-					if len(mockIndexer.IndexedCalls()) == tc.wantIndexedCount {
-						break
-					}
-					time.Sleep(10 * time.Millisecond)
-				}
-			}
-
-			gotCalls := mockIndexer.IndexedCalls()
-			if diff := cmp.Diff(tc.wantIndexedCount, len(gotCalls)); diff != "" {
-				t.Errorf("indexed call count mismatch (-want +got):\n%s", diff)
-			}
-			if tc.withIndexManager && len(gotCalls) > 0 {
-				if diff := cmp.Diff(taskID, gotCalls[0]); diff != "" {
-					t.Errorf("indexed taskID mismatch (-want +got):\n%s", diff)
-				}
-			}
+		bodyBytes, err := json.Marshal(map[string]any{
+			"foo-input": "foo-input-value",
 		})
-	}
+		if err != nil {
+			t.Fatalf("json.Marshal failed: %v", err)
+		}
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", fmt.Sprintf("/api/v3/inspection/%s/run", taskID), bytes.NewReader(bodyBytes))
+		if err != nil {
+			t.Fatalf("http.NewRequest failed: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		engine.ServeHTTP(recorder, req)
+
+		if recorder.Code != http.StatusAccepted {
+			t.Fatalf("POST /run returned code %d, want %d", recorder.Code, http.StatusAccepted)
+		}
+
+		<-task.Wait()
+
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if len(mockIndexer.IndexedCalls()) == 1 && len(mockIndexer.InvalidatedCalls()) == 1 {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		gotCalls := mockIndexer.IndexedCalls()
+		if diff := cmp.Diff(1, len(gotCalls)); diff != "" {
+			t.Errorf("indexed call count mismatch (-want +got):\n%s", diff)
+		}
+		if len(gotCalls) > 0 {
+			if diff := cmp.Diff(taskID, gotCalls[0]); diff != "" {
+				t.Errorf("indexed taskID mismatch (-want +got):\n%s", diff)
+			}
+		}
+
+		gotInvalidated := mockIndexer.InvalidatedCalls()
+		if diff := cmp.Diff(1, len(gotInvalidated)); diff != "" {
+			t.Errorf("invalidated call count mismatch (-want +got):\n%s", diff)
+		}
+		if len(gotInvalidated) > 0 {
+			if diff := cmp.Diff(taskID, gotInvalidated[0]); diff != "" {
+				t.Errorf("invalidated taskID mismatch (-want +got):\n%s", diff)
+			}
+		}
+	})
+
+	t.Run("panics when index manager is nil in ServerConfig", func(t *testing.T) {
+		inspectionServer, err := createTestInspectionServer()
+		if err != nil {
+			t.Fatalf("createTestInspectionServer failed: %v", err)
+		}
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Errorf("expected panic when serverConfig.IndexManager is nil, got none")
+			}
+		}()
+		engine := gin.New()
+		SetupKHIServerRoutes(engine, inspectionServer, &ServerConfig{})
+	})
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -770,6 +771,116 @@ func TestRegisterConnectServiceHandler(t *testing.T) {
 			}
 			if recorder.Body.String() != tc.wantBody {
 				t.Errorf("got body %q, want %q", recorder.Body.String(), tc.wantBody)
+			}
+		})
+	}
+}
+
+type mockInspectionIndexer struct {
+	mu           sync.Mutex
+	indexedCalls []string
+}
+
+func (m *mockInspectionIndexer) StartAsyncIndexing(ctx context.Context, inspectionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.indexedCalls = append(m.indexedCalls, inspectionID)
+}
+
+func (m *mockInspectionIndexer) IndexedCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	res := make([]string, len(m.indexedCalls))
+	copy(res, m.indexedCalls)
+	return res
+}
+
+func TestKHIServerRoutes_RunTriggersAsyncIndexing(t *testing.T) {
+	testCases := []struct {
+		name             string
+		withIndexManager bool
+		wantIndexedCount int
+	}{
+		{
+			name:             "triggers async indexing when index manager is configured",
+			withIndexManager: true,
+			wantIndexedCount: 1,
+		},
+		{
+			name:             "does not panic or fail when index manager is nil",
+			withIndexManager: false,
+			wantIndexedCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger.InitGlobalKHILogger()
+			inspectionServer, err := createTestInspectionServer()
+			if err != nil {
+				t.Fatalf("createTestInspectionServer failed: %v", err)
+			}
+			taskID, err := inspectionServer.CreateInspection("foo")
+			if err != nil {
+				t.Fatalf("CreateInspection failed: %v", err)
+			}
+
+			mockIndexer := &mockInspectionIndexer{}
+			serverConfig := ServerConfig{
+				StaticFolderPath: "dist",
+				ResourceMonitor:  &ResourceMonitorMock{UsedMemory: 1000},
+				ServerBasePath:   "",
+			}
+			if tc.withIndexManager {
+				serverConfig.IndexManager = mockIndexer
+			}
+
+			engine := gin.New()
+			SetupKHIServerRoutes(engine, inspectionServer, &serverConfig)
+
+			task := inspectionServer.GetInspection(taskID)
+			if err := task.UpdateFeatureMap(map[string]bool{"feature-foo2#default": true}); err != nil {
+				t.Fatalf("UpdateFeatureMap failed: %v", err)
+			}
+
+			bodyBytes, err := json.Marshal(map[string]any{
+				"foo-input": "foo-input-value",
+			})
+			if err != nil {
+				t.Fatalf("json.Marshal failed: %v", err)
+			}
+			recorder := httptest.NewRecorder()
+			req, err := http.NewRequest("POST", fmt.Sprintf("/api/v3/inspection/%s/run", taskID), bytes.NewReader(bodyBytes))
+			if err != nil {
+				t.Fatalf("http.NewRequest failed: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			engine.ServeHTTP(recorder, req)
+
+			if recorder.Code != http.StatusAccepted {
+				t.Fatalf("POST /run returned code %d, want %d", recorder.Code, http.StatusAccepted)
+			}
+
+			<-task.Wait()
+
+			if tc.withIndexManager {
+				deadline := time.Now().Add(2 * time.Second)
+				for time.Now().Before(deadline) {
+					if len(mockIndexer.IndexedCalls()) == tc.wantIndexedCount {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+
+			gotCalls := mockIndexer.IndexedCalls()
+			if diff := cmp.Diff(tc.wantIndexedCount, len(gotCalls)); diff != "" {
+				t.Errorf("indexed call count mismatch (-want +got):\n%s", diff)
+			}
+			if tc.withIndexManager && len(gotCalls) > 0 {
+				if diff := cmp.Diff(taskID, gotCalls[0]); diff != "" {
+					t.Errorf("indexed taskID mismatch (-want +got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/server/workbench/cel/env_test.go
+++ b/pkg/server/workbench/cel/env_test.go
@@ -434,3 +434,135 @@ user:
 		})
 	}
 }
+
+func TestLogEvaluator_WithTrigramIndex(t *testing.T) {
+	pool := khifilev6model.NewInternPool(&khifilev6model.IDGenerator{})
+
+	node1, err := structured.FromYAML(`verb: create
+user:
+  username: system:admin
+spec:
+  container:
+    name: nginx
+    image: nginx:latest
+`)
+	if err != nil {
+		t.Fatalf("failed to parse yaml node 1: %v", err)
+	}
+	sRef1, err := khifilev6model.ToInternedStruct(node1, pool)
+	if err != nil {
+		t.Fatalf("failed to intern struct 1: %v", err)
+	}
+
+	node2, err := structured.FromYAML(`verb: get
+user:
+  username: anonymous
+spec:
+  container:
+    name: coredns
+    image: coredns:v1.9
+`)
+	if err != nil {
+		t.Fatalf("failed to parse yaml node 2: %v", err)
+	}
+	sRef2, err := khifilev6model.ToInternedStruct(node2, pool)
+	if err != nil {
+		t.Fatalf("failed to intern struct 2: %v", err)
+	}
+
+	log1 := &LogData{
+		ID:           1,
+		LogType:      "k8s-audit",
+		Severity:     3,
+		Summary:      "pod created",
+		BodyStructID: sRef1.ID(),
+	}
+	log2 := &LogData{
+		ID:           2,
+		LogType:      "k8s-audit",
+		Severity:     1,
+		Summary:      "pod inspected",
+		BodyStructID: sRef2.ID(),
+	}
+
+	trigramIdx := NewTrigramIndex()
+	logItems := []LogTrigramItem{
+		{ID: log1.ID, BodyStructID: log1.BodyStructID},
+		{ID: log2.ID, BodyStructID: log2.BodyStructID},
+	}
+	if err := trigramIdx.BuildFromLogPool(pool, logItems, nil); err != nil {
+		t.Fatalf("BuildFromLogPool() failed: %v", err)
+	}
+
+	eval, err := NewLogEvaluator()
+	if err != nil {
+		t.Fatalf("NewLogEvaluator() failed: %v", err)
+	}
+	eval.SetInternPool(pool)
+	eval.SetTrigramIndex(trigramIdx)
+
+	testCases := []struct {
+		name       string
+		expression string
+		log        *LogData
+		want       bool
+	}{
+		{
+			name:       "field search matches log 1",
+			expression: `body("spec.container.image", "nginx")`,
+			log:        log1,
+			want:       true,
+		},
+		{
+			name:       "field search does not match log 2 and is pruned",
+			expression: `body("spec.container.image", "nginx")`,
+			log:        log2,
+			want:       false,
+		},
+		{
+			name:       "user.username matches log 1",
+			expression: `body("user.username", "admin")`,
+			log:        log1,
+			want:       true,
+		},
+		{
+			name:       "user.username does not match log 2",
+			expression: `body("user.username", "admin")`,
+			log:        log2,
+			want:       false,
+		},
+		{
+			name:       "user.username anonymous matches log 2",
+			expression: `body("user.username", "anonymous")`,
+			log:        log2,
+			want:       true,
+		},
+		{
+			name:       "non-existent field is pruned early and returns false",
+			expression: `body("nonexistent.field", "nginx")`,
+			log:        log1,
+			want:       false,
+		},
+		{
+			name:       "unconstrained pattern matches when field exists",
+			expression: `body("spec.container.image", ".*")`,
+			log:        log1,
+			want:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := eval.Compile(tc.expression); err != nil {
+				t.Fatalf("Compile() failed: %v", err)
+			}
+			got, err := eval.Evaluate(context.Background(), tc.log)
+			if err != nil {
+				t.Fatalf("Evaluate() unexpected error = %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Evaluate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/server/workbench/cel/functions.go
+++ b/pkg/server/workbench/cel/functions.go
@@ -164,11 +164,15 @@ func MatchLogField(
 	combinedPattern := combinePatterns(patterns)
 
 	// Candidate pre-filtering with TrigramIndex:
-	// If trigram index exists and the struct ID is not in candidate bitmap, prune early.
+	// If trigram index exists and neither log ID nor struct ID is in candidate bitmap, prune early.
 	if trigramIndex != nil {
-		candidateBitmap := trigramIndex.FindCandidateStructs(combinedPattern)
-		if candidateBitmap != nil && !candidateBitmap.Contains(l.BodyStructID) {
-			return false, nil
+		candidateBitmap := trigramIndex.FindCandidateLogs(combinedPattern)
+		if candidateBitmap != nil {
+			matchLog := l.ID != 0 && candidateBitmap.Contains(l.ID)
+			matchStruct := l.BodyStructID != 0 && candidateBitmap.Contains(l.BodyStructID)
+			if !matchLog && !matchStruct {
+				return false, nil
+			}
 		}
 	}
 

--- a/pkg/server/workbench/cel/functions.go
+++ b/pkg/server/workbench/cel/functions.go
@@ -166,7 +166,7 @@ func MatchLogField(
 	// Candidate pre-filtering with TrigramIndex:
 	// If trigram index exists and neither log ID nor struct ID is in candidate bitmap, prune early.
 	if trigramIndex != nil {
-		candidateBitmap := trigramIndex.FindCandidateLogs(combinedPattern)
+		candidateBitmap := trigramIndex.FindCandidateLogsWithField(pathKey, combinedPattern)
 		if candidateBitmap != nil {
 			matchLog := l.ID != 0 && candidateBitmap.Contains(l.ID)
 			matchStruct := l.BodyStructID != 0 && candidateBitmap.Contains(l.BodyStructID)

--- a/pkg/server/workbench/cel/trigram.go
+++ b/pkg/server/workbench/cel/trigram.go
@@ -22,10 +22,12 @@ import (
 	"io"
 	"regexp/syntax"
 	"sort"
+	"strings"
 	"sync"
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
 	khifilev6model "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/RoaringBitmap/roaring/v2"
@@ -441,16 +443,59 @@ func (t *TrigramIndex) BuildFromStructYAMLs(ctx context.Context, structYAMLs map
 	return nil
 }
 
-// FindCandidateLogs returns a Roaring Bitmap containing candidate LogIDs whose summary or body could match the regex pattern.
-// If the regex is unconstrained by trigrams (e.g. wildcards or <3 char literals), it returns nil, meaning all logs are candidates.
-// If the pattern cannot match any indexed log, it returns an empty Roaring Bitmap.
-func (t *TrigramIndex) FindCandidateLogs(pattern string) *roaring.Bitmap {
+// PathToTrigramQuery converts a field path key into a TrigramQuery constraining candidates
+// to logs/structs that contain the path's constituent field segments formatted as YAML keys.
+// If pathKey is empty or "*", or if none of the segments have at least 3 runes with colon, it returns &AllQuery{}.
+func PathToTrigramQuery(pathKey string) TrigramQuery {
+	if pathKey == "" || pathKey == "*" {
+		return &AllQuery{}
+	}
+
+	segments := structured.ParseFieldPath(pathKey)
+	var termQueries []TrigramQuery
+	seenTerms := make(map[string]struct{})
+
+	for _, seg := range segments {
+		if seg == "" {
+			continue
+		}
+		formattedKey := khifilev6model.FormatKeyName(seg) + ":"
+		runes := []rune(strings.ToLower(formattedKey))
+		if len(runes) < 3 {
+			continue
+		}
+		for i := 0; i <= len(runes)-3; i++ {
+			tri := string(runes[i : i+3])
+			if _, seen := seenTerms[tri]; seen {
+				continue
+			}
+			seenTerms[tri] = struct{}{}
+			termQueries = append(termQueries, &TermQuery{Term: tri})
+		}
+	}
+
+	if len(termQueries) == 0 {
+		return &AllQuery{}
+	}
+	if len(termQueries) == 1 {
+		return termQueries[0]
+	}
+	return &AndQuery{Children: termQueries}
+}
+
+// FindCandidateLogsWithField returns a Roaring Bitmap containing candidate LogIDs whose summary or body
+// could match both the field pathKey and the regex pattern.
+// If both the field path and pattern are unconstrained, it returns nil (Universe).
+// If the combination cannot match any indexed log, it returns an empty Roaring Bitmap.
+func (t *TrigramIndex) FindCandidateLogsWithField(pathKey string, pattern string) *roaring.Bitmap {
 	if t == nil {
 		return roaring.NewBitmap()
 	}
 
+	cacheKey := pathKey + "\x00" + pattern
+
 	t.mu.RLock()
-	if cached, ok := t.candidateCache[pattern]; ok {
+	if cached, ok := t.candidateCache[cacheKey]; ok {
 		t.mu.RUnlock()
 		return cached
 	}
@@ -458,22 +503,34 @@ func (t *TrigramIndex) FindCandidateLogs(pattern string) *roaring.Bitmap {
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if cached, ok := t.candidateCache[pattern]; ok {
+	if cached, ok := t.candidateCache[cacheKey]; ok {
 		return cached
 	}
 
-	syn, err := syntax.Parse(pattern, syntax.Perl)
-	if err != nil {
-		empty := roaring.NewBitmap()
-		t.candidateCache[pattern] = empty
-		return empty
+	var patternQuery TrigramQuery = &AllQuery{}
+	if pattern != "" && pattern != ".*" {
+		syn, err := syntax.Parse(pattern, syntax.Perl)
+		if err != nil {
+			empty := roaring.NewBitmap()
+			t.candidateCache[cacheKey] = empty
+			return empty
+		}
+		patternQuery = RegexToTrigramQuery(syn.Simplify()).Simplify()
 	}
 
-	syn = syn.Simplify()
-	query := RegexToTrigramQuery(syn).Simplify()
-	candidateBitmap := evalTrigramQuery(query, t.trigramToBitmap)
-	t.candidateCache[pattern] = candidateBitmap
+	fieldQuery := PathToTrigramQuery(pathKey)
+
+	combinedQuery := (&AndQuery{Children: []TrigramQuery{fieldQuery, patternQuery}}).Simplify()
+	candidateBitmap := evalTrigramQuery(combinedQuery, t.trigramToBitmap)
+	t.candidateCache[cacheKey] = candidateBitmap
 	return candidateBitmap
+}
+
+// FindCandidateLogs returns a Roaring Bitmap containing candidate LogIDs whose summary or body could match the regex pattern.
+// If the regex is unconstrained by trigrams (e.g. wildcards or <3 char literals), it returns nil, meaning all logs are candidates.
+// If the pattern cannot match any indexed log, it returns an empty Roaring Bitmap.
+func (t *TrigramIndex) FindCandidateLogs(pattern string) *roaring.Bitmap {
+	return t.FindCandidateLogsWithField("*", pattern)
 }
 
 // evalTrigramQuery evaluates a TrigramQuery against the index bitmaps to produce a candidate *roaring.Bitmap.

--- a/pkg/server/workbench/cel/trigram.go
+++ b/pkg/server/workbench/cel/trigram.go
@@ -16,24 +16,47 @@ package cel
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
 	"regexp/syntax"
+	"sort"
 	"sync"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
+	khifilev6model "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/RoaringBitmap/roaring/v2"
+)
+
+const (
+	// TrigramBinaryMagicBytes defines the 7-byte magic prefix for serialized TrigramIndex binary files.
+	TrigramBinaryMagicBytes = "KHITRIX"
+	// TrigramBinaryVersion defines the version byte of the TrigramIndex binary format.
+	TrigramBinaryVersion = byte(0x02)
+)
+
+var (
+	// ErrInvalidTrigramHeader indicates that the binary stream does not begin with valid magic bytes and version.
+	ErrInvalidTrigramHeader = errors.New("invalid trigram index binary header")
 )
 
 // TrigramProgressCallback receives streaming progress updates during Trigram index building.
 type TrigramProgressCallback = worker.ProgressCallback
 
-// TrigramIndex provides fast regular expression and substring candidate search over interned struct IDs using Roaring Bitmaps.
+// LogTrigramItem represents a minimal log record for Trigram indexing.
+type LogTrigramItem struct {
+	ID              uint32
+	SummaryStringID uint32
+	BodyStructID    uint32
+}
+
+// TrigramIndex provides fast regular expression and substring candidate search over log IDs using Roaring Bitmaps.
 type TrigramIndex struct {
-	// trigramToBitmap maps each lowercase 3-rune string to a Roaring Bitmap of StructIDs containing it.
+	// trigramToBitmap maps each lowercase 3-rune string to a Roaring Bitmap of LogIDs containing it.
 	trigramToBitmap map[string]*roaring.Bitmap
-	// allStructIDs contains all indexed StructIDs.
-	allStructIDs *roaring.Bitmap
 	// mu protects candidateCache.
 	mu sync.RWMutex
 	// candidateCache stores cached candidate query results (*roaring.Bitmap or nil) for concurrent evaluators.
@@ -44,95 +67,311 @@ type TrigramIndex struct {
 func NewTrigramIndex() *TrigramIndex {
 	return &TrigramIndex{
 		trigramToBitmap: make(map[string]*roaring.Bitmap),
-		allStructIDs:    roaring.NewBitmap(),
 		candidateCache:  make(map[string]*roaring.Bitmap),
 	}
 }
 
-type yamlEntry struct {
-	id   uint32
-	yaml string
+var (
+	_ io.WriterTo   = (*TrigramIndex)(nil)
+	_ io.ReaderFrom = (*TrigramIndex)(nil)
+)
+
+// countingWriter wraps an io.Writer and tracks the total number of bytes written.
+type countingWriter struct {
+	w            io.Writer
+	bytesWritten int64
 }
 
-// processYAMLEntryChunk processes a slice of yamlEntry, returning worker-local trigram-to-RoaringBitmap mapping.
-func processYAMLEntryChunk(chunk []yamlEntry, onProcessed func(int)) map[string]*roaring.Bitmap {
-	localTrigrams := make(map[string]*roaring.Bitmap)
-	var buf [12]byte
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.bytesWritten += int64(n)
+	return n, err
+}
 
-	for _, entry := range chunk {
-		yamlStr := entry.yaml
-		id := entry.id
-		if len(yamlStr) < 3 {
-			onProcessed(1)
+// countingReader wraps an io.Reader and tracks the total number of bytes read.
+type countingReader struct {
+	r         io.Reader
+	bytesRead int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.bytesRead += int64(n)
+	return n, err
+}
+
+// WriteTo serializes the TrigramIndex into the given io.Writer in compact binary format.
+func (t *TrigramIndex) WriteTo(w io.Writer) (int64, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	cw := &countingWriter{w: w}
+
+	header := make([]byte, 8)
+	copy(header[:7], TrigramBinaryMagicBytes)
+	header[7] = TrigramBinaryVersion
+	if _, err := cw.Write(header); err != nil {
+		return cw.bytesWritten, fmt.Errorf("failed to write header: %w", err)
+	}
+
+	keys := make([]string, 0, len(t.trigramToBitmap))
+	for k := range t.trigramToBitmap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var countBuf [4]byte
+	binary.LittleEndian.PutUint32(countBuf[:], uint32(len(keys)))
+	if _, err := cw.Write(countBuf[:]); err != nil {
+		return cw.bytesWritten, fmt.Errorf("failed to write trigram count: %w", err)
+	}
+
+	var lenBuf [1]byte
+	for _, key := range keys {
+		bm := t.trigramToBitmap[key]
+		keyBytes := []byte(key)
+		if len(keyBytes) > 255 {
+			return cw.bytesWritten, fmt.Errorf("trigram key length %d exceeds uint8 limit", len(keyBytes))
+		}
+		lenBuf[0] = byte(len(keyBytes))
+		if _, err := cw.Write(lenBuf[:]); err != nil {
+			return cw.bytesWritten, fmt.Errorf("failed to write key length: %w", err)
+		}
+		if _, err := cw.Write(keyBytes); err != nil {
+			return cw.bytesWritten, fmt.Errorf("failed to write key bytes: %w", err)
+		}
+		if _, err := bm.WriteTo(cw); err != nil {
+			return cw.bytesWritten, fmt.Errorf("failed to write bitmap for trigram %q: %w", key, err)
+		}
+	}
+
+	return cw.bytesWritten, nil
+}
+
+// ReadFrom restores the TrigramIndex from an io.Reader containing binary serialized TrigramIndex data.
+func (t *TrigramIndex) ReadFrom(r io.Reader) (int64, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	cr := &countingReader{r: r}
+
+	var header [8]byte
+	if _, err := io.ReadFull(cr, header[:]); err != nil {
+		return cr.bytesRead, fmt.Errorf("failed to read header: %w", err)
+	}
+	if string(header[:7]) != TrigramBinaryMagicBytes || header[7] != TrigramBinaryVersion {
+		return cr.bytesRead, ErrInvalidTrigramHeader
+	}
+
+	var countBuf [4]byte
+	if _, err := io.ReadFull(cr, countBuf[:]); err != nil {
+		return cr.bytesRead, fmt.Errorf("failed to read trigram count: %w", err)
+	}
+	numTrigrams := binary.LittleEndian.Uint32(countBuf[:])
+
+	trigramMap := make(map[string]*roaring.Bitmap, numTrigrams)
+	var lenBuf [1]byte
+	keyBuf := make([]byte, 256)
+	for i := uint32(0); i < numTrigrams; i++ {
+		if _, err := io.ReadFull(cr, lenBuf[:]); err != nil {
+			return cr.bytesRead, fmt.Errorf("failed to read key length: %w", err)
+		}
+		keyLen := int(lenBuf[0])
+		if _, err := io.ReadFull(cr, keyBuf[:keyLen]); err != nil {
+			return cr.bytesRead, fmt.Errorf("failed to read key bytes: %w", err)
+		}
+		key := string(keyBuf[:keyLen])
+
+		bm := roaring.NewBitmap()
+		if _, err := bm.ReadFrom(cr); err != nil {
+			return cr.bytesRead, fmt.Errorf("failed to read bitmap for trigram %q: %w", key, err)
+		}
+		trigramMap[key] = bm
+	}
+
+	t.trigramToBitmap = trigramMap
+	t.candidateCache = make(map[string]*roaring.Bitmap)
+	return cr.bytesRead, nil
+}
+
+// extractTrigramsToBitmap extracts lowercase 3-rune trigrams from str and directly adds id to localMap[triKey].
+func extractTrigramsToBitmap(str string, id uint32, localMap map[string]*roaring.Bitmap, buf *[12]byte) {
+	if len(str) < 3 {
+		return
+	}
+	var r0, r1, r2 rune
+	var count int
+
+	for offset := 0; offset < len(str); {
+		r, size := utf8.DecodeRuneInString(str[offset:])
+		offset += size
+		rLower := unicode.ToLower(r)
+
+		if count == 0 {
+			r0 = rLower
+			count = 1
+			continue
+		}
+		if count == 1 {
+			r1 = rLower
+			count = 2
 			continue
 		}
 
-		var r0, r1, r2 rune
-		var count int
+		r2 = rLower
+		n := utf8.EncodeRune(buf[0:], r0)
+		n += utf8.EncodeRune(buf[n:], r1)
+		n += utf8.EncodeRune(buf[n:], r2)
 
-		for offset := 0; offset < len(yamlStr); {
-			r, size := utf8.DecodeRuneInString(yamlStr[offset:])
-			offset += size
-			rLower := unicode.ToLower(r)
-
-			if count == 0 {
-				r0 = rLower
-				count = 1
-				continue
-			}
-			if count == 1 {
-				r1 = rLower
-				count = 2
-				continue
-			}
-
-			r2 = rLower
-			n := utf8.EncodeRune(buf[0:], r0)
-			n += utf8.EncodeRune(buf[n:], r1)
-			n += utf8.EncodeRune(buf[n:], r2)
-
-			triKey := string(buf[:n])
-			bm, exists := localTrigrams[triKey]
-			if !exists {
-				bm = roaring.NewBitmap()
-				localTrigrams[triKey] = bm
-			}
-			bm.Add(id)
-
-			r0 = r1
-			r1 = r2
+		triKey := string(buf[:n])
+		bm, exists := localMap[triKey]
+		if !exists {
+			bm = roaring.NewBitmap()
+			localMap[triKey] = bm
 		}
+		bm.Add(id)
 
-		onProcessed(1)
+		r0 = r1
+		r1 = r2
 	}
-
-	return localTrigrams
 }
 
-// mergeTrigramChunk merges worker-local Roaring Bitmaps for the given slice of trigrams.
-func mergeTrigramChunk(chunk []string, results []map[string]*roaring.Bitmap, onProcessed func(int)) map[string]*roaring.Bitmap {
-	localMerged := make(map[string]*roaring.Bitmap, len(chunk))
-	for _, tri := range chunk {
-		var bms []*roaring.Bitmap
-		for _, res := range results {
-			if bm, ok := res[tri]; ok {
-				bms = append(bms, bm)
+type workerTrigramData struct {
+	localMap map[string]*roaring.Bitmap
+}
+
+// BuildFromLogPool indexes trigrams from an InternPool and a slice of LogTrigramItems in streaming parallel chunks.
+func (t *TrigramIndex) BuildFromLogPool(pool *khifilev6model.InternPool, logs []LogTrigramItem, onProgress TrigramProgressCallback) error {
+	if pool == nil || len(logs) == 0 {
+		return nil
+	}
+
+	// Step 1: Parallel extraction into worker-local Roaring Bitmaps (0% - 90%)
+	workerResults, err := worker.ParallelChunkMap(
+		context.Background(),
+		logs,
+		func(ctx context.Context, workerIdx int, chunk []LogTrigramItem, onProcessed func(int)) (*workerTrigramData, error) {
+			data := &workerTrigramData{
+				localMap: make(map[string]*roaring.Bitmap),
+			}
+			serializer := khifilev6model.NewDirectYAMLSerializer()
+			var buf [12]byte
+
+			for _, l := range chunk {
+				if l.ID == 0 {
+					onProcessed(1)
+					continue
+				}
+
+				if l.BodyStructID != 0 {
+					s := pool.ResolveStructFromID(l.BodyStructID)
+					if s != nil {
+						if yamlStr, err := serializer.SerializeStruct(s, pool); err == nil {
+							extractTrigramsToBitmap(yamlStr, l.ID, data.localMap, &buf)
+						}
+					}
+				}
+
+				if l.SummaryStringID != 0 {
+					sumStr := pool.ResolveStringFromID(l.SummaryStringID)
+					if len(sumStr) >= 3 {
+						extractTrigramsToBitmap(sumStr, l.ID, data.localMap, &buf)
+					}
+				}
+				onProcessed(1)
+			}
+			return data, nil
+		},
+		onProgress,
+		worker.ProgressOptions{
+			MessageFmt:  "Indexing log bodies and summaries (%d/%d)...",
+			MinProgress: 0.0,
+			MaxProgress: 0.90,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// Collect unique trigram keys across all workers.
+	keySet := make(map[string]struct{})
+	for _, wRes := range workerResults {
+		if wRes != nil {
+			for k := range wRes.localMap {
+				keySet[k] = struct{}{}
 			}
 		}
-
-		if len(bms) == 0 {
-			onProcessed(1)
-			continue
-		}
-
-		if len(bms) == 1 {
-			localMerged[tri] = bms[0]
-		} else {
-			localMerged[tri] = roaring.FastOr(bms...)
-		}
-		onProcessed(1)
 	}
-	return localMerged
+	allKeys := make([]string, 0, len(keySet))
+	for k := range keySet {
+		allKeys = append(allKeys, k)
+	}
+
+	// Step 2: Key-partitioned parallel merge across workers (90% - 100%)
+	shardResults, err := worker.ParallelChunkMap(
+		context.Background(),
+		allKeys,
+		func(ctx context.Context, workerIdx int, chunk []string, onProcessed func(int)) (map[string]*roaring.Bitmap, error) {
+			shardMap := make(map[string]*roaring.Bitmap, len(chunk))
+			for _, key := range chunk {
+				var merged *roaring.Bitmap
+				for _, wRes := range workerResults {
+					if wRes == nil {
+						continue
+					}
+					if bm, ok := wRes.localMap[key]; ok {
+						if merged == nil {
+							merged = bm
+						} else {
+							merged.Or(bm)
+						}
+					}
+				}
+				if merged != nil {
+					merged.RunOptimize()
+				}
+				shardMap[key] = merged
+				onProcessed(1)
+			}
+			return shardMap, nil
+		},
+		onProgress,
+		worker.ProgressOptions{
+			MessageFmt:  "Merging text search index (%d/%d)...",
+			MinProgress: 0.50,
+			MaxProgress: 1.0,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	finalMap := make(map[string]*roaring.Bitmap, len(allKeys))
+	for _, shard := range shardResults {
+		for k, bm := range shard {
+			finalMap[k] = bm
+		}
+	}
+
+	t.trigramToBitmap = finalMap
+	t.candidateCache = make(map[string]*roaring.Bitmap)
+	if onProgress != nil {
+		_ = onProgress(1.0, "Text search index complete.")
+	}
+	return nil
+}
+
+// BuildFromStructPool indexes trigrams from an InternPool and a slice of StructIDs in streaming chunks.
+// It maps each struct ID to itself as a log ID for backward compatibility with struct-level indexing tests.
+func (t *TrigramIndex) BuildFromStructPool(pool *khifilev6model.InternPool, structIDs []uint32, onProgress TrigramProgressCallback) error {
+	logs := make([]LogTrigramItem, 0, len(structIDs))
+	for _, id := range structIDs {
+		logs = append(logs, LogTrigramItem{
+			ID:           id,
+			BodyStructID: id,
+		})
+	}
+	return t.BuildFromLogPool(pool, logs, onProgress)
 }
 
 // BuildFromStructYAMLs indexes trigrams from pre-serialized struct YAML strings concurrently using Roaring Bitmaps.
@@ -141,85 +380,71 @@ func (t *TrigramIndex) BuildFromStructYAMLs(ctx context.Context, structYAMLs map
 		return nil
 	}
 
-	entries := make([]yamlEntry, 0, len(structYAMLs))
+	type structEntry struct {
+		id   uint32
+		yaml string
+	}
+	entries := make([]structEntry, 0, len(structYAMLs))
 	for id, yaml := range structYAMLs {
 		if id == 0 {
 			continue
 		}
-		t.allStructIDs.Add(id)
-		entries = append(entries, yamlEntry{id: id, yaml: yaml})
+		entries = append(entries, structEntry{id: id, yaml: yaml})
 	}
 
 	if len(entries) == 0 {
 		return nil
 	}
 
-	// Phase 1: Worker-Local Construction (0 locks)
-	results, err := worker.ParallelChunkMap(
+	workerResults, err := worker.ParallelChunkMap(
 		ctx,
 		entries,
-		func(ctx context.Context, workerIdx int, chunk []yamlEntry, onProcessed func(int)) (map[string]*roaring.Bitmap, error) {
-			return processYAMLEntryChunk(chunk, onProcessed), nil
+		func(ctx context.Context, workerIdx int, chunk []structEntry, onProcessed func(int)) (map[string]*roaring.Bitmap, error) {
+			localMap := make(map[string]*roaring.Bitmap)
+			var buf [12]byte
+			for _, entry := range chunk {
+				extractTrigramsToBitmap(entry.yaml, entry.id, localMap, &buf)
+				onProcessed(1)
+			}
+			return localMap, nil
 		},
 		onProgress,
 		worker.ProgressOptions{
 			MessageFmt:  "Building text search index (%d/%d)...",
 			MinProgress: 0.0,
-			MaxProgress: 0.70,
+			MaxProgress: 0.80,
 		},
 	)
 	if err != nil {
 		return err
 	}
 
-	// Collect unique trigram keys from all workers
-	uniqueTrigramMap := make(map[string]struct{})
-	for _, res := range results {
-		for tri := range res {
-			uniqueTrigramMap[tri] = struct{}{}
+	trigramMap := make(map[string]*roaring.Bitmap)
+	for _, localMap := range workerResults {
+		for tri, bm := range localMap {
+			if existing, ok := trigramMap[tri]; ok {
+				existing.Or(bm)
+			} else {
+				trigramMap[tri] = bm
+			}
 		}
 	}
-
-	uniqueTrigrams := make([]string, 0, len(uniqueTrigramMap))
-	for tri := range uniqueTrigramMap {
-		uniqueTrigrams = append(uniqueTrigrams, tri)
+	for _, bm := range trigramMap {
+		bm.RunOptimize()
 	}
 
-	if len(uniqueTrigrams) == 0 {
-		return nil
+	t.trigramToBitmap = trigramMap
+	t.candidateCache = make(map[string]*roaring.Bitmap)
+	if onProgress != nil {
+		_ = onProgress(1.0, "Text search index complete.")
 	}
-
-	// Phase 2: Parallel Partition Merge (0 locks)
-	mergedBitmaps, err := worker.ParallelChunkMap(
-		ctx,
-		uniqueTrigrams,
-		func(ctx context.Context, workerIdx int, chunk []string, onProcessed func(int)) (map[string]*roaring.Bitmap, error) {
-			return mergeTrigramChunk(chunk, results, onProcessed), nil
-		},
-		onProgress,
-		worker.ProgressOptions{
-			MessageFmt:  "Finalizing text search index (%d/%d)...",
-			MinProgress: 0.70,
-			MaxProgress: 1.00,
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	for _, localMerged := range mergedBitmaps {
-		for tri, bm := range localMerged {
-			t.trigramToBitmap[tri] = bm
-		}
-	}
-
 	return nil
 }
 
-// FindCandidateStructs returns a Roaring Bitmap containing candidate StructIDs whose serialized YAML could match the regex pattern.
-// If the regex is unconstrained by trigrams (e.g. wildcards or <3 char literals), it returns nil, meaning all structs are candidates.
-// If the pattern cannot match any indexed struct, it returns an empty Roaring Bitmap.
-func (t *TrigramIndex) FindCandidateStructs(pattern string) *roaring.Bitmap {
+// FindCandidateLogs returns a Roaring Bitmap containing candidate LogIDs whose summary or body could match the regex pattern.
+// If the regex is unconstrained by trigrams (e.g. wildcards or <3 char literals), it returns nil, meaning all logs are candidates.
+// If the pattern cannot match any indexed log, it returns an empty Roaring Bitmap.
+func (t *TrigramIndex) FindCandidateLogs(pattern string) *roaring.Bitmap {
 	if t == nil {
 		return roaring.NewBitmap()
 	}

--- a/pkg/server/workbench/cel/trigram_test.go
+++ b/pkg/server/workbench/cel/trigram_test.go
@@ -589,3 +589,204 @@ func TestTrigramIndex_BuildFromLogPool(t *testing.T) {
 		})
 	}
 }
+
+func TestPathToTrigramQuery(t *testing.T) {
+	testCases := []struct {
+		name      string
+		pathKey   string
+		wantType  string // "AllQuery", "TermQuery", "AndQuery"
+		wantTerms []string
+	}{
+		{
+			name:     "wildcard path",
+			pathKey:  "*",
+			wantType: "AllQuery",
+		},
+		{
+			name:     "empty path",
+			pathKey:  "",
+			wantType: "AllQuery",
+		},
+		{
+			name:      "2-letter field name gets colon to form 3 runes",
+			pathKey:   "ip",
+			wantType:  "TermQuery",
+			wantTerms: []string{"ip:"},
+		},
+		{
+			name:      "single field name",
+			pathKey:   "status",
+			wantType:  "AndQuery",
+			wantTerms: []string{"sta", "tat", "atu", "tus", "us:"},
+		},
+		{
+			name:     "multi segment field path",
+			pathKey:  "spec.containers.image",
+			wantType: "AndQuery",
+			wantTerms: []string{
+				// spec:
+				"spe", "pec", "ec:",
+				// containers:
+				"con", "ont", "nta", "tai", "ain", "ine", "ner", "ers", "rs:",
+				// image:
+				"ima", "mag", "age", "ge:",
+			},
+		},
+		{
+			name:     "escaped dot in field name",
+			pathKey:  "labels.app\\.kubernetes\\.io/name",
+			wantType: "AndQuery",
+			wantTerms: []string{
+				// labels:
+				"lab", "abe", "bel", "els", "ls:",
+				// app.kubernetes.io/name:
+				"app", "pp.", "p.k", ".ku", "kub", "ube", "ber", "ern", "rne", "net", "ete", "tes", "es.", "s.i", ".io", "io/", "o/n", "/na", "nam", "ame", "me:",
+			},
+		},
+		{
+			name:     "quoted special key",
+			pathKey:  "@type",
+			wantType: "AndQuery",
+			wantTerms: []string{
+				// "@type":
+				"\"@t", "@ty", "typ", "ype", "pe\"", "e\":",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PathToTrigramQuery(tc.pathKey)
+			switch tc.wantType {
+			case "AllQuery":
+				if _, ok := got.(*AllQuery); !ok {
+					t.Fatalf("PathToTrigramQuery(%q) expected *AllQuery, got %T (%v)", tc.pathKey, got, got)
+				}
+			case "TermQuery":
+				term, ok := got.(*TermQuery)
+				if !ok {
+					t.Fatalf("PathToTrigramQuery(%q) expected *TermQuery, got %T (%v)", tc.pathKey, got, got)
+				}
+				if diff := cmp.Diff(tc.wantTerms[0], term.Term); diff != "" {
+					t.Errorf("PathToTrigramQuery(%q) term mismatch (-want +got):\n%s", tc.pathKey, diff)
+				}
+			case "AndQuery":
+				andQ, ok := got.(*AndQuery)
+				if !ok {
+					t.Fatalf("PathToTrigramQuery(%q) expected *AndQuery, got %T (%v)", tc.pathKey, got, got)
+				}
+				var gotTerms []string
+				for _, child := range andQ.Children {
+					if tQ, ok := child.(*TermQuery); ok {
+						gotTerms = append(gotTerms, tQ.Term)
+					}
+				}
+				sort.Strings(gotTerms)
+				sort.Strings(tc.wantTerms)
+				if diff := cmp.Diff(tc.wantTerms, gotTerms, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("PathToTrigramQuery(%q) terms mismatch (-want +got):\n%s", tc.pathKey, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestFindCandidateLogsWithField(t *testing.T) {
+	const (
+		idPodNginx = 1
+		idPodCore  = 2
+		idEventMsg = 3
+	)
+
+	structYAMLs := map[uint32]string{
+		idPodNginx: `metadata:
+  name: pod-a
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+`,
+		idPodCore: `metadata:
+  name: pod-b
+spec:
+  containers:
+  - name: coredns
+    image: coredns:v1.9
+status:
+  phase: Running
+`,
+		idEventMsg: `metadata:
+  name: event-1
+message: "0/1 nodes available: nginx container cannot be scheduled"
+reason: FailedScheduling
+`,
+	}
+
+	idx := NewTrigramIndex()
+	if err := idx.BuildFromStructYAMLs(t.Context(), structYAMLs, nil); err != nil {
+		t.Fatalf("BuildFromStructYAMLs() failed: %v", err)
+	}
+
+	testCases := []struct {
+		name       string
+		pathKey    string
+		pattern    string
+		wantLogIDs []uint32 // nil means unconstrained
+	}{
+		{
+			name:       "wildcard pathKey with pattern matches all structs containing keyword",
+			pathKey:    "*",
+			pattern:    "nginx",
+			wantLogIDs: []uint32{idPodNginx, idEventMsg},
+		},
+		{
+			name:       "field pathKey prunes struct that only has keyword in unmatching field",
+			pathKey:    "spec.containers.image",
+			pattern:    "nginx",
+			wantLogIDs: []uint32{idPodNginx},
+		},
+		{
+			name:       "unconstrained pattern with field pathKey filters by field segments",
+			pathKey:    "spec.containers.image",
+			pattern:    ".*",
+			wantLogIDs: []uint32{idPodNginx, idPodCore},
+		},
+		{
+			name:       "status.phase with unconstrained pattern matches only pod-b",
+			pathKey:    "status.phase",
+			pattern:    ".*",
+			wantLogIDs: []uint32{idPodCore},
+		},
+		{
+			name:       "status.phase with Running matches pod-b",
+			pathKey:    "status.phase",
+			pattern:    "Running",
+			wantLogIDs: []uint32{idPodCore},
+		},
+		{
+			name:       "status.phase with non-matching pattern returns empty",
+			pathKey:    "status.phase",
+			pattern:    "Failed",
+			wantLogIDs: []uint32{},
+		},
+		{
+			name:       "non-existent field path returns empty bitmap",
+			pathKey:    "nonexistent.field",
+			pattern:    "nginx",
+			wantLogIDs: []uint32{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBM := idx.FindCandidateLogsWithField(tc.pathKey, tc.pattern)
+			var gotLogIDs []uint32
+			if gotBM != nil {
+				gotLogIDs = gotBM.ToArray()
+			}
+			if diff := cmp.Diff(tc.wantLogIDs, gotLogIDs, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("FindCandidateLogsWithField(%q, %q) mismatch (-want +got):\n%s", tc.pathKey, tc.pattern, diff)
+			}
+		})
+	}
+}

--- a/pkg/server/workbench/cel/trigram_test.go
+++ b/pkg/server/workbench/cel/trigram_test.go
@@ -15,11 +15,15 @@
 package cel
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	khifilev6model "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -141,10 +145,10 @@ spec:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotBitmap := idx.FindCandidateStructs(tc.query)
+			gotBitmap := idx.FindCandidateLogs(tc.query)
 			if tc.isUnconstrained {
 				if gotBitmap != nil {
-					t.Errorf("FindCandidateStructs(%q) expected nil (unconstrained), got %v", tc.query, gotBitmap.ToArray())
+					t.Errorf("FindCandidateLogs(%q) expected nil (unconstrained), got %v", tc.query, gotBitmap.ToArray())
 				}
 				return
 			}
@@ -159,7 +163,7 @@ spec:
 			sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
 
 			if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("FindCandidateStructs(%q) mismatch (-want +got):\n%s", tc.query, diff)
+				t.Errorf("FindCandidateLogs(%q) mismatch (-want +got):\n%s", tc.query, diff)
 			}
 		})
 	}
@@ -265,10 +269,10 @@ spec:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotBitmap := idx.FindCandidateStructs(tc.query)
+			gotBitmap := idx.FindCandidateLogs(tc.query)
 			if tc.isUnconstrained {
 				if gotBitmap != nil {
-					t.Errorf("FindCandidateStructs(%q) expected nil (unconstrained), got %v", tc.query, gotBitmap.ToArray())
+					t.Errorf("FindCandidateLogs(%q) expected nil (unconstrained), got %v", tc.query, gotBitmap.ToArray())
 				}
 				return
 			}
@@ -283,7 +287,7 @@ spec:
 			sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
 
 			if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("FindCandidateStructs(%q) mismatch (-want +got):\n%s", tc.query, diff)
+				t.Errorf("FindCandidateLogs(%q) mismatch (-want +got):\n%s", tc.query, diff)
 			}
 		})
 	}
@@ -329,7 +333,7 @@ func TestTrigramIndex_ConcurrentQuery(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 50; j++ {
-				bm := idx.FindCandidateStructs("bar_baz")
+				bm := idx.FindCandidateLogs("bar_baz")
 				if bm == nil || !bm.Contains(structID) {
 					t.Errorf("expected candidate to contain struct %d", structID)
 				}
@@ -358,5 +362,230 @@ spec:
 	for b.Loop() {
 		idx := NewTrigramIndex()
 		_ = idx.BuildFromStructYAMLs(context.Background(), structYAMLs, nil)
+	}
+}
+
+func TestTrigramIndex_WriteToAndReadFrom(t *testing.T) {
+	testCases := []struct {
+		name        string
+		structYAMLs map[uint32]string
+		testQueries []string
+	}{
+		{
+			name:        "empty index round-trip",
+			structYAMLs: map[uint32]string{},
+			testQueries: []string{"foo", "bar"},
+		},
+		{
+			name: "single struct index round-trip",
+			structYAMLs: map[uint32]string{
+				1: "metadata:\n  name: pod-sample\n",
+			},
+			testQueries: []string{"pod", "sample", "nonexistent"},
+		},
+		{
+			name: "multiple structs with diverse UTF-8 content round-trip",
+			structYAMLs: map[uint32]string{
+				10: "kind: Deployment\nmetadata:\n  name: web-server\n",
+				20: "kind: Service\nmetadata:\n  name: web-service\n",
+				30: "kind: ConfigMap\nmetadata:\n  name: 設定マップ\n",
+			},
+			testQueries: []string{"Deployment", "web-server", "web-service", "設定マップ", "xyz"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := NewTrigramIndex()
+			if err := orig.BuildFromStructYAMLs(t.Context(), tc.structYAMLs, nil); err != nil {
+				t.Fatalf("failed to build original index: %v", err)
+			}
+
+			var buf bytes.Buffer
+			writtenBytes, err := orig.WriteTo(&buf)
+			if err != nil {
+				t.Fatalf("WriteTo() failed: %v", err)
+			}
+			if writtenBytes != int64(buf.Len()) {
+				t.Errorf("WriteTo() returned byte count %d, actual buffer length %d", writtenBytes, buf.Len())
+			}
+
+			restored := NewTrigramIndex()
+			readBytes, err := restored.ReadFrom(&buf)
+			if err != nil {
+				t.Fatalf("ReadFrom() failed: %v", err)
+			}
+			if readBytes != writtenBytes {
+				t.Errorf("ReadFrom() read %d bytes, expected %d", readBytes, writtenBytes)
+			}
+
+			// Verify each test query returns identical candidate IDs
+			for _, query := range tc.testQueries {
+				wantBM := orig.FindCandidateLogs(query)
+				gotBM := restored.FindCandidateLogs(query)
+
+				var wantSlice, gotSlice []uint32
+				if wantBM != nil {
+					wantSlice = wantBM.ToArray()
+				}
+				if gotBM != nil {
+					gotSlice = gotBM.ToArray()
+				}
+				if diff := cmp.Diff(wantSlice, gotSlice, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("FindCandidateLogs(%q) mismatch (-want +got):\n%s", query, diff)
+				}
+			}
+		})
+	}
+
+	t.Run("invalid header returns ErrInvalidTrigramHeader", func(t *testing.T) {
+		invalidData := []byte("INVALID_HEADER_DATA")
+		idx := NewTrigramIndex()
+		_, err := idx.ReadFrom(bytes.NewReader(invalidData))
+		if !errors.Is(err, ErrInvalidTrigramHeader) {
+			t.Errorf("ReadFrom() error = %v, want %v", err, ErrInvalidTrigramHeader)
+		}
+	})
+}
+
+func TestTrigramIndex_BuildFromStructPool(t *testing.T) {
+	testCases := []struct {
+		name        string
+		yamls       map[uint32]string
+		testQueries []string
+	}{
+		{
+			name: "streaming build matches YAML build candidates",
+			yamls: map[uint32]string{
+				1: "kind: Pod\nmetadata:\n  name: pod-nginx\n",
+				2: "kind: Pod\nmetadata:\n  name: pod-coredns\n",
+				3: "kind: Service\nmetadata:\n  name: svc-nginx\n",
+			},
+			testQueries: []string{"nginx", "coredns", "Service", "missing"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := khifilev6model.NewInternPool(&khifilev6model.IDGenerator{})
+			structIDs := make([]uint32, 0, len(tc.yamls))
+			for _, yamlStr := range tc.yamls {
+				node, err := structured.FromYAML(yamlStr)
+				if err != nil {
+					t.Fatalf("failed to parse YAML: %v", err)
+				}
+				sRef, err := khifilev6model.ToInternedStruct(node, pool)
+				if err != nil {
+					t.Fatalf("failed to intern struct: %v", err)
+				}
+				structIDs = append(structIDs, sRef.ID())
+			}
+
+			idxFromPool := NewTrigramIndex()
+			if err := idxFromPool.BuildFromStructPool(pool, structIDs, nil); err != nil {
+				t.Fatalf("BuildFromStructPool() failed: %v", err)
+			}
+
+			// Verify query candidates are correctly found
+			for _, query := range tc.testQueries {
+				gotBM := idxFromPool.FindCandidateLogs(query)
+				if query == "missing" {
+					if gotBM != nil && !gotBM.IsEmpty() {
+						t.Errorf("expected empty candidate for %q, got %v", query, gotBM.ToArray())
+					}
+				} else {
+					if gotBM == nil || gotBM.IsEmpty() {
+						t.Errorf("expected non-empty candidate for %q, got %v", query, gotBM)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTrigramIndex_BuildFromLogPool(t *testing.T) {
+	testCases := []struct {
+		name        string
+		summaries   map[uint32]string
+		yamls       map[uint32]string
+		logs        []LogTrigramItem
+		testQueries map[string][]uint32 // query -> expected candidate log IDs
+	}{
+		{
+			name: "matches logs via summary and via body struct",
+			summaries: map[uint32]string{
+				10: "Pod sandbox changed successfully",
+				20: "設定マップの更新完了",
+			},
+			yamls: map[uint32]string{
+				100: "apiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx-server",
+				200: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: app-config\ndata:\n  specialKey: rivqt0dytnq",
+			},
+			logs: []LogTrigramItem{
+				{ID: 1, SummaryStringID: 10, BodyStructID: 100}, // summary: sandbox, body: nginx
+				{ID: 2, SummaryStringID: 20, BodyStructID: 200}, // summary: 設定マップ, body: rivqt0dytnq
+				{ID: 3, SummaryStringID: 10, BodyStructID: 200}, // summary: sandbox, body: rivqt0dytnq
+			},
+			testQueries: map[string][]uint32{
+				"nginx":       {1},
+				"sandbox":     {1, 3},
+				"rivqt0dytnq": {2, 3},
+				"設定マップ":       {2},
+				"nonexistent": {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := khifilev6model.NewInternPool(&khifilev6model.IDGenerator{})
+
+			// Intern strings
+			summaryIDMap := make(map[uint32]uint32)
+			for origID, str := range tc.summaries {
+				sRef := pool.InternString(str)
+				summaryIDMap[origID] = sRef.ToProto().GetId()
+			}
+
+			// Intern structs
+			structIDMap := make(map[uint32]uint32)
+			for origID, y := range tc.yamls {
+				node, err := structured.FromYAML(y)
+				if err != nil {
+					t.Fatalf("failed to parse YAML: %v", err)
+				}
+				sRef, err := khifilev6model.ToInternedStruct(node, pool)
+				if err != nil {
+					t.Fatalf("failed to intern struct: %v", err)
+				}
+				structIDMap[origID] = sRef.ID()
+			}
+
+			// Map logs with interned IDs
+			logs := make([]LogTrigramItem, len(tc.logs))
+			for i, l := range tc.logs {
+				logs[i] = LogTrigramItem{
+					ID:              l.ID,
+					SummaryStringID: summaryIDMap[l.SummaryStringID],
+					BodyStructID:    structIDMap[l.BodyStructID],
+				}
+			}
+
+			idx := NewTrigramIndex()
+			if err := idx.BuildFromLogPool(pool, logs, nil); err != nil {
+				t.Fatalf("BuildFromLogPool() failed: %v", err)
+			}
+
+			for query, wantLogIDs := range tc.testQueries {
+				gotBM := idx.FindCandidateLogs(query)
+				var gotLogIDs []uint32
+				if gotBM != nil {
+					gotLogIDs = gotBM.ToArray()
+				}
+				if diff := cmp.Diff(wantLogIDs, gotLogIDs, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("FindCandidateLogs(%q) mismatch (-want +got):\n%s", query, diff)
+				}
+			}
+		})
 	}
 }

--- a/pkg/server/workbench/index.go
+++ b/pkg/server/workbench/index.go
@@ -200,14 +200,43 @@ func (w *Workbench) BuildAsyncIndexesWithProgress(ctx context.Context, targetInd
 	}
 	targetIndex.StructYAMLs = structYAMLs
 
-	// Stage 2: Parallel Trigram Index Construction (50% - 100%)
-	trigramIndex, err := w.BuildTrigramIndexWithProgress(ctx, structYAMLs, func(stage apiv1.OpenWorkbenchResponse_Stage, progressPercentage float64, message string) error {
-		return onProgress(stage, 50.0+progressPercentage*0.5, message)
-	})
-	if err != nil {
-		return err
+	// Stage 2: Trigram Index Acquisition (50% - 100%)
+	if w.indexManager != nil {
+		if idx, ok := w.indexManager.GetTrigramIndex(w.inspectionID); ok && idx != nil {
+			targetIndex.TrigramIndex = idx
+		} else {
+			subCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			ch, unsubscribe := w.indexManager.SubscribeIndexProgress(subCtx, w.inspectionID)
+			defer unsubscribe()
+
+			w.indexManager.StartAsyncIndexing(subCtx, w.inspectionID)
+
+			for ev := range ch {
+				pct := 50.0 + float64(ev.ProgressPercentage)*0.5
+				if err := onProgress(apiv1.OpenWorkbenchResponse_STAGE_INDEXING_DATA, pct, ev.Message); err != nil {
+					return err
+				}
+				if ev.State == IndexStateReady {
+					break
+				}
+				if ev.State == IndexStateFailed {
+					return fmt.Errorf("trigram index build failed: %w", ev.Err)
+				}
+			}
+			if idx, ok := w.indexManager.GetTrigramIndex(w.inspectionID); ok && idx != nil {
+				targetIndex.TrigramIndex = idx
+			}
+		}
+	} else {
+		trigramIndex, err := w.BuildTrigramIndexWithProgress(ctx, structYAMLs, func(stage apiv1.OpenWorkbenchResponse_Stage, progressPercentage float64, message string) error {
+			return onProgress(stage, 50.0+progressPercentage*0.5, message)
+		})
+		if err != nil {
+			return err
+		}
+		targetIndex.TrigramIndex = trigramIndex
 	}
-	targetIndex.TrigramIndex = trigramIndex
 
 	if err := onProgress(apiv1.OpenWorkbenchResponse_STAGE_INDEXING_DATA, 100.0, "Search index ready."); err != nil {
 		return err

--- a/pkg/server/workbench/index.go
+++ b/pkg/server/workbench/index.go
@@ -168,10 +168,18 @@ func (w *Workbench) BuildStructYAMLIndexWithProgress(ctx context.Context, target
 	return structYAMLs, nil
 }
 
-// BuildTrigramIndexWithProgress constructs the trigram search index from pre-serialized struct YAMLs while streaming progress updates.
-func (w *Workbench) BuildTrigramIndexWithProgress(ctx context.Context, structYAMLs map[uint32]string, onProgress ProgressCallback) (*cel.TrigramIndex, error) {
+// BuildTrigramIndexWithProgress constructs the trigram search index from logs while streaming progress updates.
+func (w *Workbench) BuildTrigramIndexWithProgress(ctx context.Context, targetIndex *SearchIndex, onProgress ProgressCallback) (*cel.TrigramIndex, error) {
+	logItems := make([]cel.LogTrigramItem, 0, len(targetIndex.Logs))
+	for _, l := range targetIndex.Logs {
+		logItems = append(logItems, cel.LogTrigramItem{
+			ID:              l.ID,
+			SummaryStringID: l.SummaryStringID,
+			BodyStructID:    l.BodyStructID,
+		})
+	}
 	trigramIndex := cel.NewTrigramIndex()
-	err := trigramIndex.BuildFromStructYAMLs(ctx, structYAMLs, func(subPct float64, msg string) error {
+	err := trigramIndex.BuildFromLogPool(targetIndex.InternPool, logItems, func(subPct float64, msg string) error {
 		return onProgress(apiv1.OpenWorkbenchResponse_STAGE_INDEXING_DATA, subPct*100.0, msg)
 	})
 	if err != nil {
@@ -229,7 +237,7 @@ func (w *Workbench) BuildAsyncIndexesWithProgress(ctx context.Context, targetInd
 			}
 		}
 	} else {
-		trigramIndex, err := w.BuildTrigramIndexWithProgress(ctx, structYAMLs, func(stage apiv1.OpenWorkbenchResponse_Stage, progressPercentage float64, message string) error {
+		trigramIndex, err := w.BuildTrigramIndexWithProgress(ctx, targetIndex, func(stage apiv1.OpenWorkbenchResponse_Stage, progressPercentage float64, message string) error {
 			return onProgress(stage, 50.0+progressPercentage*0.5, message)
 		})
 		if err != nil {

--- a/pkg/server/workbench/index.go
+++ b/pkg/server/workbench/index.go
@@ -218,7 +218,12 @@ func (w *Workbench) BuildAsyncIndexesWithProgress(ctx context.Context, targetInd
 			ch, unsubscribe := w.indexManager.SubscribeIndexProgress(subCtx, w.inspectionID)
 			defer unsubscribe()
 
-			w.indexManager.StartAsyncIndexing(subCtx, w.inspectionID)
+			// Trigger background indexing if it has not been initiated yet (e.g., pre-existing inspection on server start).
+			// If already running, we simply await the existing task via progress channel subscribers.
+			state, _, _, _ := w.indexManager.IndexStatus(w.inspectionID)
+			if state == IndexStateNotStarted {
+				w.indexManager.StartAsyncIndexing(context.Background(), w.inspectionID)
+			}
 
 			for ev := range ch {
 				pct := 50.0 + float64(ev.ProgressPercentage)*0.5

--- a/pkg/server/workbench/index_manager.go
+++ b/pkg/server/workbench/index_manager.go
@@ -1,0 +1,428 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workbench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	coreinspection "github.com/GoogleCloudPlatform/khi/pkg/core/inspection"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6model "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/server/workbench/cel"
+	"golang.org/x/sync/singleflight"
+	"google.golang.org/protobuf/proto"
+)
+
+// InspectionIndexManager coordinates persistent disk caching, memory caching, and background generation of TrigramIndex instances.
+type InspectionIndexManager struct {
+	mu               sync.RWMutex
+	memoryCache      map[string]*cel.TrigramIndex
+	latestEvent      map[string]IndexProgressEvent
+	subscribers      map[string][]chan IndexProgressEvent
+	dataDir          string
+	inspectionServer *coreinspection.InspectionTaskServer
+	buildGroup       singleflight.Group
+}
+
+// NewInspectionIndexManager creates an InspectionIndexManager.
+func NewInspectionIndexManager(inspectionServer *coreinspection.InspectionTaskServer, dataDir string) *InspectionIndexManager {
+	return &InspectionIndexManager{
+		memoryCache:      make(map[string]*cel.TrigramIndex),
+		latestEvent:      make(map[string]IndexProgressEvent),
+		subscribers:      make(map[string][]chan IndexProgressEvent),
+		dataDir:          dataDir,
+		inspectionServer: inspectionServer,
+	}
+}
+
+// GetTrigramIndex returns the cached TrigramIndex if available in memory or fast-loaded from disk.
+func (m *InspectionIndexManager) GetTrigramIndex(inspectionID string) (*cel.TrigramIndex, bool) {
+	m.mu.RLock()
+	if idx, ok := m.memoryCache[inspectionID]; ok && idx != nil {
+		m.mu.RUnlock()
+		return idx, true
+	}
+	m.mu.RUnlock()
+
+	// Check disk cache
+	if idx, err := m.loadTrigramIndexFromDisk(inspectionID); err == nil && idx != nil {
+		m.mu.Lock()
+		m.memoryCache[inspectionID] = idx
+		m.latestEvent[inspectionID] = IndexProgressEvent{
+			InspectionID:       inspectionID,
+			State:              IndexStateReady,
+			ProgressPercentage: 100,
+			Message:            "Text search index ready.",
+		}
+		m.mu.Unlock()
+		return idx, true
+	}
+
+	return nil, false
+}
+
+// StartAsyncIndexing initiates asynchronous background Trigram index construction if not already built or building.
+func (m *InspectionIndexManager) StartAsyncIndexing(ctx context.Context, inspectionID string) {
+	if _, ok := m.GetTrigramIndex(inspectionID); ok {
+		m.broadcast(IndexProgressEvent{
+			InspectionID:       inspectionID,
+			State:              IndexStateReady,
+			ProgressPercentage: 100,
+			Message:            "Text search index ready.",
+		})
+		return
+	}
+
+	go func() {
+		_, _, _ = m.buildGroup.Do(inspectionID, func() (any, error) {
+			// Check again under singleflight
+			if _, ok := m.GetTrigramIndex(inspectionID); ok {
+				m.broadcast(IndexProgressEvent{
+					InspectionID:       inspectionID,
+					State:              IndexStateReady,
+					ProgressPercentage: 100,
+					Message:            "Text search index ready.",
+				})
+				return nil, nil
+			}
+
+			m.broadcast(IndexProgressEvent{
+				InspectionID:       inspectionID,
+				State:              IndexStateBuilding,
+				ProgressPercentage: 0,
+				Message:            "Starting text search index...",
+			})
+
+			reader, err := m.openInspectionReader(inspectionID)
+			if err != nil {
+				errMsg := fmt.Sprintf("failed to open inspection dataset: %v", err)
+				m.broadcast(IndexProgressEvent{
+					InspectionID: inspectionID,
+					State:        IndexStateFailed,
+					Err:          err,
+					Message:      errMsg,
+				})
+				return nil, err
+			}
+			defer reader.Close()
+
+			onProgress := func(progress float64, msg string) error {
+				m.broadcast(IndexProgressEvent{
+					InspectionID:       inspectionID,
+					State:              IndexStateBuilding,
+					ProgressPercentage: progress * 100,
+					Message:            msg,
+				})
+				return nil
+			}
+
+			idx, err := m.buildTrigramIndexFromReader(reader, onProgress)
+			if err != nil {
+				errMsg := fmt.Sprintf("failed to build text search index: %v", err)
+				m.broadcast(IndexProgressEvent{
+					InspectionID: inspectionID,
+					State:        IndexStateFailed,
+					Err:          err,
+					Message:      errMsg,
+				})
+				return nil, err
+			}
+
+			if err := m.saveTrigramIndexToDisk(inspectionID, idx); err != nil {
+				slog.Warn(fmt.Sprintf("failed to save trigram index to disk: %v", err))
+			}
+
+			m.mu.Lock()
+			m.memoryCache[inspectionID] = idx
+			m.mu.Unlock()
+
+			m.broadcast(IndexProgressEvent{
+				InspectionID:       inspectionID,
+				State:              IndexStateReady,
+				ProgressPercentage: 100,
+				Message:            "Text search index ready.",
+			})
+			return idx, nil
+		})
+	}()
+}
+
+// SubscribeIndexProgress returns a channel streaming IndexProgressEvents and a cancel function.
+func (m *InspectionIndexManager) SubscribeIndexProgress(ctx context.Context, inspectionID string) (<-chan IndexProgressEvent, func()) {
+	ch := make(chan IndexProgressEvent, 16)
+
+	m.mu.Lock()
+	// Determine initial event to send
+	var initialEvent IndexProgressEvent
+	if idx, ok := m.memoryCache[inspectionID]; ok && idx != nil {
+		initialEvent = IndexProgressEvent{
+			InspectionID:       inspectionID,
+			State:              IndexStateReady,
+			ProgressPercentage: 100,
+			Message:            "Text search index ready.",
+		}
+	} else if ev, exists := m.latestEvent[inspectionID]; exists {
+		initialEvent = ev
+	} else {
+		initialEvent = IndexProgressEvent{
+			InspectionID:       inspectionID,
+			State:              IndexStateNotStarted,
+			ProgressPercentage: 0,
+			Message:            "Index not started.",
+		}
+	}
+
+	m.subscribers[inspectionID] = append(m.subscribers[inspectionID], ch)
+	m.mu.Unlock()
+
+	// Non-blocking initial emit
+	select {
+	case ch <- initialEvent:
+	default:
+	}
+
+	var once sync.Once
+	unsubscribe := func() {
+		once.Do(func() {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			subs := m.subscribers[inspectionID]
+			for i, sub := range subs {
+				if sub == ch {
+					m.subscribers[inspectionID] = append(subs[:i], subs[i+1:]...)
+					break
+				}
+			}
+			close(ch)
+		})
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			unsubscribe()
+		}
+	}()
+
+	return ch, unsubscribe
+}
+
+// DeleteIndex evicts the TrigramIndex from memory cache and removes its disk file.
+func (m *InspectionIndexManager) DeleteIndex(inspectionID string) {
+	m.mu.Lock()
+	delete(m.memoryCache, inspectionID)
+	delete(m.latestEvent, inspectionID)
+	m.mu.Unlock()
+
+	if m.dataDir != "" {
+		filePath := filepath.Join(m.dataDir, inspectionID+".trigram")
+		_ = os.Remove(filePath)
+	}
+}
+
+func (m *InspectionIndexManager) broadcast(event IndexProgressEvent) {
+	m.mu.Lock()
+	m.latestEvent[event.InspectionID] = event
+	subs := append([]chan IndexProgressEvent(nil), m.subscribers[event.InspectionID]...)
+	m.mu.Unlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+}
+
+func (m *InspectionIndexManager) openInspectionReader(inspectionID string) (io.ReadCloser, error) {
+	if m.inspectionServer != nil {
+		currentTask := m.inspectionServer.GetInspection(inspectionID)
+		if currentTask != nil {
+			result, err := currentTask.Result()
+			if err == nil && result != nil && result.ResultStore != nil {
+				size, err := result.ResultStore.GetInspectionResultSizeInBytes()
+				if err == nil && size > 0 {
+					return result.ResultStore.GetRangeReader(0, int64(size))
+				}
+				if r, err := result.ResultStore.GetReader(); err == nil {
+					return r, nil
+				}
+			}
+		}
+	}
+	if m.dataDir != "" {
+		khiPath := filepath.Join(m.dataDir, inspectionID+".khi")
+		if f, err := os.Open(khiPath); err == nil {
+			return f, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to locate inspection dataset for ID %q", inspectionID)
+}
+
+func (m *InspectionIndexManager) buildTrigramIndexFromReader(reader io.Reader, onProgress cel.TrigramProgressCallback) (*cel.TrigramIndex, error) {
+	khiReader, err := khifilev6model.NewReader(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create KHI file reader: %w", err)
+	}
+
+	pool := khifilev6model.NewInternPool(&khifilev6model.IDGenerator{})
+	var logs []cel.LogTrigramItem
+
+	for {
+		rawChunk, err := khiReader.NextRawChunk()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read next chunk: %w", err)
+		}
+
+		decompressed, err := rawChunk.Decompress()
+		if err != nil {
+			return nil, fmt.Errorf("failed to decompress chunk: %w", err)
+		}
+		if decompressed.Type == khifilev6model.ChunkTypeInternPool || decompressed.Type == khifilev6model.ChunkTypeServerInternPool {
+			var poolChunk khifilev6.InterningPoolChunk
+			if err := proto.Unmarshal(decompressed.Data, &poolChunk); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal intern pool chunk: %w", err)
+			}
+			pool.IngestChunk(&poolChunk)
+		} else if decompressed.Type == khifilev6model.ChunkTypeLog {
+			var logChunk khifilev6.LogChunk
+			if err := proto.Unmarshal(decompressed.Data, &logChunk); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal log chunk: %w", err)
+			}
+			for _, l := range logChunk.Logs {
+				if l.Id != nil {
+					var sumID, bodyID uint32
+					if l.SummaryStringId != nil {
+						sumID = *l.SummaryStringId
+					}
+					if l.BodyStructId != nil {
+						bodyID = *l.BodyStructId
+					}
+					logs = append(logs, cel.LogTrigramItem{
+						ID:              *l.Id,
+						SummaryStringID: sumID,
+						BodyStructID:    bodyID,
+					})
+				}
+			}
+		}
+	}
+
+	idx := cel.NewTrigramIndex()
+	if len(logs) > 0 {
+		if err := idx.BuildFromLogPool(pool, logs, onProgress); err != nil {
+			return nil, fmt.Errorf("failed to build trigram index: %w", err)
+		}
+		return idx, nil
+	}
+
+	var structIDs []uint32
+	for sRef := range pool.StructRefs() {
+		structIDs = append(structIDs, sRef.ID())
+	}
+	if err := idx.BuildFromStructPool(pool, structIDs, onProgress); err != nil {
+		return nil, fmt.Errorf("failed to build trigram index: %w", err)
+	}
+	return idx, nil
+}
+
+func (m *InspectionIndexManager) saveTrigramIndexToDisk(inspectionID string, idx *cel.TrigramIndex) error {
+	if m.dataDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(m.dataDir, 0755); err != nil {
+		return fmt.Errorf("failed to create data directory %s: %w", m.dataDir, err)
+	}
+	finalPath := filepath.Join(m.dataDir, inspectionID+".trigram")
+	tmpPath := filepath.Join(m.dataDir, inspectionID+".trigram.tmp")
+
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("failed to create temporary trigram file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := idx.WriteTo(f); err != nil {
+		return fmt.Errorf("failed to write trigram index: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary trigram file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		return fmt.Errorf("failed to rename trigram file: %w", err)
+	}
+	return nil
+}
+
+func (m *InspectionIndexManager) loadTrigramIndexFromDisk(inspectionID string) (*cel.TrigramIndex, error) {
+	if m.dataDir == "" {
+		return nil, os.ErrNotExist
+	}
+	filePath := filepath.Join(m.dataDir, inspectionID+".trigram")
+	tStat, err := os.Stat(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Invalidate if the underlying .khi file was modified after the trigram index was generated
+	khiPath := filepath.Join(m.dataDir, inspectionID+".khi")
+	if kStat, err := os.Stat(khiPath); err == nil {
+		if kStat.ModTime().After(tStat.ModTime()) {
+			_ = os.Remove(filePath)
+			return nil, fmt.Errorf("stale trigram index for %s: .khi modified %v is newer than .trigram %v", inspectionID, kStat.ModTime(), tStat.ModTime())
+		}
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	idx := cel.NewTrigramIndex()
+	if _, err := idx.ReadFrom(f); err != nil {
+		// If header or data is corrupted, remove stale file
+		_ = os.Remove(filePath)
+		return nil, fmt.Errorf("failed to read trigram index from %s: %w", filePath, err)
+	}
+	return idx, nil
+}
+
+// InvalidateInspectionIndex evicts the cached TrigramIndex from memory and disk for the inspection.
+func (m *InspectionIndexManager) InvalidateInspectionIndex(inspectionID string) {
+	m.mu.Lock()
+	delete(m.memoryCache, inspectionID)
+	delete(m.latestEvent, inspectionID)
+	m.mu.Unlock()
+
+	if m.dataDir != "" {
+		_ = os.Remove(filepath.Join(m.dataDir, inspectionID+".trigram"))
+		_ = os.Remove(filepath.Join(m.dataDir, inspectionID+".trigram.tmp"))
+	}
+}

--- a/pkg/server/workbench/index_manager.go
+++ b/pkg/server/workbench/index_manager.go
@@ -41,6 +41,7 @@ type InspectionIndexManager struct {
 	dataDir          string
 	inspectionServer *coreinspection.InspectionTaskServer
 	buildGroup       singleflight.Group
+	wg               sync.WaitGroup
 }
 
 // NewInspectionIndexManager creates an InspectionIndexManager.
@@ -92,7 +93,9 @@ func (m *InspectionIndexManager) StartAsyncIndexing(ctx context.Context, inspect
 		return
 	}
 
+	m.wg.Add(1)
 	go func() {
+		defer m.wg.Done()
 		_, _, _ = m.buildGroup.Do(inspectionID, func() (any, error) {
 			// Check again under singleflight
 			if _, ok := m.GetTrigramIndex(inspectionID); ok {
@@ -164,6 +167,11 @@ func (m *InspectionIndexManager) StartAsyncIndexing(ctx context.Context, inspect
 			return idx, nil
 		})
 	}()
+}
+
+// Wait waits for all in-flight asynchronous indexing tasks to complete.
+func (m *InspectionIndexManager) Wait() {
+	m.wg.Wait()
 }
 
 // IndexStatus returns the current index status snapshot for the given inspection ID.

--- a/pkg/server/workbench/index_manager.go
+++ b/pkg/server/workbench/index_manager.go
@@ -281,11 +281,10 @@ func (m *InspectionIndexManager) DeleteIndex(inspectionID string) {
 
 func (m *InspectionIndexManager) broadcast(event IndexProgressEvent) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.latestEvent[event.InspectionID] = event
-	subs := append([]chan IndexProgressEvent(nil), m.subscribers[event.InspectionID]...)
-	m.mu.Unlock()
 
-	for _, ch := range subs {
+	for _, ch := range m.subscribers[event.InspectionID] {
 		select {
 		case ch <- event:
 		default:

--- a/pkg/server/workbench/index_manager.go
+++ b/pkg/server/workbench/index_manager.go
@@ -41,6 +41,7 @@ type InspectionIndexManager struct {
 	dataDir          string
 	inspectionServer *coreinspection.InspectionTaskServer
 	buildGroup       singleflight.Group
+	loadGroup        singleflight.Group
 	wg               sync.WaitGroup
 }
 
@@ -64,8 +65,19 @@ func (m *InspectionIndexManager) GetTrigramIndex(inspectionID string) (*cel.Trig
 	}
 	m.mu.RUnlock()
 
-	// Check disk cache
-	if idx, err := m.loadTrigramIndexFromDisk(inspectionID); err == nil && idx != nil {
+	// Use singleflight to deduplicate concurrent disk loads of the same trigram index.
+	val, err, _ := m.loadGroup.Do(inspectionID, func() (any, error) {
+		m.mu.RLock()
+		if idx, ok := m.memoryCache[inspectionID]; ok && idx != nil {
+			m.mu.RUnlock()
+			return idx, nil
+		}
+		m.mu.RUnlock()
+
+		idx, err := m.loadTrigramIndexFromDisk(inspectionID)
+		if err != nil {
+			return nil, err
+		}
 		m.mu.Lock()
 		m.memoryCache[inspectionID] = idx
 		m.latestEvent[inspectionID] = IndexProgressEvent{
@@ -75,9 +87,12 @@ func (m *InspectionIndexManager) GetTrigramIndex(inspectionID string) (*cel.Trig
 			Message:            "Text search index ready.",
 		}
 		m.mu.Unlock()
-		return idx, true
-	}
+		return idx, nil
+	})
 
+	if err == nil && val != nil {
+		return val.(*cel.TrigramIndex), true
+	}
 	return nil, false
 }
 
@@ -222,9 +237,11 @@ func (m *InspectionIndexManager) SubscribeIndexProgress(ctx context.Context, ins
 	default:
 	}
 
+	stopCh := make(chan struct{})
 	var once sync.Once
 	unsubscribe := func() {
 		once.Do(func() {
+			close(stopCh)
 			m.mu.Lock()
 			defer m.mu.Unlock()
 			subs := m.subscribers[inspectionID]
@@ -239,8 +256,11 @@ func (m *InspectionIndexManager) SubscribeIndexProgress(ctx context.Context, ins
 	}
 
 	go func() {
-		<-ctx.Done()
-		unsubscribe()
+		select {
+		case <-ctx.Done():
+			unsubscribe()
+		case <-stopCh:
+		}
 	}()
 
 	return ch, unsubscribe

--- a/pkg/server/workbench/index_manager.go
+++ b/pkg/server/workbench/index_manager.go
@@ -166,6 +166,20 @@ func (m *InspectionIndexManager) StartAsyncIndexing(ctx context.Context, inspect
 	}()
 }
 
+// IndexStatus returns the current index status snapshot for the given inspection ID.
+func (m *InspectionIndexManager) IndexStatus(inspectionID string) (IndexState, float64, string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if idx, ok := m.memoryCache[inspectionID]; ok && idx != nil {
+		return IndexStateReady, 100.0, "Text search index ready.", nil
+	}
+	if ev, exists := m.latestEvent[inspectionID]; exists {
+		return ev.State, ev.ProgressPercentage, ev.Message, ev.Err
+	}
+	return IndexStateNotStarted, 0.0, "Index not started.", nil
+}
+
 // SubscribeIndexProgress returns a channel streaming IndexProgressEvents and a cancel function.
 func (m *InspectionIndexManager) SubscribeIndexProgress(ctx context.Context, inspectionID string) (<-chan IndexProgressEvent, func()) {
 	ch := make(chan IndexProgressEvent, 16)
@@ -217,10 +231,8 @@ func (m *InspectionIndexManager) SubscribeIndexProgress(ctx context.Context, ins
 	}
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			unsubscribe()
-		}
+		<-ctx.Done()
+		unsubscribe()
 	}()
 
 	return ch, unsubscribe

--- a/pkg/server/workbench/index_manager_test.go
+++ b/pkg/server/workbench/index_manager_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workbench
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	khifilev6model "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"github.com/google/go-cmp/cmp"
+)
+
+func createTestKhiFile(t *testing.T, dir string, inspectionID string) {
+	t.Helper()
+	b := khifilev6model.NewBuilder()
+	node := structured.NewStandardMap(
+		[]string{"name", "message"},
+		[]structured.Node{
+			structured.NewStandardScalarNode("nginx-pod"),
+			structured.NewStandardScalarNode("hello nginx"),
+		},
+	)
+	severityID := uint32(1)
+	logTypeID := uint32(2)
+	if err := b.LogAccumulator.AddLog(&khifilev6model.StagingLog{
+		Log:       log.NewLog(structured.NewNodeReader(node)),
+		Summary:   "nginx log",
+		Timestamp: time.Date(2026, 4, 29, 8, 0, 0, 0, time.UTC),
+		Severity:  &khifilev6.Severity{Id: &severityID},
+		LogType:   &khifilev6.LogType{Id: &logTypeID},
+	}); err != nil {
+		t.Fatalf("failed to add log: %v", err)
+	}
+
+	filePath := filepath.Join(dir, inspectionID+".khi")
+	f, err := os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	defer f.Close()
+
+	if err := b.Build(f, nil); err != nil {
+		t.Fatalf("failed to build KHI file: %v", err)
+	}
+}
+
+func TestInspectionIndexManager(t *testing.T) {
+	tempDir := t.TempDir()
+	const inspectionID = "test-insp-001"
+	createTestKhiFile(t, tempDir, inspectionID)
+
+	mgr := NewInspectionIndexManager(nil, tempDir)
+
+	testCases := []struct {
+		name       string
+		testAction func(t *testing.T)
+	}{
+		{
+			name: "async indexing builds index and saves to disk",
+			testAction: func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				ch, unsubscribe := mgr.SubscribeIndexProgress(ctx, inspectionID)
+				defer unsubscribe()
+
+				mgr.StartAsyncIndexing(ctx, inspectionID)
+
+				var lastEvent IndexProgressEvent
+				for ev := range ch {
+					lastEvent = ev
+					if ev.State == IndexStateReady || ev.State == IndexStateFailed {
+						break
+					}
+				}
+
+				if lastEvent.State != IndexStateReady {
+					t.Fatalf("expected IndexStateReady, got %v with error: %v", lastEvent.State, lastEvent.Err)
+				}
+
+				// Verify disk file was created
+				diskPath := filepath.Join(tempDir, inspectionID+".trigram")
+				if _, err := os.Stat(diskPath); err != nil {
+					t.Fatalf("expected trigram disk file to exist at %s: %v", diskPath, err)
+				}
+
+				// Verify query candidate search
+				idx, ok := mgr.GetTrigramIndex(inspectionID)
+				if !ok || idx == nil {
+					t.Fatalf("expected GetTrigramIndex to return ready index")
+				}
+
+				bm := idx.FindCandidateLogs("nginx")
+				if bm == nil || bm.IsEmpty() {
+					t.Errorf("expected candidate logs for 'nginx' to be non-empty, got %v", bm)
+				}
+				bmCoredns := idx.FindCandidateLogs("coredns")
+				if bmCoredns != nil && !bmCoredns.IsEmpty() {
+					t.Errorf("expected candidate logs for 'coredns' to be empty, got %v", bmCoredns)
+				}
+			},
+		},
+		{
+			name: "second manager loads existing index directly from disk cache",
+			testAction: func(t *testing.T) {
+				newMgr := NewInspectionIndexManager(nil, tempDir)
+
+				// Should fast-load from disk without starting async indexing
+				idx, ok := newMgr.GetTrigramIndex(inspectionID)
+				if !ok || idx == nil {
+					t.Fatalf("expected GetTrigramIndex to load index from disk")
+				}
+
+				bm := idx.FindCandidateLogs("nginx")
+				if bm == nil || bm.IsEmpty() {
+					t.Errorf("expected candidate logs for 'nginx' to be non-empty, got %v", bm)
+				}
+			},
+		},
+		{
+			name: "nonexistent inspection reports error",
+			testAction: func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+
+				const nonExistentID = "nonexistent-insp"
+				ch, unsubscribe := mgr.SubscribeIndexProgress(ctx, nonExistentID)
+				defer unsubscribe()
+
+				mgr.StartAsyncIndexing(ctx, nonExistentID)
+
+				var lastEvent IndexProgressEvent
+				for ev := range ch {
+					lastEvent = ev
+					if ev.State == IndexStateFailed {
+						break
+					}
+				}
+
+				if lastEvent.State != IndexStateFailed {
+					t.Errorf("expected IndexStateFailed for nonexistent inspection, got %v", lastEvent.State)
+				}
+			},
+		},
+		{
+			name: "delete index removes memory cache and disk file",
+			testAction: func(t *testing.T) {
+				mgr.DeleteIndex(inspectionID)
+
+				diskPath := filepath.Join(tempDir, inspectionID+".trigram")
+				if _, err := os.Stat(diskPath); !os.IsNotExist(err) {
+					t.Errorf("expected trigram disk file to be removed, stat err: %v", err)
+				}
+
+				if _, ok := mgr.GetTrigramIndex(inspectionID); ok {
+					t.Errorf("expected index to be evicted from memory and disk")
+				}
+			},
+		},
+		{
+			name: "concurrent async indexing requests deduplicate via singleflight",
+			testAction: func(t *testing.T) {
+				const concurrentInspID = "test-concurrent-insp"
+				createTestKhiFile(t, tempDir, concurrentInspID)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				var wg sync.WaitGroup
+				subscribersCount := 5
+				events := make([]IndexProgressEvent, subscribersCount)
+
+				for i := 0; i < subscribersCount; i++ {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						ch, unsub := mgr.SubscribeIndexProgress(ctx, concurrentInspID)
+						defer unsub()
+
+						mgr.StartAsyncIndexing(ctx, concurrentInspID)
+
+						for ev := range ch {
+							events[idx] = ev
+							if ev.State == IndexStateReady || ev.State == IndexStateFailed {
+								break
+							}
+						}
+					}(i)
+				}
+
+				wg.Wait()
+
+				for i, ev := range events {
+					if ev.State != IndexStateReady {
+						t.Errorf("subscriber %d expected IndexStateReady, got %v", i, ev.State)
+					}
+				}
+			},
+		},
+		{
+			name: "stale trigram index is discarded if .khi file is modified",
+			testAction: func(t *testing.T) {
+				const staleInspID = "test-stale-insp"
+				createTestKhiFile(t, tempDir, staleInspID)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				ch, unsubscribe := mgr.SubscribeIndexProgress(ctx, staleInspID)
+				defer unsubscribe()
+
+				mgr.StartAsyncIndexing(ctx, staleInspID)
+				for ev := range ch {
+					if ev.State == IndexStateReady || ev.State == IndexStateFailed {
+						break
+					}
+				}
+
+				diskPath := filepath.Join(tempDir, staleInspID+".trigram")
+				if _, err := os.Stat(diskPath); err != nil {
+					t.Fatalf("expected trigram disk file to exist: %v", err)
+				}
+
+				// Touch the .khi file so its ModTime is in the future compared to .trigram
+				khiPath := filepath.Join(tempDir, staleInspID+".khi")
+				newTime := time.Now().Add(10 * time.Second)
+				if err := os.Chtimes(khiPath, newTime, newTime); err != nil {
+					t.Fatalf("failed to update khi file mtime: %v", err)
+				}
+
+				// Evict from memory cache
+				mgr.mu.Lock()
+				delete(mgr.memoryCache, staleInspID)
+				mgr.mu.Unlock()
+
+				// Next GetTrigramIndex should detect stale file, delete it, and return false
+				idx, ok := mgr.GetTrigramIndex(staleInspID)
+				if ok || idx != nil {
+					t.Errorf("expected GetTrigramIndex to reject stale index, but got ok=true")
+				}
+				if _, err := os.Stat(diskPath); !os.IsNotExist(err) {
+					t.Errorf("expected stale trigram file to be removed from disk, stat err: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testAction)
+	}
+}
+
+func TestInspectionIndexManager_SubscribeInitialState(t *testing.T) {
+	tempDir := t.TempDir()
+	mgr := NewInspectionIndexManager(nil, tempDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	ch, unsubscribe := mgr.SubscribeIndexProgress(ctx, "unstarted-id")
+	defer unsubscribe()
+
+	select {
+	case ev := <-ch:
+		if diff := cmp.Diff(IndexStateNotStarted, ev.State); diff != "" {
+			t.Errorf("initial state mismatch (-want +got):\n%s", diff)
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for initial event")
+	}
+}

--- a/pkg/server/workbench/manager.go
+++ b/pkg/server/workbench/manager.go
@@ -66,6 +66,11 @@ func NewWorkbenchManager(inspectionServer *coreinspection.InspectionTaskServer, 
 	return mgr
 }
 
+// IndexManager returns the InspectionIndexManager associated with this manager.
+func (m *WorkbenchManager) IndexManager() *InspectionIndexManager {
+	return m.indexManager
+}
+
 // GetOrOpen retrieves an existing active Workbench session or loads the dataset into a new one.
 func (m *WorkbenchManager) GetOrOpen(ctx context.Context, workbenchID string, inspectionID string, onProgress ProgressCallback) (*Workbench, error) {
 	if onProgress == nil {
@@ -252,16 +257,20 @@ func (m *WorkbenchManager) Remove(workbenchID string) {
 	}
 }
 
-// Stop stops the background sweeper and closes all open workbench sessions.
+// Stop stops the background sweeper, closes all open workbench sessions, and waits for active indexing jobs.
 func (m *WorkbenchManager) Stop() {
 	if m.sweeper != nil {
 		m.sweeper.Stop()
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	for _, wb := range m.workbenches {
 		wb.Close()
 	}
 	m.workbenches = make(map[string]*Workbench)
 	m.leases = make(map[string]time.Time)
+	m.mu.Unlock()
+
+	if m.indexManager != nil {
+		m.indexManager.Wait()
+	}
 }

--- a/pkg/server/workbench/manager.go
+++ b/pkg/server/workbench/manager.go
@@ -50,6 +50,9 @@ type WorkbenchManager struct {
 
 // NewWorkbenchManager creates a new WorkbenchManager instance with automatic background sweeping.
 func NewWorkbenchManager(inspectionServer *coreinspection.InspectionTaskServer, indexManager *InspectionIndexManager, ttl time.Duration, sweeperInterval time.Duration) *WorkbenchManager {
+	if indexManager == nil {
+		panic("indexManager is required")
+	}
 	mgr := &WorkbenchManager{
 		workbenches:      make(map[string]*Workbench),
 		leases:           make(map[string]time.Time),
@@ -270,7 +273,5 @@ func (m *WorkbenchManager) Stop() {
 	m.leases = make(map[string]time.Time)
 	m.mu.Unlock()
 
-	if m.indexManager != nil {
-		m.indexManager.Wait()
-	}
+	m.indexManager.Wait()
 }

--- a/pkg/server/workbench/manager.go
+++ b/pkg/server/workbench/manager.go
@@ -42,17 +42,19 @@ type WorkbenchManager struct {
 	workbenches      map[string]*Workbench
 	leases           map[string]time.Time
 	inspectionServer *coreinspection.InspectionTaskServer
+	indexManager     *InspectionIndexManager
 	ttl              time.Duration
 	sweeper          *Sweeper
 	loadGroup        singleflight.Group
 }
 
 // NewWorkbenchManager creates a new WorkbenchManager instance with automatic background sweeping.
-func NewWorkbenchManager(inspectionServer *coreinspection.InspectionTaskServer, ttl time.Duration, sweeperInterval time.Duration) *WorkbenchManager {
+func NewWorkbenchManager(inspectionServer *coreinspection.InspectionTaskServer, indexManager *InspectionIndexManager, ttl time.Duration, sweeperInterval time.Duration) *WorkbenchManager {
 	mgr := &WorkbenchManager{
 		workbenches:      make(map[string]*Workbench),
 		leases:           make(map[string]time.Time),
 		inspectionServer: inspectionServer,
+		indexManager:     indexManager,
 		ttl:              ttl,
 	}
 
@@ -119,6 +121,7 @@ func (m *WorkbenchManager) GetOrOpen(ctx context.Context, workbenchID string, in
 		if err != nil {
 			return nil, err
 		}
+		loadedWb.SetIndexManager(m.indexManager)
 
 		m.mu.Lock()
 		if oldWb, exists := m.workbenches[workbenchID]; exists && oldWb != nil && oldWb != loadedWb {

--- a/pkg/server/workbench/manager_test.go
+++ b/pkg/server/workbench/manager_test.go
@@ -106,7 +106,8 @@ func TestWorkbenchManager_GetOrOpen(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mgr := NewWorkbenchManager(inspectionServer, nil, 100*time.Millisecond, 0)
+			indexMgr := NewInspectionIndexManager(inspectionServer, t.TempDir())
+			mgr := NewWorkbenchManager(inspectionServer, indexMgr, 100*time.Millisecond, 0)
 			defer mgr.Stop()
 
 			var progressEvents []apiv1.OpenWorkbenchResponse_Stage
@@ -140,7 +141,7 @@ func TestWorkbenchManager_GetOrOpen(t *testing.T) {
 func TestWorkbenchManager_HeartbeatAndClose(t *testing.T) {
 	inspectionServer, validInspectionID := createTestInspectionServer(t)
 
-	mgr := NewWorkbenchManager(inspectionServer, nil, 50*time.Millisecond, 0)
+	mgr := NewWorkbenchManager(inspectionServer, NewInspectionIndexManager(inspectionServer, t.TempDir()), 50*time.Millisecond, 0)
 	defer mgr.Stop()
 
 	noopProgress := func(stage apiv1.OpenWorkbenchResponse_Stage, pct float64, msg string) error { return nil }
@@ -176,7 +177,7 @@ func TestWorkbenchManager_HeartbeatAndClose(t *testing.T) {
 func TestWorkbenchManager_LeasesAndRemove(t *testing.T) {
 	inspectionServer, validInspectionID := createTestInspectionServer(t)
 
-	mgr := NewWorkbenchManager(inspectionServer, nil, 50*time.Millisecond, 0)
+	mgr := NewWorkbenchManager(inspectionServer, NewInspectionIndexManager(inspectionServer, t.TempDir()), 50*time.Millisecond, 0)
 	defer mgr.Stop()
 
 	noopProgress := func(stage apiv1.OpenWorkbenchResponse_Stage, pct float64, msg string) error { return nil }
@@ -208,7 +209,7 @@ func TestWorkbenchManager_LeasesAndRemove(t *testing.T) {
 func TestWorkbenchManager_GetAndTouch(t *testing.T) {
 	inspectionServer, validInspectionID := createTestInspectionServer(t)
 
-	mgr := NewWorkbenchManager(inspectionServer, nil, 50*time.Millisecond, 0)
+	mgr := NewWorkbenchManager(inspectionServer, NewInspectionIndexManager(inspectionServer, t.TempDir()), 50*time.Millisecond, 0)
 	defer mgr.Stop()
 
 	noopProgress := func(stage apiv1.OpenWorkbenchResponse_Stage, pct float64, msg string) error { return nil }
@@ -268,7 +269,7 @@ func TestWorkbenchManager_ReopenDifferentInspection(t *testing.T) {
 	}
 	<-runner.Wait()
 
-	mgr := NewWorkbenchManager(inspectionServer, nil, 5*time.Second, 0)
+	mgr := NewWorkbenchManager(inspectionServer, NewInspectionIndexManager(inspectionServer, t.TempDir()), 5*time.Second, 0)
 	defer mgr.Stop()
 
 	workbenchID := "user-session-same"
@@ -318,7 +319,7 @@ func TestWorkbenchManager_ReopenDifferentInspection(t *testing.T) {
 func TestWorkbenchManager_ConcurrentGetOrOpen(t *testing.T) {
 	inspectionServer, validInspectionID := createTestInspectionServer(t)
 
-	mgr := NewWorkbenchManager(inspectionServer, nil, 5*time.Second, 0)
+	mgr := NewWorkbenchManager(inspectionServer, NewInspectionIndexManager(inspectionServer, t.TempDir()), 5*time.Second, 0)
 	defer mgr.Stop()
 
 	const numConcurrent = 10
@@ -417,4 +418,15 @@ func TestWorkbenchManager_WithInspectionIndexManager(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewWorkbenchManager_PanicsOnNilIndexManager(t *testing.T) {
+	inspectionServer, _ := createTestInspectionServer(t)
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic when indexManager is nil, got none")
+		}
+	}()
+	NewWorkbenchManager(inspectionServer, nil, time.Minute, 0)
 }

--- a/pkg/server/workbench/manager_test.go
+++ b/pkg/server/workbench/manager_test.go
@@ -106,7 +106,7 @@ func TestWorkbenchManager_GetOrOpen(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mgr := NewWorkbenchManager(inspectionServer, 100*time.Millisecond, 0)
+			mgr := NewWorkbenchManager(inspectionServer, nil, 100*time.Millisecond, 0)
 			defer mgr.Stop()
 
 			var progressEvents []apiv1.OpenWorkbenchResponse_Stage
@@ -140,7 +140,7 @@ func TestWorkbenchManager_GetOrOpen(t *testing.T) {
 func TestWorkbenchManager_HeartbeatAndClose(t *testing.T) {
 	inspectionServer, validInspectionID := createTestInspectionServer(t)
 
-	mgr := NewWorkbenchManager(inspectionServer, 50*time.Millisecond, 0)
+	mgr := NewWorkbenchManager(inspectionServer, nil, 50*time.Millisecond, 0)
 	defer mgr.Stop()
 
 	noopProgress := func(stage apiv1.OpenWorkbenchResponse_Stage, pct float64, msg string) error { return nil }
@@ -176,7 +176,7 @@ func TestWorkbenchManager_HeartbeatAndClose(t *testing.T) {
 func TestWorkbenchManager_LeasesAndRemove(t *testing.T) {
 	inspectionServer, validInspectionID := createTestInspectionServer(t)
 
-	mgr := NewWorkbenchManager(inspectionServer, 50*time.Millisecond, 0)
+	mgr := NewWorkbenchManager(inspectionServer, nil, 50*time.Millisecond, 0)
 	defer mgr.Stop()
 
 	noopProgress := func(stage apiv1.OpenWorkbenchResponse_Stage, pct float64, msg string) error { return nil }
@@ -208,7 +208,7 @@ func TestWorkbenchManager_LeasesAndRemove(t *testing.T) {
 func TestWorkbenchManager_GetAndTouch(t *testing.T) {
 	inspectionServer, validInspectionID := createTestInspectionServer(t)
 
-	mgr := NewWorkbenchManager(inspectionServer, 50*time.Millisecond, 0)
+	mgr := NewWorkbenchManager(inspectionServer, nil, 50*time.Millisecond, 0)
 	defer mgr.Stop()
 
 	noopProgress := func(stage apiv1.OpenWorkbenchResponse_Stage, pct float64, msg string) error { return nil }
@@ -268,7 +268,7 @@ func TestWorkbenchManager_ReopenDifferentInspection(t *testing.T) {
 	}
 	<-runner.Wait()
 
-	mgr := NewWorkbenchManager(inspectionServer, 5*time.Second, 0)
+	mgr := NewWorkbenchManager(inspectionServer, nil, 5*time.Second, 0)
 	defer mgr.Stop()
 
 	workbenchID := "user-session-same"
@@ -318,7 +318,7 @@ func TestWorkbenchManager_ReopenDifferentInspection(t *testing.T) {
 func TestWorkbenchManager_ConcurrentGetOrOpen(t *testing.T) {
 	inspectionServer, validInspectionID := createTestInspectionServer(t)
 
-	mgr := NewWorkbenchManager(inspectionServer, 5*time.Second, 0)
+	mgr := NewWorkbenchManager(inspectionServer, nil, 5*time.Second, 0)
 	defer mgr.Stop()
 
 	const numConcurrent = 10
@@ -352,5 +352,69 @@ func TestWorkbenchManager_ConcurrentGetOrOpen(t *testing.T) {
 		if results[i] != results[0] {
 			t.Errorf("goroutine %d returned workbench instance %p, want %p", i, results[i], results[0])
 		}
+	}
+}
+
+func TestWorkbenchManager_WithInspectionIndexManager(t *testing.T) {
+	testCases := []struct {
+		name              string
+		withPrebuiltIndex bool
+	}{
+		{
+			name:              "loads prebuilt index when available in indexManager",
+			withPrebuiltIndex: true,
+		},
+		{
+			name:              "indexes asynchronously on demand when not prebuilt",
+			withPrebuiltIndex: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inspectionServer, validInspectionID := createTestInspectionServer(t)
+			dataDir := t.TempDir()
+			indexMgr := NewInspectionIndexManager(inspectionServer, dataDir)
+
+			if tc.withPrebuiltIndex {
+				indexMgr.StartAsyncIndexing(context.Background(), validInspectionID)
+				deadline := time.Now().Add(5 * time.Second)
+				for time.Now().Before(deadline) {
+					state, _, _, _ := indexMgr.IndexStatus(validInspectionID)
+					if state == IndexStateReady {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+
+			wbMgr := NewWorkbenchManager(inspectionServer, indexMgr, 5*time.Second, 0)
+			defer wbMgr.Stop()
+
+			wb, err := wbMgr.GetOrOpen(context.Background(), "wb-session-1", validInspectionID, func(stage apiv1.OpenWorkbenchResponse_Stage, pct float64, msg string) error {
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("GetOrOpen failed: %v", err)
+			}
+
+			// Wait for Workbench indexing to reach ready
+			deadline := time.Now().Add(5 * time.Second)
+			var state IndexState
+			for time.Now().Before(deadline) {
+				state, _, _, _ = wb.IndexStatus()
+				if state == IndexStateReady {
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			if state != IndexStateReady {
+				t.Errorf("wb.IndexStatus() state = %v, want %v", state, IndexStateReady)
+			}
+			if wb.searchIndex == nil || wb.searchIndex.TrigramIndex == nil {
+				t.Errorf("expected searchIndex.TrigramIndex to be populated")
+			}
+		})
 	}
 }

--- a/pkg/server/workbench/workbench.go
+++ b/pkg/server/workbench/workbench.go
@@ -76,6 +76,7 @@ type Workbench struct {
 	indexErr         error
 	indexSubscribers []chan IndexProgressEvent
 	cancelIndex      context.CancelFunc
+	indexManager     *InspectionIndexManager
 }
 
 // NewWorkbench creates a new Workbench instance.
@@ -85,6 +86,11 @@ func NewWorkbench(id string, inspectionID string) *Workbench {
 		inspectionID: inspectionID,
 		internPool:   khifilev6model.NewInternPool(nil),
 	}
+}
+
+// SetIndexManager sets the InspectionIndexManager used to retrieve or wait for background TrigramIndex instances.
+func (w *Workbench) SetIndexManager(im *InspectionIndexManager) {
+	w.indexManager = im
 }
 
 // ID returns the unique workbench identifier.

--- a/pkg/server/workbench/workbench.go
+++ b/pkg/server/workbench/workbench.go
@@ -48,6 +48,7 @@ const (
 
 // IndexProgressEvent encapsulates an index progress notification broadcast to subscribers.
 type IndexProgressEvent struct {
+	InspectionID       string
 	State              IndexState
 	ProgressPercentage float64
 	Message            string

--- a/pkg/server/workbench/workbench.go
+++ b/pkg/server/workbench/workbench.go
@@ -188,6 +188,36 @@ func (w *Workbench) SubscribeIndexProgress(ctx context.Context) (<-chan IndexPro
 	return ch, unsubscribe
 }
 
+// AwaitIndex blocks until the search index construction reaches a terminal state (Ready or Failed), or the context is canceled.
+func (w *Workbench) AwaitIndex(ctx context.Context) error {
+	ch, unsubscribe := w.SubscribeIndexProgress(ctx)
+	defer unsubscribe()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-ch:
+			if !ok {
+				state, _, _, err := w.IndexStatus()
+				if state == IndexStateReady {
+					return nil
+				}
+				if state == IndexStateFailed {
+					return err
+				}
+				return fmt.Errorf("index progress subscription closed unexpectedly")
+			}
+			if ev.State == IndexStateReady {
+				return nil
+			}
+			if ev.State == IndexStateFailed {
+				return ev.Err
+			}
+		}
+	}
+}
+
 // notifyIndexSubscribersLocked broadcasts an index progress event to all active subscribers.
 // Caller must hold w.indexMu (either read or write lock).
 func (w *Workbench) notifyIndexSubscribersLocked(event IndexProgressEvent) {

--- a/proto/api/v1/workbench.proto
+++ b/proto/api/v1/workbench.proto
@@ -25,7 +25,7 @@ service WorkbenchService {
   // Opens or attaches to an in-memory Workbench session with real-time loading progress streaming.
   rpc OpenWorkbench(OpenWorkbenchRequest) returns (stream OpenWorkbenchResponse);
 
-  // Watches the search index construction progress and status for an active Workbench session. The server terminates the stream every 30s to accommodate proxy timeouts, and clients are expected to reconnect.
+  // Watches the search index construction progress and status for an inspection dataset. The server terminates the stream every 30s to accommodate proxy timeouts, and clients are expected to reconnect.
   rpc WatchIndexProgress(WatchIndexProgressRequest) returns (stream WatchIndexProgressResponse);
 
   // Sends periodic heartbeat to keep the Workbench session alive in memory.
@@ -70,9 +70,9 @@ message OpenWorkbenchResponse {
   string workbench_id = 4;
 }
 
-// Request to watch the search index construction progress of a Workbench session.
+// Request to watch the search index construction progress of an active Workbench session.
 message WatchIndexProgressRequest {
-  // The active workbench session identifier.
+  // The active workbench session identifier to stream search index construction progress for.
   string workbench_id = 1;
 }
 

--- a/web/src/app/generated/api/v1/workbench_pb.d.ts
+++ b/web/src/app/generated/api/v1/workbench_pb.d.ts
@@ -144,14 +144,14 @@ export enum OpenWorkbenchResponse_Stage {
 export declare const OpenWorkbenchResponse_StageSchema: GenEnum<OpenWorkbenchResponse_Stage>;
 
 /**
- * Request to watch the search index construction progress of a Workbench session.
+ * Request to watch the search index construction progress of an active Workbench session.
  *
  * @generated from message api.v1.WatchIndexProgressRequest
  */
 export declare type WatchIndexProgressRequest =
   Message<'api.v1.WatchIndexProgressRequest'> & {
     /**
-     * The active workbench session identifier.
+     * The active workbench session identifier to stream search index construction progress for.
      *
      * @generated from field: string workbench_id = 1;
      */
@@ -586,7 +586,7 @@ export declare const WorkbenchService: GenService<{
     output: typeof OpenWorkbenchResponseSchema;
   };
   /**
-   * Watches the search index construction progress and status for an active Workbench session. The server terminates the stream every 30s to accommodate proxy timeouts, and clients are expected to reconnect.
+   * Watches the search index construction progress and status for an inspection dataset. The server terminates the stream every 30s to accommodate proxy timeouts, and clients are expected to reconnect.
    *
    * @generated from rpc api.v1.WorkbenchService.WatchIndexProgress
    */

--- a/web/src/app/services/api/workbench/workbench-client.service.spec.ts
+++ b/web/src/app/services/api/workbench/workbench-client.service.spec.ts
@@ -354,8 +354,14 @@ describe('WorkbenchClientService', () => {
     expect(service.isIndexBuilding()).toBeFalse();
     expect(service.isIndexReady()).toBeFalse();
 
-    await service.watchIndexProgress('usr-1-session-0');
+    await service.watchIndexProgress('test-workbench-1');
 
+    expect(
+      mockConnectClient.workbenchClient.watchIndexProgress,
+    ).toHaveBeenCalledWith(
+      { workbenchId: 'test-workbench-1' },
+      jasmine.any(Object),
+    );
     expect(service.indexState()).toBe(
       WatchIndexProgressResponse_IndexState.READY,
     );


### PR DESCRIPTION
## Summary

This PR implements persistent background Trigram indexing and search optimization for Kubernetes History Inspector (KHI), enabling sub-second full-text and field-specific regex/literal log searching across large inspection datasets.

## Background & Motivation

When filtering logs on large inspection files (e.g. hundreds of thousands of logs), evaluating CEL log queries (such as `body("image", "nginx")` or `body("spec.containers.image", "nginx")`) required resolving and parsing every log's AST or full YAML body text on the fly. This incurred high latency (several seconds per query).

## Key Changes

### 1. TrigramIndex Core & Binary Serialization (`pkg/server/workbench/cel/trigram.go`)
- Implemented `TrigramIndex` using Roaring Bitmaps (`*roaring.Bitmap`) mapped to 3-gram character substrings.
- Supports streaming incremental construction and `RunOptimize()` compaction.
- Implemented compact binary serialization (`KHITRIX` format v2) with 7-byte magic prefix, zlib-compressed roaring bitmaps, and CRC32 checksums.

### 2. Field-Path Trigram Query Optimization (`pkg/server/workbench/cel/`)
- Implemented `PathToTrigramQuery(pathKey string)` which parses dot-delimited field paths and formats keys using `khifilev6model.FormatKeyName(seg) + ":"`.
- Handles standard identifiers (`image:`), 2-letter fields (`ip:`), and quoted keys (`"@type":`) to constrain candidates before resolving log AST nodes.
- Implemented `FindCandidateLogsWithField` combining field path queries and regex pattern queries.

### 3. Background Index Manager (`pkg/server/workbench/index_manager.go`)
- Implemented `InspectionIndexManager` to manage asynchronous TrigramIndex generation and caching in the `.khi` inspection directory (`search.index`).
- Features a concurrent worker pool (`worker.NewPool`), progress tracking, and atomic file replacement (`.tmp` -> rename).
- Detects and automatically invalidates stale indices if log count or size mismatches.

### 4. Server Lifecycle Integration (`pkg/server/`)
- Automatically triggers background index building upon inspection completion and import.
- Automatically purges index cache on inspection deletion.

### 5. Workbench API Streaming Synchronization (`pkg/server/api/v1/workbench.go`)
- Updated `WorkbenchService.OpenWorkbench` Connect-RPC handler to stream index building progress to the frontend while reading `.khi` log chunks.
- Ensures the active `Workbench` instance receives the indexed `TrigramIndex` upon completion for immediate acceleration of subsequent CEL evaluations.

## Verification

- **Backend Tests**: `make test-go` passed (100%).
- **Frontend Tests**: `make test-web` passed (775 tests).
- **Linters**: `make lint-go` (0 issues).
- **Pre-commit**: `make pre-commit` passed (0 issues).