### PR TITLE
feat(api): configure Connect-RPC serialization format based on environment

### DIFF
--- a/pkg/server/api/v1/workbench_test.go
+++ b/pkg/server/api/v1/workbench_test.go
@@ -514,7 +514,7 @@ func TestWorkbenchServiceServer_ProtoJSONClient(t *testing.T) {
 	if err := openStream.Err(); err != nil {
 		t.Fatalf("OpenWorkbench() stream with ProtoJSON error = %v", err)
 	}
-	if lastMsg == nil || lastMsg.GetWorkbenchId() == "" {
+	if lastMsg.GetWorkbenchId() == "" {
 		t.Fatalf("expected last OpenWorkbench message to have workbench_id, got %v", lastMsg)
 	}
 

--- a/pkg/server/api/v1/workbench_test.go
+++ b/pkg/server/api/v1/workbench_test.go
@@ -490,3 +490,41 @@ func TestWorkbenchServiceServer_WatchIndexProgress(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkbenchServiceServer_ProtoJSONClient(t *testing.T) {
+	ts, _, manager, validInspID := setupTestWorkbenchServer(t)
+	defer ts.Close()
+	defer manager.Stop()
+
+	// Client configured with connect.WithProtoJSON() to mimic frontend development mode.
+	jsonClient := apiv1connect.NewWorkbenchServiceClient(ts.Client(), ts.URL, connect.WithProtoJSON())
+
+	openStream, err := jsonClient.OpenWorkbench(context.Background(), connect.NewRequest(&apiv1.OpenWorkbenchRequest{
+		UserId:       proto.String("user-json"),
+		SessionId:    proto.String("session-0"),
+		InspectionId: proto.String(validInspID),
+	}))
+	if err != nil {
+		t.Fatalf("OpenWorkbench() with ProtoJSON error = %v", err)
+	}
+	var lastMsg *apiv1.OpenWorkbenchResponse
+	for openStream.Receive() {
+		lastMsg = openStream.Msg()
+	}
+	if err := openStream.Err(); err != nil {
+		t.Fatalf("OpenWorkbench() stream with ProtoJSON error = %v", err)
+	}
+	if lastMsg == nil || lastMsg.GetWorkbenchId() == "" {
+		t.Fatalf("expected last OpenWorkbench message to have workbench_id, got %v", lastMsg)
+	}
+
+	hbRes, err := jsonClient.HeartbeatWorkbench(context.Background(), connect.NewRequest(&apiv1.HeartbeatWorkbenchRequest{
+		WorkbenchId: proto.String(lastMsg.GetWorkbenchId()),
+	}))
+	if err != nil {
+		t.Fatalf("HeartbeatWorkbench() with ProtoJSON error = %v", err)
+	}
+	if !hbRes.Msg.GetActive() {
+		t.Errorf("HeartbeatWorkbench() active = false, want true")
+	}
+}

--- a/web/src/app/services/api/connect-client.service.spec.ts
+++ b/web/src/app/services/api/connect-client.service.spec.ts
@@ -35,9 +35,40 @@ describe('ConnectClientService', () => {
     expect(service.workbenchClient).toBeTruthy();
     expect(typeof service.workbenchClient.openWorkbench).toBe('function');
   });
-
   it('should initialize serverStatusClient with watchServerStat method', () => {
     expect(service.serverStatusClient).toBeTruthy();
     expect(typeof service.serverStatusClient.watchServerStat).toBe('function');
+  });
+
+  it('should initialize fileParameterUploadClient', () => {
+    expect(service.fileParameterUploadClient).toBeTruthy();
+    expect(typeof service.fileParameterUploadClient.startFileUpload).toBe(
+      'function',
+    );
+  });
+
+  it('should initialize importInspectionClient', () => {
+    expect(service.importInspectionClient).toBeTruthy();
+    expect(typeof service.importInspectionClient.startImportInspection).toBe(
+      'function',
+    );
+  });
+
+  it('should use JSON content-type when environment.production is false', async () => {
+    let capturedContentType: string | null = null;
+    spyOn(globalThis, 'fetch').and.callFake((_input, init) => {
+      const headers = new Headers(init?.headers);
+      capturedContentType = headers.get('content-type');
+      return Promise.resolve(
+        new Response(JSON.stringify({ active: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    });
+
+    await service.workbenchClient.heartbeatWorkbench({ workbenchId: 'test' });
+
+    expect(capturedContentType).toContain('application/json');
   });
 });

--- a/web/src/app/services/api/connect-client.service.ts
+++ b/web/src/app/services/api/connect-client.service.ts
@@ -17,11 +17,14 @@
 import { Injectable } from '@angular/core';
 import { createClient, Client } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-web';
-import { WorkbenchService } from 'src/app/generated/api/v1/workbench_pb';
 import { CELValidationService } from 'src/app/generated/api/v1/cel_validation_pb';
+import { FileParameterUploadService } from 'src/app/generated/api/v1/file_parameter_upload_pb';
+import { ImportInspectionService } from 'src/app/generated/api/v1/import_inspection_pb';
 import { PopupService } from 'src/app/generated/api/v1/popup_pb';
 import { ServerStatusService } from 'src/app/generated/api/v1/server_status_pb';
+import { WorkbenchService } from 'src/app/generated/api/v1/workbench_pb';
 import { ApiPathUtil } from 'src/app/services/api/api-path-util';
+import { environment } from 'src/environments/environment';
 
 /**
  * ConnectClientService manages Connect-RPC clients and transports.
@@ -32,7 +35,7 @@ import { ApiPathUtil } from 'src/app/services/api/api-path-util';
 export class ConnectClientService {
   private readonly transport = createConnectTransport({
     baseUrl: ApiPathUtil.getServerBaseUrl(),
-    useBinaryFormat: true,
+    useBinaryFormat: environment.production,
   });
 
   /**
@@ -60,4 +63,18 @@ export class ConnectClientService {
    */
   public readonly serverStatusClient: Client<typeof ServerStatusService> =
     createClient(ServerStatusService, this.transport);
+
+  /**
+   * FileParameterUploadService Connect-RPC client.
+   */
+  public readonly fileParameterUploadClient: Client<
+    typeof FileParameterUploadService
+  > = createClient(FileParameterUploadService, this.transport);
+
+  /**
+   * ImportInspectionService Connect-RPC client.
+   */
+  public readonly importInspectionClient: Client<
+    typeof ImportInspectionService
+  > = createClient(ImportInspectionService, this.transport);
 }

--- a/web/src/app/services/api/file-parameter-upload-client.service.spec.ts
+++ b/web/src/app/services/api/file-parameter-upload-client.service.spec.ts
@@ -20,19 +20,15 @@ import {
   FileParameterUploadOptions,
 } from 'src/app/services/api/file-parameter-upload-client.service';
 import { Client } from '@connectrpc/connect';
+import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import { FileParameterUploadService } from 'src/app/generated/api/v1/file_parameter_upload_pb';
 
 describe('FileParameterUploadClientService', () => {
   let service: FileParameterUploadClientService;
   let mockClient: jasmine.SpyObj<Client<typeof FileParameterUploadService>>;
+  let mockConnectClient: jasmine.SpyObj<ConnectClientService>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [FileParameterUploadClientService],
-    });
-
-    service = TestBed.inject(FileParameterUploadClientService);
-
     mockClient = jasmine.createSpyObj<
       Client<typeof FileParameterUploadService>
     >('FileParameterUploadClient', [
@@ -41,12 +37,22 @@ describe('FileParameterUploadClientService', () => {
       'completeFileUpload',
       'abortFileUpload',
     ]);
-    // Replace internal client with spy object for unit testing
-    (
-      service as unknown as {
-        client: Client<typeof FileParameterUploadService>;
-      }
-    ).client = mockClient;
+    mockConnectClient = jasmine.createSpyObj<ConnectClientService>(
+      'ConnectClientService',
+      [],
+      {
+        fileParameterUploadClient: mockClient,
+      },
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        FileParameterUploadClientService,
+        { provide: ConnectClientService, useValue: mockConnectClient },
+      ],
+    });
+
+    service = TestBed.inject(FileParameterUploadClientService);
   });
 
   it('uploads a file in chunks and returns result on complete', async () => {

--- a/web/src/app/services/api/file-parameter-upload-client.service.ts
+++ b/web/src/app/services/api/file-parameter-upload-client.service.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
-import { createClient, Client } from '@connectrpc/connect';
-import { createConnectTransport } from '@connectrpc/connect-web';
+import { Injectable, inject } from '@angular/core';
+import { Client } from '@connectrpc/connect';
 import { FileParameterUploadService } from 'src/app/generated/api/v1/file_parameter_upload_pb';
-import { ApiPathUtil } from 'src/app/services/api/api-path-util';
+import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import {
   executeChunkedUpload,
   ChunkUploadProgressCallback,
@@ -54,14 +53,9 @@ export interface FileParameterUploadResult {
   providedIn: 'root',
 })
 export class FileParameterUploadClientService {
-  private readonly client: Client<typeof FileParameterUploadService>;
-
-  constructor() {
-    const transport = createConnectTransport({
-      baseUrl: ApiPathUtil.getServerBasePath(),
-    });
-    this.client = createClient(FileParameterUploadService, transport);
-  }
+  private readonly connectClient = inject(ConnectClientService);
+  private readonly client: Client<typeof FileParameterUploadService> =
+    this.connectClient.fileParameterUploadClient;
 
   /**
    * Uploads a file parameter to the backend using chunked transfer.

--- a/web/src/app/services/api/import-inspection-client.service.spec.ts
+++ b/web/src/app/services/api/import-inspection-client.service.spec.ts
@@ -20,19 +20,15 @@ import {
   ImportFileOptions,
 } from 'src/app/services/api/import-inspection-client.service';
 import { Client } from '@connectrpc/connect';
+import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import { ImportInspectionService } from 'src/app/generated/api/v1/import_inspection_pb';
 
 describe('ImportInspectionClientService', () => {
   let service: ImportInspectionClientService;
   let mockClient: jasmine.SpyObj<Client<typeof ImportInspectionService>>;
+  let mockConnectClient: jasmine.SpyObj<ConnectClientService>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [ImportInspectionClientService],
-    });
-
-    service = TestBed.inject(ImportInspectionClientService);
-
     mockClient = jasmine.createSpyObj<Client<typeof ImportInspectionService>>(
       'ImportInspectionClient',
       [
@@ -42,12 +38,22 @@ describe('ImportInspectionClientService', () => {
         'abortImportInspection',
       ],
     );
-    // Replace internal client with spy object for unit testing
-    (
-      service as unknown as {
-        client: Client<typeof ImportInspectionService>;
-      }
-    ).client = mockClient;
+    mockConnectClient = jasmine.createSpyObj<ConnectClientService>(
+      'ConnectClientService',
+      [],
+      {
+        importInspectionClient: mockClient,
+      },
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        ImportInspectionClientService,
+        { provide: ConnectClientService, useValue: mockConnectClient },
+      ],
+    });
+
+    service = TestBed.inject(ImportInspectionClientService);
   });
 
   it('uploads a file in chunks and returns inspection details on complete', async () => {

--- a/web/src/app/services/api/import-inspection-client.service.ts
+++ b/web/src/app/services/api/import-inspection-client.service.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
-import { createClient, Client } from '@connectrpc/connect';
-import { createConnectTransport } from '@connectrpc/connect-web';
+import { Injectable, inject } from '@angular/core';
+import { Client } from '@connectrpc/connect';
 import { ImportInspectionService } from 'src/app/generated/api/v1/import_inspection_pb';
-import { ApiPathUtil } from 'src/app/services/api/api-path-util';
+import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import {
   executeChunkedUpload,
   ChunkUploadProgressCallback,
@@ -68,14 +67,9 @@ export class ImportInspectionClientService {
   /** Default maximum number of concurrent chunk uploads. */
   public static readonly DEFAULT_MAX_CONCURRENCY = DEFAULT_MAX_CONCURRENCY;
 
-  private readonly client: Client<typeof ImportInspectionService>;
-
-  constructor() {
-    const transport = createConnectTransport({
-      baseUrl: ApiPathUtil.getServerBasePath(),
-    });
-    this.client = createClient(ImportInspectionService, transport);
-  }
+  private readonly connectClient = inject(ConnectClientService);
+  private readonly client: Client<typeof ImportInspectionService> =
+    this.connectClient.importInspectionClient;
 
   /**
    * Imports a .khi file in chunks to the backend server.


### PR DESCRIPTION
## Summary
Configures Connect-RPC serialization format based on the frontend build environment (`environment.production`).

- Introduces `ConnectClientService` to centrally create and configure Connect-RPC transports and clients.
- In production (`environment.production: true`), clients default to compact binary Protobuf serialization for maximum efficiency and reduced bandwidth.
- In development (`environment.production: false`), clients use `useBinaryFormat: false` (ProtoJSON) for transparent network payloads in browser DevTools.
- Refactors `FileParameterUploadClientService` and `ImportInspectionClientService` to inject clients from `ConnectClientService` instead of creating independent transports.
- Adds Go backend test `TestWorkbenchServiceServer_ProtoJSONClient` to verify server-side compatibility when requests are sent using ProtoJSON format.

## Verification
- `make test-go`
- `make test-web`
- `make pre-commit`