### PR TITLE
feat(web): tune legacy polling intervals and switch to sequential short polling for async jobs

### DIFF
--- a/web/src/app/services/api/legacy-polling.interceptor.spec.ts
+++ b/web/src/app/services/api/legacy-polling.interceptor.spec.ts
@@ -363,6 +363,49 @@ describe('LegacyPollingInterceptor', () => {
       expect(canceled).toBeTrue();
     });
 
+    it('adapts OpenWorkbench and yields stages until READY', async () => {
+      let openCalls = 0;
+      const mockTransport = createMockUnaryTransport((methodName) => {
+        if (methodName === 'OpenWorkbenchSync') {
+          openCalls++;
+          if (openCalls === 1) {
+            return create(OpenWorkbenchSyncResponseSchema, {
+              jobId: 'job-wb-ready',
+              stage: OpenWorkbenchResponse_Stage.READING_FILE,
+              progressPercentage: 20.0,
+              message: 'Reading data...',
+            });
+          }
+          return create(OpenWorkbenchSyncResponseSchema, {
+            jobId: 'job-wb-ready',
+            stage: OpenWorkbenchResponse_Stage.READY,
+            progressPercentage: 100.0,
+            message: 'Workbench ready.',
+            workbenchId: 'wb-ready-1',
+          });
+        }
+        throw new Error(`Unexpected method: ${methodName}`);
+      });
+
+      const interceptor = createLegacyPollingInterceptor(mockTransport, true);
+      const clientTransport = createMockStreamTransport(interceptor);
+      const client = createClient(WorkbenchService, clientTransport);
+      const stages: OpenWorkbenchResponse_Stage[] = [];
+      for await (const res of client.openWorkbench({
+        userId: 'u1',
+        sessionId: 's1',
+        inspectionId: 'i1',
+      })) {
+        stages.push(res.stage);
+      }
+
+      expect(stages).toEqual([
+        OpenWorkbenchResponse_Stage.READING_FILE,
+        OpenWorkbenchResponse_Stage.READY,
+      ]);
+      expect(openCalls).toBe(2);
+    });
+
     it('adapts FilterTimeline and sends cancellation on abort', async () => {
       let filterCalls = 0;
       let canceled = false;

--- a/web/src/app/services/api/legacy-polling.interceptor.ts
+++ b/web/src/app/services/api/legacy-polling.interceptor.ts
@@ -137,7 +137,7 @@ async function* adaptWatchPopup(
         return;
       }
     }
-    await delay(1000, req.signal);
+    await delay(500, req.signal);
   }
 }
 
@@ -183,7 +183,7 @@ async function* adaptWatchInspections(
         return;
       }
     }
-    await delay(1000, req.signal);
+    await delay(500, req.signal);
   }
 }
 
@@ -257,7 +257,6 @@ async function* adaptOpenWorkbench(
       if (res.stage === OpenWorkbenchResponse_Stage.READY) {
         return;
       }
-      await delay(300, req.signal);
     }
   } finally {
     if (req.signal.aborted && jobId) {
@@ -311,7 +310,6 @@ async function* adaptFilterTimeline(
     }
 
     while (!req.signal.aborted) {
-      await delay(300, req.signal);
       const pollRes = await wbClient.filterTimelineSync(
         {
           workbenchId: input.workbenchId,


### PR DESCRIPTION
## Summary

This PR adjusts the polling intervals and timing behavior in `legacy-polling.interceptor.ts` when legacy polling fallback is active:

1. **State Observation RPCs**:
   - `WatchPopup`: Reduced polling interval from 1000ms to 500ms for faster UI popup notifications.
   - `WatchInspections`: Reduced polling interval from 1000ms to 500ms for faster reflection of inspection list changes.

2. **Async Job RPCs**:
   - `OpenWorkbench` & `FilterTimeline`: Removed client-side fixed wait delays (`delay(300, req.signal)`) inside the polling loop, adopting sequential short polling. Because requests are sequentially awaited (`while (!req.signal.aborted)`), concurrency is strictly limited to at most 1 in-flight request at all times.

3. **Tests**:
   - Added test case `adapts OpenWorkbench and yields stages until READY` to verify multi-stage polling progression and clean termination without cancellations in `legacy-polling.interceptor.spec.ts`.

## Testing

- `make test-web` (All 862 tests pass)
- `make lint-web`
- `make format-web`
- `make test-go`
- `make pre-commit`