### PR TITLE
fix(web): update form validation on in-flight requests and migrate to signals

### DIFF
--- a/web/src/app/dialogs/new-inspection/components/file-parameter.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/file-parameter.component.spec.ts
@@ -127,7 +127,11 @@ describe('FileParameterComponent', () => {
     fixture.componentInstance.onClickUploadButton();
     fixture.detectChanges();
     const harnessLoader = TestbedHarnessEnvironment.loader(fixture);
-    const spinner = await harnessLoader.getHarness(MatProgressSpinnerHarness);
+    const spinner = await harnessLoader.getHarness(
+      MatProgressSpinnerHarness.with({
+        selector: '.progress-wrapper mat-progress-spinner',
+      }),
+    );
 
     expect(fixture.componentInstance).toBeTruthy();
     expect(await spinner.getMode()).toBe('determinate');
@@ -150,7 +154,11 @@ describe('FileParameterComponent', () => {
     fixture.componentInstance.onClickUploadButton();
     fixture.detectChanges();
     const harnessLoader = TestbedHarnessEnvironment.loader(fixture);
-    const spinner = await harnessLoader.getHarness(MatProgressSpinnerHarness);
+    const spinner = await harnessLoader.getHarness(
+      MatProgressSpinnerHarness.with({
+        selector: '.progress-wrapper mat-progress-spinner',
+      }),
+    );
 
     expect(fixture.componentInstance).toBeTruthy();
     expect(await spinner.getMode()).toBe('indeterminate');

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.html
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.html
@@ -17,14 +17,16 @@
 <div class="container">
   <div class="label-row">
     @if (showValidationStatus()) {
-      @if (param.hintType === ParameterHintType.Error) {
+      @if (isValidating()) {
+        <mat-spinner diameter="16" class="validation-spinner"></mat-spinner>
+      } @else if (param.hintType === ParameterHintType.Error) {
         <mat-icon class="error">error</mat-icon>
       } @else {
         <mat-icon class="verified">check_circle</mat-icon>
       }
     }
     <p class="label">{{ param.label }}</p>
-    @if (store.watchDirty(param.id) | async) {
+    @if (isDirty()) {
       <mat-icon class="dirty" [matTooltip]="dirtyIconTooltip">edit</mat-icon>
     }
   </div>

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.scss
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.scss
@@ -40,6 +40,10 @@ $dirty-icon-size: 15px;
     height: $dirty-icon-size;
     font-size: $dirty-icon-size;
   }
+
+  .validation-spinner {
+    margin: 4px;
+  }
 }
 
 .label {

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.spec.ts
@@ -62,6 +62,7 @@ describe('ParameterHeaderComponent', () => {
     matIconRegistry.setDefaultFontSetClass('material-symbols-outlined');
     fixture = TestBed.createComponent(ParameterHeaderComponent);
     fixture.componentRef.setInput('parameter', {
+      id: 'test-param',
       label: 'test-label',
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, \n sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
@@ -88,6 +89,7 @@ describe('ParameterHeaderComponent', () => {
 
   it('should show error icon when hintType = ERROR', async () => {
     fixture.componentRef.setInput('parameter', {
+      id: 'test-param',
       label: 'test-label',
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, \n sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
@@ -98,5 +100,22 @@ describe('ParameterHeaderComponent', () => {
 
     expect(matIcon.length).toBe(1);
     expect(await matIcon[0].getName()).toBe('error');
+  });
+
+  it('should show spinner when field is validating', () => {
+    const store = TestBed.inject(PARAMETER_STORE);
+    store.set('test-param', 'new-value');
+    store.setValidatedParameters({ 'test-param': 'old-value' });
+
+    fixture.detectChanges();
+
+    const spinner = fixture.debugElement.query(By.css('.validation-spinner'));
+    expect(spinner).toBeTruthy();
+
+    // Icons should not be shown while validating
+    const icons = fixture.debugElement.queryAll(
+      By.css('mat-icon.verified, mat-icon.error'),
+    );
+    expect(icons.length).toBe(0);
   });
 });

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.ts
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, inject, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { BreaklinePipe } from 'src/app/common/breakline.pipe';
 import {
@@ -24,6 +24,7 @@ import {
 import { PARAMETER_STORE } from './service/parameter-store';
 import { CommonModule } from '@angular/common';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 /**
  * Component of common parameter headers used in new inspection dialog.
@@ -32,7 +33,13 @@ import { MatTooltipModule } from '@angular/material/tooltip';
   selector: 'khi-new-inspection-parameter-header',
   templateUrl: './parameter-header.component.html',
   styleUrls: ['./parameter-header.component.scss'],
-  imports: [CommonModule, BreaklinePipe, MatIconModule, MatTooltipModule],
+  imports: [
+    CommonModule,
+    BreaklinePipe,
+    MatIconModule,
+    MatTooltipModule,
+    MatProgressSpinnerModule,
+  ],
 })
 export class ParameterHeaderComponent {
   readonly ParameterHintType = ParameterHintType;
@@ -42,12 +49,26 @@ export class ParameterHeaderComponent {
   /**
    * The spec of this text type parameter.
    */
-  parameter = input.required<ParameterFormFieldBase>();
+  readonly parameter = input.required<ParameterFormFieldBase>();
 
   /**
    * If the status of validation should show on header or not.
    */
-  showValidationStatus = input(true);
+  readonly showValidationStatus = input(true);
 
-  store = inject(PARAMETER_STORE);
+  private readonly store = inject(PARAMETER_STORE);
+
+  /**
+   * Computed signal indicating if the parameter is currently being validated.
+   */
+  readonly isValidating = computed(() => {
+    return this.store.isValidating(this.parameter().id)();
+  });
+
+  /**
+   * Computed signal indicating if the parameter was modified by the user.
+   */
+  readonly isDirty = computed(() => {
+    return this.store.isDirty(this.parameter().id)();
+  });
 }

--- a/web/src/app/dialogs/new-inspection/components/service/parameter-store.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/service/parameter-store.spec.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-import { firstValueFrom, lastValueFrom, take } from 'rxjs';
-import { DefaultParameterStore } from './parameter-store';
+import {
+  areValuesEqual,
+  DefaultParameterStore,
+  haveEqualKeyValues,
+} from './parameter-store';
 
 describe('DefaultParameterStore', () => {
   let parameterStore: DefaultParameterStore;
@@ -28,94 +31,132 @@ describe('DefaultParameterStore', () => {
     parameterStore.destroy();
   });
 
-  describe('watch', () => {
-    it('emits value set before the subscribe', async () => {
+  describe('get', () => {
+    it('returns the value set in the store', () => {
       parameterStore.setDefaultValues({ foo: 'bar' });
       parameterStore.set('foo', 'qux');
 
-      expect(await firstValueFrom(parameterStore.watch('foo'))).toBe('qux');
+      expect(parameterStore.get('foo')()).toBe('qux');
     });
   });
 
   describe('set', () => {
-    it('put the value after the default value being available', async () => {
+    it('puts the value after the default value is available', () => {
       parameterStore.set('foo', 'qux');
       parameterStore.setDefaultValues({ foo: 'bar' });
 
-      expect(
-        await lastValueFrom(parameterStore.watch('foo').pipe(take(1))),
-      ).toBe('qux');
+      expect(parameterStore.get('foo')()).toBe('qux');
     });
 
-    it('put the value after the default value being available and keep the order', async () => {
+    it('puts the value after the default value is available and keeps the latest value', () => {
       parameterStore.set('foo', 'qux');
       parameterStore.set('foo', 'quux');
       parameterStore.setDefaultValues({ foo: 'bar' });
 
-      expect(
-        await lastValueFrom(parameterStore.watch('foo').pipe(take(1))),
-      ).toBe('quux');
+      expect(parameterStore.get('foo')()).toBe('quux');
     });
   });
 
   describe('setDefaultValues', () => {
-    it("doesn't overwrite the value set before", async () => {
+    it("doesn't overwrite the value set before if user modified it", () => {
       parameterStore.setDefaultValues({ foo: 'bar' });
       parameterStore.set('foo', 'qux');
       parameterStore.setDefaultValues({ foo: 'bar', bar: 'qux' });
 
-      expect(
-        await lastValueFrom(parameterStore.watch('foo').pipe(take(1))),
-      ).toBe('qux');
+      expect(parameterStore.get('foo')()).toBe('qux');
     });
 
-    it('update the value if the previous value is same as the default value', async () => {
+    it('updates the value if the previous value is same as the default value', () => {
       parameterStore.setDefaultValues({ foo: 'bar' });
       parameterStore.set('foo', 'bar');
       parameterStore.setDefaultValues({ foo: 'qux' });
 
-      expect(
-        await lastValueFrom(parameterStore.watch('foo').pipe(take(1))),
-      ).toBe('qux');
+      expect(parameterStore.get('foo')()).toBe('qux');
     });
   });
 
-  describe('watchDirty', () => {
-    it("becomes false when the value hasn't set", async () => {
+  describe('isDirty', () => {
+    it("is false when the value hasn't been modified from default", () => {
       parameterStore.setDefaultValues({ foo: 'bar' });
 
-      expect(
-        await lastValueFrom(parameterStore.watchDirty('foo').pipe(take(1))),
-      ).toBe(false);
+      expect(parameterStore.isDirty('foo')()).toBe(false);
     });
 
-    it('becomes false when the value has set', async () => {
+    it('is true when the value has been modified from default', () => {
       parameterStore.setDefaultValues({ foo: 'bar' });
       parameterStore.set('foo', 'qux');
 
-      expect(
-        await lastValueFrom(parameterStore.watchDirty('foo').pipe(take(1))),
-      ).toBe(true);
+      expect(parameterStore.isDirty('foo')()).toBe(true);
     });
 
-    it('becomes false when the previous value returned to the same as the default value', async () => {
+    it('becomes false when the value returns to the same as default value', () => {
       parameterStore.setDefaultValues({ foo: 'bar' });
       parameterStore.set('foo', 'qux');
       parameterStore.set('foo', 'bar');
 
-      expect(
-        await lastValueFrom(parameterStore.watchDirty('foo').pipe(take(1))),
-      ).toBe(false);
+      expect(parameterStore.isDirty('foo')()).toBe(false);
     });
 
-    it('becomes false when the default value was updated and it matched the current value', async () => {
+    it('becomes false when default value is updated and matches the current value', () => {
       parameterStore.setDefaultValues({ foo: 'bar' });
       parameterStore.set('foo', 'qux');
       parameterStore.setDefaultValues({ foo: 'qux' });
 
-      expect(
-        await lastValueFrom(parameterStore.watchDirty('foo').pipe(take(1))),
-      ).toBe(false);
+      expect(parameterStore.isDirty('foo')()).toBe(false);
+    });
+    it('handles array values by content without falsely marking as dirty', () => {
+      parameterStore.setDefaultValues({ foo: ['a', 'b'] });
+
+      expect(parameterStore.isDirty('foo')()).toBe(false);
+
+      parameterStore.set('foo', ['a']);
+      expect(parameterStore.isDirty('foo')()).toBe(true);
+
+      parameterStore.set('foo', ['a', 'b']);
+      expect(parameterStore.isDirty('foo')()).toBe(false);
+    });
+  });
+
+  describe('isValidating', () => {
+    it('is false initially when field is not in store', () => {
+      expect(parameterStore.isValidating('foo')()).toBe(false);
+    });
+
+    it('is true when current value differs from validated value', () => {
+      parameterStore.set('foo', 'bar');
+      parameterStore.setValidatedParameters({ foo: 'old' });
+
+      expect(parameterStore.isValidating('foo')()).toBe(true);
+    });
+
+    it('becomes false when validated value matches current value', () => {
+      parameterStore.set('foo', 'bar');
+      parameterStore.setValidatedParameters({ foo: 'bar' });
+
+      expect(parameterStore.isValidating('foo')()).toBe(false);
+    });
+
+    it('compares array values by content, not reference', () => {
+      parameterStore.set('foo', ['item1', 'item2']);
+      parameterStore.setValidatedParameters({ foo: ['item1', 'item2'] });
+
+      expect(parameterStore.isValidating('foo')()).toBe(false);
+
+      parameterStore.set('foo', ['item1']);
+      expect(parameterStore.isValidating('foo')()).toBe(true);
+    });
+  });
+
+  describe('areValuesEqual and haveEqualKeyValues', () => {
+    it('correctly compares array and primitive equality', () => {
+      expect(areValuesEqual(['a', 'b'], ['a', 'b'])).toBe(true);
+      expect(areValuesEqual(['a', 'b'], ['a', 'c'])).toBe(false);
+      expect(areValuesEqual(['a'], ['a', 'b'])).toBe(false);
+      expect(areValuesEqual('hello', 'hello')).toBe(true);
+      expect(areValuesEqual('hello', 'world')).toBe(false);
+
+      expect(haveEqualKeyValues({ a: ['x'] }, { a: ['x'] })).toBe(true);
+      expect(haveEqualKeyValues({ a: ['x'] }, { a: ['y'] })).toBe(false);
     });
   });
 });

--- a/web/src/app/dialogs/new-inspection/components/service/parameter-store.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/service/parameter-store.spec.ts
@@ -38,6 +38,13 @@ describe('DefaultParameterStore', () => {
 
       expect(parameterStore.get('foo')()).toBe('qux');
     });
+
+    it('returns the same signal instance on subsequent calls for the same id', () => {
+      const sig1 = parameterStore.get('foo');
+      const sig2 = parameterStore.get('foo');
+
+      expect(sig1).toBe(sig2);
+    });
   });
 
   describe('set', () => {
@@ -115,6 +122,13 @@ describe('DefaultParameterStore', () => {
       parameterStore.set('foo', ['a', 'b']);
       expect(parameterStore.isDirty('foo')()).toBe(false);
     });
+
+    it('returns the same signal instance on subsequent calls for the same id', () => {
+      const sig1 = parameterStore.isDirty('foo');
+      const sig2 = parameterStore.isDirty('foo');
+
+      expect(sig1).toBe(sig2);
+    });
   });
 
   describe('isValidating', () => {
@@ -134,6 +148,13 @@ describe('DefaultParameterStore', () => {
       parameterStore.setValidatedParameters({ foo: 'bar' });
 
       expect(parameterStore.isValidating('foo')()).toBe(false);
+    });
+
+    it('returns the same signal instance on subsequent calls for the same id', () => {
+      const sig1 = parameterStore.isValidating('foo');
+      const sig2 = parameterStore.isValidating('foo');
+
+      expect(sig1).toBe(sig2);
     });
 
     it('compares array values by content, not reference', () => {

--- a/web/src/app/dialogs/new-inspection/components/service/parameter-store.ts
+++ b/web/src/app/dialogs/new-inspection/components/service/parameter-store.ts
@@ -14,18 +14,7 @@
  * limitations under the License.
  */
 
-import { InjectionToken } from '@angular/core';
-import {
-  distinctUntilChanged,
-  filter,
-  map,
-  Observable,
-  ReplaySubject,
-  Subject,
-  take,
-  takeUntil,
-  withLatestFrom,
-} from 'rxjs';
+import { computed, InjectionToken, Signal, signal } from '@angular/core';
 
 /**
  * The injection token to get an implementation of ParameterStore.
@@ -39,21 +28,34 @@ export const PARAMETER_STORE = new InjectionToken<ParameterStore>(
  */
 export interface ParameterStore {
   /**
-   * Get the observable to monitor the value of speicifed value.
-   * When the specified id is not available parameter for now, it waits the value to be available.
+   * Signal holding all current parameter values.
    */
-  watch<T>(id: string): Observable<T>;
+  readonly currentParameters: Signal<{ [id: string]: unknown }>;
 
   /**
-   * Get the observable to monitor the dirtiness of the field.
-   * true is emitted after user modified the field.
+   * Signal holding the parameters verified by the last completed dryrun.
    */
-  watchDirty(id: string): Observable<boolean>;
+  readonly validatedParameters: Signal<{ [id: string]: unknown }>;
 
   /**
-   * Watch the all parameters.
+   * Signal holding the default parameters returned by the backend.
    */
-  watchAll(): Observable<{ [id: string]: unknown }>;
+  readonly defaultParameters: Signal<{ [id: string]: unknown }>;
+
+  /**
+   * Returns a computed signal of the value for the given parameter ID.
+   */
+  get<T>(id: string): Signal<T>;
+
+  /**
+   * Returns a computed signal indicating if the field has pending unverified changes.
+   */
+  isValidating(id: string): Signal<boolean>;
+
+  /**
+   * Returns a computed signal indicating if the field was modified by the user.
+   */
+  isDirty(id: string): Signal<boolean>;
 
   /**
    * Set the value for the parameter with the given id.
@@ -64,128 +66,147 @@ export interface ParameterStore {
    * Set the default value of parameters.
    */
   setDefaultValues(defaultValues: { [id: string]: unknown }): void;
+
+  /**
+   * Set the snapshot of parameters that were validated by a completed dryrun.
+   */
+  setValidatedParameters(params: { [id: string]: unknown }): void;
 }
 
-export class DefaultParameterStore implements ParameterStore {
-  readonly destroyed = new Subject();
-
-  readonly currentParameters = new ReplaySubject<{ [id: string]: unknown }>(1);
-
-  readonly currentDefaultParameters = new ReplaySubject<{
-    [id: string]: unknown;
-  }>(1);
-
-  private dirtyFields = this.currentParameters.pipe(
-    takeUntil(this.destroyed),
-    withLatestFrom(this.currentDefaultParameters),
-    map(
-      ([parameters, defaultParameters]) =>
-        new Set(
-          Object.keys(parameters).filter(
-            (key) => parameters[key] !== defaultParameters[key],
-          ),
-        ),
-    ),
-  );
-  constructor() {
-    this.currentParameters.next({});
-    this.currentDefaultParameters.next({});
+/**
+ * Checks if two parameter values are deeply equal (supporting primitives, arrays, and Dates).
+ */
+export function areValuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
   }
-  watchAll(): Observable<{ [id: string]: unknown }> {
-    return this.currentParameters.pipe(
-      takeUntil(this.destroyed),
-      distinctUntilChanged((prev, current) => {
-        return this.haveEqualKeyValues(prev, current);
-      }),
-    );
-  }
-
-  watch<T>(id: string): Observable<T> {
-    return this.currentParameters.pipe(
-      takeUntil(this.destroyed),
-      filter((parameters) => id in parameters),
-      map((parameters) => parameters[id] as T),
-      distinctUntilChanged(),
-    );
-  }
-
-  watchDirty(id: string): Observable<boolean> {
-    return this.dirtyFields.pipe(
-      takeUntil(this.destroyed),
-      map((dirtyFields) => dirtyFields.has(id)),
-      distinctUntilChanged(),
-    );
-  }
-
-  set(id: string, value: unknown): void {
-    this.currentParameters
-      .pipe(
-        takeUntil(this.destroyed),
-        filter((parameters) => id in parameters),
-        take(1),
-      )
-      .subscribe((parameters) => {
-        this.currentParameters.next({
-          ...parameters,
-          [id]: value,
-        });
-      });
-  }
-
-  /**
-   * Update the default values for parameters.
-   * If the current value is same as the previous default values, the parameter is updated with the newer default values.
-   * If not, the parameter value is kept because it was updated by the user.
-   */
-  setDefaultValues(defaultValues: { [id: string]: unknown }): void {
-    this.currentParameters
-      .pipe(
-        takeUntil(this.destroyed),
-        take(1),
-        withLatestFrom(this.dirtyFields),
-      )
-      .subscribe(([parameters, dirtyFields]) => {
-        const nextParameter: { [id: string]: unknown } = {};
-        for (const id of Object.keys({ ...parameters, ...defaultValues })) {
-          if (dirtyFields.has(id)) {
-            nextParameter[id] = parameters[id];
-          } else {
-            nextParameter[id] = defaultValues[id];
-          }
-        }
-        this.currentParameters.next(nextParameter);
-      });
-    this.currentDefaultParameters.next(defaultValues);
-  }
-
-  /**
-   * Unregister subscriptions registered in this store.
-   */
-  public destroy(): void {
-    this.destroyed.next(void 0);
-  }
-
-  /**
-   * Check if the given objects are both having same key and its value.
-   * This doesn't compare them recursively, because currently the parameter values are all primitives.
-   */
-  private haveEqualKeyValues(
-    prev: { [id: string]: unknown },
-    current: { [id: string]: unknown },
-  ): boolean {
-    for (const prevFieldKey in prev) {
-      if (
-        !(prevFieldKey in current) ||
-        prev[prevFieldKey] !== current[prevFieldKey]
-      ) {
-        return false;
-      }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
     }
-    for (const currentFieldKey in current) {
-      if (!(currentFieldKey in prev)) {
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
         return false;
       }
     }
     return true;
+  }
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  return false;
+}
+
+/**
+ * Checks if two parameter objects have equal keys and values.
+ */
+export function haveEqualKeyValues(
+  prev: { [id: string]: unknown },
+  current: { [id: string]: unknown },
+): boolean {
+  const prevKeys = Object.keys(prev);
+  const currentKeys = Object.keys(current);
+  if (prevKeys.length !== currentKeys.length) {
+    return false;
+  }
+  for (const key of prevKeys) {
+    if (!(key in current) || !areValuesEqual(prev[key], current[key])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Default implementation of ParameterStore backed by Angular Signals.
+ */
+export class DefaultParameterStore implements ParameterStore {
+  readonly currentParameters = signal<{ [id: string]: unknown }>({});
+
+  readonly validatedParameters = signal<{ [id: string]: unknown }>({});
+
+  readonly defaultParameters = signal<{ [id: string]: unknown }>({});
+
+  private readonly dirtyFields = computed(() => {
+    const current = this.currentParameters();
+    const defaults = this.defaultParameters();
+    const dirty = new Set<string>();
+    for (const key of Object.keys(current)) {
+      if (!areValuesEqual(current[key], defaults[key])) {
+        dirty.add(key);
+      }
+    }
+    return dirty;
+  });
+
+  /**
+   * Returns a computed signal of the value for the given parameter ID.
+   */
+  get<T>(id: string): Signal<T> {
+    return computed(() => this.currentParameters()[id] as T);
+  }
+
+  /**
+   * Returns a computed signal indicating if the field's current value differs from the validated value.
+   */
+  isValidating(id: string): Signal<boolean> {
+    return computed(() => {
+      const current = this.currentParameters();
+      const validated = this.validatedParameters();
+      if (!(id in current)) {
+        return false;
+      }
+      return !areValuesEqual(current[id], validated[id]);
+    });
+  }
+
+  /**
+   * Returns a computed signal indicating if the field was modified by the user from its default value.
+   */
+  isDirty(id: string): Signal<boolean> {
+    return computed(() => this.dirtyFields().has(id));
+  }
+
+  /**
+   * Sets the value for the parameter with the given ID.
+   */
+  set(id: string, value: unknown): void {
+    this.currentParameters.update((prev) => ({
+      ...prev,
+      [id]: value,
+    }));
+  }
+
+  /**
+   * Updates default values for parameters.
+   * Preserves user-modified (dirty) values while updating untouched fields.
+   */
+  setDefaultValues(defaultValues: { [id: string]: unknown }): void {
+    const current = this.currentParameters();
+    const dirty = this.dirtyFields();
+    const next: { [id: string]: unknown } = {};
+    for (const id of Object.keys({ ...current, ...defaultValues })) {
+      if (dirty.has(id)) {
+        next[id] = current[id];
+      } else {
+        next[id] = defaultValues[id];
+      }
+    }
+    this.currentParameters.set(next);
+    this.defaultParameters.set(defaultValues);
+  }
+
+  /**
+   * Sets the parameters that have been validated by a completed dryrun.
+   */
+  setValidatedParameters(params: { [id: string]: unknown }): void {
+    this.validatedParameters.set({ ...params });
+  }
+
+  /**
+   * Unregisters resources when the store is destroyed.
+   */
+  public destroy(): void {
+    // Signals automatically clean up without requiring manual unsubscription.
   }
 }

--- a/web/src/app/dialogs/new-inspection/components/service/parameter-store.ts
+++ b/web/src/app/dialogs/new-inspection/components/service/parameter-store.ts
@@ -127,6 +127,12 @@ export class DefaultParameterStore implements ParameterStore {
 
   readonly defaultParameters = signal<{ [id: string]: unknown }>({});
 
+  private readonly getSignals = new Map<string, Signal<unknown>>();
+
+  private readonly validatingSignals = new Map<string, Signal<boolean>>();
+
+  private readonly dirtySignals = new Map<string, Signal<boolean>>();
+
   private readonly dirtyFields = computed(() => {
     const current = this.currentParameters();
     const defaults = this.defaultParameters();
@@ -143,28 +149,43 @@ export class DefaultParameterStore implements ParameterStore {
    * Returns a computed signal of the value for the given parameter ID.
    */
   get<T>(id: string): Signal<T> {
-    return computed(() => this.currentParameters()[id] as T);
+    let sig = this.getSignals.get(id);
+    if (!sig) {
+      sig = computed(() => this.currentParameters()[id]);
+      this.getSignals.set(id, sig);
+    }
+    return sig as Signal<T>;
   }
 
   /**
    * Returns a computed signal indicating if the field's current value differs from the validated value.
    */
   isValidating(id: string): Signal<boolean> {
-    return computed(() => {
-      const current = this.currentParameters();
-      const validated = this.validatedParameters();
-      if (!(id in current)) {
-        return false;
-      }
-      return !areValuesEqual(current[id], validated[id]);
-    });
+    let sig = this.validatingSignals.get(id);
+    if (!sig) {
+      sig = computed(() => {
+        const current = this.currentParameters();
+        const validated = this.validatedParameters();
+        if (!(id in current)) {
+          return false;
+        }
+        return !areValuesEqual(current[id], validated[id]);
+      });
+      this.validatingSignals.set(id, sig);
+    }
+    return sig;
   }
 
   /**
    * Returns a computed signal indicating if the field was modified by the user from its default value.
    */
   isDirty(id: string): Signal<boolean> {
-    return computed(() => this.dirtyFields().has(id));
+    let sig = this.dirtySignals.get(id);
+    if (!sig) {
+      sig = computed(() => this.dirtyFields().has(id));
+      this.dirtySignals.set(id, sig);
+    }
+    return sig;
   }
 
   /**
@@ -207,6 +228,8 @@ export class DefaultParameterStore implements ParameterStore {
    * Unregisters resources when the store is destroyed.
    */
   public destroy(): void {
-    // Signals automatically clean up without requiring manual unsubscription.
+    this.getSignals.clear();
+    this.validatingSignals.clear();
+    this.dirtySignals.clear();
   }
 }

--- a/web/src/app/dialogs/new-inspection/components/set-parameter.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/set-parameter.component.spec.ts
@@ -28,7 +28,6 @@ import {
   DefaultParameterStore,
   PARAMETER_STORE,
 } from './service/parameter-store';
-import { firstValueFrom } from 'rxjs';
 import {
   BrowserTestingModule,
   platformBrowserTesting,
@@ -118,7 +117,7 @@ describe('SetParameterComponent', () => {
     // Simulate selection change
     component.onSelectionChange(['opt1', 'opt2']);
 
-    expect(await firstValueFrom(parameterStore.watchAll())).toEqual({
+    expect(parameterStore.currentParameters()).toEqual({
       'test-parameter-id': ['opt1', 'opt2'],
     });
   });

--- a/web/src/app/dialogs/new-inspection/components/set-parameter.component.ts
+++ b/web/src/app/dialogs/new-inspection/components/set-parameter.component.ts
@@ -15,17 +15,8 @@
  */
 
 import { CommonModule } from '@angular/common';
-import {
-  Component,
-  inject,
-  input,
-  OnInit,
-  OnDestroy,
-  computed,
-  signal,
-} from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { Subject, takeUntil } from 'rxjs';
 import {
   ParameterHintType,
   SetParameterFormField,
@@ -57,37 +48,24 @@ import { SetInputDescriptionOptionComponent } from './option-item.component';
     SetInputDescriptionOptionComponent,
   ],
 })
-export class SetParameterComponent implements OnInit, OnDestroy {
+export class SetParameterComponent {
   readonly ParameterHintType = ParameterHintType;
   readonly parameter = input.required<SetParameterFormField>();
 
   private readonly store = inject(PARAMETER_STORE);
-  private readonly destroyed = new Subject<void>();
-  readonly stagingInput = signal<string[]>([]);
 
-  choices = computed(() => {
+  readonly choices = computed(() => {
     return this.parameter().options.map((opt): SetInputItem => ({
       id: opt.id,
       value: opt,
     }));
   });
 
-  ngOnInit(): void {
-    this.store
-      .watch<string[]>(this.parameter().id)
-      .pipe(takeUntil(this.destroyed))
-      .subscribe((value) => {
-        this.stagingInput.set(value);
-      });
-  }
-
-  ngOnDestroy(): void {
-    this.destroyed.next();
-    this.destroyed.complete();
-  }
+  readonly stagingInput = computed(() => {
+    return this.store.get<string[]>(this.parameter().id)() ?? [];
+  });
 
   onSelectionChange(selectedItems: string[]): void {
-    this.stagingInput.set(selectedItems);
     this.store.set(this.parameter().id, selectedItems);
   }
 }

--- a/web/src/app/dialogs/new-inspection/components/set-parameter.stories.ts
+++ b/web/src/app/dialogs/new-inspection/components/set-parameter.stories.ts
@@ -16,18 +16,20 @@
 
 import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
 import { SetParameterComponent } from './set-parameter.component';
-import { PARAMETER_STORE } from './service/parameter-store';
+import {
+  DefaultParameterStore,
+  PARAMETER_STORE,
+} from './service/parameter-store';
 import {
   ParameterHintType,
   ParameterInputType,
 } from 'src/app/common/schema/form-types';
-import { of } from 'rxjs';
 
-const createParameterStoreMock = (initialValue: string[] = []) => ({
-  watch: () => of(initialValue),
-  watchDirty: () => of(false),
-  set: () => {},
-});
+const createParameterStore = (paramId: string, initialValue: string[] = []) => {
+  const store = new DefaultParameterStore();
+  store.setDefaultValues({ [paramId]: initialValue });
+  return store;
+};
 
 const meta: Meta<SetParameterComponent> = {
   title: 'Dialogs/NewInspection/SetParameter',
@@ -39,7 +41,7 @@ const meta: Meta<SetParameterComponent> = {
       providers: [
         {
           provide: PARAMETER_STORE,
-          useValue: createParameterStoreMock(),
+          useValue: new DefaultParameterStore(),
         },
       ],
     }),
@@ -75,7 +77,7 @@ export const Default: Story = {
       providers: [
         {
           provide: PARAMETER_STORE,
-          useValue: createParameterStoreMock([
+          useValue: createParameterStore('test-set-param', [
             '@managed',
             '-@any',
             '-pods',
@@ -113,7 +115,10 @@ export const WithPreselectedValues: Story = {
       providers: [
         {
           provide: PARAMETER_STORE,
-          useValue: createParameterStoreMock(['Option 2', 'Option 4']),
+          useValue: createParameterStore('test-set-param-preselected', [
+            'Option 2',
+            'Option 4',
+          ]),
         },
       ],
     }),

--- a/web/src/app/dialogs/new-inspection/components/text-parameter.component.html
+++ b/web/src/app/dialogs/new-inspection/components/text-parameter.component.html
@@ -24,7 +24,8 @@
     <input
       class="text-input"
       matInput
-      [value]="value | async"
+      [value]="value()"
+      (focus)="onFocus()"
       (input)="onInput($event)"
       (blur)="onBlur($event)"
       [placeholder]="param.default"

--- a/web/src/app/dialogs/new-inspection/components/text-parameter.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/text-parameter.component.spec.ts
@@ -31,7 +31,6 @@ import {
   DefaultParameterStore,
   PARAMETER_STORE,
 } from './service/parameter-store';
-import { firstValueFrom } from 'rxjs';
 import {
   BrowserTestingModule,
   platformBrowserTesting,
@@ -109,7 +108,7 @@ describe('TextParameterComponent', () => {
     const matInput = await harnessLoader.getHarness(MatInputHarness);
 
     await matInput.setValue('updated value');
-    expect(await firstValueFrom(parameterStore.watchAll())).toEqual({
+    expect(parameterStore.currentParameters()).toEqual({
       'test-parameter-id': 'updated value',
     });
   });
@@ -125,14 +124,34 @@ describe('TextParameterComponent', () => {
     const matInput = await harnessLoader.getHarness(MatInputHarness);
 
     await matInput.setValue('updated value');
-    expect(await firstValueFrom(parameterStore.watchAll())).toEqual({
+    expect(parameterStore.currentParameters()).toEqual({
       'test-parameter-id': 'the default value',
     });
 
     await matInput.blur();
-    expect(await firstValueFrom(parameterStore.watchAll())).toEqual({
+    expect(parameterStore.currentParameters()).toEqual({
       'test-parameter-id': 'updated value',
     });
+  });
+
+  it('should not overwrite input value when store is updated in background while focused', async () => {
+    fixture.componentRef.setInput('parameter', {
+      ...defaultParameter,
+      validationTiming: ParameterFormValidationTiming.Blur,
+    });
+    fixture.detectChanges();
+
+    const matInput = await harnessLoader.getHarness(MatInputHarness);
+    await matInput.focus();
+    await matInput.setValue('typing in progress');
+
+    // Simulate background dryrun updating default values
+    parameterStore.setDefaultValues({
+      'test-parameter-id': 'background updated value',
+    });
+    fixture.detectChanges();
+
+    expect(await matInput.getValue()).toBe('typing in progress');
   });
 
   it('should make its input disabled when parameter.readonly = true', async () => {

--- a/web/src/app/dialogs/new-inspection/components/text-parameter.component.ts
+++ b/web/src/app/dialogs/new-inspection/components/text-parameter.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { Component, inject, input, OnInit } from '@angular/core';
+import { Component, computed, inject, input, signal } from '@angular/core';
 import { ParameterHeaderComponent } from './parameter-header.component';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -31,14 +31,6 @@ import {
   MatAutocompleteSelectedEvent,
 } from '@angular/material/autocomplete';
 import { PARAMETER_STORE } from './service/parameter-store';
-import {
-  distinctUntilChanged,
-  merge,
-  Observable,
-  ReplaySubject,
-  Subject,
-  takeUntil,
-} from 'rxjs';
 
 /**
  * A form field of parameter in the new-inspection dialog.
@@ -57,76 +49,79 @@ import {
     MatAutocompleteModule,
   ],
 })
-export class TextParameterComponent implements OnInit {
+export class TextParameterComponent {
   /**
    * Exposes ParameterHintType enum to the template.
    */
   readonly ParameterHintType = ParameterHintType;
-  /**
-   * Subject that emits when the component is destroyed. Used for unsubscribing from observables.
-   */
-  readonly destroyed = new Subject();
+
   /**
    * The spec of this text type parameter.
    */
-  parameter = input.required<TextParameterFormField>();
+  readonly parameter = input.required<TextParameterFormField>();
 
   /**
    * Injects the PARAMETER_STORE service.
    */
-  store = inject(PARAMETER_STORE);
+  private readonly store = inject(PARAMETER_STORE);
 
   /**
-   * Observable that emits the current display value of the parameter.
+   * Tracks whether the input field currently has focus.
    */
-  value!: Observable<string>;
+  readonly isFocused = signal(false);
 
   /**
-   * ReplaySubject that keeps input values when validationTiming is 'onblur'.
+   * Staged input value when validationTiming is 'Blur'.
    */
-  private readonly stagingInput = new ReplaySubject<string>(1);
+  readonly stagingInput = signal<string | null>(null);
 
   /**
-   * Initializes the component.
-   * Subscribes to the parameter store and staging input to update the `value` observable.
+   * Computed display value of the parameter.
+   * While focused with staged input, preserves staged input to avoid background overwrites.
    */
-  ngOnInit(): void {
-    this.value = merge(
-      this.store.watch<string>(this.parameter().id),
-      this.stagingInput,
-    ).pipe(distinctUntilChanged(), takeUntil(this.destroyed));
+  readonly value = computed(() => {
+    const staged = this.stagingInput();
+    if (this.isFocused() && staged !== null) {
+      return staged;
+    }
+    return this.store.get<string>(this.parameter().id)() ?? '';
+  });
+
+  /**
+   * Handles focus event from the text field.
+   */
+  onFocus() {
+    this.isFocused.set(true);
   }
 
   /**
    * Handles input events from the text field.
-   * Updates the parameter store immediately if validationTiming is 'ParameterFormValidationTiming.Change', otherwise stages the input.
+   * Updates the parameter store immediately if validationTiming is 'Change', otherwise stages the input.
    */
   onInput(ev: Event) {
+    const inputValue = (ev.target as HTMLInputElement).value;
     if (
       this.parameter().validationTiming === ParameterFormValidationTiming.Change
     ) {
-      this.store.set(
-        this.parameter().id,
-        (ev.target as HTMLInputElement).value,
-      );
+      this.store.set(this.parameter().id, inputValue);
     } else {
-      this.stagingInput.next((ev.target as HTMLInputElement).value);
+      this.stagingInput.set(inputValue);
     }
   }
 
   /**
    * Handles blur events from the text field.
-   * Updates the parameter store if validationTiming is 'ParameterFormValidationTiming.Blur'.
+   * Commits the parameter store value if validationTiming is 'Blur'.
    */
   onBlur(ev: Event) {
+    this.isFocused.set(false);
     if (
       this.parameter().validationTiming === ParameterFormValidationTiming.Blur
     ) {
-      this.store.set(
-        this.parameter().id,
-        (ev.target as HTMLInputElement).value,
-      );
+      const inputValue = (ev.target as HTMLInputElement).value;
+      this.store.set(this.parameter().id, inputValue);
     }
+    this.stagingInput.set(null);
   }
 
   /**
@@ -134,5 +129,6 @@ export class TextParameterComponent implements OnInit {
    */
   onOptionSelected(ev: MatAutocompleteSelectedEvent) {
     this.store.set(this.parameter().id, ev.option.value);
+    this.stagingInput.set(null);
   }
 }

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.html
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.html
@@ -102,7 +102,7 @@ limitations under the License.
     <!--Step3 : Input parameters-->
     <mat-step>
       <ng-template matStepLabel>Input parameters</ng-template>
-      @if (parameterViewModel | async; as parameterViewModel) {
+      @if (parameterViewModel(); as parameterViewModel) {
         <div class="parameter-view">
           <div class="parameters-form-view allow-vertical-scroll">
             <khi-new-inspection-group-parameter

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
@@ -18,7 +18,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { signal } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { of, Subject } from 'rxjs';
+import { Observable, of, Subject } from 'rxjs';
 
 import {
   NewInspectionDialogComponent,
@@ -484,6 +484,32 @@ describe('NewInspectionDialogTest', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(mockDryrunDirect.calls.count()).toBe(initialCalls);
+    });
+
+    it('should unsubscribe from in-flight dryrun request when leaving parameter step', async () => {
+      let unsubscribed = false;
+      const observable = new Observable<InspectionDryRunResponse>(() => {
+        return () => {
+          unsubscribed = true;
+        };
+      });
+      mockDryrunDirect.and.returnValue(observable);
+
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT,
+      );
+      await fixture.whenStable();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(unsubscribed).toBe(false);
+
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_FEATURE_SELECTION,
+      );
+      await fixture.whenStable();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(unsubscribed).toBe(true);
     });
   });
 });

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
@@ -18,6 +18,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { signal } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of, Subject } from 'rxjs';
 
 import {
   NewInspectionDialogComponent,
@@ -26,7 +27,20 @@ import {
 } from './new-inspection.component';
 import { BACKEND_API } from 'src/app/services/api/backend-api-interface';
 import { BACKEND_SYNC } from 'src/app/services/api/backend-sync.service';
+import {
+  InspectionType,
+  InspectionDryRunResponse,
+} from 'src/app/common/schema/api-types';
 import { InspectionMetadataQuery } from 'src/app/common/schema/metadata-types';
+import {
+  ParameterHintType,
+  ParameterInputType,
+  ParameterFormValidationTiming,
+} from 'src/app/common/schema/form-types';
+import {
+  PARAMETER_STORE,
+  ParameterStore,
+} from './components/service/parameter-store';
 
 import {
   EXTENSION_STORE,
@@ -236,6 +250,240 @@ describe('NewInspectionDialogTest', () => {
         displayText: '>1,000 logs estimated (some parameters incomplete)',
         severity: TotalEstimatedLogsSeverity.Normal,
       });
+    });
+  });
+
+  describe('dryrunLoop', () => {
+    let mockDryrunDirect: jasmine.Spy;
+    let mockInspectionClient: {
+      features: unknown;
+      dryrunDirect: jasmine.Spy;
+      run: jasmine.Spy;
+    };
+    let mockApiClient: {
+      createInspection: jasmine.Spy;
+    };
+    let store: ParameterStore;
+
+    beforeEach(() => {
+      mockDryrunDirect = jasmine.createSpy('dryrunDirect');
+      mockInspectionClient = {
+        features: of([]),
+        dryrunDirect: mockDryrunDirect,
+        run: jasmine.createSpy('run').and.returnValue(of({})),
+      };
+      mockApiClient = TestBed.inject(BACKEND_API) as unknown as {
+        createInspection: jasmine.Spy;
+      };
+      mockApiClient.createInspection = jasmine
+        .createSpy('createInspection')
+        .and.returnValue(of(mockInspectionClient));
+
+      store = fixture.debugElement.injector.get(PARAMETER_STORE);
+      const testType: InspectionType = {
+        id: 'test-type',
+        name: 'Test Type',
+        icon: '',
+        description: '',
+      };
+      component.setInspectionType(testType);
+    });
+
+    it('should start dryrun loop and update parameterViewModel on response with default values not validating', async () => {
+      const dryrunResponse: InspectionDryRunResponse = {
+        metadata: {
+          form: [
+            {
+              id: 'text-param',
+              type: ParameterInputType.Text,
+              label: 'Text',
+              description: '',
+              hint: '',
+              hintType: ParameterHintType.None,
+              default: 'default-text',
+              readonly: false,
+              suggestions: [],
+              validationTiming: ParameterFormValidationTiming.Blur,
+            },
+            {
+              id: 'set-param',
+              type: ParameterInputType.Set,
+              label: 'Set',
+              description: '',
+              hint: '',
+              hintType: ParameterHintType.None,
+              options: [],
+              default: ['opt1', 'opt2'],
+              allowAddAll: false,
+              allowRemoveAll: false,
+              allowCustomValue: true,
+            },
+          ],
+          query: [],
+          plan: { taskGraph: '' },
+          jobCommand: { command: 'test-cmd' },
+        },
+      };
+      mockDryrunDirect.and.returnValue(of(dryrunResponse));
+
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT,
+      );
+
+      await fixture.whenStable();
+
+      expect(mockDryrunDirect).toHaveBeenCalledTimes(2);
+      const vm = component.parameterViewModel();
+      expect(vm).toBeTruthy();
+      expect(vm?.job?.command).toBe('test-cmd');
+      expect(store.isValidating('text-param')()).toBe(false);
+      expect(store.isValidating('set-param')()).toBe(false);
+      expect(store.isDirty('text-param')()).toBe(false);
+      expect(store.isDirty('set-param')()).toBe(false);
+    });
+
+    it('should keep fields in validating state after defaults are assigned until the next dryrun completes', async () => {
+      const dryrunResponse: InspectionDryRunResponse = {
+        metadata: {
+          form: [
+            {
+              id: 'text-param',
+              type: ParameterInputType.Text,
+              label: 'Text',
+              description: '',
+              hint: '',
+              hintType: ParameterHintType.None,
+              default: 'default-text',
+              readonly: false,
+              suggestions: [],
+              validationTiming: ParameterFormValidationTiming.Blur,
+            },
+          ],
+          query: [],
+          plan: { taskGraph: '' },
+          jobCommand: { command: 'test-cmd' },
+        },
+      };
+      const subject1 = new Subject<InspectionDryRunResponse>();
+      const subject2 = new Subject<InspectionDryRunResponse>();
+
+      let callCount = 0;
+      mockDryrunDirect.and.callFake(() => {
+        callCount++;
+        if (callCount === 1) {
+          return subject1;
+        }
+        return subject2;
+      });
+
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(mockDryrunDirect).toHaveBeenCalledTimes(1);
+
+      // Dryrun 1 response provides defaults
+      subject1.next(dryrunResponse);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // After defaults are assigned, text-param must be validating for the next dryrun
+      expect(store.isValidating('text-param')()).toBe(true);
+      expect(mockDryrunDirect).toHaveBeenCalledTimes(2);
+
+      // Second dryrun completes, validating the assigned defaults
+      subject2.next(dryrunResponse);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Once the next dryrun completes, text-param is no longer validating
+      expect(store.isValidating('text-param')()).toBe(false);
+    });
+
+    it('should discard stale response when parameters change while request is in flight', async () => {
+      const subject1 = new Subject<InspectionDryRunResponse>();
+      const subject2 = new Subject<InspectionDryRunResponse>();
+
+      let callCount = 0;
+      mockDryrunDirect.and.callFake(() => {
+        callCount++;
+        if (callCount === 1) {
+          return subject1;
+        }
+        return subject2;
+      });
+
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockDryrunDirect).toHaveBeenCalledTimes(1);
+
+      // User changes parameter while request 1 is in-flight
+      store.set('param1', 'updated-value');
+
+      // Request 1 responds with stale job command
+      subject1.next({
+        metadata: {
+          form: [],
+          query: [],
+          plan: { taskGraph: '' },
+          jobCommand: { command: 'stale-cmd' },
+        },
+      });
+      subject1.complete();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Loop should have immediately triggered second request with updated params
+      expect(mockDryrunDirect).toHaveBeenCalledTimes(2);
+      expect(mockDryrunDirect.calls.mostRecent().args[0]).toEqual({
+        param1: 'updated-value',
+      });
+      // The stale result should NOT have been set
+      expect(component.parameterViewModel()).toBeNull();
+
+      // Request 2 responds with updated job command
+      subject2.next({
+        metadata: {
+          form: [],
+          query: [],
+          plan: { taskGraph: '' },
+          jobCommand: { command: 'updated-cmd' },
+        },
+      });
+      subject2.complete();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const vm = component.parameterViewModel();
+      expect(vm?.job?.command).toBe('updated-cmd');
+      expect(store.validatedParameters()['param1']).toBe('updated-value');
+    });
+
+    it('should stop dryrun loop when leaving parameter step', async () => {
+      mockDryrunDirect.and.returnValue(
+        of({
+          metadata: {
+            form: [],
+            query: [],
+            plan: { taskGraph: '' },
+            jobCommand: { command: 'cmd' },
+          },
+        }),
+      );
+
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT,
+      );
+      await fixture.whenStable();
+
+      const initialCalls = mockDryrunDirect.calls.count();
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_FEATURE_SELECTION,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mockDryrunDirect.calls.count()).toBe(initialCalls);
     });
   });
 });

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.ts
@@ -20,9 +20,8 @@ import {
   BehaviorSubject,
   Subject,
   filter,
-  interval,
+  firstValueFrom,
   map,
-  merge,
   shareReplay,
   switchMap,
   take,
@@ -30,7 +29,7 @@ import {
   withLatestFrom,
 } from 'rxjs';
 import {
-  InspectionDryRunRequest,
+  InspectionMetadataInDryrun,
   InspectionType,
 } from 'src/app/common/schema/api-types';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -57,6 +56,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import {
   DefaultParameterStore,
+  haveEqualKeyValues,
   PARAMETER_STORE,
 } from './components/service/parameter-store';
 import {
@@ -257,39 +257,13 @@ export class NewInspectionDialogComponent implements OnDestroy {
       .subscribe(([featureIds, client]) => {
         client.setFeatures(featureIds);
       });
-    this.dryrunRequest
-      .pipe(takeUntil(this.destroyed), withLatestFrom(this.currentTaskClient))
-      .subscribe(([req, client]) => {
-        client.dryrun(req);
-      });
-
-    // Send dryrun request to server when any of the parameters changed or every seconds to validate parameters.
-    const newValueFromStore = this.store.watchAll();
-    const periodicUpdate = interval(1000).pipe(
-      withLatestFrom(this.store.watchAll()),
-      map(([, values]) => values),
-    );
-    merge(newValueFromStore, periodicUpdate)
-      .pipe(takeUntil(this.destroyed))
-      .subscribe((values) => {
-        this.dryrunRequest.next(values);
-      });
-
-    // Receive the form field parameters and extract default values, then set it to the store.
-    this.currentDryrunMetadata
-      .pipe(takeUntil(this.destroyed))
-      .subscribe((metadata) => {
-        const defaultValues = this.flattenDefaultValues(metadata.form);
-        this.store.setDefaultValues(defaultValues);
-      });
-
     // Event handler reacting to the `Run` button click.
     this.startInspectionSubject
       .pipe(
         takeUntil(this.destroyed),
         take(1),
-        withLatestFrom(this.currentTaskClient, this.store.watchAll()),
-        switchMap(([, client, parameters]) => client.run(parameters)),
+        withLatestFrom(this.currentTaskClient),
+        switchMap(([, client]) => client.run(this.store.currentParameters())),
       )
       .subscribe(() => {
         this.extension.notifyLifecycleOnInspectionStart();
@@ -335,45 +309,18 @@ export class NewInspectionDialogComponent implements OnDestroy {
 
   private featureToggleRequest = new Subject<string>();
 
-  private dryrunRequest = new Subject<InspectionDryRunRequest>();
-
   private startInspectionSubject = new Subject<void>();
 
-  private currentDryrunMetadata = this.currentTaskClient.pipe(
-    switchMap((client) => client.dryRunResult),
-    map((result) => result.metadata),
-  );
+  /**
+   * parameterViewModel contains the current ParameterPageViewModel.
+   * Holds null initially until the first dryrun finishes, or when reset.
+   */
+  readonly parameterViewModel = signal<ParameterPageViewModel | null>(null);
 
   /**
-   * parameterViewModelResetSubject emits null when the previous parameterViewModel needs to be refreshed.
+   * Abort controller for cancelling the ongoing dryrun loop.
    */
-  private parameterViewModelResetSubject = new Subject<null>();
-
-  /**
-   * parameterViewModel emits the current ParameterViewModel.
-   * This emits null as its initial value on opening the parameter page.
-   */
-  parameterViewModel = merge(
-    this.currentDryrunMetadata.pipe(
-      map((metadata) => {
-        const errorFieldCount = this.countErrorFields(metadata.form);
-        const fieldCount = this.countAllFields(metadata.form);
-        return {
-          rootGroupForm: {
-            type: ParameterInputType.Group,
-            children: metadata.form,
-          },
-          queries: metadata.query,
-          plan: metadata.plan,
-          job: metadata.jobCommand,
-          errorFieldCount: errorFieldCount,
-          fieldCount: fieldCount,
-          totalEstimatedSummary: computeTotalEstimatedLogs(metadata.query),
-        } as ParameterPageViewModel;
-      }),
-    ),
-    this.parameterViewModelResetSubject,
-  );
+  private loopAbortController: AbortController | null = null;
 
   public setInspectionType(inspectionType: InspectionType) {
     this.currentInspectionType.next(inspectionType);
@@ -385,10 +332,109 @@ export class NewInspectionDialogComponent implements OnDestroy {
   public selectedStepChange(stepIndex: number) {
     if (stepIndex === NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT) {
       // Reset the parameter view model every time entering STEP_INDEX_PARAMETER_INPUT otherwise parameter list can be stale.
-      this.parameterViewModelResetSubject.next(null);
-
-      this.dryrunRequest.next({});
+      this.parameterViewModel.set(null);
+      this.startDryrunLoop();
+    } else {
+      this.stopDryrunLoop();
     }
+  }
+
+  /**
+   * Runs the dryrun loop sequentially. Executes a dryrun request, checks if user input changed during flight,
+   * updates the store and view model if unchanged, or immediately re-runs if inputs changed while in-flight.
+   */
+  private async startDryrunLoop() {
+    this.stopDryrunLoop();
+    const abortController = new AbortController();
+    this.loopAbortController = abortController;
+    const signal = abortController.signal;
+
+    const client = await firstValueFrom(this.currentTaskClient);
+    if (signal.aborted || !client) {
+      return;
+    }
+
+    while (!signal.aborted) {
+      const sentParams = this.store.currentParameters();
+      try {
+        const res = await firstValueFrom(client.dryrunDirect(sentParams));
+        if (signal.aborted) {
+          break;
+        }
+
+        const currentParams = this.store.currentParameters();
+        const changedDuringFlight = !haveEqualKeyValues(
+          sentParams,
+          currentParams,
+        );
+
+        if (!changedDuringFlight) {
+          this.store.setValidatedParameters(sentParams);
+          this.updateParameterViewModel(res.metadata);
+          this.store.setDefaultValues(
+            this.flattenDefaultValues(res.metadata.form),
+          );
+
+          // If setDefaultValues assigned new defaults, currentParameters now differs from sentParams.
+          // In this case, do not delay so the next dryrun validating those defaults executes immediately.
+          const paramsAfterDefaults = this.store.currentParameters();
+          if (haveEqualKeyValues(sentParams, paramsAfterDefaults)) {
+            await this.delay(800, signal);
+          }
+        }
+        // If changedDuringFlight is true, immediately loop without delay to validate the new inputs.
+      } catch {
+        if (signal.aborted) {
+          break;
+        }
+        await this.delay(1000, signal);
+      }
+    }
+  }
+
+  private stopDryrunLoop() {
+    if (this.loopAbortController) {
+      this.loopAbortController.abort();
+      this.loopAbortController = null;
+    }
+  }
+
+  private delay(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(resolve, ms);
+      signal.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+  }
+
+  private updateParameterViewModel(metadata: InspectionMetadataInDryrun) {
+    const errorFieldCount = this.countErrorFields(metadata.form);
+    const fieldCount = this.countAllFields(metadata.form);
+    this.parameterViewModel.set({
+      rootGroupForm: {
+        id: 'root',
+        label: '',
+        description: '',
+        hint: '',
+        hintType: ParameterHintType.None,
+        type: ParameterInputType.Group,
+        collapsible: false,
+        collapsedByDefault: false,
+        children: metadata.form,
+      },
+      queries: metadata.query,
+      plan: metadata.plan,
+      job: metadata.jobCommand,
+      errorFieldCount: errorFieldCount,
+      fieldCount: fieldCount,
+      totalEstimatedSummary: computeTotalEstimatedLogs(metadata.query),
+    });
   }
 
   public toggleFeature(featureId: string) {
@@ -461,6 +507,7 @@ export class NewInspectionDialogComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.stopDryrunLoop();
     if (this.store instanceof DefaultParameterStore) {
       this.store.destroy();
     }

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.ts
@@ -21,6 +21,7 @@ import {
   Subject,
   filter,
   firstValueFrom,
+  fromEvent,
   map,
   shareReplay,
   switchMap,
@@ -76,6 +77,16 @@ import {
   EXTENSION_STORE,
   ExtensionStore,
 } from 'src/app/extensions/extension-common/extension-store';
+
+/**
+ * Error indicating that an asynchronous operation or delay was cancelled.
+ */
+export class CancellationError extends Error {
+  constructor(message = 'Operation was cancelled') {
+    super(message);
+    this.name = 'CancellationError';
+  }
+}
 
 export interface NewInspectionDialogResult {
   readonly inspectionTaskStarted: boolean;
@@ -357,7 +368,11 @@ export class NewInspectionDialogComponent implements OnDestroy {
     while (!signal.aborted) {
       const sentParams = this.store.currentParameters();
       try {
-        const res = await firstValueFrom(client.dryrunDirect(sentParams));
+        const res = await firstValueFrom(
+          client
+            .dryrunDirect(sentParams)
+            .pipe(takeUntil(fromEvent(signal, 'abort'))),
+        );
         if (signal.aborted) {
           break;
         }
@@ -383,11 +398,17 @@ export class NewInspectionDialogComponent implements OnDestroy {
           }
         }
         // If changedDuringFlight is true, immediately loop without delay to validate the new inputs.
-      } catch {
-        if (signal.aborted) {
+      } catch (err) {
+        if (signal.aborted || err instanceof CancellationError) {
           break;
         }
-        await this.delay(1000, signal);
+        try {
+          await this.delay(1000, signal);
+        } catch {
+          if (signal.aborted) {
+            break;
+          }
+        }
       }
     }
   }
@@ -400,13 +421,16 @@ export class NewInspectionDialogComponent implements OnDestroy {
   }
 
   private delay(ms: number, signal: AbortSignal): Promise<void> {
-    return new Promise((resolve) => {
+    if (signal.aborted) {
+      return Promise.reject(new CancellationError('Delay aborted'));
+    }
+    return new Promise((resolve, reject) => {
       const timer = setTimeout(resolve, ms);
       signal.addEventListener(
         'abort',
         () => {
           clearTimeout(timer);
-          resolve();
+          reject(new CancellationError('Delay aborted'));
         },
         { once: true },
       );


### PR DESCRIPTION
## Summary
Resolves an issue where user input during in-flight dryrun requests in the new-inspection dialog prevented form validation states from updating.

- Implements a sequential completion-driven dryrun loop in `NewInspectionDialogComponent` that checks whether parameters changed during flight.
- If parameters changed while a request was in flight, the stale response is discarded and an immediate re-validation dryrun is dispatched with the latest inputs without waiting for the polling delay.
- Migrates `ParameterStore` from RxJS subjects to Angular Signals (`signal()`, `computed()`), removing legacy watchers (`watch`, `watchDirty`, `watchAll`).
- Introduces `areValuesEqual` deep value equality helper in `ParameterStore` so array parameters (`SetParameter`) and Date objects compare by value rather than reference equality, preventing fields from endlessly remaining in the validating state.
- Accurately tracks validation lifecycle for remote-assigned default values, keeping fields in validating state until the subsequent dryrun actually validates them.
- Protects `TextParameterComponent` inputs from being overwritten by completed background dryruns while focused, and stages input locally when `validationTiming === Blur`.
- Displays a small spinner next to form field titles while validation is in-flight.

## Verification
- `make test-web` (784 tests pass)
- `make pre-commit` (linters, formatters, and style checkers pass cleanly with 0 issues)