### PR TITLE
feat(web): support dynamic upload/download config overrides and binary transport

### DIFF
--- a/web/src/app/services/api/backend-api.service.spec.ts
+++ b/web/src/app/services/api/backend-api.service.spec.ts
@@ -22,6 +22,10 @@ import {
   BackendAPIUtil,
   InspectionClient,
 } from './backend-api.service';
+import {
+  environment,
+  DownloadEnvironmentConfig,
+} from 'src/environments/environment';
 import { ViewStateService } from '../view-state.service';
 import { ProgressDialogStatusUpdator } from 'src/app/services/progress/progress-interface';
 import {
@@ -284,6 +288,52 @@ describe('BackendAPIImpl testing', () => {
     const reporterSpy = jasmine.createSpy('reporter');
     await firstValueFrom(api.getInspectionData('test', reporterSpy));
     expect(reporterSpy).toHaveBeenCalledWith(100, 100);
+  });
+
+  it('respects environment download chunk size and concurrency in getInspectionData', async () => {
+    const originalDownload = environment.download;
+    try {
+      (environment as { download: DownloadEnvironmentConfig }).download = {
+        chunkSizeBytes: 20,
+        maxConcurrency: 2,
+      };
+
+      const fileSize = 50;
+      mockInspectionClient.getInspectionMetadata.and.returnValue(
+        Promise.resolve(
+          create(GetInspectionMetadataResponseSchema, {
+            header: {
+              inspectionType: 'test',
+              inspectionName: 'test',
+              suggestedFilename: 'test.khi',
+              fileSize: BigInt(fileSize),
+            },
+          }),
+        ),
+      );
+
+      mockInspectionClient.getInspectionDataChunk.and.callFake((req) => {
+        const size = Number(req.maxSizeBytes);
+        return Promise.resolve(
+          create(GetInspectionDataChunkResponseSchema, {
+            data: new Uint8Array(size),
+          }),
+        );
+      });
+
+      const data = await firstValueFrom(
+        api.getInspectionData('test', () => {}),
+      );
+      expect(data.fileName).toEqual('test.khi');
+      expect(data.content.size).toEqual(fileSize);
+      // 50 bytes total with 20 bytes chunks => 3 chunks (20, 20, 10)
+      expect(mockInspectionClient.getInspectionDataChunk).toHaveBeenCalledTimes(
+        3,
+      );
+    } finally {
+      (environment as { download: DownloadEnvironmentConfig }).download =
+        originalDownload;
+    }
   });
 
   it('initializes progress dialog immediately when downloadInspectionDataAsFile is called', async () => {

--- a/web/src/app/services/api/backend-api.service.ts
+++ b/web/src/app/services/api/backend-api.service.ts
@@ -51,6 +51,7 @@ import { ProgressDialogStatusUpdator } from '../progress/progress-interface';
 import { ProgressUtil } from '../progress/progress-util';
 import { ApiPathUtil } from 'src/app/services/api/api-path-util';
 import { ConnectClientService } from 'src/app/services/api/connect-client.service';
+import { resolveDownloadConfig } from 'src/app/services/api/download-config-resolver';
 import {
   convertMapToParameterValues,
   convertProtoDryRunResponseToFrontend,
@@ -68,9 +69,6 @@ import {
 export class BackendAPIImpl implements BackendAPI {
   private readonly viewState = inject(ViewStateService);
   private readonly connectClient = inject(ConnectClientService);
-
-  private readonly MAX_INSPECTION_DATA_DOWNLOAD_CHUNK_SIZE = 16 * 1024 * 1024;
-  private readonly INSPECTION_DATA_DOWNLOAD_CONCURRENCY = 10;
 
   /**
    * Get the server base path configuration path which is a configuration given as meta tag from backend.
@@ -230,6 +228,7 @@ export class BackendAPIImpl implements BackendAPI {
     inspectionID: string,
     reporter: DownloadProgressReporter,
   ): Observable<{ fileName: string; content: Blob }> {
+    const downloadConfig = resolveDownloadConfig();
     return from(
       this.connectClient.inspectionClient.getInspectionMetadata({
         inspectionId: inspectionID,
@@ -240,15 +239,14 @@ export class BackendAPIImpl implements BackendAPI {
         const fileName = metadata.header?.suggestedFilename || 'inspection.khi';
         const chunks = Math.max(
           1,
-          Math.ceil(totalSize / this.MAX_INSPECTION_DATA_DOWNLOAD_CHUNK_SIZE),
+          Math.ceil(totalSize / downloadConfig.chunkSize),
         );
         const chunkLoaded: number[] = new Array(chunks).fill(0);
         return range(0, chunks).pipe(
           map((index) => {
-            const startInBytes =
-              index * this.MAX_INSPECTION_DATA_DOWNLOAD_CHUNK_SIZE;
+            const startInBytes = index * downloadConfig.chunkSize;
             const maxSizeInBytes = Math.min(
-              this.MAX_INSPECTION_DATA_DOWNLOAD_CHUNK_SIZE,
+              downloadConfig.chunkSize,
               totalSize - startInBytes,
             );
             return { index, startInBytes, maxSizeInBytes };
@@ -269,7 +267,7 @@ export class BackendAPIImpl implements BackendAPI {
                 return { index, blob };
               }),
             );
-          }, this.INSPECTION_DATA_DOWNLOAD_CONCURRENCY),
+          }, downloadConfig.maxConcurrency),
           reduce(
             (acc: Blob[], downloadResult: { index: number; blob: Blob }) => {
               acc[downloadResult.index] = downloadResult.blob;

--- a/web/src/app/services/api/connect-client.service.spec.ts
+++ b/web/src/app/services/api/connect-client.service.spec.ts
@@ -16,6 +16,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { ConnectClientService } from 'src/app/services/api/connect-client.service';
+import { environment } from 'src/environments/environment';
 
 describe('ConnectClientService', () => {
   let service: ConnectClientService;
@@ -76,5 +77,33 @@ describe('ConnectClientService', () => {
     expect(typeof service.inspectionClient.getInspectionTypes).toBe('function');
     expect(typeof service.inspectionClient.watchInspections).toBe('function');
     expect(typeof service.inspectionClient.createInspection).toBe('function');
+  });
+
+  it('should use proto content-type when useBinaryFormat is true', async () => {
+    const originalEnv = environment.useBinaryFormat;
+    try {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = true;
+      const binaryService = new ConnectClientService();
+      let capturedContentType: string | null = null;
+      spyOn(globalThis, 'fetch').and.callFake((_input, init) => {
+        const headers = new Headers(init?.headers);
+        capturedContentType = headers.get('content-type');
+        return Promise.resolve(
+          new Response(new Uint8Array([]), {
+            status: 200,
+            headers: { 'content-type': 'application/proto' },
+          }),
+        );
+      });
+
+      await binaryService.workbenchClient.heartbeatWorkbench({
+        workbenchId: 'test',
+      });
+
+      expect(capturedContentType).toContain('application/proto');
+    } finally {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat =
+        originalEnv;
+    }
   });
 });

--- a/web/src/app/services/api/connect-client.service.ts
+++ b/web/src/app/services/api/connect-client.service.ts
@@ -26,7 +26,7 @@ import { WorkbenchService } from 'src/app/generated/api/v1/workbench_pb';
 import { InspectionService } from 'src/app/generated/api/v1/inspection_pb';
 import { ApiPathUtil } from 'src/app/services/api/api-path-util';
 import { createLegacyPollingInterceptor } from 'src/app/services/api/legacy-polling.interceptor';
-import { environment } from 'src/environments/environment';
+import { resolveUseBinaryFormat } from 'src/app/services/api/transport-config-resolver';
 
 /**
  * ConnectClientService manages Connect-RPC clients and transports.
@@ -37,7 +37,7 @@ import { environment } from 'src/environments/environment';
 export class ConnectClientService {
   private readonly transport = createConnectTransport({
     baseUrl: ApiPathUtil.getServerBaseUrl(),
-    useBinaryFormat: environment.production,
+    useBinaryFormat: resolveUseBinaryFormat(),
     interceptors: [createLegacyPollingInterceptor()],
   });
 

--- a/web/src/app/services/api/download-config-resolver.spec.ts
+++ b/web/src/app/services/api/download-config-resolver.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DEFAULT_DOWNLOAD_CHUNK_SIZE_BYTES,
+  DEFAULT_DOWNLOAD_MAX_CONCURRENCY,
+  resolveDownloadConfig,
+} from 'src/app/services/api/download-config-resolver';
+import {
+  DownloadEnvironmentConfig,
+  environment,
+} from 'src/environments/environment';
+
+describe('download-config-resolver', () => {
+  let originalEnvDownload: DownloadEnvironmentConfig;
+
+  beforeEach(() => {
+    originalEnvDownload = environment.download;
+  });
+
+  afterEach(() => {
+    (environment as { download: DownloadEnvironmentConfig }).download =
+      originalEnvDownload;
+  });
+
+  it('uses default values when unconfigured and query params are empty', () => {
+    (environment as { download: DownloadEnvironmentConfig }).download = {};
+    const config = resolveDownloadConfig({ searchString: '' });
+    expect(config.chunkSize).toBe(DEFAULT_DOWNLOAD_CHUNK_SIZE_BYTES);
+    expect(config.maxConcurrency).toBe(DEFAULT_DOWNLOAD_MAX_CONCURRENCY);
+  });
+
+  it('uses environment configuration when present', () => {
+    (environment as { download: DownloadEnvironmentConfig }).download = {
+      chunkSizeBytes: 2 * 1024 * 1024,
+      maxConcurrency: 6,
+    };
+    const config = resolveDownloadConfig({ searchString: '' });
+    expect(config.chunkSize).toBe(2 * 1024 * 1024);
+    expect(config.maxConcurrency).toBe(6);
+  });
+
+  it('overrides environment settings with URL query parameters', () => {
+    (environment as { download: DownloadEnvironmentConfig }).download = {
+      chunkSizeBytes: 8 * 1024 * 1024,
+      maxConcurrency: 8,
+    };
+    const config = resolveDownloadConfig({
+      searchString: '?downloadChunkSize=1MB&downloadConcurrency=3',
+    });
+    expect(config.chunkSize).toBe(1024 * 1024);
+    expect(config.maxConcurrency).toBe(3);
+  });
+
+  it('parses raw byte count in URL query parameter', () => {
+    const config = resolveDownloadConfig({
+      searchString: '?downloadChunkSize=5242880',
+    });
+    expect(config.chunkSize).toBe(5242880);
+  });
+
+  it('falls back to environment or default when query parameter is invalid', () => {
+    (environment as { download: DownloadEnvironmentConfig }).download = {
+      chunkSizeBytes: 4 * 1024 * 1024,
+      maxConcurrency: 5,
+    };
+    const config = resolveDownloadConfig({
+      searchString: '?downloadChunkSize=invalid&downloadConcurrency=abc',
+    });
+    expect(config.chunkSize).toBe(4 * 1024 * 1024);
+    expect(config.maxConcurrency).toBe(5);
+  });
+
+  it('clamps values to a minimum of 1', () => {
+    const config = resolveDownloadConfig({
+      searchString: '?downloadChunkSize=0&downloadConcurrency=0',
+      environmentConfig: {
+        chunkSizeBytes: 0,
+        maxConcurrency: 0,
+      },
+    });
+    // If parsed as 0, it falls back to defaults (which are > 1)
+    expect(config.chunkSize).toBe(DEFAULT_DOWNLOAD_CHUNK_SIZE_BYTES);
+    expect(config.maxConcurrency).toBe(DEFAULT_DOWNLOAD_MAX_CONCURRENCY);
+  });
+});

--- a/web/src/app/services/api/download-config-resolver.ts
+++ b/web/src/app/services/api/download-config-resolver.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DownloadEnvironmentConfig } from 'src/environments/environment-types';
+import { environment } from 'src/environments/environment';
+import {
+  parseByteSizeQueryParam,
+  parseIntegerQueryParam,
+  resolveParam,
+} from 'src/app/utils/config-resolver';
+
+/**
+ * Default chunk payload size for inspection data downloads (16 MB).
+ */
+export const DEFAULT_DOWNLOAD_CHUNK_SIZE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Default concurrency for inspection data downloads.
+ */
+export const DEFAULT_DOWNLOAD_MAX_CONCURRENCY = 10;
+
+/**
+ * Options supplied to resolve the effective download configuration.
+ */
+export interface ResolveDownloadConfigOptions {
+  /** Optional URL search query string (defaults to window.location.search when available). */
+  readonly searchString?: string;
+  /** Optional explicit environment download configuration override. */
+  readonly environmentConfig?: DownloadEnvironmentConfig;
+}
+
+/**
+ * Effective download configuration.
+ */
+export interface ResolvedDownloadConfig {
+  /** Effective chunk payload size in bytes. */
+  readonly chunkSize: number;
+  /** Effective maximum number of concurrent chunk downloads. */
+  readonly maxConcurrency: number;
+}
+
+/**
+ * Resolves effective chunk size and concurrency for inspection data downloads.
+ *
+ * Precedence for chunkSize:
+ * 1. URL GET parameter `downloadChunkSize` (e.g. `?downloadChunkSize=2MB` or `?downloadChunkSize=4194304`).
+ * 2. `environment.download.chunkSizeBytes`.
+ * 3. Default fallback (16 MB).
+ *
+ * Precedence for maxConcurrency:
+ * 1. URL GET parameter `downloadConcurrency` (e.g. `?downloadConcurrency=4`).
+ * 2. `environment.download.maxConcurrency`.
+ * 3. Default fallback (10).
+ */
+export function resolveDownloadConfig(
+  options?: ResolveDownloadConfigOptions,
+): ResolvedDownloadConfig {
+  const envConfig = options?.environmentConfig ?? environment.download;
+
+  const chunkSize = resolveParam({
+    paramName: 'downloadChunkSize',
+    parser: parseByteSizeQueryParam,
+    searchString: options?.searchString,
+    candidates: [envConfig?.chunkSizeBytes],
+    defaultValue: DEFAULT_DOWNLOAD_CHUNK_SIZE_BYTES,
+    validator: (v) => v > 0,
+  });
+
+  const maxConcurrency = resolveParam({
+    paramName: 'downloadConcurrency',
+    parser: (val) => parseIntegerQueryParam(val, 1),
+    searchString: options?.searchString,
+    candidates: [envConfig?.maxConcurrency],
+    defaultValue: DEFAULT_DOWNLOAD_MAX_CONCURRENCY,
+    validator: (v) => v > 0,
+  });
+
+  return {
+    chunkSize: Math.max(1, Math.floor(chunkSize)),
+    maxConcurrency: Math.max(1, Math.floor(maxConcurrency)),
+  };
+}

--- a/web/src/app/services/api/file-parameter-upload-client.service.spec.ts
+++ b/web/src/app/services/api/file-parameter-upload-client.service.spec.ts
@@ -22,6 +22,7 @@ import {
 import { Client } from '@connectrpc/connect';
 import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import { FileParameterUploadService } from 'src/app/generated/api/v1/file_parameter_upload_pb';
+import { environment } from 'src/environments/environment';
 
 describe('FileParameterUploadClientService', () => {
   let service: FileParameterUploadClientService;
@@ -149,5 +150,46 @@ describe('FileParameterUploadClientService', () => {
     expect(mockClient.abortFileUpload).toHaveBeenCalledWith({
       sessionToken: 'session-error',
     });
+  });
+
+  it('overrides server suggestedChunkSizeBytes when environment.upload is configured', async () => {
+    const originalUpload = environment.upload;
+    try {
+      (environment as { upload: typeof originalUpload }).upload = {
+        chunkSizeBytes: 4,
+        maxConcurrency: 2,
+      };
+
+      mockClient.startFileUpload.and.returnValue(
+        Promise.resolve({
+          sessionToken: 'session-env',
+          suggestedChunkSizeBytes: BigInt(20),
+        } as unknown as Awaited<ReturnType<typeof mockClient.startFileUpload>>),
+      );
+
+      mockClient.uploadFileChunk.and.returnValue(
+        Promise.resolve({
+          totalReceivedBytes: BigInt(4),
+        } as unknown as Awaited<ReturnType<typeof mockClient.uploadFileChunk>>),
+      );
+
+      mockClient.completeFileUpload.and.returnValue(
+        Promise.resolve({
+          fileSizeBytes: BigInt(8),
+        } as unknown as Awaited<
+          ReturnType<typeof mockClient.completeFileUpload>
+        >),
+      );
+
+      const file = new File([new Uint8Array(8)], 'env-param.log');
+      const result = await service.uploadFile('token-env', file);
+
+      // 8 bytes with 4 bytes chunk size => 2 chunks (even though server suggested 20)
+      expect(mockClient.uploadFileChunk).toHaveBeenCalledTimes(2);
+      expect(result.fileSizeBytes).toBe(8);
+    } finally {
+      (environment as { upload: typeof originalUpload }).upload =
+        originalUpload;
+    }
   });
 });

--- a/web/src/app/services/api/file-parameter-upload-client.service.ts
+++ b/web/src/app/services/api/file-parameter-upload-client.service.ts
@@ -21,8 +21,8 @@ import { ConnectClientService } from 'src/app/services/api/connect-client.servic
 import {
   executeChunkedUpload,
   ChunkUploadProgressCallback,
-  DEFAULT_CHUNK_SIZE_BYTES,
 } from 'src/app/services/api/chunked-uploader';
+import { resolveUploadConfig } from 'src/app/services/api/upload-config-resolver';
 
 /**
  * Options for uploading a file parameter in chunks.
@@ -81,16 +81,16 @@ export class FileParameterUploadClientService {
     );
 
     const sessionToken = startResponse.sessionToken;
-    const chunkSize =
-      Number(startResponse.suggestedChunkSizeBytes) > 0
-        ? Number(startResponse.suggestedChunkSizeBytes)
-        : DEFAULT_CHUNK_SIZE_BYTES;
+    const uploadConfig = resolveUploadConfig({
+      suggestedChunkSizeBytes: Number(startResponse.suggestedChunkSizeBytes),
+      callerMaxConcurrency: options?.maxConcurrency,
+    });
 
     try {
       await executeChunkedUpload({
         file,
-        chunkSize,
-        maxConcurrency: options?.maxConcurrency,
+        chunkSize: uploadConfig.chunkSize,
+        maxConcurrency: uploadConfig.maxConcurrency,
         abortSignal: options?.abortSignal,
         onProgress: options?.onProgress,
         uploadChunk: async (offsetBytes, data, signal) => {

--- a/web/src/app/services/api/import-inspection-client.service.spec.ts
+++ b/web/src/app/services/api/import-inspection-client.service.spec.ts
@@ -22,6 +22,7 @@ import {
 import { Client } from '@connectrpc/connect';
 import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import { ImportInspectionService } from 'src/app/generated/api/v1/import_inspection_pb';
+import { environment } from 'src/environments/environment';
 
 describe('ImportInspectionClientService', () => {
   let service: ImportInspectionClientService;
@@ -243,5 +244,52 @@ describe('ImportInspectionClientService', () => {
     expect(mockClient.abortImportInspection).toHaveBeenCalledWith({
       importToken: 'token-abort',
     });
+  });
+
+  it('overrides server suggestedChunkSizeBytes when environment.upload is configured', async () => {
+    const originalUpload = environment.upload;
+    try {
+      (environment as { upload: typeof originalUpload }).upload = {
+        chunkSizeBytes: 3,
+        maxConcurrency: 2,
+      };
+
+      mockClient.startImportInspection.and.returnValue(
+        Promise.resolve({
+          importToken: 'test-token-env',
+          suggestedChunkSizeBytes: BigInt(10),
+        } as unknown as Awaited<
+          ReturnType<typeof mockClient.startImportInspection>
+        >),
+      );
+
+      mockClient.uploadInspectionChunk.and.returnValue(
+        Promise.resolve({
+          totalReceivedBytes: BigInt(3),
+        } as unknown as Awaited<
+          ReturnType<typeof mockClient.uploadInspectionChunk>
+        >),
+      );
+
+      mockClient.completeImportInspection.and.returnValue(
+        Promise.resolve({
+          inspectionId: 'inspection-env',
+          inspectionName: 'Env Test',
+          fileSizeBytes: BigInt(9),
+        } as unknown as Awaited<
+          ReturnType<typeof mockClient.completeImportInspection>
+        >),
+      );
+
+      const file = new File([new Uint8Array(9)], 'env.khi');
+      const result = await service.importFile(file);
+
+      // 9 bytes with 3 bytes chunk size => 3 chunks (even though server suggested 10)
+      expect(mockClient.uploadInspectionChunk).toHaveBeenCalledTimes(3);
+      expect(result.inspectionId).toBe('inspection-env');
+    } finally {
+      (environment as { upload: typeof originalUpload }).upload =
+        originalUpload;
+    }
   });
 });

--- a/web/src/app/services/api/import-inspection-client.service.ts
+++ b/web/src/app/services/api/import-inspection-client.service.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_CHUNK_SIZE_BYTES,
   DEFAULT_MAX_CONCURRENCY,
 } from 'src/app/services/api/chunked-uploader';
+import { resolveUploadConfig } from 'src/app/services/api/upload-config-resolver';
 
 /**
  * Callback function type for reporting file upload progress.
@@ -92,16 +93,16 @@ export class ImportInspectionClientService {
     );
 
     const token = startResponse.importToken;
-    const chunkSize =
-      Number(startResponse.suggestedChunkSizeBytes) > 0
-        ? Number(startResponse.suggestedChunkSizeBytes)
-        : ImportInspectionClientService.DEFAULT_CHUNK_SIZE_BYTES;
+    const uploadConfig = resolveUploadConfig({
+      suggestedChunkSizeBytes: Number(startResponse.suggestedChunkSizeBytes),
+      callerMaxConcurrency: options?.maxConcurrency,
+    });
 
     try {
       await executeChunkedUpload({
         file,
-        chunkSize,
-        maxConcurrency: options?.maxConcurrency,
+        chunkSize: uploadConfig.chunkSize,
+        maxConcurrency: uploadConfig.maxConcurrency,
         abortSignal: options?.abortSignal,
         onProgress: options?.onProgress,
         uploadChunk: async (offsetBytes, data, signal) => {

--- a/web/src/app/services/api/transport-config-resolver.spec.ts
+++ b/web/src/app/services/api/transport-config-resolver.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolveUseBinaryFormat } from 'src/app/services/api/transport-config-resolver';
+import { parseBooleanQueryParam } from 'src/app/utils/config-resolver';
+import { environment } from 'src/environments/environment';
+
+describe('transport-config-resolver', () => {
+  describe('parseBooleanQueryParam', () => {
+    it('parses truthy boolean strings correctly', () => {
+      expect(parseBooleanQueryParam('true')).toBeTrue();
+      expect(parseBooleanQueryParam('TRUE')).toBeTrue();
+      expect(parseBooleanQueryParam('1')).toBeTrue();
+      expect(parseBooleanQueryParam('yes')).toBeTrue();
+      expect(parseBooleanQueryParam('YES')).toBeTrue();
+      expect(parseBooleanQueryParam(' true ')).toBeTrue();
+    });
+
+    it('parses falsy boolean strings correctly', () => {
+      expect(parseBooleanQueryParam('false')).toBeFalse();
+      expect(parseBooleanQueryParam('FALSE')).toBeFalse();
+      expect(parseBooleanQueryParam('0')).toBeFalse();
+      expect(parseBooleanQueryParam('no')).toBeFalse();
+      expect(parseBooleanQueryParam('NO')).toBeFalse();
+      expect(parseBooleanQueryParam(' false ')).toBeFalse();
+    });
+
+    it('returns undefined for invalid or empty inputs', () => {
+      expect(parseBooleanQueryParam(null)).toBeUndefined();
+      expect(parseBooleanQueryParam(undefined)).toBeUndefined();
+      expect(parseBooleanQueryParam('')).toBeUndefined();
+      expect(parseBooleanQueryParam('unknown')).toBeUndefined();
+      expect(parseBooleanQueryParam('2')).toBeUndefined();
+      expect(parseBooleanQueryParam('-1')).toBeUndefined();
+    });
+  });
+
+  describe('resolveUseBinaryFormat', () => {
+    let originalEnvUseBinary: boolean | undefined;
+
+    beforeEach(() => {
+      originalEnvUseBinary = environment.useBinaryFormat;
+    });
+
+    afterEach(() => {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat =
+        originalEnvUseBinary;
+    });
+
+    it('defaults to false when unconfigured and query params are empty', () => {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat =
+        undefined;
+      const result = resolveUseBinaryFormat({ searchString: '' });
+      expect(result).toBeFalse();
+    });
+
+    it('uses environment.useBinaryFormat when no query parameter is provided', () => {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = true;
+      expect(resolveUseBinaryFormat({ searchString: '' })).toBeTrue();
+
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = false;
+      expect(resolveUseBinaryFormat({ searchString: '' })).toBeFalse();
+    });
+
+    it('uses explicit environmentUseBinaryFormat option over global environment', () => {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = false;
+      const result = resolveUseBinaryFormat({
+        searchString: '',
+        environmentUseBinaryFormat: true,
+      });
+      expect(result).toBeTrue();
+    });
+
+    it('overrides environment setting with URL query parameter', () => {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = false;
+      const resultTrue = resolveUseBinaryFormat({
+        searchString: '?useBinaryFormat=true',
+      });
+      expect(resultTrue).toBeTrue();
+
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = true;
+      const resultFalse = resolveUseBinaryFormat({
+        searchString: '?useBinaryFormat=false',
+      });
+      expect(resultFalse).toBeFalse();
+    });
+
+    it('supports 1 and 0 in URL query parameter', () => {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = false;
+      expect(
+        resolveUseBinaryFormat({ searchString: '?useBinaryFormat=1' }),
+      ).toBeTrue();
+
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = true;
+      expect(
+        resolveUseBinaryFormat({ searchString: '?useBinaryFormat=0' }),
+      ).toBeFalse();
+    });
+
+    it('falls back to environment when URL query parameter is unrecognized', () => {
+      (environment as { useBinaryFormat?: boolean }).useBinaryFormat = true;
+      const result = resolveUseBinaryFormat({
+        searchString: '?useBinaryFormat=invalid',
+      });
+      expect(result).toBeTrue();
+    });
+  });
+});

--- a/web/src/app/services/api/transport-config-resolver.ts
+++ b/web/src/app/services/api/transport-config-resolver.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { environment } from 'src/environments/environment';
+import {
+  parseBooleanQueryParam,
+  resolveParam,
+} from 'src/app/utils/config-resolver';
+
+/**
+ * Options supplied to resolve the effective transport binary format setting.
+ */
+export interface ResolveTransportConfigOptions {
+  /** Optional URL search query string (defaults to window.location.search when available). */
+  readonly searchString?: string;
+  /** Optional explicit boolean override or environment value. */
+  readonly environmentUseBinaryFormat?: boolean;
+}
+
+/**
+ * Resolves whether Connect-RPC transport should use binary format (protobuf).
+ *
+ * Priority order:
+ * 1. URL GET parameter `useBinaryFormat` (e.g. `?useBinaryFormat=true` or `?useBinaryFormat=0`).
+ * 2. Environment configuration (`environment.useBinaryFormat`).
+ * 3. Default fallback (`false`).
+ */
+export function resolveUseBinaryFormat(
+  options?: ResolveTransportConfigOptions,
+): boolean {
+  return resolveParam({
+    paramName: 'useBinaryFormat',
+    parser: parseBooleanQueryParam,
+    searchString: options?.searchString,
+    candidates: [
+      options?.environmentUseBinaryFormat,
+      environment.useBinaryFormat,
+    ],
+    defaultValue: false,
+  });
+}

--- a/web/src/app/services/api/upload-config-resolver.spec.ts
+++ b/web/src/app/services/api/upload-config-resolver.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolveUploadConfig } from 'src/app/services/api/upload-config-resolver';
+import { parseByteSizeQueryParam as parseByteSizeString } from 'src/app/utils/config-resolver';
+import {
+  DEFAULT_CHUNK_SIZE_BYTES,
+  DEFAULT_MAX_CONCURRENCY,
+} from 'src/app/services/api/chunked-uploader';
+
+describe('upload-config-resolver', () => {
+  describe('parseByteSizeString', () => {
+    it('returns undefined for empty, null, or undefined input', () => {
+      expect(parseByteSizeString(null)).toBeUndefined();
+      expect(parseByteSizeString(undefined)).toBeUndefined();
+      expect(parseByteSizeString('')).toBeUndefined();
+      expect(parseByteSizeString('   ')).toBeUndefined();
+    });
+
+    it('parses plain byte numbers', () => {
+      expect(parseByteSizeString('1024')).toBe(1024);
+      expect(parseByteSizeString('16777216')).toBe(16777216);
+      expect(parseByteSizeString('  500  ')).toBe(500);
+    });
+
+    it('parses byte sizes with unit suffixes case-insensitively', () => {
+      expect(parseByteSizeString('512K')).toBe(512 * 1024);
+      expect(parseByteSizeString('512kb')).toBe(512 * 1024);
+      expect(parseByteSizeString('512KiB')).toBe(512 * 1024);
+      expect(parseByteSizeString('2M')).toBe(2 * 1024 * 1024);
+      expect(parseByteSizeString('2mb')).toBe(2 * 1024 * 1024);
+      expect(parseByteSizeString('2MiB')).toBe(2 * 1024 * 1024);
+      expect(parseByteSizeString('1G')).toBe(1024 * 1024 * 1024);
+      expect(parseByteSizeString('1gb')).toBe(1024 * 1024 * 1024);
+      expect(parseByteSizeString('1GiB')).toBe(1024 * 1024 * 1024);
+      expect(parseByteSizeString('2048B')).toBe(2048);
+    });
+
+    it('handles decimal values with units', () => {
+      expect(parseByteSizeString('1.5MB')).toBe(Math.round(1.5 * 1024 * 1024));
+      expect(parseByteSizeString('0.5KB')).toBe(Math.round(0.5 * 1024));
+    });
+
+    it('handles whitespace between numbers and units', () => {
+      expect(parseByteSizeString('4 MB')).toBe(4 * 1024 * 1024);
+      expect(parseByteSizeString(' 128  kb ')).toBe(128 * 1024);
+    });
+
+    it('returns undefined for non-positive or invalid strings', () => {
+      expect(parseByteSizeString('0')).toBeUndefined();
+      expect(parseByteSizeString('0MB')).toBeUndefined();
+      expect(parseByteSizeString('-10MB')).toBeUndefined();
+      expect(parseByteSizeString('abc')).toBeUndefined();
+      expect(parseByteSizeString('invalidMB')).toBeUndefined();
+    });
+  });
+
+  describe('resolveUploadConfig', () => {
+    it('returns defaults when no options or environment configurations are provided', () => {
+      const config = resolveUploadConfig({
+        searchString: '',
+        environmentConfig: {},
+      });
+
+      expect(config.chunkSize).toBe(DEFAULT_CHUNK_SIZE_BYTES);
+      expect(config.maxConcurrency).toBe(DEFAULT_MAX_CONCURRENCY);
+    });
+
+    it('uses backend suggestedChunkSizeBytes when provided and no overrides exist', () => {
+      const config = resolveUploadConfig({
+        suggestedChunkSizeBytes: 25 * 1024 * 1024,
+        searchString: '',
+        environmentConfig: {},
+      });
+
+      expect(config.chunkSize).toBe(25 * 1024 * 1024);
+      expect(config.maxConcurrency).toBe(DEFAULT_MAX_CONCURRENCY);
+    });
+
+    it('prefers environment config over backend suggestedChunkSizeBytes and default concurrency', () => {
+      const config = resolveUploadConfig({
+        suggestedChunkSizeBytes: 25 * 1024 * 1024,
+        searchString: '',
+        environmentConfig: {
+          chunkSizeBytes: 8 * 1024 * 1024,
+          maxConcurrency: 6,
+        },
+      });
+
+      expect(config.chunkSize).toBe(8 * 1024 * 1024);
+      expect(config.maxConcurrency).toBe(6);
+    });
+
+    it('prefers callerMaxConcurrency over environment config', () => {
+      const config = resolveUploadConfig({
+        callerMaxConcurrency: 3,
+        searchString: '',
+        environmentConfig: {
+          maxConcurrency: 8,
+        },
+      });
+
+      expect(config.maxConcurrency).toBe(3);
+    });
+
+    it('prefers GET query parameters over environment config, server suggestions, and caller options', () => {
+      const config = resolveUploadConfig({
+        suggestedChunkSizeBytes: 25 * 1024 * 1024,
+        callerMaxConcurrency: 2,
+        searchString: '?uploadChunkSize=1MB&uploadConcurrency=10',
+        environmentConfig: {
+          chunkSizeBytes: 8 * 1024 * 1024,
+          maxConcurrency: 4,
+        },
+      });
+
+      expect(config.chunkSize).toBe(1024 * 1024);
+      expect(config.maxConcurrency).toBe(10);
+    });
+
+    it('falls back to environment config if GET parameters are invalid', () => {
+      const config = resolveUploadConfig({
+        suggestedChunkSizeBytes: 25 * 1024 * 1024,
+        searchString: '?uploadChunkSize=invalid&uploadConcurrency=notanumber',
+        environmentConfig: {
+          chunkSizeBytes: 4 * 1024 * 1024,
+          maxConcurrency: 5,
+        },
+      });
+
+      expect(config.chunkSize).toBe(4 * 1024 * 1024);
+      expect(config.maxConcurrency).toBe(5);
+    });
+
+    it('clamps chunkSize and maxConcurrency to at least 1', () => {
+      const config = resolveUploadConfig({
+        searchString: '?uploadConcurrency=0',
+        suggestedChunkSizeBytes: 0,
+        callerMaxConcurrency: 0,
+        environmentConfig: {
+          chunkSizeBytes: 0,
+          maxConcurrency: 0,
+        },
+      });
+
+      expect(config.chunkSize).toBeGreaterThanOrEqual(1);
+      expect(config.maxConcurrency).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/web/src/app/services/api/upload-config-resolver.ts
+++ b/web/src/app/services/api/upload-config-resolver.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UploadEnvironmentConfig } from 'src/environments/environment-types';
+import { environment } from 'src/environments/environment';
+import {
+  DEFAULT_CHUNK_SIZE_BYTES,
+  DEFAULT_MAX_CONCURRENCY,
+} from 'src/app/services/api/chunked-uploader';
+import {
+  parseByteSizeQueryParam,
+  parseIntegerQueryParam,
+  resolveParam,
+} from 'src/app/utils/config-resolver';
+
+/**
+ * Options supplied to resolve the effective upload configuration.
+ */
+export interface ResolveUploadConfigOptions {
+  /** Optional chunk size suggested by the backend server in bytes. */
+  readonly suggestedChunkSizeBytes?: number;
+  /** Optional max concurrency requested by the programmatic caller. */
+  readonly callerMaxConcurrency?: number;
+  /** Optional URL search query string (defaults to window.location.search when available). */
+  readonly searchString?: string;
+  /** Optional environment upload config (defaults to environment.upload). */
+  readonly environmentConfig?: UploadEnvironmentConfig;
+}
+
+/**
+ * Resolved chunk upload parameters.
+ */
+export interface ResolvedUploadConfig {
+  /** The effective chunk size in bytes (clamped to >= 1). */
+  readonly chunkSize: number;
+  /** The effective maximum concurrency limit (clamped to >= 1). */
+  readonly maxConcurrency: number;
+}
+
+/**
+ * Resolves chunk upload configuration with priority:
+ *
+ * For chunkSize:
+ * 1. URL GET parameter `uploadChunkSize` (bytes or human-readable format like `2MB`, `512KB`).
+ * 2. `environment.upload.chunkSizeBytes`.
+ * 3. Server `suggestedChunkSizeBytes` (from StartImportInspection / StartFileUpload).
+ * 4. Fallback default (16 MB).
+ *
+ * For maxConcurrency:
+ * 1. URL GET parameter `uploadConcurrency` (integer).
+ * 2. Programmatic caller options (`callerMaxConcurrency`).
+ * 3. `environment.upload.maxConcurrency`.
+ * 4. Fallback default (4).
+ */
+export function resolveUploadConfig(
+  options?: ResolveUploadConfigOptions,
+): ResolvedUploadConfig {
+  const envConfig = options?.environmentConfig ?? environment.upload;
+
+  const chunkSize = resolveParam({
+    paramName: 'uploadChunkSize',
+    parser: parseByteSizeQueryParam,
+    searchString: options?.searchString,
+    candidates: [envConfig?.chunkSizeBytes, options?.suggestedChunkSizeBytes],
+    defaultValue: DEFAULT_CHUNK_SIZE_BYTES,
+    validator: (v) => v > 0,
+  });
+
+  const maxConcurrency = resolveParam({
+    paramName: 'uploadConcurrency',
+    parser: (val) => parseIntegerQueryParam(val, 1),
+    searchString: options?.searchString,
+    candidates: [options?.callerMaxConcurrency, envConfig?.maxConcurrency],
+    defaultValue: DEFAULT_MAX_CONCURRENCY,
+    validator: (v) => v > 0,
+  });
+
+  return {
+    chunkSize: Math.max(1, Math.floor(chunkSize)),
+    maxConcurrency: Math.max(1, Math.floor(maxConcurrency)),
+  };
+}

--- a/web/src/app/utils/config-resolver.spec.ts
+++ b/web/src/app/utils/config-resolver.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getQueryParam,
+  parseBooleanQueryParam,
+  parseByteSizeQueryParam,
+  parseIntegerQueryParam,
+  resolveConfigValue,
+  resolveParam,
+} from 'src/app/utils/config-resolver';
+
+describe('config-resolver', () => {
+  describe('resolveConfigValue', () => {
+    it('returns the first non-null and non-undefined candidate', () => {
+      expect(
+        resolveConfigValue([undefined, null, 'first', 'second'], 'default'),
+      ).toBe('first');
+      expect(resolveConfigValue([undefined, 0, 10], 100)).toBe(0);
+      expect(resolveConfigValue([false, true], true)).toBe(false);
+    });
+
+    it('returns defaultValue when all candidates are null or undefined', () => {
+      expect(resolveConfigValue([undefined, null, undefined], 'default')).toBe(
+        'default',
+      );
+      expect(resolveConfigValue([], 42)).toBe(42);
+    });
+  });
+
+  describe('getQueryParam', () => {
+    it('retrieves and parses an existing query parameter', () => {
+      const result = getQueryParam(
+        'count',
+        (v) => parseInt(v, 10),
+        '?count=42&other=foo',
+      );
+      expect(result).toBe(42);
+    });
+
+    it('returns undefined if parameter is not in search string', () => {
+      const result = getQueryParam(
+        'missing',
+        (v) => parseInt(v, 10),
+        '?count=42',
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if parser returns undefined', () => {
+      const result = getQueryParam('count', () => undefined, '?count=invalid');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('resolveParam', () => {
+    it('resolves query parameter when present and valid', () => {
+      const result = resolveParam({
+        paramName: 'limit',
+        parser: (v) => parseIntegerQueryParam(v, 1),
+        searchString: '?limit=20',
+        candidates: [10],
+        defaultValue: 5,
+      });
+      expect(result).toBe(20);
+    });
+
+    it('resolves candidate when query parameter is missing or invalid', () => {
+      const result = resolveParam({
+        paramName: 'limit',
+        parser: (v) => parseIntegerQueryParam(v, 1),
+        searchString: '?limit=invalid',
+        candidates: [10],
+        defaultValue: 5,
+      });
+      expect(result).toBe(10);
+    });
+
+    it('falls back to defaultValue when query param and candidates are undefined', () => {
+      const result = resolveParam({
+        paramName: 'limit',
+        parser: (v) => parseIntegerQueryParam(v, 1),
+        searchString: '',
+        candidates: [undefined, null],
+        defaultValue: 5,
+      });
+      expect(result).toBe(5);
+    });
+  });
+
+  describe('parseBooleanQueryParam', () => {
+    it('parses truthy values correctly', () => {
+      expect(parseBooleanQueryParam('true')).toBeTrue();
+      expect(parseBooleanQueryParam('TRUE')).toBeTrue();
+      expect(parseBooleanQueryParam('1')).toBeTrue();
+      expect(parseBooleanQueryParam('yes')).toBeTrue();
+      expect(parseBooleanQueryParam('YES')).toBeTrue();
+      expect(parseBooleanQueryParam('  true  ')).toBeTrue();
+    });
+
+    it('parses falsy values correctly', () => {
+      expect(parseBooleanQueryParam('false')).toBeFalse();
+      expect(parseBooleanQueryParam('FALSE')).toBeFalse();
+      expect(parseBooleanQueryParam('0')).toBeFalse();
+      expect(parseBooleanQueryParam('no')).toBeFalse();
+      expect(parseBooleanQueryParam('NO')).toBeFalse();
+      expect(parseBooleanQueryParam('  false  ')).toBeFalse();
+    });
+
+    it('returns undefined for invalid boolean values', () => {
+      expect(parseBooleanQueryParam(null)).toBeUndefined();
+      expect(parseBooleanQueryParam(undefined)).toBeUndefined();
+      expect(parseBooleanQueryParam('')).toBeUndefined();
+      expect(parseBooleanQueryParam('foo')).toBeUndefined();
+      expect(parseBooleanQueryParam('2')).toBeUndefined();
+    });
+  });
+
+  describe('parseIntegerQueryParam', () => {
+    it('parses positive integers correctly', () => {
+      expect(parseIntegerQueryParam('10')).toBe(10);
+      expect(parseIntegerQueryParam('  5  ')).toBe(5);
+    });
+
+    it('enforces min constraint', () => {
+      expect(parseIntegerQueryParam('0', 1)).toBeUndefined();
+      expect(parseIntegerQueryParam('-5', 1)).toBeUndefined();
+      expect(parseIntegerQueryParam('3', 5)).toBeUndefined();
+      expect(parseIntegerQueryParam('5', 5)).toBe(5);
+    });
+
+    it('returns undefined for non-numeric inputs', () => {
+      expect(parseIntegerQueryParam(null)).toBeUndefined();
+      expect(parseIntegerQueryParam(undefined)).toBeUndefined();
+      expect(parseIntegerQueryParam('')).toBeUndefined();
+      expect(parseIntegerQueryParam('abc')).toBeUndefined();
+    });
+  });
+
+  describe('parseByteSizeQueryParam', () => {
+    it('parses plain byte counts', () => {
+      expect(parseByteSizeQueryParam('1024')).toBe(1024);
+      expect(parseByteSizeQueryParam('1048576')).toBe(1048576);
+    });
+
+    it('parses unit suffixes case-insensitively', () => {
+      expect(parseByteSizeQueryParam('1KB')).toBe(1024);
+      expect(parseByteSizeQueryParam('2kb')).toBe(2048);
+      expect(parseByteSizeQueryParam('4kib')).toBe(4096);
+      expect(parseByteSizeQueryParam('1MB')).toBe(1024 * 1024);
+      expect(parseByteSizeQueryParam('2mb')).toBe(2 * 1024 * 1024);
+      expect(parseByteSizeQueryParam('16MiB')).toBe(16 * 1024 * 1024);
+      expect(parseByteSizeQueryParam('1GB')).toBe(1024 * 1024 * 1024);
+    });
+
+    it('parses decimal values with units', () => {
+      expect(parseByteSizeQueryParam('1.5MB')).toBe(
+        Math.floor(1.5 * 1024 * 1024),
+      );
+      expect(parseByteSizeQueryParam('0.5KB')).toBe(512);
+    });
+
+    it('handles spaces between number and unit', () => {
+      expect(parseByteSizeQueryParam('2 MB')).toBe(2 * 1024 * 1024);
+      expect(parseByteSizeQueryParam(' 512  KB ')).toBe(512 * 1024);
+    });
+
+    it('returns undefined for invalid inputs', () => {
+      expect(parseByteSizeQueryParam(null)).toBeUndefined();
+      expect(parseByteSizeQueryParam(undefined)).toBeUndefined();
+      expect(parseByteSizeQueryParam('')).toBeUndefined();
+      expect(parseByteSizeQueryParam('abc')).toBeUndefined();
+      expect(parseByteSizeQueryParam('10XB')).toBeUndefined();
+      expect(parseByteSizeQueryParam('-5MB')).toBeUndefined();
+      expect(parseByteSizeQueryParam('0MB')).toBeUndefined();
+    });
+  });
+});

--- a/web/src/app/utils/config-resolver.spec.ts
+++ b/web/src/app/utils/config-resolver.spec.ts
@@ -147,6 +147,9 @@ describe('config-resolver', () => {
       expect(parseIntegerQueryParam(undefined)).toBeUndefined();
       expect(parseIntegerQueryParam('')).toBeUndefined();
       expect(parseIntegerQueryParam('abc')).toBeUndefined();
+      expect(parseIntegerQueryParam('4abc')).toBeUndefined();
+      expect(parseIntegerQueryParam('12.34')).toBeUndefined();
+      expect(parseIntegerQueryParam('1e5')).toBeUndefined();
     });
   });
 

--- a/web/src/app/utils/config-resolver.ts
+++ b/web/src/app/utils/config-resolver.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Options for resolving a parameter value from query parameter, candidate overrides, and a default value.
+ */
+export interface ResolveParamOptions<T> {
+  /** Optional URL query parameter name to inspect (e.g. 'downloadChunkSize'). */
+  readonly paramName?: string;
+  /** Function to parse raw query parameter string into T, returning undefined if invalid. */
+  readonly parser?: (rawValue: string) => T | undefined;
+  /** Optional URL search query string (defaults to window.location.search when available). */
+  readonly searchString?: string;
+  /** Candidate values in priority order (e.g. [callerOption, envValue]). */
+  readonly candidates?: readonly (T | undefined | null)[];
+  /** Mandatory fallback default value. */
+  readonly defaultValue: T;
+  /** Optional validator function to ensure candidate value is valid before accepting. */
+  readonly validator?: (value: T) => boolean;
+}
+
+/**
+ * Resolves a value by checking a cascade of candidate values in order.
+ *
+ * Returns the first candidate that is not undefined and not null (and passes validator if provided).
+ * Returns the defaultValue if no candidate is valid.
+ */
+export function resolveConfigValue<T>(
+  candidates: readonly (T | undefined | null)[],
+  defaultValue: T,
+  validator?: (value: T) => boolean,
+): T {
+  for (const candidate of candidates) {
+    if (candidate !== undefined && candidate !== null) {
+      if (!validator || validator(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return defaultValue;
+}
+
+/**
+ * Retrieves and parses a query parameter from a URL search string.
+ *
+ * Returns undefined if searchString is empty, the parameter is not present, or the parser returns undefined.
+ */
+export function getQueryParam<T>(
+  paramName: string,
+  parser: (rawValue: string) => T | undefined,
+  searchString?: string,
+): T | undefined {
+  let search = searchString;
+  if (
+    search === undefined &&
+    typeof window !== 'undefined' &&
+    window.location?.search
+  ) {
+    search = window.location.search;
+  }
+  if (!search) {
+    return undefined;
+  }
+  const params = new URLSearchParams(search);
+  const raw = params.get(paramName);
+  if (raw === null) {
+    return undefined;
+  }
+  return parser(raw);
+}
+
+/**
+ * Resolves a parameter value from query parameters, candidate overrides, and a default value.
+ *
+ * Precedence:
+ * 1. Query parameter value (if paramName and parser are provided and query parameter exists).
+ * 2. Candidate values in provided order.
+ * 3. Default value.
+ */
+export function resolveParam<T>(options: ResolveParamOptions<T>): T {
+  const queryVal =
+    options.paramName && options.parser
+      ? getQueryParam(options.paramName, options.parser, options.searchString)
+      : undefined;
+  return resolveConfigValue(
+    [queryVal, ...(options.candidates ?? [])],
+    options.defaultValue,
+    options.validator,
+  );
+}
+
+/**
+ * Parses a boolean string value from query parameters.
+ *
+ * Accepts 'true', '1', 'yes' as true, and 'false', '0', 'no' as false (case-insensitive).
+ * Returns undefined if input is not a recognized boolean representation.
+ */
+export function parseBooleanQueryParam(
+  input: string | null | undefined,
+): boolean | undefined {
+  if (input === null || input === undefined) {
+    return undefined;
+  }
+  const normalized = input.trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+    return true;
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+    return false;
+  }
+  return undefined;
+}
+
+/**
+ * Parses an integer string value from query parameters.
+ *
+ * Returns parsed integer if valid and >= min (default 1).
+ * Returns undefined otherwise.
+ */
+export function parseIntegerQueryParam(
+  input: string | null | undefined,
+  min = 1,
+): number | undefined {
+  if (input === null || input === undefined) {
+    return undefined;
+  }
+  const parsed = parseInt(input.trim(), 10);
+  if (isNaN(parsed) || parsed < min) {
+    return undefined;
+  }
+  return parsed;
+}
+
+/**
+ * Multipliers for byte units (binary 1024-based).
+ */
+const BYTE_UNIT_MULTIPLIERS: Readonly<Record<string, number>> = {
+  b: 1,
+  k: 1024,
+  kb: 1024,
+  kib: 1024,
+  m: 1024 * 1024,
+  mb: 1024 * 1024,
+  mib: 1024 * 1024,
+  g: 1024 * 1024 * 1024,
+  gb: 1024 * 1024 * 1024,
+  gib: 1024 * 1024 * 1024,
+};
+
+/**
+ * Parses a byte size string with optional unit suffix into bytes.
+ *
+ * Examples of valid inputs:
+ * - '1048576' -> 1048576
+ * - '512KB' / '512KiB' -> 524288
+ * - '2MB' / '2MiB' -> 2097152
+ * - '1GB' / '1GiB' -> 1073741824
+ *
+ * Returns undefined if invalid or below min (default 1).
+ */
+export function parseByteSizeQueryParam(
+  input: string | null | undefined,
+  min = 1,
+): number | undefined {
+  if (input === null || input === undefined) {
+    return undefined;
+  }
+  const trimmed = input.trim();
+  if (trimmed === '') {
+    return undefined;
+  }
+
+  // Regex pattern matching numeric prefix with optional unit suffix
+  const match = /^([0-9]+(?:\.[0-9]+)?)\s*([a-zA-Z]*)$/.exec(trimmed);
+  if (!match) {
+    return undefined;
+  }
+
+  const num = parseFloat(match[1]);
+  if (isNaN(num) || num <= 0) {
+    return undefined;
+  }
+
+  const unit = match[2].toLowerCase();
+  let multiplier = 1;
+  if (unit !== '') {
+    const found = BYTE_UNIT_MULTIPLIERS[unit];
+    if (found === undefined) {
+      return undefined;
+    }
+    multiplier = found;
+  }
+
+  const result = Math.floor(num * multiplier);
+  if (result < min) {
+    return undefined;
+  }
+  return result;
+}

--- a/web/src/app/utils/config-resolver.ts
+++ b/web/src/app/utils/config-resolver.ts
@@ -137,7 +137,11 @@ export function parseIntegerQueryParam(
   if (input === null || input === undefined) {
     return undefined;
   }
-  const parsed = parseInt(input.trim(), 10);
+  const trimmed = input.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = parseInt(trimmed, 10);
   if (isNaN(parsed) || parsed < min) {
     return undefined;
   }

--- a/web/src/environments/environment-types.ts
+++ b/web/src/environments/environment-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Configuration options for chunked uploads defined in environments.
+ */
+export interface UploadEnvironmentConfig {
+  /** Default chunk payload size in bytes. */
+  readonly chunkSizeBytes?: number;
+  /** Maximum number of concurrent chunk uploads. */
+  readonly maxConcurrency?: number;
+}
+
+/**
+ * Configuration options for chunked downloads defined in environments.
+ */
+export interface DownloadEnvironmentConfig {
+  /** Default chunk payload size in bytes. */
+  readonly chunkSizeBytes?: number;
+  /** Maximum number of concurrent chunk downloads. */
+  readonly maxConcurrency?: number;
+}

--- a/web/src/environments/environment.dev.ts
+++ b/web/src/environments/environment.dev.ts
@@ -15,14 +15,22 @@
  */
 
 import { PublicKHIExtension } from 'src/app/extensions/public/module';
+export * from 'src/environments/environment-types';
+import {
+  UploadEnvironmentConfig,
+  DownloadEnvironmentConfig,
+} from 'src/environments/environment-types';
 
 export const environment = {
   production: false,
+  useBinaryFormat: false,
   bugReportUrl:
     'https://github.com/GoogleCloudPlatform/khi/issues/new?template=Blank+issue',
   documentUrl: 'https://github.com/GoogleCloudPlatform/khi',
   pluginModules: [PublicKHIExtension],
   options: {} as Record<string, unknown>,
+  upload: {} as UploadEnvironmentConfig,
+  download: {} as DownloadEnvironmentConfig,
   links: [
     {
       label: 'GitHub',

--- a/web/src/environments/environment.prod.ts
+++ b/web/src/environments/environment.prod.ts
@@ -15,14 +15,22 @@
  */
 
 import { PublicKHIExtension } from 'src/app/extensions/public/module';
+export * from 'src/environments/environment-types';
+import {
+  UploadEnvironmentConfig,
+  DownloadEnvironmentConfig,
+} from 'src/environments/environment-types';
 
 export const environment = {
   production: true,
+  useBinaryFormat: true,
   bugReportUrl:
     'https://github.com/GoogleCloudPlatform/khi/issues/new?template=Blank+issue',
   documentUrl: 'https://github.com/GoogleCloudPlatform/khi',
   pluginModules: [PublicKHIExtension],
   options: {} as Record<string, unknown>,
+  upload: {} as UploadEnvironmentConfig,
+  download: {} as DownloadEnvironmentConfig,
   links: [
     {
       label: 'GitHub',

--- a/web/src/environments/environment.ts
+++ b/web/src/environments/environment.ts
@@ -14,12 +14,21 @@
  * limitations under the License.
  */
 
+export * from 'src/environments/environment-types';
+import {
+  UploadEnvironmentConfig,
+  DownloadEnvironmentConfig,
+} from 'src/environments/environment-types';
+
 export const environment = {
   production: false,
+  useBinaryFormat: false,
   bugReportUrl: '',
   documentUrl: '',
   pluginModules: [],
   options: {} as Record<string, unknown>,
+  upload: {} as UploadEnvironmentConfig,
+  download: {} as DownloadEnvironmentConfig,
   links: [],
   /**
    * Enables unary polling fallback for Server-Side Streaming RPCs.


### PR DESCRIPTION
## Summary
Enable flexible configuration and URL parameter overrides for chunked upload, chunked download, and Connect-RPC binary transport format, alongside a generalized configuration resolver utility.

## Changes
- **Generalized Config Resolver (`config-resolver.ts`)**:
  - Provides `resolveParam` combining query parameter extraction, candidate fallback cascades (e.g. caller options, environment configs), validators, and default values.
  - Provides robust parsers for booleans (`parseBooleanQueryParam`), integers with minimum bounds (`parseIntegerQueryParam`), and human-readable byte sizes (`parseByteSizeQueryParam`, e.g. `2MB`, `512KB`).
- **Dynamic Upload Config**:
  - Resolves chunk size via `?uploadChunkSize` > `environment.upload.chunkSizeBytes` > backend suggestion > 16 MB.
  - Resolves concurrency via `?uploadConcurrency` > caller option > `environment.upload.maxConcurrency` > 4.
  - Integrated into `import-inspection-client.service.ts` and `file-parameter-upload-client.service.ts`.
- **Dynamic Binary Transport Format**:
  - Decoupled Connect-RPC protobuf transport from `environment.production` to `environment.useBinaryFormat` (`false` in dev, `true` in prod).
  - Supports runtime override via `?useBinaryFormat=true` / `?useBinaryFormat=false` (also accepts `1`/`0`/`yes`/`no`).
- **Dynamic Download Config**:
  - Resolves inspection data download chunk size via `?downloadChunkSize` > `environment.download.chunkSizeBytes` > 16 MB.
  - Resolves download concurrency via `?downloadConcurrency` > `environment.download.maxConcurrency` > 10.
  - Integrated into `backend-api.service.ts` `getInspectionData()`.
- **Unit Tests**:
  - Added unit test suites for `config-resolver`, `transport-config-resolver`, `download-config-resolver`, `upload-config-resolver`, `connect-client.service`, and `backend-api.service`.

## Verification
- `make test-web`: 857 of 857 tests passed (0 failures)
- `make lint-web`: All files pass linting
- `make format-web`: All files formatted
- `make build-storybook`: Storybook build completed successfully
- `make pre-commit`: All formatters, linters, and markdownlint passed cleanly