### PR TITLE
feat(inspection): add pending status for asynchronous validation and estimation

### DIFF
--- a/pkg/api/googlecloud/logestimator/cached_estimator.go
+++ b/pkg/api/googlecloud/logestimator/cached_estimator.go
@@ -67,27 +67,9 @@ func (e *CachedStructuredLogEstimator) EstimateWithTaskSlot(
 	startTime, endTime time.Time,
 	provider EstimatorProvider,
 ) (*EstimateResult, error) {
-	cacheKey := fmt.Sprintf("%s|%s|%d|%d",
-		container.Identifier(),
-		query.GenerateCloudLoggingQuery(),
-		startTime.UnixNano(),
-		endTime.UnixNano(),
-	)
-
-	res, pending, err := e.EstimateWithTaskSlotNonBlocking(ctx, taskSlotKey, container, query, startTime, endTime, provider)
+	res, flight, pending, err := e.estimateWithTaskSlotInternal(ctx, taskSlotKey, container, query, startTime, endTime, provider)
 	if !pending {
 		return res, err
-	}
-
-	e.mu.Lock()
-	flight, ok := e.flights[cacheKey]
-	e.mu.Unlock()
-	if !ok {
-		// Finished between non-blocking call and lock
-		e.mu.Lock()
-		res := e.cache[cacheKey]
-		e.mu.Unlock()
-		return res, nil
 	}
 
 	select {
@@ -110,6 +92,19 @@ func (e *CachedStructuredLogEstimator) EstimateWithTaskSlotNonBlocking(
 	startTime, endTime time.Time,
 	provider EstimatorProvider,
 ) (*EstimateResult, bool, error) {
+	res, _, pending, err := e.estimateWithTaskSlotInternal(ctx, taskSlotKey, container, query, startTime, endTime, provider)
+	return res, pending, err
+}
+
+// estimateWithTaskSlotInternal handles the core estimation logic under lock and returns the active flightCall pointer.
+func (e *CachedStructuredLogEstimator) estimateWithTaskSlotInternal(
+	ctx context.Context,
+	taskSlotKey string,
+	container googlecloud.ResourceContainer,
+	query *StructuredLogQuery,
+	startTime, endTime time.Time,
+	provider EstimatorProvider,
+) (*EstimateResult, *flightCall, bool, error) {
 	cacheKey := fmt.Sprintf("%s|%s|%d|%d",
 		container.Identifier(),
 		query.GenerateCloudLoggingQuery(),
@@ -122,7 +117,7 @@ func (e *CachedStructuredLogEstimator) EstimateWithTaskSlotNonBlocking(
 	// 1. Return cached result if present.
 	if res, ok := e.cache[cacheKey]; ok {
 		e.mu.Unlock()
-		return res, false, nil
+		return res, nil, false, nil
 	}
 
 	// 2. If an in-flight query exists for this task slot with a different query, cancel it.
@@ -144,7 +139,7 @@ func (e *CachedStructuredLogEstimator) EstimateWithTaskSlotNonBlocking(
 			}
 		}
 		e.mu.Unlock()
-		return nil, true, nil
+		return nil, flight, true, nil
 	}
 
 	// 4. Start a new in-flight execution.
@@ -192,7 +187,7 @@ func (e *CachedStructuredLogEstimator) EstimateWithTaskSlotNonBlocking(
 		res, err = estimator.Estimate(callCtx, container, query, startTime, endTime)
 	}()
 
-	return nil, true, nil
+	return nil, flight, true, nil
 }
 
 // Close cancels all active in-flight requests and clears the estimation cache.

--- a/pkg/api/googlecloud/logestimator/cached_estimator.go
+++ b/pkg/api/googlecloud/logestimator/cached_estimator.go
@@ -74,12 +74,55 @@ func (e *CachedStructuredLogEstimator) EstimateWithTaskSlot(
 		endTime.UnixNano(),
 	)
 
+	res, pending, err := e.EstimateWithTaskSlotNonBlocking(ctx, taskSlotKey, container, query, startTime, endTime, provider)
+	if !pending {
+		return res, err
+	}
+
+	e.mu.Lock()
+	flight, ok := e.flights[cacheKey]
+	e.mu.Unlock()
+	if !ok {
+		// Finished between non-blocking call and lock
+		e.mu.Lock()
+		res := e.cache[cacheKey]
+		e.mu.Unlock()
+		return res, nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-flight.done:
+		return flight.res, flight.err
+	}
+}
+
+// EstimateWithTaskSlotNonBlocking estimates the log volume for the given query asynchronously without blocking the caller.
+// It returns (res, false, nil) if the result is already cached.
+// It returns (nil, true, nil) if the estimation is currently in-flight (pending).
+// It returns (nil, false, err) if an error occurred during estimation.
+func (e *CachedStructuredLogEstimator) EstimateWithTaskSlotNonBlocking(
+	ctx context.Context,
+	taskSlotKey string,
+	container googlecloud.ResourceContainer,
+	query *StructuredLogQuery,
+	startTime, endTime time.Time,
+	provider EstimatorProvider,
+) (*EstimateResult, bool, error) {
+	cacheKey := fmt.Sprintf("%s|%s|%d|%d",
+		container.Identifier(),
+		query.GenerateCloudLoggingQuery(),
+		startTime.UnixNano(),
+		endTime.UnixNano(),
+	)
+
 	e.mu.Lock()
 
 	// 1. Return cached result if present.
 	if res, ok := e.cache[cacheKey]; ok {
 		e.mu.Unlock()
-		return res, nil
+		return res, false, nil
 	}
 
 	// 2. If an in-flight query exists for this task slot with a different query, cancel it.
@@ -101,13 +144,7 @@ func (e *CachedStructuredLogEstimator) EstimateWithTaskSlot(
 			}
 		}
 		e.mu.Unlock()
-
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-flight.done:
-			return flight.res, flight.err
-		}
+		return nil, true, nil
 	}
 
 	// 4. Start a new in-flight execution.
@@ -155,12 +192,7 @@ func (e *CachedStructuredLogEstimator) EstimateWithTaskSlot(
 		res, err = estimator.Estimate(callCtx, container, query, startTime, endTime)
 	}()
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-flight.done:
-		return flight.res, flight.err
-	}
+	return nil, true, nil
 }
 
 // Close cancels all active in-flight requests and clears the estimation cache.

--- a/pkg/api/googlecloud/logestimator/cached_estimator_test.go
+++ b/pkg/api/googlecloud/logestimator/cached_estimator_test.go
@@ -340,3 +340,66 @@ func TestCachedStructuredLogEstimator_Close(t *testing.T) {
 		t.Errorf("expected in-flight task to be cancelled on Close()")
 	}
 }
+
+func TestCachedStructuredLogEstimator_EstimateWithTaskSlotNonBlocking(t *testing.T) {
+	cachedEstimator := NewCachedStructuredLogEstimator()
+	defer cachedEstimator.Close()
+
+	started := make(chan struct{})
+	provider := func(ctx context.Context, container googlecloud.ResourceContainer) (*StructuredLogEstimator, error) {
+		close(started)
+		return NewStructuredLogEstimator(&mockMetricLogCountFetcher{
+			delay: 50 * time.Millisecond,
+			count: 350,
+		}, nil, nil), nil
+	}
+
+	query := &StructuredLogQuery{
+		ResourceTypes: []string{"k8s_cluster"},
+	}
+	container := googlecloud.Project("test-project")
+	now := time.Now()
+	startTime := now.Add(-time.Hour)
+	endTime := now
+
+	// Call 1: Initiates non-blocking worker, should return pending immediately
+	res1, pending1, err1 := cachedEstimator.EstimateWithTaskSlotNonBlocking(context.Background(), "task-nb", container, query, startTime, endTime, provider)
+	if err1 != nil {
+		t.Fatalf("first EstimateWithTaskSlotNonBlocking unexpected error: %v", err1)
+	}
+	if !pending1 {
+		t.Errorf("first EstimateWithTaskSlotNonBlocking pending = false, want true")
+	}
+	if res1 != nil {
+		t.Errorf("first EstimateWithTaskSlotNonBlocking res = %v, want nil", res1)
+	}
+
+	<-started
+
+	// Call 2: While in flight, should also return pending immediately
+	res2, pending2, err2 := cachedEstimator.EstimateWithTaskSlotNonBlocking(context.Background(), "task-nb", container, query, startTime, endTime, provider)
+	if err2 != nil {
+		t.Fatalf("second EstimateWithTaskSlotNonBlocking unexpected error: %v", err2)
+	}
+	if !pending2 {
+		t.Errorf("second EstimateWithTaskSlotNonBlocking pending = false, want true")
+	}
+	if res2 != nil {
+		t.Errorf("second EstimateWithTaskSlotNonBlocking res = %v, want nil", res2)
+	}
+
+	// Wait for worker to finish
+	time.Sleep(100 * time.Millisecond)
+
+	// Call 3: After completion, should return cached result and pending = false
+	res3, pending3, err3 := cachedEstimator.EstimateWithTaskSlotNonBlocking(context.Background(), "task-nb", container, query, startTime, endTime, provider)
+	if err3 != nil {
+		t.Fatalf("third EstimateWithTaskSlotNonBlocking unexpected error: %v", err3)
+	}
+	if pending3 {
+		t.Errorf("third EstimateWithTaskSlotNonBlocking pending = true, want false")
+	}
+	if res3 == nil || res3.EstimatedCount != 350 {
+		t.Errorf("third EstimateWithTaskSlotNonBlocking res = %v, want count 350", res3)
+	}
+}

--- a/pkg/core/inspection/formtask/fileform.go
+++ b/pkg/core/inspection/formtask/fileform.go
@@ -105,7 +105,8 @@ func setFormHintsFromUploadResult(result upload.UploadResult, field inspectionme
 		field.HintType = inspectionmetadata.Error
 	case result.Status != upload.UploadStatusCompleted:
 		field.Hint = "File is being processed. Please wait a moment."
-		field.HintType = inspectionmetadata.Error
+		field.HintType = inspectionmetadata.Info
+		field.Pending = true
 	}
 	return field
 }

--- a/pkg/core/inspection/formtask/fileform_test.go
+++ b/pkg/core/inspection/formtask/fileform_test.go
@@ -135,8 +135,9 @@ func TestSetFormHintsFromUploadResult(t *testing.T) {
 					Type:     inspectionmetadata.File,
 					Label:    "Test File Field",
 					Priority: 0,
-					HintType: inspectionmetadata.Error,
+					HintType: inspectionmetadata.Info,
 					Hint:     "File is being processed. Please wait a moment.",
+					Pending:  true,
 				},
 				Token:  mockToken,
 				Status: upload.UploadStatusWaiting,
@@ -168,9 +169,9 @@ func TestSetFormHintsFromUploadResult(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := setFormHintsFromUploadResult(tc.uploadResult, baseField)
 
-			if result.Hint != tc.expectedField.Hint || result.HintType != tc.expectedField.HintType {
-				t.Errorf("setFormHintsFromUploadResult() unexpected result:\nwant: (hint=%s, hintType=%v)\ngot: (hint=%s, hintType=%v)",
-					tc.expectedField.Hint, tc.expectedField.HintType, result.Hint, result.HintType)
+			if result.Hint != tc.expectedField.Hint || result.HintType != tc.expectedField.HintType || result.Pending != tc.expectedField.Pending {
+				t.Errorf("setFormHintsFromUploadResult() unexpected result:\nwant: (hint=%s, hintType=%v, pending=%v)\ngot: (hint=%s, hintType=%v, pending=%v)",
+					tc.expectedField.Hint, tc.expectedField.HintType, tc.expectedField.Pending, result.Hint, result.HintType, result.Pending)
 			}
 		})
 	}

--- a/pkg/core/inspection/metadata/form_metadata.go
+++ b/pkg/core/inspection/metadata/form_metadata.go
@@ -82,6 +82,8 @@ type ParameterFormFieldBase struct {
 	HintType ParameterHintType `json:"hintType"`
 	// Hint is the message shown under the form field. Assign HintType as well when you assign a value to this field.
 	Hint string `json:"hint"`
+	// Pending indicates whether this form field has an asynchronous operation in progress.
+	Pending bool `json:"pending,omitempty"`
 }
 
 // GroupParameterFormField represents Group type parameter specific data.

--- a/pkg/core/inspection/metadata/query_metadata.go
+++ b/pkg/core/inspection/metadata/query_metadata.go
@@ -28,6 +28,7 @@ type QueryItem struct {
 	Query          string `json:"query"`
 	EstimatedCount *int64 `json:"estimatedCount,omitempty"`
 	Incomplete     bool   `json:"incomplete,omitempty"`
+	Pending        bool   `json:"pending,omitempty"`
 }
 
 type QueryMetadata struct {
@@ -50,20 +51,25 @@ func (q *QueryMetadata) ToSerializable() interface{} {
 
 // SetQuery sets or updates the query item with no estimated count (nil).
 func (q *QueryMetadata) SetQuery(id string, name string, queryString string) {
-	q.setQueryInternal(id, name, queryString, nil, false)
+	q.setQueryInternal(id, name, queryString, nil, false, false)
 }
 
 // SetIncompleteQuery sets or updates the query item marked as incomplete without an estimated count.
 func (q *QueryMetadata) SetIncompleteQuery(id string, name string, queryString string) {
-	q.setQueryInternal(id, name, queryString, nil, true)
+	q.setQueryInternal(id, name, queryString, nil, true, false)
+}
+
+// SetPendingQuery sets or updates the query item marked as pending without an estimated count.
+func (q *QueryMetadata) SetPendingQuery(id string, name string, queryString string) {
+	q.setQueryInternal(id, name, queryString, nil, false, true)
 }
 
 // SetQueryWithEstimate sets or updates the query item along with its estimated log count.
 func (q *QueryMetadata) SetQueryWithEstimate(id string, name string, queryString string, estimatedCount int64) {
-	q.setQueryInternal(id, name, queryString, &estimatedCount, false)
+	q.setQueryInternal(id, name, queryString, &estimatedCount, false, false)
 }
 
-func (q *QueryMetadata) setQueryInternal(id string, name string, queryString string, estimatedCount *int64, incomplete bool) {
+func (q *QueryMetadata) setQueryInternal(id string, name string, queryString string, estimatedCount *int64, incomplete bool, pending bool) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	for _, qi := range q.Queries {
@@ -72,6 +78,7 @@ func (q *QueryMetadata) setQueryInternal(id string, name string, queryString str
 			qi.Query = queryString
 			qi.EstimatedCount = estimatedCount
 			qi.Incomplete = incomplete
+			qi.Pending = pending
 			return
 		}
 	}
@@ -81,6 +88,7 @@ func (q *QueryMetadata) setQueryInternal(id string, name string, queryString str
 		Query:          queryString,
 		EstimatedCount: estimatedCount,
 		Incomplete:     incomplete,
+		Pending:        pending,
 	})
 }
 

--- a/pkg/core/inspection/metadata/query_metadata_test.go
+++ b/pkg/core/inspection/metadata/query_metadata_test.go
@@ -64,3 +64,18 @@ func TestQueryMetadata_SetQueryWithEstimate(t *testing.T) {
 		t.Errorf("SetQueryWithEstimate mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestQueryMetadata_SetPendingQuery(t *testing.T) {
+	qm := NewQueryMetadata()
+	qm.SetQuery("q1", "Query 1", "resource.type=k8s_container")
+	qm.SetPendingQuery("q2", "Query 2", "resource.type=k8s_node")
+
+	expected := []*QueryItem{
+		{Id: "q1", Name: "Query 1", Query: "resource.type=k8s_container"},
+		{Id: "q2", Name: "Query 2", Query: "resource.type=k8s_node", Pending: true},
+	}
+
+	if diff := cmp.Diff(expected, qm.ToSerializable()); diff != "" {
+		t.Errorf("SetPendingQuery mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
@@ -206,9 +206,10 @@ func estimateAndRecordQueries(
 
 		var totalEstimatedCount int64
 		var estimated *int64
+		anyPending := false
 		for _, group := range groups {
 			taskSlotKey := fmt.Sprintf("%s/%s/%d", taskID, group.container.Identifier(), queryIndex)
-			res, estErr := estimatorCache.EstimateWithTaskSlot(
+			res, isPending, estErr := estimatorCache.EstimateWithTaskSlotNonBlocking(
 				ctx,
 				taskSlotKey,
 				group.container,
@@ -224,15 +225,18 @@ func estimateAndRecordQueries(
 					return logestimator.NewStructuredLogEstimatorFromClients(loggingClient, metricClient, callOptionInjector), nil
 				},
 			)
-			if estErr != nil {
+			switch {
+			case isPending:
+				anyPending = true
+			case estErr != nil:
 				slog.WarnContext(ctx, fmt.Sprintf("log estimation failed for query %s in %s: %v", queryName, group.container.Identifier(), estErr))
-			} else {
+			case res != nil:
 				totalEstimatedCount += res.EstimatedCount
 				estimated = &totalEstimatedCount
 			}
 		}
 		filterString := q.GenerateCloudLoggingQuery()
-		if err := setStructuredQueryInfo(ctx, taskID, filterString, queryIndex, len(queries), startTime, endTime, queryName, estimated, false); err != nil {
+		if err := setStructuredQueryInfoWithPending(ctx, taskID, filterString, queryIndex, len(queries), startTime, endTime, queryName, estimated, false, anyPending); err != nil {
 			return err
 		}
 	}
@@ -294,6 +298,11 @@ func fetchLogsForStructuredQueries(
 
 // setStructuredQueryInfo records the generated Cloud Logging query details and estimated count into the inspection run metadata.
 func setStructuredQueryInfo(ctx context.Context, taskID, baseLogFilter string, logFilterIndex, totalLogFilterCount int, startTime, endTime time.Time, queryName string, estimatedCount *int64, incomplete bool) error {
+	return setStructuredQueryInfoWithPending(ctx, taskID, baseLogFilter, logFilterIndex, totalLogFilterCount, startTime, endTime, queryName, estimatedCount, incomplete, false)
+}
+
+// setStructuredQueryInfoWithPending records the generated Cloud Logging query details, estimated count, and pending status into the inspection run metadata.
+func setStructuredQueryInfoWithPending(ctx context.Context, taskID, baseLogFilter string, logFilterIndex, totalLogFilterCount int, startTime, endTime time.Time, queryName string, estimatedCount *int64, incomplete bool, pending bool) error {
 	metadata := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionRunMetadata)
 	queryInfo, found := typedmap.Get(metadata, inspectionmetadata.QueryMetadataKey)
 	if !found {
@@ -311,6 +320,8 @@ func setStructuredQueryInfo(ctx context.Context, taskID, baseLogFilter string, l
 	switch {
 	case incomplete:
 		queryInfo.SetIncompleteQuery(taskID, logFilterName, finalFilter)
+	case pending:
+		queryInfo.SetPendingQuery(taskID, logFilterName, finalFilter)
 	case estimatedCount != nil:
 		queryInfo.SetQueryWithEstimate(taskID, logFilterName, finalFilter, *estimatedCount)
 	default:

--- a/web/src/app/common/schema/form-types.ts
+++ b/web/src/app/common/schema/form-types.ts
@@ -62,6 +62,10 @@ export interface ParameterFormFieldBase {
    * The hint message shown at the bottom of inputs.
    */
   hint: string;
+  /**
+   * Whether this parameter field has an asynchronous operation in progress.
+   */
+  readonly pending?: boolean;
 }
 
 /**

--- a/web/src/app/common/schema/metadata-types.ts
+++ b/web/src/app/common/schema/metadata-types.ts
@@ -32,6 +32,7 @@ export type InspectionMetadataQuery = {
   readonly query: string;
   readonly estimatedCount?: number;
   readonly incomplete?: boolean;
+  readonly pending?: boolean;
 };
 
 export type InspectionMetadataErrorSet = {

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.html
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.html
@@ -17,7 +17,7 @@
 <div class="container">
   <div class="label-row">
     @if (showValidationStatus()) {
-      @if (isValidating()) {
+      @if (isPendingOrValidating()) {
         <mat-spinner diameter="16" class="validation-spinner"></mat-spinner>
       } @else if (param.hintType === ParameterHintType.Error) {
         <mat-icon class="error">error</mat-icon>

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.scss
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.scss
@@ -60,6 +60,10 @@ $dirty-icon-size: 15px;
   color: $error-icon-color;
 }
 
+.pending-spinner {
+  margin: 3px;
+}
+
 .description {
   margin: 0 0 2px 20px;
   font-size: 12px;

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.scss
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.scss
@@ -60,10 +60,6 @@ $dirty-icon-size: 15px;
   color: $error-icon-color;
 }
 
-.pending-spinner {
-  margin: 3px;
-}
-
 .description {
   margin: 0 0 2px 20px;
   font-size: 12px;

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.spec.ts
@@ -118,4 +118,23 @@ describe('ParameterHeaderComponent', () => {
     );
     expect(icons.length).toBe(0);
   });
+
+  it('should show spinner when pending = true', () => {
+    fixture.componentRef.setInput('parameter', {
+      id: 'test-param-pending',
+      label: 'test-label',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, \n sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      hintType: ParameterHintType.None,
+      pending: true,
+    });
+    fixture.detectChanges();
+    const spinner = fixture.debugElement.query(By.css('.validation-spinner'));
+    expect(spinner).toBeTruthy();
+
+    const icons = fixture.debugElement.queryAll(
+      By.css('mat-icon.verified, mat-icon.error'),
+    );
+    expect(icons.length).toBe(0);
+  });
 });

--- a/web/src/app/dialogs/new-inspection/components/parameter-header.component.ts
+++ b/web/src/app/dialogs/new-inspection/components/parameter-header.component.ts
@@ -23,8 +23,8 @@ import {
 } from 'src/app/common/schema/form-types';
 import { PARAMETER_STORE } from './service/parameter-store';
 import { CommonModule } from '@angular/common';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 /**
  * Component of common parameter headers used in new inspection dialog.
@@ -63,6 +63,13 @@ export class ParameterHeaderComponent {
    */
   readonly isValidating = computed(() => {
     return this.store.isValidating(this.parameter().id)();
+  });
+
+  /**
+   * Computed signal indicating if the parameter is currently being validated or has a server-side pending task.
+   */
+  readonly isPendingOrValidating = computed(() => {
+    return this.isValidating() || !!this.parameter().pending;
   });
 
   /**

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.html
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.html
@@ -143,7 +143,9 @@ limitations under the License.
                           <span class="query-incomplete"
                             >Incomplete parameters</span
                           >
-                        } @else if (query.estimatedCount !== undefined) {
+                        } @else if (
+                          query.estimatedCount !== undefined && !query.pending
+                        ) {
                           <span class="query-estimated-count"
                             >~{{ query.estimatedCount | number }} logs
                             estimated</span
@@ -186,15 +188,24 @@ limitations under the License.
             </mat-card>
           </div>
           <div class="parameters-footer">
-            @if (parameterViewModel.errorFieldCount !== 0) {
+            @if (errorFieldCount() !== 0) {
               <p class="errmsg-parameters-error">
                 Fix the validation errors on the input parameters:
-                {{ parameterViewModel.errorFieldCount }} /
+                {{ errorFieldCount() }} /
                 {{ parameterViewModel.fieldCount }}
               </p>
+            } @else if (pendingFieldCount() !== 0) {
+              <div class="pending-parameters">
+                <mat-spinner diameter="14"></mat-spinner>
+                <span>
+                  Resolving parameters:
+                  {{ pendingFieldCount() }} /
+                  {{ parameterViewModel.fieldCount }}
+                </span>
+              </div>
             }
             <button
-              [disabled]="hadRun() || parameterViewModel.errorFieldCount !== 0"
+              [disabled]="isRunButtonDisabled()"
               mat-raised-button
               color="primary"
               (click)="onRunButtonClick()"

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.scss
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.scss
@@ -30,6 +30,7 @@ $callout-warning-text: #e65100;
 $callout-danger-bg: #ffebee;
 $callout-danger-border: #ffcdd2;
 $callout-danger-text: #c62828;
+$pending-parameters-color: #555;
 
 mat-dialog-content {
   overflow: hidden;
@@ -225,6 +226,18 @@ mat-step {
   .errmsg-parameters-error {
     color: red;
     margin: 0 20px;
+  }
+
+  .pending-parameters {
+    display: grid;
+    grid-template:
+      'spinner text' auto
+      / auto 1fr;
+    align-items: center;
+    gap: 8px;
+    margin: 0 20px;
+    color: $pending-parameters-color;
+    font-size: 0.88em;
   }
 }
 

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.spec.ts
@@ -251,6 +251,22 @@ describe('NewInspectionDialogTest', () => {
         severity: TotalEstimatedLogsSeverity.Normal,
       });
     });
+
+    it('should treat queries with pending = true as estimating', () => {
+      const queries: InspectionMetadataQuery[] = [
+        { id: 'q1', name: 'q1', query: 'query1', estimatedCount: 1000 },
+        { id: 'q2', name: 'q2', query: 'query2', pending: true },
+      ];
+      const result = computeTotalEstimatedLogs(queries);
+      expect(result).toEqual({
+        knownCount: 1000,
+        isComplete: false,
+        isEstimating: true,
+        isIncomplete: false,
+        displayText: '>1,000 logs estimated so far',
+        severity: TotalEstimatedLogsSeverity.Normal,
+      });
+    });
   });
 
   describe('dryrunLoop', () => {
@@ -340,6 +356,82 @@ describe('NewInspectionDialogTest', () => {
       expect(store.isValidating('set-param')()).toBe(false);
       expect(store.isDirty('text-param')()).toBe(false);
       expect(store.isDirty('set-param')()).toBe(false);
+    });
+
+    it('should track pendingFieldCount and disable run button when a field is server-pending or validating', async () => {
+      const dryrunResponse: InspectionDryRunResponse = {
+        metadata: {
+          form: [
+            {
+              id: 'text-param',
+              type: ParameterInputType.Text,
+              label: 'Text',
+              description: '',
+              hint: '',
+              hintType: ParameterHintType.None,
+              default: 'default-text',
+              readonly: false,
+              suggestions: [],
+              validationTiming: ParameterFormValidationTiming.Blur,
+              pending: true,
+            },
+          ],
+          query: [],
+          plan: { taskGraph: '' },
+          jobCommand: { command: 'test-cmd' },
+        },
+      };
+      mockDryrunDirect.and.returnValue(of(dryrunResponse));
+
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT,
+      );
+      await fixture.whenStable();
+
+      expect(component.pendingFieldCount()).toBe(1);
+      expect(component.isRunButtonDisabled()).toBe(true);
+    });
+
+    it('should suppress stale errors when field is validating', async () => {
+      const dryrunResponse: InspectionDryRunResponse = {
+        metadata: {
+          form: [
+            {
+              id: 'text-param',
+              type: ParameterInputType.Text,
+              label: 'Text',
+              description: '',
+              hint: 'Error message',
+              hintType: ParameterHintType.Error,
+              default: 'default-text',
+              readonly: false,
+              suggestions: [],
+              validationTiming: ParameterFormValidationTiming.Blur,
+            },
+          ],
+          query: [],
+          plan: { taskGraph: '' },
+          jobCommand: { command: 'test-cmd' },
+        },
+      };
+      mockDryrunDirect.and.returnValue(of(dryrunResponse));
+
+      component.selectedStepChange(
+        NewInspectionDialogComponent.STEP_INDEX_PARAMETER_INPUT,
+      );
+      await fixture.whenStable();
+
+      expect(component.errorFieldCount()).toBe(1);
+      expect(component.pendingFieldCount()).toBe(0);
+
+      // User changes the value, making it validating on client side
+      store.set('text-param', 'new-text');
+      fixture.detectChanges();
+
+      // Validating field should suppress the stale error and increase pendingFieldCount
+      expect(component.errorFieldCount()).toBe(0);
+      expect(component.pendingFieldCount()).toBe(1);
+      expect(component.isRunButtonDisabled()).toBe(true);
     });
 
     it('should keep fields in validating state after defaults are assigned until the next dryrun completes', async () => {

--- a/web/src/app/dialogs/new-inspection/new-inspection.component.ts
+++ b/web/src/app/dialogs/new-inspection/new-inspection.component.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { Component, inject, OnDestroy, signal, ViewChild } from '@angular/core';
+import {
+  Component,
+  computed,
+  inject,
+  OnDestroy,
+  signal,
+  ViewChild,
+} from '@angular/core';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import {
   BehaviorSubject,
@@ -124,10 +131,10 @@ export function computeTotalEstimatedLogs(
   }
   const hasIncomplete = queries.some((q) => q.incomplete);
   const hasUnestimated = queries.some(
-    (q) => q.estimatedCount === undefined && !q.incomplete,
+    (q) => (q.estimatedCount === undefined || q.pending) && !q.incomplete,
   );
   const knownCount = queries
-    .filter((q) => q.estimatedCount !== undefined)
+    .filter((q) => q.estimatedCount !== undefined && !q.pending)
     .reduce((sum, q) => sum + (q.estimatedCount ?? 0), 0);
 
   let severity = TotalEstimatedLogsSeverity.Normal;
@@ -196,6 +203,7 @@ export interface ParameterPageViewModel {
   readonly plan: InspectionMetadataPlan;
   readonly job?: InspectionMetadataJobModeCommand;
   readonly errorFieldCount: number;
+  readonly pendingFieldCount: number;
   readonly fieldCount: number;
   readonly totalEstimatedSummary?: TotalEstimatedLogsSummary;
 }
@@ -333,6 +341,41 @@ export class NewInspectionDialogComponent implements OnDestroy {
    */
   private loopAbortController: AbortController | null = null;
 
+  /**
+   * Computed signal of pending field count.
+   * Counts fields that are currently undergoing server pending task or client validation.
+   */
+  readonly pendingFieldCount = computed(() => {
+    const vm = this.parameterViewModel();
+    if (!vm) {
+      return 0;
+    }
+    return this.countPendingFields(vm.rootGroupForm.children);
+  });
+
+  /**
+   * Computed signal of error field count.
+   * Suppresses stale errors for fields that are currently undergoing validation or server pending.
+   */
+  readonly errorFieldCount = computed(() => {
+    const vm = this.parameterViewModel();
+    if (!vm) {
+      return 0;
+    }
+    return this.countErrorFields(vm.rootGroupForm.children);
+  });
+
+  /**
+   * Computed signal indicating if the run button should be disabled.
+   */
+  readonly isRunButtonDisabled = computed(() => {
+    return (
+      this.hadRun() ||
+      this.errorFieldCount() !== 0 ||
+      this.pendingFieldCount() !== 0
+    );
+  });
+
   public setInspectionType(inspectionType: InspectionType) {
     this.currentInspectionType.next(inspectionType);
     setTimeout(() => {
@@ -439,6 +482,7 @@ export class NewInspectionDialogComponent implements OnDestroy {
 
   private updateParameterViewModel(metadata: InspectionMetadataInDryrun) {
     const errorFieldCount = this.countErrorFields(metadata.form);
+    const pendingFieldCount = this.countPendingFields(metadata.form);
     const fieldCount = this.countAllFields(metadata.form);
     this.parameterViewModel.set({
       rootGroupForm: {
@@ -456,6 +500,7 @@ export class NewInspectionDialogComponent implements OnDestroy {
       plan: metadata.plan,
       job: metadata.jobCommand,
       errorFieldCount: errorFieldCount,
+      pendingFieldCount: pendingFieldCount,
       fieldCount: fieldCount,
       totalEstimatedSummary: computeTotalEstimatedLogs(metadata.query),
     });
@@ -500,15 +545,41 @@ export class NewInspectionDialogComponent implements OnDestroy {
 
   /**
    * Count error fields.
+   * Suppresses error count when the field is pending or validating.
    * This ignores Group type form because the group itself isn't a field.
    */
-  private countErrorFields(parameters: ParameterFormField[]): number {
+  private countErrorFields(parameters: readonly ParameterFormField[]): number {
     let result = 0;
     for (const parameter of parameters) {
       if (parameter.type === ParameterInputType.Group) {
         result += this.countErrorFields(parameter.children);
-      } else if (parameter.hintType === ParameterHintType.Error) {
-        result++;
+      } else {
+        const isClientValidating = this.store.isValidating(parameter.id)();
+        const isPending = !!parameter.pending || isClientValidating;
+        if (parameter.hintType === ParameterHintType.Error && !isPending) {
+          result++;
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Count pending fields.
+   * This ignores Group type form because the group itself isn't a field.
+   */
+  private countPendingFields(
+    parameters: readonly ParameterFormField[],
+  ): number {
+    let result = 0;
+    for (const parameter of parameters) {
+      if (parameter.type === ParameterInputType.Group) {
+        result += this.countPendingFields(parameter.children);
+      } else {
+        const isClientValidating = this.store.isValidating(parameter.id)();
+        if (parameter.pending || isClientValidating) {
+          result++;
+        }
       }
     }
     return result;


### PR DESCRIPTION
## Summary

This PR introduces pending status representation and handling for asynchronous operations during dryrun across both backend and frontend.

## Background & Motivation

1. **Server-side Asynchronous Tasks**: Tasks executed during dryrun—such as file validation (e.g. archive extraction and file integrity verification) and log volume estimation—run asynchronously in background worker slots or goroutines. Previously, the client had no standardized way to know that the backend is still evaluating a parameter or estimating log counts, causing parameters to appear prematurely valid.
2. **Non-blocking Log Estimation**: In `CachedStructuredLogEstimator`, previous implementations blocked synchronous dryrun execution while awaiting estimation. With non-blocking estimation, dryrun returns immediately with pending state while the estimation runs concurrently.
3. **Client-side Validation Latency Synchronization**: When a user modifies an input field or when the backend updates default values remotely, there is an in-flight latency window before the next dryrun response arrives. Without client-side pending synchronization, fields would retain stale validation checkmarks or old error messages, and users could click "Run" before their input was validated.

## Key Changes

### 1. Backend (`pkg/`)
- **Metadata Schema**:
  - `pkg/core/inspection/metadata/form_metadata.go`: Added `Pending bool \`json:"pending,omitempty"\`` to `ParameterFormFieldBase`.
  - `pkg/core/inspection/metadata/query_metadata.go`: Added `Pending bool \`json:"pending,omitempty"\`` to `QueryItem` and helper `SetPendingQuery`.
- **Log Estimation**:
  - `pkg/api/googlecloud/logestimator/cached_estimator.go`: Added `EstimateWithTaskSlotNonBlocking(ctx, taskSlotKey, container, query, startTime, endTime, provider)` returning `(*EstimateResult, bool, error)` (`isPending=true` when running). Reimplemented `EstimateWithTaskSlot` to delegate to the non-blocking variant.
  - `pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go`: Switched to `EstimateWithTaskSlotNonBlocking` and marked queries as pending using `setStructuredQueryInfoWithPending`.
- **File Upload Verification**:
  - `pkg/core/inspection/formtask/fileform.go`: Set `Pending: true` and `HintType: Info` on file form fields while file upload/processing status is not completed.

### 2. Frontend (`web/`)
- **Schema**:
  - `web/src/app/common/schema/form-types.ts`: Added `readonly pending?: boolean;` to `ParameterFormFieldBase`.
  - `web/src/app/common/schema/metadata-types.ts`: Added `readonly pending?: boolean;` to `InspectionMetadataQuery`.
- **Parameter Header (`ParameterHeaderComponent`)**:
  - Combined client-side `isValidating()` (from PR #907) and server-side `parameter().pending` into `isPendingOrValidating`.
  - Displays `.validation-spinner` whenever a field is either server-pending or client-validating.
- **Dialog Validation & Run Button (`NewInspectionDialogComponent`)**:
  - Implemented reactive `pendingFieldCount` and `errorFieldCount` computed signals.
  - Suppressed stale error counts when a field is undergoing validation or server pending.
  - Added `isRunButtonDisabled = computed(() => this.hadRun() || this.errorFieldCount() !== 0 || this.pendingFieldCount() !== 0)` to immediately prevent execution while unvalidated changes or pending server tasks exist.
  - Added footer indicator showing `Resolving parameters: X / Y` with a spinner while pending.
  - Updated `computeTotalEstimatedLogs` to treat pending queries as estimating.

## Verification

- **Backend Unit Tests**: `make test-go` passed (all packages).
- **Backend Lint**: `make lint-go` passed (0 issues).
- **Frontend Unit Tests**: `make test-web` passed (795 / 795 SUCCESS).
- **Frontend Lint & Stylelint**: `make lint-web` passed (0 issues).
- **Pre-commit**: `make pre-commit` passed with 0 issues.
- **Production Build**: `make build-go && make build-web` succeeded.
