### PR TITLE
fix(progressutil): resolve race condition in ProgressUpdator

### DIFF
--- a/pkg/core/inspection/progressutil/progress_updator.go
+++ b/pkg/core/inspection/progressutil/progress_updator.go
@@ -17,6 +17,7 @@ package progressutil
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
@@ -34,6 +35,7 @@ type ProgressUpdator struct {
 	OnTick   ProgressUpdatorOnTickFunc
 	context  context.Context
 	cancel   func()
+	wg       sync.WaitGroup
 }
 
 // NewProgressUpdator creates and initializes a new ProgressUpdator.
@@ -49,18 +51,29 @@ func NewProgressUpdator(progress *inspectionmetadata.TaskProgressMetadata, inter
 // and then continues to call it at the specified interval until Done is called.
 // It returns an error if the updator has already been started.
 func (p *ProgressUpdator) Start(ctx context.Context) error {
+	if p.context != nil {
+		return fmt.Errorf("this updator is already started")
+	}
 	p.OnTick(p.Progress)
 	cancellable, cancel := context.WithCancel(ctx)
 	p.cancel = cancel
 	p.context = cancellable
+	p.wg.Add(1)
 	go func() {
-		for itr := 1; true; itr++ {
+		defer p.wg.Done()
+		ticker := time.NewTicker(p.Interval)
+		defer ticker.Stop()
+		for {
 			select {
 			case <-p.context.Done():
 				return
-			case <-time.After(p.Interval):
+			case <-ticker.C:
+				select {
+				case <-p.context.Done():
+					return
+				default:
+				}
 				p.OnTick(p.Progress)
-				itr++
 			}
 		}
 	}()
@@ -74,5 +87,6 @@ func (p *ProgressUpdator) Done() error {
 		return fmt.Errorf("this updator is not yet started")
 	}
 	p.cancel()
+	p.wg.Wait()
 	return nil
 }

--- a/pkg/core/inspection/progressutil/progress_updator.go
+++ b/pkg/core/inspection/progressutil/progress_updator.go
@@ -29,6 +29,8 @@ type ProgressUpdatorOnTickFunc = func(tp *inspectionmetadata.TaskProgressMetadat
 
 // ProgressUpdator periodically updates a TaskProgress object at a specified
 // interval. It uses a callback function to perform the update logic on each tick.
+// A ProgressUpdator instance is intended for a single-use lifecycle and cannot be
+// reused once started.
 type ProgressUpdator struct {
 	Progress *inspectionmetadata.TaskProgressMetadata
 	Interval time.Duration
@@ -49,7 +51,8 @@ func NewProgressUpdator(progress *inspectionmetadata.TaskProgressMetadata, inter
 
 // Start begins the periodic updates. It invokes the OnTick callback immediately
 // and then continues to call it at the specified interval until Done is called.
-// It returns an error if the updator has already been started.
+// It returns an error if the updator has already been started. A ProgressUpdator
+// instance cannot be reused or restarted once started.
 func (p *ProgressUpdator) Start(ctx context.Context) error {
 	if p.context != nil {
 		return fmt.Errorf("this updator is already started")
@@ -65,11 +68,11 @@ func (p *ProgressUpdator) Start(ctx context.Context) error {
 		defer ticker.Stop()
 		for {
 			select {
-			case <-p.context.Done():
+			case <-cancellable.Done():
 				return
 			case <-ticker.C:
 				select {
-				case <-p.context.Done():
+				case <-cancellable.Done():
 					return
 				default:
 				}
@@ -80,8 +83,9 @@ func (p *ProgressUpdator) Start(ctx context.Context) error {
 	return nil
 }
 
-// Done stops the periodic updates.
-// It returns an error if the updator was not started.
+// Done stops the periodic updates and waits for the worker goroutine to complete.
+// It returns an error if the updator was not started. Calling Done multiple times
+// is idempotent.
 func (p *ProgressUpdator) Done() error {
 	if p.context == nil {
 		return fmt.Errorf("this updator is not yet started")

--- a/pkg/core/inspection/progressutil/progress_updator_test.go
+++ b/pkg/core/inspection/progressutil/progress_updator_test.go
@@ -143,3 +143,19 @@ func TestProgressUpdator_StartTwice(t *testing.T) {
 		t.Errorf("start() should return an error if already started")
 	}
 }
+
+func TestProgressUpdator_DoneIdempotent(t *testing.T) {
+	updator := NewProgressUpdator(&inspectionmetadata.TaskProgressMetadata{}, 1*time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {})
+	if err := updator.Start(context.Background()); err != nil {
+		t.Fatalf("Start() returned an error: %v", err)
+	}
+	if err := updator.Done(); err != nil {
+		t.Fatalf("first Done() returned an error: %v", err)
+	}
+	if err := updator.Done(); err != nil {
+		t.Errorf("subsequent Done() should be idempotent, but returned error: %v", err)
+	}
+	if err := updator.Start(context.Background()); err == nil {
+		t.Errorf("start() after Done() should return an error because updator cannot be reused")
+	}
+}

--- a/pkg/core/inspection/progressutil/progress_updator_test.go
+++ b/pkg/core/inspection/progressutil/progress_updator_test.go
@@ -131,3 +131,15 @@ func TestProgressUpdator_ParentContextCancellation(t *testing.T) {
 	}
 	mu.Unlock()
 }
+
+func TestProgressUpdator_StartTwice(t *testing.T) {
+	updator := NewProgressUpdator(&inspectionmetadata.TaskProgressMetadata{}, 1*time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {})
+	if err := updator.Start(context.Background()); err != nil {
+		t.Fatalf("Start() returned an error: %v", err)
+	}
+	defer updator.Done()
+
+	if err := updator.Start(context.Background()); err == nil {
+		t.Errorf("start() should return an error if already started")
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes a flaky test failure in `TestProgressUpdator_StartAndDone` caused by race conditions in `ProgressUpdator`.

## Background & Motivation

`TestProgressUpdator_StartAndDone` occasionally failed in CI, for example in [GitHub Actions Run 32937279763 (PR #908)](https://github.com/GoogleCloudPlatform/khi/actions/runs/32937279763/job/98080874197?pr=908):
```
--- FAIL: TestProgressUpdator_StartAndDone (0.60s)
    progress_updator_test.go:87: OnTick should not be called after Done, got count 3, want 2
FAIL
```

### Root Cause
1. **Asynchronous `Done()`**: `ProgressUpdator.Done()` previously only invoked `cancel()` on the context and returned immediately without synchronizing with or waiting for the worker goroutine.
2. **Race at Interval Boundary**: The test verifies ticks, sleeps for `interval * 2` (100ms), and calls `Done()`. At roughly the 100ms mark, the periodic timer triggers. When `Done()` returned before the worker goroutine terminated, `tickCountJustAfterDone` was recorded as 2, and then the worker goroutine executed `OnTick`, incrementing `tickCount` to 3.
3. **`select` Non-determinism**: In Go, when both `<-p.context.Done()` and the timer/ticker channel are simultaneously ready, `select` picks uniformly at random, which could execute `OnTick` even after cancellation.
4. **Timer Allocation in Loop**: Using `time.After` in a loop repeatedly created temporary timers.

## Key Changes

- **Synchronized Worker Goroutine in `Done()`**: Added `sync.WaitGroup` to `ProgressUpdator`. `Done()` now calls `p.wg.Wait()` to guarantee that all in-flight updates have completely finished before `Done()` returns.
- **Ticker & Context Cancellation Guard**: Replaced `time.After` with `time.NewTicker` and added a non-blocking check for `<-p.context.Done()` before calling `OnTick` to prevent race execution if cancellation arrived concurrently with the tick.
- **Start Guard**: Prevented restarting an already started updator by returning an error as documented in `Start()` GoDoc.
- **Unit Tests**: Added `TestProgressUpdator_StartTwice` in `progress_updator_test.go` to test starting twice error handling without modifying existing tests.

## Verification

- **Stress Test**: `go test ./pkg/core/inspection/progressutil -count=100` (100/100 passes without failure).
- **Race Detector**: `go test -race ./pkg/core/inspection/progressutil` passed with 0 data races.
- **Backend Tests**: `make test-go` passed across all backend packages.
- **Linters & Formatters**: `make format-go`, `make lint-go`, and `make pre-commit` passed with 0 issues.
