### PR TITLE
feat(workbench): introduce timeline severity bitmask cache and hasSeverity CEL function

### DIFF
--- a/pkg/server/workbench/cel/env.go
+++ b/pkg/server/workbench/cel/env.go
@@ -139,7 +139,11 @@ func NewTimelineEvaluator() (*TimelineEvaluator, error) {
 		if !ok {
 			return types.False
 		}
-		sz := list.Size().(types.Int)
+		szVal := list.Size()
+		sz, ok := szVal.(types.Int)
+		if !ok {
+			return types.False
+		}
 		var queryMask uint8
 		for i := int64(0); i < int64(sz); i++ {
 			val := list.Get(types.Int(i))

--- a/pkg/server/workbench/cel/env.go
+++ b/pkg/server/workbench/cel/env.go
@@ -120,6 +120,37 @@ func NewTimelineEvaluator() (*TimelineEvaluator, error) {
 		return types.Bool(eval.currentTimeline.MaxSeverity >= uint32(minOrder))
 	}
 
+	hasSeveritySingle := func(arg ref.Val) ref.Val {
+		if eval.currentTimeline == nil {
+			return types.False
+		}
+		sev, ok := arg.(types.Int)
+		if !ok || sev < 0 || sev >= 8 {
+			return types.False
+		}
+		return types.Bool((eval.currentTimeline.SeverityMask & (1 << uint8(sev))) != 0)
+	}
+
+	hasSeverityList := func(arg ref.Val) ref.Val {
+		if eval.currentTimeline == nil {
+			return types.False
+		}
+		list, ok := arg.(traits.Lister)
+		if !ok {
+			return types.False
+		}
+		sz := list.Size().(types.Int)
+		var queryMask uint8
+		for i := int64(0); i < int64(sz); i++ {
+			val := list.Get(types.Int(i))
+			sev, ok := val.(types.Int)
+			if ok && sev >= 0 && sev < 8 {
+				queryMask |= (1 << uint8(sev))
+			}
+		}
+		return types.Bool((eval.currentTimeline.SeverityMask & queryMask) != 0)
+	}
+
 	env, err := cel.NewEnv(
 		cel.Variable("t", cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable("name", cel.StringType),
@@ -194,6 +225,15 @@ func NewTimelineEvaluator() (*TimelineEvaluator, error) {
 		cel.Function("minSeverity",
 			cel.Overload("minSeverity_int", []*cel.Type{cel.IntType}, cel.BoolType,
 				cel.UnaryBinding(minSeverityBinding),
+			),
+		),
+		// hasSeverity functions
+		cel.Function("hasSeverity",
+			cel.Overload("hasSeverity_int", []*cel.Type{cel.IntType}, cel.BoolType,
+				cel.UnaryBinding(hasSeveritySingle),
+			),
+			cel.Overload("hasSeverity_list", []*cel.Type{cel.ListType(cel.IntType)}, cel.BoolType,
+				cel.UnaryBinding(hasSeverityList),
 			),
 		),
 	)

--- a/pkg/server/workbench/cel/env_test.go
+++ b/pkg/server/workbench/cel/env_test.go
@@ -62,7 +62,8 @@ spec:
 		ParentID:     2,
 		Name:         "pod-sample",
 		TimelineType: "Pod",
-		MaxSeverity:  2, // WARNING
+		MaxSeverity:  2,                   // WARNING
+		SeverityMask: (1 << 1) | (1 << 2), // INFO and WARNING
 		Revisions: []RevisionInfo{
 			{
 				ResourceBodyStructID: sRef.ID(),
@@ -136,6 +137,26 @@ spec:
 		{
 			name:       "minSeverity helper higher than max",
 			expression: `minSeverity(ERROR)`,
+			want:       false,
+		},
+		{
+			name:       "hasSeverity with matching single severity",
+			expression: `hasSeverity(INFO)`,
+			want:       true,
+		},
+		{
+			name:       "hasSeverity with non-matching single severity",
+			expression: `hasSeverity(ERROR)`,
+			want:       false,
+		},
+		{
+			name:       "hasSeverity with list matching at least one",
+			expression: `hasSeverity([ERROR, WARNING])`,
+			want:       true,
+		},
+		{
+			name:       "hasSeverity with list matching none",
+			expression: `hasSeverity([ERROR, FATAL])`,
 			want:       false,
 		},
 		{
@@ -290,6 +311,16 @@ func TestValidateTimelineQuery(t *testing.T) {
 		{
 			name:    "valid timeline query",
 			query:   `name == "pod-sample" && minSeverity(WARNING)`,
+			wantErr: false,
+		},
+		{
+			name:    "valid timeline query with hasSeverity int",
+			query:   `hasSeverity(ERROR)`,
+			wantErr: false,
+		},
+		{
+			name:    "valid timeline query with hasSeverity list",
+			query:   `hasSeverity([INFO, WARNING])`,
 			wantErr: false,
 		},
 		{

--- a/pkg/server/workbench/cel/types.go
+++ b/pkg/server/workbench/cel/types.go
@@ -53,6 +53,7 @@ type TimelineData struct {
 	Events       []EventInfo
 	Revisions    []RevisionInfo
 	MaxSeverity  uint32
+	SeverityMask uint8
 }
 
 // ForEachLogID iterates over all log IDs associated with this timeline's events and revisions.

--- a/pkg/server/workbench/index.go
+++ b/pkg/server/workbench/index.go
@@ -384,6 +384,7 @@ func (w *Workbench) indexTimelinesParallel(
 					var events []cel.EventInfo
 					var revisions []cel.RevisionInfo
 					var maxSeverity uint32
+					var severityMask uint8
 
 					if item, ok := itemsMap[tl.GetTimelineItemsId()]; ok {
 						for _, evt := range item.Events {
@@ -391,6 +392,9 @@ func (w *Workbench) indexTimelinesParallel(
 							sev := getLogSeverity(logID)
 							if sev > maxSeverity {
 								maxSeverity = sev
+							}
+							if sev < 8 {
+								severityMask |= (1 << sev)
 							}
 							events = append(events, cel.EventInfo{
 								LogID:    logID,
@@ -405,6 +409,9 @@ func (w *Workbench) indexTimelinesParallel(
 							sev := getLogSeverity(logID)
 							if sev > maxSeverity {
 								maxSeverity = sev
+							}
+							if sev < 8 {
+								severityMask |= (1 << sev)
 							}
 
 							changedTime := int64(0)
@@ -432,6 +439,7 @@ func (w *Workbench) indexTimelinesParallel(
 						Events:       events,
 						Revisions:    revisions,
 						MaxSeverity:  maxSeverity,
+						SeverityMask: severityMask,
 					}
 
 					localTimelines = append(localTimelines, tData)

--- a/pkg/server/workbench/index_test.go
+++ b/pkg/server/workbench/index_test.go
@@ -195,6 +195,9 @@ func TestWorkbench_BuildSearchIndex(t *testing.T) {
 	if path["cluster"] != "my-cluster" {
 		t.Errorf("path[\"cluster\"] = %q, want %q", path["cluster"], "my-cluster")
 	}
+	if tl.SeverityMask != (1 << 1) {
+		t.Errorf("tl.SeverityMask = %d, want %d", tl.SeverityMask, 1<<1)
+	}
 }
 
 func TestBuildBaseSearchIndex(t *testing.T) {
@@ -207,7 +210,9 @@ func TestBuildBaseSearchIndex(t *testing.T) {
 		wantTL2Path      map[string]string
 		wantTL1Children  []uint32
 		wantTL1MaxSev    uint32
+		wantTL1SevMask   uint8
 		wantTL2MaxSev    uint32
+		wantTL2SevMask   uint8
 		wantTL2LogIDs    []uint32
 		wantLog1Severity uint32
 		wantLog2Severity uint32
@@ -330,7 +335,9 @@ func TestBuildBaseSearchIndex(t *testing.T) {
 			},
 			wantTL1Children:  []uint32{2},
 			wantTL1MaxSev:    1,
+			wantTL1SevMask:   1 << 1,
 			wantTL2MaxSev:    3,
+			wantTL2SevMask:   1 << 3,
 			wantTL2LogIDs:    []uint32{2},
 			wantLog1Severity: 1,
 			wantLog2Severity: 3,
@@ -368,6 +375,9 @@ func TestBuildBaseSearchIndex(t *testing.T) {
 			if tl1.MaxSeverity != tc.wantTL1MaxSev {
 				t.Errorf("timeline 1 MaxSeverity mismatch (-want +got):\n%s", cmp.Diff(tc.wantTL1MaxSev, tl1.MaxSeverity))
 			}
+			if tl1.SeverityMask != tc.wantTL1SevMask {
+				t.Errorf("timeline 1 SeverityMask mismatch (-want +got):\n%s", cmp.Diff(tc.wantTL1SevMask, tl1.SeverityMask))
+			}
 
 			tl2 := idx.TimelineMap[2]
 			if tl2 == nil {
@@ -378,6 +388,9 @@ func TestBuildBaseSearchIndex(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantTL2MaxSev, tl2.MaxSeverity); diff != "" {
 				t.Errorf("timeline 2 MaxSeverity mismatch (-want +got):\n%s", cmp.Diff(tc.wantTL2MaxSev, tl2.MaxSeverity))
+			}
+			if tl2.SeverityMask != tc.wantTL2SevMask {
+				t.Errorf("timeline 2 SeverityMask mismatch (-want +got):\n%s", cmp.Diff(tc.wantTL2SevMask, tl2.SeverityMask))
 			}
 			var tl2LogIDs []uint32
 			tl2.ForEachLogID(func(id uint32) bool {


### PR DESCRIPTION
## Summary
Previously, timeline filtering by severity in the backend was limited to `minSeverity(order)`, which only checked whether the timeline's maximum severity met a given threshold. Specific severity matching or arbitrary sets of severities could not be filtered efficiently at the timeline level.

This PR introduces:
- `SeverityMask uint8` on `cel.TimelineData` to record which severity levels are present in each timeline using bitwise operations across events and revisions during indexing.
- `hasSeverity(int)` and `hasSeverity(list<int>)` CEL functions in `TimelineEvaluator` to evaluate whether a timeline contains logs matching a single severity or any severity in a given list.
- Comprehensive table-driven tests in `cel/env_test.go` and `workbench/index_test.go`.

## Testing
- `go test ./pkg/server/workbench/...`
- `make build-go`
- `make test-go`
- `make lint-go`
- `make format-go`
- `make pre-commit`