### PR TITLE
feat(web): detect workbench session expiration and support reopening

### DIFF
--- a/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.html
+++ b/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.html
@@ -50,7 +50,13 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end" class="dialog-actions">
-  <button mat-button (click)="returnToStartup.emit()">Return to Startup</button>
+  <button
+    mat-button
+    [disabled]="isReconnecting()"
+    (click)="returnToStartup.emit()"
+  >
+    Return to Startup
+  </button>
   <button
     mat-flat-button
     color="primary"

--- a/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.html
+++ b/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.html
@@ -1,0 +1,62 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<h2 mat-dialog-title class="dialog-title">
+  @if (errorMessage()) {
+    <mat-icon class="title-icon error-icon">error_outline</mat-icon>
+    <span>Failed to Reconnect</span>
+  } @else {
+    <mat-icon class="title-icon warning-icon">schedule</mat-icon>
+    <span>Session Timed Out</span>
+  }
+</h2>
+
+<mat-dialog-content class="dialog-content">
+  @if (errorMessage()) {
+    <p class="description error-description">
+      An error occurred while reconnecting to the server:
+    </p>
+    <div class="error-box">
+      {{ errorMessage() }}
+    </div>
+    <p class="hint-text">
+      You can retry reconnecting, or return to the startup screen to load
+      another inspection.
+    </p>
+  } @else {
+    <p class="description">Your session timed out due to inactivity.</p>
+    <p class="detail-text">
+      Features such as viewing resource YAML and timeline search require a
+      server connection.
+    </p>
+    <p class="hint-text">
+      Please reconnect to resume your inspection, or return to the startup
+      screen.
+    </p>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="dialog-actions">
+  <button mat-button (click)="returnToStartup.emit()">Return to Startup</button>
+  <button
+    mat-flat-button
+    color="primary"
+    [disabled]="isReconnecting()"
+    (click)="reconnect.emit()"
+  >
+    {{ errorMessage() ? "Retry" : "Reconnect" }}
+  </button>
+</mat-dialog-actions>

--- a/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.scss
+++ b/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.scss
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+$dialog-min-width: 480px;
+$dialog-max-width: 560px;
+$title-color: #1f1f1f;
+$warning-icon-color: #f59e0b;
+$error-icon-color: #d93025;
+$text-primary-color: #374151;
+$text-secondary-color: #6b7280;
+$error-box-bg: #fef2f2;
+$error-box-border: #fca5a5;
+$error-box-text: #991b1b;
+$actions-border-color: #e5e7eb;
+
+:host {
+  display: grid;
+  grid-template:
+    'title' auto
+    'content' 1fr
+    'actions' auto
+    / 1fr;
+  min-width: $dialog-min-width;
+  max-width: $dialog-max-width;
+}
+
+.dialog-title {
+  grid-area: title;
+  display: grid;
+  grid-template:
+    'icon heading' auto
+    / auto 1fr;
+  gap: 12px;
+  align-items: center;
+  margin: 0;
+  padding: 20px 24px 12px;
+  color: $title-color;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.title-icon {
+  grid-area: icon;
+  font-size: 24px;
+  width: 24px;
+  height: 24px;
+
+  &.warning-icon {
+    color: $warning-icon-color;
+  }
+
+  &.error-icon {
+    color: $error-icon-color;
+  }
+}
+
+.dialog-content {
+  grid-area: content;
+  display: grid;
+  grid-template:
+    'body' 1fr
+    / 1fr;
+  margin: 0;
+  padding: 8px 24px 16px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: $text-primary-color;
+
+  .description {
+    margin: 0 0 12px;
+    font-weight: 500;
+  }
+
+  .detail-text {
+    margin: 0 0 12px;
+    color: $text-secondary-color;
+  }
+
+  .hint-text {
+    margin: 0;
+    color: $text-secondary-color;
+    font-size: 13px;
+  }
+
+  .error-description {
+    color: $error-box-text;
+  }
+
+  .error-box {
+    margin: 0 0 12px;
+    padding: 10px 12px;
+    background-color: $error-box-bg;
+    border: 1px solid $error-box-border;
+    border-radius: 4px;
+    color: $error-box-text;
+    font-family: monospace;
+    font-size: 12px;
+    word-break: break-all;
+    max-height: 120px;
+    overflow-y: auto;
+  }
+}
+
+.dialog-actions {
+  grid-area: actions;
+  display: grid;
+  grid-template:
+    'cancel submit' auto
+    / auto auto;
+  justify-content: end;
+  gap: 12px;
+  padding: 12px 24px 20px;
+  margin: 0;
+  border-top: 1px solid $actions-border-color;
+}

--- a/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.spec.ts
+++ b/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.spec.ts
@@ -105,7 +105,7 @@ describe('SessionTimedOutLayoutComponent', () => {
     expect(retryEmitted).toBeTrue();
   });
 
-  it('should disable action button when isReconnecting is true', () => {
+  it('should disable both action buttons when isReconnecting is true', () => {
     fixture.componentRef.setInput('isReconnecting', true);
     fixture.detectChanges();
 
@@ -113,6 +113,10 @@ describe('SessionTimedOutLayoutComponent', () => {
     const reconnectBtn = buttons.find((b) =>
       b.nativeElement.textContent.includes('Reconnect'),
     );
+    const startupBtn = buttons.find((b) =>
+      b.nativeElement.textContent.includes('Return to Startup'),
+    );
     expect(reconnectBtn?.nativeElement.disabled).toBeTrue();
+    expect(startupBtn?.nativeElement.disabled).toBeTrue();
   });
 });

--- a/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.spec.ts
+++ b/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SessionTimedOutLayoutComponent } from 'src/app/dialogs/session-timed-out/components/session-timed-out-layout.component';
+import { By } from '@angular/platform-browser';
+
+describe('SessionTimedOutLayoutComponent', () => {
+  let component: SessionTimedOutLayoutComponent;
+  let fixture: ComponentFixture<SessionTimedOutLayoutComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SessionTimedOutLayoutComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SessionTimedOutLayoutComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create and render session timed out title when errorMessage is null', () => {
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+    const title = fixture.debugElement.query(By.css('.dialog-title'));
+    expect(title.nativeElement.textContent).toContain('Session Timed Out');
+  });
+
+  it('should emit reconnect event when Reconnect button is clicked', () => {
+    fixture.detectChanges();
+
+    let emitted = false;
+    component.reconnect.subscribe(() => {
+      emitted = true;
+    });
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const reconnectBtn = buttons.find((b) =>
+      b.nativeElement.textContent.includes('Reconnect'),
+    );
+    expect(reconnectBtn).toBeDefined();
+    reconnectBtn?.nativeElement.click();
+
+    expect(emitted).toBeTrue();
+  });
+
+  it('should emit returnToStartup event when Return to Startup button is clicked', () => {
+    fixture.detectChanges();
+
+    let emitted = false;
+    component.returnToStartup.subscribe(() => {
+      emitted = true;
+    });
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const startupBtn = buttons.find((b) =>
+      b.nativeElement.textContent.includes('Return to Startup'),
+    );
+    expect(startupBtn).toBeDefined();
+    startupBtn?.nativeElement.click();
+
+    expect(emitted).toBeTrue();
+  });
+
+  it('should render error message and action buttons when errorMessage is provided', () => {
+    fixture.componentRef.setInput('errorMessage', 'Connection refused');
+    fixture.detectChanges();
+
+    const title = fixture.debugElement.query(By.css('.dialog-title'));
+    expect(title.nativeElement.textContent).toContain('Failed to Reconnect');
+
+    const errorBox = fixture.debugElement.query(By.css('.error-box'));
+    expect(errorBox.nativeElement.textContent).toContain('Connection refused');
+  });
+
+  it('should emit reconnect event when Retry button is clicked in error state', () => {
+    fixture.componentRef.setInput('errorMessage', 'Server crashed');
+    fixture.detectChanges();
+
+    let retryEmitted = false;
+    component.reconnect.subscribe(() => {
+      retryEmitted = true;
+    });
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const retryBtn = buttons.find((b) =>
+      b.nativeElement.textContent.includes('Retry'),
+    );
+
+    retryBtn?.nativeElement.click();
+    expect(retryEmitted).toBeTrue();
+  });
+
+  it('should disable action button when isReconnecting is true', () => {
+    fixture.componentRef.setInput('isReconnecting', true);
+    fixture.detectChanges();
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const reconnectBtn = buttons.find((b) =>
+      b.nativeElement.textContent.includes('Reconnect'),
+    );
+    expect(reconnectBtn?.nativeElement.disabled).toBeTrue();
+  });
+});

--- a/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.ts
+++ b/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.component.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+
+/**
+ * Layout component for the session timed out dialog.
+ * Renders the session timeout prompt or failure states and delegates user actions.
+ */
+@Component({
+  selector: 'khi-session-timed-out-layout',
+  imports: [
+    MatButtonModule,
+    MatDialogModule,
+    MatIconModule,
+    KHIIconRegistrationModule,
+  ],
+  templateUrl: './session-timed-out-layout.component.html',
+  styleUrls: ['./session-timed-out-layout.component.scss'],
+})
+export class SessionTimedOutLayoutComponent {
+  /**
+   * Optional error message if a reconnection attempt failed.
+   */
+  readonly errorMessage = input<string | null>(null);
+
+  /**
+   * Indicates whether a reconnection request is currently pending.
+   */
+  readonly isReconnecting = input<boolean>(false);
+
+  /**
+   * Emits when the user requests reconnecting or retrying to connect to the server.
+   */
+  readonly reconnect = output<void>();
+
+  /**
+   * Emits when the user chooses to return to the startup dialog.
+   */
+  readonly returnToStartup = output<void>();
+}

--- a/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.stories.ts
+++ b/web/src/app/dialogs/session-timed-out/components/session-timed-out-layout.stories.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { SessionTimedOutLayoutComponent } from 'src/app/dialogs/session-timed-out/components/session-timed-out-layout.component';
+
+export default {
+  title: 'Dialogs/SessionTimedOut/SessionTimedOutLayout',
+  component: SessionTimedOutLayoutComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [SessionTimedOutLayoutComponent],
+    }),
+  ],
+} as Meta<SessionTimedOutLayoutComponent>;
+
+type Story = StoryObj<SessionTimedOutLayoutComponent>;
+
+export const Default: Story = {
+  args: {
+    errorMessage: null,
+    isReconnecting: false,
+  },
+};
+
+export const Reconnecting: Story = {
+  args: {
+    errorMessage: null,
+    isReconnecting: true,
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    errorMessage: 'Failed to reconnect to the server. Connection timed out.',
+    isReconnecting: false,
+  },
+};

--- a/web/src/app/dialogs/session-timed-out/session-timed-out-smart.component.html
+++ b/web/src/app/dialogs/session-timed-out/session-timed-out-smart.component.html
@@ -1,0 +1,22 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<khi-session-timed-out-layout
+  [errorMessage]="errorMessage()"
+  [isReconnecting]="isReconnecting()"
+  (reconnect)="onReconnect()"
+  (returnToStartup)="onReturnToStartup()"
+/>

--- a/web/src/app/dialogs/session-timed-out/session-timed-out-smart.component.scss
+++ b/web/src/app/dialogs/session-timed-out/session-timed-out-smart.component.scss
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+:host {
+  display: contents;
+}

--- a/web/src/app/dialogs/session-timed-out/session-timed-out-smart.component.spec.ts
+++ b/web/src/app/dialogs/session-timed-out/session-timed-out-smart.component.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+import { signal } from '@angular/core';
+import {
+  openSessionTimedOutDialog,
+  SessionTimedOutSmartComponent,
+} from 'src/app/dialogs/session-timed-out/session-timed-out-smart.component';
+import { SessionTimedOutLayoutComponent } from 'src/app/dialogs/session-timed-out/components/session-timed-out-layout.component';
+import { WorkbenchClientService } from 'src/app/services/api/workbench/workbench-client.service';
+import {
+  PROGRESS_DIALOG_STATUS_UPDATOR,
+  ProgressDialogStatusUpdator,
+} from 'src/app/services/progress/progress-interface';
+
+describe('SessionTimedOutSmartComponent', () => {
+  let component: SessionTimedOutSmartComponent;
+  let fixture: ComponentFixture<SessionTimedOutSmartComponent>;
+  let dialogRefSpy: jasmine.SpyObj<
+    MatDialogRef<SessionTimedOutSmartComponent, void>
+  >;
+  let dialogSpy: jasmine.SpyObj<MatDialog>;
+  let workbenchClientSpy: jasmine.SpyObj<WorkbenchClientService>;
+  let progressDialogSpy: jasmine.SpyObj<ProgressDialogStatusUpdator>;
+
+  beforeEach(async () => {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+    dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    workbenchClientSpy = jasmine.createSpyObj(
+      'WorkbenchClientService',
+      ['reopenWorkbench', 'closeWorkbench'],
+      {
+        isReopening: signal(false).asReadonly(),
+      },
+    );
+    progressDialogSpy = jasmine.createSpyObj('ProgressDialogStatusUpdator', [
+      'show',
+      'dismiss',
+      'updateProgress',
+    ]);
+
+    TestBed.overrideProvider(MatDialog, { useValue: dialogSpy });
+
+    await TestBed.configureTestingModule({
+      imports: [SessionTimedOutSmartComponent, NoopAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        { provide: WorkbenchClientService, useValue: workbenchClientSpy },
+        {
+          provide: PROGRESS_DIALOG_STATUS_UPDATOR,
+          useValue: progressDialogSpy,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SessionTimedOutSmartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create and render layout component', () => {
+    expect(component).toBeTruthy();
+    const layoutEl = fixture.debugElement.query(
+      By.directive(SessionTimedOutLayoutComponent),
+    );
+    expect(layoutEl).toBeTruthy();
+  });
+
+  it('should show progress, reconnect session, and close dialog on success', async () => {
+    workbenchClientSpy.reopenWorkbench.and.callFake((onProgress) => {
+      onProgress?.('Reading...', 50, 2);
+      return Promise.resolve('wb-restored');
+    });
+
+    const layoutEl = fixture.debugElement.query(
+      By.directive(SessionTimedOutLayoutComponent),
+    );
+    layoutEl.triggerEventHandler('reconnect', undefined);
+    await fixture.whenStable();
+
+    expect(progressDialogSpy.show).toHaveBeenCalledOnceWith();
+    expect(progressDialogSpy.updateProgress).toHaveBeenCalled();
+    expect(progressDialogSpy.dismiss).toHaveBeenCalledOnceWith();
+    expect(dialogRefSpy.close).toHaveBeenCalledOnceWith();
+  });
+
+  it('should dismiss progress and update error message on reconnection failure', async () => {
+    workbenchClientSpy.reopenWorkbench.and.rejectWith(
+      new Error('Connection failed'),
+    );
+
+    const layoutEl = fixture.debugElement.query(
+      By.directive(SessionTimedOutLayoutComponent),
+    );
+    layoutEl.triggerEventHandler('reconnect', undefined);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(progressDialogSpy.show).toHaveBeenCalledOnceWith();
+    expect(progressDialogSpy.dismiss).toHaveBeenCalledOnceWith();
+    expect(dialogRefSpy.close).not.toHaveBeenCalled();
+
+    const layoutInstance =
+      layoutEl.componentInstance as SessionTimedOutLayoutComponent;
+    expect(layoutInstance.errorMessage()).toContain('Connection failed');
+  });
+
+  it('should close workbench, close dialog, and open startup dialog when returnToStartup is triggered', () => {
+    const layoutEl = fixture.debugElement.query(
+      By.directive(SessionTimedOutLayoutComponent),
+    );
+    layoutEl.triggerEventHandler('returnToStartup', undefined);
+
+    expect(workbenchClientSpy.closeWorkbench).toHaveBeenCalledOnceWith();
+    expect(dialogRefSpy.close).toHaveBeenCalledOnceWith();
+    expect(dialogSpy.open).toHaveBeenCalled();
+  });
+
+  describe('openSessionTimedOutDialog', () => {
+    it('should open dialog with disableClose set to true', () => {
+      openSessionTimedOutDialog(dialogSpy);
+      expect(dialogSpy.open).toHaveBeenCalledWith(
+        SessionTimedOutSmartComponent,
+        jasmine.objectContaining({
+          disableClose: true,
+        }),
+      );
+    });
+  });
+});

--- a/web/src/app/dialogs/session-timed-out/session-timed-out-smart.component.ts
+++ b/web/src/app/dialogs/session-timed-out/session-timed-out-smart.component.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, inject, signal } from '@angular/core';
+import {
+  MatDialog,
+  MatDialogConfig,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { SessionTimedOutLayoutComponent } from 'src/app/dialogs/session-timed-out/components/session-timed-out-layout.component';
+import { WorkbenchClientService } from 'src/app/services/api/workbench/workbench-client.service';
+import {
+  PROGRESS_DIALOG_STATUS_UPDATOR,
+  ProgressDialogStatusUpdator,
+} from 'src/app/services/progress/progress-interface';
+import { openStartupDialog } from 'src/app/dialogs/startup/startup-smart.component';
+
+/**
+ * Smart component for the Session Timed Out dialog.
+ * Orchestrates reconnection attempts, progress indicator display, and navigation to startup.
+ */
+@Component({
+  selector: 'khi-session-timed-out-smart',
+  imports: [SessionTimedOutLayoutComponent],
+  templateUrl: './session-timed-out-smart.component.html',
+  styleUrls: ['./session-timed-out-smart.component.scss'],
+})
+export class SessionTimedOutSmartComponent {
+  private readonly dialogRef =
+    inject<MatDialogRef<SessionTimedOutSmartComponent, void>>(MatDialogRef);
+  private readonly dialog = inject(MatDialog);
+  private readonly workbenchClient = inject(WorkbenchClientService);
+  private readonly progressDialog = inject<ProgressDialogStatusUpdator>(
+    PROGRESS_DIALOG_STATUS_UPDATOR,
+  );
+
+  /**
+   * Holds the error message if the previous reconnection attempt failed.
+   */
+  protected readonly errorMessage = signal<string | null>(null);
+
+  /**
+   * Tracks whether a reconnection operation is currently running.
+   */
+  protected readonly isReconnecting = this.workbenchClient.isReopening;
+
+  /**
+   * Handles user confirmation to reconnect the session on the backend.
+   */
+  protected async onReconnect(): Promise<void> {
+    this.progressDialog.show();
+    this.progressDialog.updateProgress({
+      message: 'Reconnecting to server...',
+      percent: 0,
+      mode: 'indeterminate',
+    });
+
+    try {
+      await this.workbenchClient.reopenWorkbench((msg, pct) => {
+        this.progressDialog.updateProgress({
+          message: msg,
+          percent: pct,
+          mode: 'determinate',
+        });
+      });
+      this.dialogRef.close();
+    } catch (err) {
+      console.error('[SessionTimedOut] Failed to reconnect:', err);
+      const message = err instanceof Error ? err.message : String(err);
+      this.errorMessage.set(message);
+    } finally {
+      this.progressDialog.dismiss();
+    }
+  }
+
+  /**
+   * Handles user action to return to the startup screen and resets the current session.
+   */
+  protected onReturnToStartup(): void {
+    this.workbenchClient.closeWorkbench();
+    this.dialogRef.close();
+    openStartupDialog(this.dialog);
+  }
+}
+
+/**
+ * Opens the Session Timed Out dialog.
+ *
+ * @param dialog The Angular Material MatDialog service instance.
+ * @param config Optional dialog configuration overrides.
+ * @returns Reference to the opened dialog.
+ */
+export function openSessionTimedOutDialog(
+  dialog: MatDialog,
+  config?: MatDialogConfig,
+): MatDialogRef<SessionTimedOutSmartComponent, void> {
+  return dialog.open<SessionTimedOutSmartComponent, void>(
+    SessionTimedOutSmartComponent,
+    {
+      disableClose: true,
+      ...config,
+    },
+  );
+}

--- a/web/src/app/pages/main/main.component.ts
+++ b/web/src/app/pages/main/main.component.ts
@@ -50,6 +50,7 @@ import {
   SETTINGS_STORAGE,
   SettingsStorage,
 } from 'src/app/services/settings/settings-storage';
+import { SessionTimeoutDialogService } from 'src/app/services/api/workbench/session-timeout-dialog.service';
 import {
   RequestUserActionPopupComponent,
   RequestUserActionPopupRequest,
@@ -118,6 +119,9 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     inject(NotificationManager);
 
   constructor() {
+    // Eagerly instantiate dialog monitor to observe session expiration.
+    inject(SessionTimeoutDialogService);
+
     let lastDialogRef: MatDialogRef<RequestUserActionPopupComponent> | null =
       null;
     let lastPopupId: string | null = null;

--- a/web/src/app/services/api/workbench/session-timeout-dialog.service.spec.ts
+++ b/web/src/app/services/api/workbench/session-timeout-dialog.service.spec.ts
@@ -16,7 +16,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { EMPTY } from 'rxjs';
+import { Subject } from 'rxjs';
 import { signal } from '@angular/core';
 import { SessionTimeoutDialogService } from 'src/app/services/api/workbench/session-timeout-dialog.service';
 import { WorkbenchClientService } from 'src/app/services/api/workbench/workbench-client.service';
@@ -29,14 +29,18 @@ describe('SessionTimeoutDialogService', () => {
   let mockDialogRef: jasmine.SpyObj<
     MatDialogRef<SessionTimedOutSmartComponent, void>
   >;
+  let afterClosedSubject: Subject<void>;
 
   beforeEach(() => {
     isWorkbenchExpiredSignal = signal(false);
+    afterClosedSubject = new Subject<void>();
     mockDialogRef = jasmine.createSpyObj('MatDialogRef', [
       'close',
       'afterClosed',
     ]);
-    mockDialogRef.afterClosed.and.returnValue(EMPTY);
+    mockDialogRef.afterClosed.and.returnValue(
+      afterClosedSubject.asObservable(),
+    );
 
     dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
     dialogSpy.open.and.returnValue(mockDialogRef);
@@ -80,5 +84,54 @@ describe('SessionTimeoutDialogService', () => {
     TestBed.flushEffects();
 
     expect(mockDialogRef.close).toHaveBeenCalled();
+  });
+
+  it('should reset activeDialogRef when afterClosed emits', () => {
+    isWorkbenchExpiredSignal.set(true);
+    TestBed.flushEffects();
+
+    afterClosedSubject.next();
+
+    // After afterClosed emitted, transitioning isWorkbenchExpired to false
+    // should not call close on the already closed dialogRef
+    isWorkbenchExpiredSignal.set(false);
+    TestBed.flushEffects();
+
+    expect(mockDialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('should not reset activeDialogRef if afterClosed emits from a previously opened dialog', () => {
+    const firstAfterClosed = new Subject<void>();
+    const firstDialogRef = jasmine.createSpyObj<
+      MatDialogRef<SessionTimedOutSmartComponent, void>
+    >('FirstMatDialogRef', ['close', 'afterClosed']);
+    firstDialogRef.afterClosed.and.returnValue(firstAfterClosed.asObservable());
+
+    const secondAfterClosed = new Subject<void>();
+    const secondDialogRef = jasmine.createSpyObj<
+      MatDialogRef<SessionTimedOutSmartComponent, void>
+    >('SecondMatDialogRef', ['close', 'afterClosed']);
+    secondDialogRef.afterClosed.and.returnValue(
+      secondAfterClosed.asObservable(),
+    );
+
+    dialogSpy.open.and.returnValues(firstDialogRef, secondDialogRef);
+
+    // Open first dialog
+    isWorkbenchExpiredSignal.set(true);
+    TestBed.flushEffects();
+
+    // Simulate closing first dialog synchronously and opening second
+    (service as unknown as { activeDialogRef: unknown }).activeDialogRef =
+      secondDialogRef;
+
+    // First dialog's afterClosed finishes later
+    firstAfterClosed.next();
+
+    // activeDialogRef should still be secondDialogRef, so close should be called on it
+    isWorkbenchExpiredSignal.set(false);
+    TestBed.flushEffects();
+
+    expect(secondDialogRef.close).toHaveBeenCalled();
   });
 });

--- a/web/src/app/services/api/workbench/session-timeout-dialog.service.spec.ts
+++ b/web/src/app/services/api/workbench/session-timeout-dialog.service.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { EMPTY } from 'rxjs';
+import { signal } from '@angular/core';
+import { SessionTimeoutDialogService } from 'src/app/services/api/workbench/session-timeout-dialog.service';
+import { WorkbenchClientService } from 'src/app/services/api/workbench/workbench-client.service';
+import { SessionTimedOutSmartComponent } from 'src/app/dialogs/session-timed-out/session-timed-out-smart.component';
+
+describe('SessionTimeoutDialogService', () => {
+  let service: SessionTimeoutDialogService;
+  let dialogSpy: jasmine.SpyObj<MatDialog>;
+  let isWorkbenchExpiredSignal: ReturnType<typeof signal<boolean>>;
+  let mockDialogRef: jasmine.SpyObj<
+    MatDialogRef<SessionTimedOutSmartComponent, void>
+  >;
+
+  beforeEach(() => {
+    isWorkbenchExpiredSignal = signal(false);
+    mockDialogRef = jasmine.createSpyObj('MatDialogRef', [
+      'close',
+      'afterClosed',
+    ]);
+    mockDialogRef.afterClosed.and.returnValue(EMPTY);
+
+    dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    dialogSpy.open.and.returnValue(mockDialogRef);
+
+    const mockWorkbenchClient = {
+      isWorkbenchExpired: isWorkbenchExpiredSignal.asReadonly(),
+    };
+
+    TestBed.overrideProvider(MatDialog, { useValue: dialogSpy });
+
+    TestBed.configureTestingModule({
+      providers: [
+        SessionTimeoutDialogService,
+        { provide: WorkbenchClientService, useValue: mockWorkbenchClient },
+      ],
+    });
+
+    service = TestBed.inject(SessionTimeoutDialogService);
+  });
+
+  it('should be created and not open dialog initially when session is active', () => {
+    expect(service).toBeTruthy();
+    expect(dialogSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('should open dialog when isWorkbenchExpired transitions to true', () => {
+    isWorkbenchExpiredSignal.set(true);
+    TestBed.flushEffects();
+
+    expect(dialogSpy.open).toHaveBeenCalledOnceWith(
+      SessionTimedOutSmartComponent,
+      jasmine.objectContaining({ disableClose: true }),
+    );
+  });
+
+  it('should close dialog when isWorkbenchExpired becomes false', () => {
+    isWorkbenchExpiredSignal.set(true);
+    TestBed.flushEffects();
+
+    isWorkbenchExpiredSignal.set(false);
+    TestBed.flushEffects();
+
+    expect(mockDialogRef.close).toHaveBeenCalled();
+  });
+});

--- a/web/src/app/services/api/workbench/session-timeout-dialog.service.ts
+++ b/web/src/app/services/api/workbench/session-timeout-dialog.service.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable, effect, inject, untracked } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { WorkbenchClientService } from 'src/app/services/api/workbench/workbench-client.service';
+import {
+  openSessionTimedOutDialog,
+  SessionTimedOutSmartComponent,
+} from 'src/app/dialogs/session-timed-out/session-timed-out-smart.component';
+
+/**
+ * Monitors session timeout status and manages the lifecycle of the timeout dialog.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SessionTimeoutDialogService {
+  private readonly dialog = inject(MatDialog);
+  private readonly workbenchClient = inject(WorkbenchClientService);
+
+  private activeDialogRef: MatDialogRef<
+    SessionTimedOutSmartComponent,
+    void
+  > | null = null;
+
+  constructor() {
+    effect(() => {
+      const isExpired = this.workbenchClient.isWorkbenchExpired();
+
+      if (isExpired) {
+        untracked(() => {
+          if (!this.activeDialogRef) {
+            this.openDialog();
+          }
+        });
+      } else {
+        untracked(() => {
+          if (this.activeDialogRef) {
+            this.activeDialogRef.close();
+            this.activeDialogRef = null;
+          }
+        });
+      }
+    });
+  }
+
+  /**
+   * Opens the Session Timed Out dialog if not already open.
+   */
+  private openDialog(): void {
+    if (this.activeDialogRef) {
+      return;
+    }
+
+    this.activeDialogRef = openSessionTimedOutDialog(this.dialog);
+    this.activeDialogRef.afterClosed().subscribe(() => {
+      this.activeDialogRef = null;
+    });
+  }
+}

--- a/web/src/app/services/api/workbench/session-timeout-dialog.service.ts
+++ b/web/src/app/services/api/workbench/session-timeout-dialog.service.ts
@@ -66,9 +66,12 @@ export class SessionTimeoutDialogService {
       return;
     }
 
-    this.activeDialogRef = openSessionTimedOutDialog(this.dialog);
-    this.activeDialogRef.afterClosed().subscribe(() => {
-      this.activeDialogRef = null;
+    const dialogRef = openSessionTimedOutDialog(this.dialog);
+    this.activeDialogRef = dialogRef;
+    dialogRef.afterClosed().subscribe(() => {
+      if (this.activeDialogRef === dialogRef) {
+        this.activeDialogRef = null;
+      }
     });
   }
 }

--- a/web/src/app/services/api/workbench/workbench-client.service.spec.ts
+++ b/web/src/app/services/api/workbench/workbench-client.service.spec.ts
@@ -609,4 +609,63 @@ describe('WorkbenchClientService', () => {
     expect(service.isWorkbenchExpired()).toBeFalse();
     expect(service.isReopening()).toBeFalse();
   });
+
+  it('should not restart or trigger heartbeat on visibilitychange when session is expired', async () => {
+    (
+      mockConnectClient.workbenchClient.heartbeatWorkbench as jasmine.Spy
+    ).and.returnValue(Promise.resolve({ active: false }));
+
+    await service.heartbeat('wb-expired');
+    expect(service.isWorkbenchExpired()).toBeTrue();
+
+    const heartbeatSpy = mockConnectClient.workbenchClient
+      .heartbeatWorkbench as jasmine.Spy;
+    heartbeatSpy.calls.reset();
+
+    // Dispatch visibilitychange when document is visible
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(heartbeatSpy).not.toHaveBeenCalled();
+  });
+
+  it('should close new workbench and not activate it if session was closed while openWorkbench was in flight', async () => {
+    let completeStream!: () => void;
+    const streamPromise = new Promise<void>((resolve) => {
+      completeStream = resolve;
+    });
+
+    async function* delayedOpenStream() {
+      await streamPromise;
+      yield {
+        stage: OpenWorkbenchResponse_Stage.READY,
+        progressPercentage: 100,
+        message: 'Ready',
+        workbenchId: 'wb-orphaned',
+      };
+    }
+
+    (
+      mockConnectClient.workbenchClient.openWorkbench as jasmine.Spy
+    ).and.returnValue(delayedOpenStream());
+    (
+      mockConnectClient.workbenchClient.closeWorkbench as jasmine.Spy
+    ).and.returnValue(Promise.resolve({ closed: true }));
+
+    const openPromise = service.openWorkbench('s-1', 'i-1');
+
+    // While open is pending, user returns to startup / closes workbench
+    await service.closeWorkbench();
+
+    // Now open response arrives
+    completeStream();
+    const result = await openPromise;
+
+    expect(result).toBeUndefined();
+    expect(service.activeWorkbenchId()).toBeNull();
+    expect(
+      mockConnectClient.workbenchClient.closeWorkbench,
+    ).toHaveBeenCalledWith({
+      workbenchId: 'wb-orphaned',
+    });
+  });
 });

--- a/web/src/app/services/api/workbench/workbench-client.service.spec.ts
+++ b/web/src/app/services/api/workbench/workbench-client.service.spec.ts
@@ -22,6 +22,7 @@ import {
   WatchIndexProgressResponse_IndexState,
 } from 'src/app/generated/api/v1/workbench_pb';
 import { create } from '@bufbuild/protobuf';
+import { ConnectError, Code } from '@connectrpc/connect';
 import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import { UserIdentityService } from 'src/app/services/api/workbench/user-identity.service';
 import {
@@ -443,5 +444,169 @@ describe('WorkbenchClientService', () => {
 
     await service.closeWorkbench('wb-1');
     expect(capturedSignal?.aborted).toBeTrue();
+  });
+
+  it('should mark workbench as expired when heartbeat returns inactive', async () => {
+    (
+      mockConnectClient.workbenchClient.heartbeatWorkbench as jasmine.Spy
+    ).and.returnValue(Promise.resolve({ active: false }));
+
+    const isActive = await service.heartbeat('wb-1');
+
+    expect(isActive).toBeFalse();
+    expect(service.isWorkbenchExpired()).toBeTrue();
+  });
+
+  it('should mark workbench as expired when heartbeat throws ConnectError Code.NotFound', async () => {
+    const notFoundErr = new ConnectError('session expired', Code.NotFound);
+    (
+      mockConnectClient.workbenchClient.heartbeatWorkbench as jasmine.Spy
+    ).and.returnValue(Promise.reject(notFoundErr));
+
+    const isActive = await service.heartbeat('wb-1');
+
+    expect(isActive).toBeFalse();
+    expect(service.isWorkbenchExpired()).toBeTrue();
+  });
+
+  it('should mark workbench as expired when readStructYAML throws ConnectError Code.NotFound', async () => {
+    async function* mockOpenStream() {
+      yield {
+        stage: OpenWorkbenchResponse_Stage.READY,
+        progressPercentage: 100,
+        message: 'Ready',
+        workbenchId: 'wb-active',
+      };
+    }
+    (
+      mockConnectClient.workbenchClient.openWorkbench as jasmine.Spy
+    ).and.returnValue(mockOpenStream());
+    const notFoundErr = new ConnectError('not found', Code.NotFound);
+    (
+      mockConnectClient.workbenchClient.readStructYAML as jasmine.Spy
+    ).and.returnValue(Promise.reject(notFoundErr));
+
+    await service.openWorkbench('s-1', 'i-1');
+    expect(service.isWorkbenchExpired()).toBeFalse();
+
+    await expectAsync(service.readStructYAML(10)).toBeRejectedWith(notFoundErr);
+    expect(service.isWorkbenchExpired()).toBeTrue();
+  });
+
+  it('should mark workbench as expired when filterTimeline throws ConnectError Code.NotFound', async () => {
+    async function* mockOpenStream() {
+      yield {
+        stage: OpenWorkbenchResponse_Stage.READY,
+        progressPercentage: 100,
+        message: 'Ready',
+        workbenchId: 'wb-active',
+      };
+    }
+    (
+      mockConnectClient.workbenchClient.openWorkbench as jasmine.Spy
+    ).and.returnValue(mockOpenStream());
+    const notFoundErr = new ConnectError('not found', Code.NotFound);
+    (
+      mockConnectClient.workbenchClient.filterTimeline as jasmine.Spy
+    ).and.returnValue(
+      (async function* () {
+        throw notFoundErr;
+      })(),
+    );
+
+    await service.openWorkbench('s-1', 'i-1');
+    expect(service.isWorkbenchExpired()).toBeFalse();
+
+    await expectAsync(service.filterTimeline({})).toBeRejectedWith(notFoundErr);
+    expect(service.isWorkbenchExpired()).toBeTrue();
+  });
+
+  it('should reopen workbench using stored session and inspection IDs and reset expired flag', async () => {
+    (
+      mockConnectClient.workbenchClient.openWorkbench as jasmine.Spy
+    ).and.callFake(() => {
+      return (async function* () {
+        yield {
+          stage: OpenWorkbenchResponse_Stage.READY,
+          progressPercentage: 100,
+          message: 'Ready',
+          workbenchId: 'wb-reopened',
+        };
+      })();
+    });
+
+    await service.openWorkbench('my-session', 'my-inspection');
+    (
+      service as unknown as {
+        isWorkbenchExpiredSignal: { set: (v: boolean) => void };
+      }
+    ).isWorkbenchExpiredSignal.set(true);
+    expect(service.isWorkbenchExpired()).toBeTrue();
+
+    const reopenedId = await service.reopenWorkbench();
+
+    expect(reopenedId).toBe('wb-reopened');
+    expect(service.activeWorkbenchId()).toBe('wb-reopened');
+    expect(service.isWorkbenchExpired()).toBeFalse();
+  });
+
+  it('should deduplicate concurrent reopenWorkbench invocations', async () => {
+    let callCount = 0;
+    (
+      mockConnectClient.workbenchClient.openWorkbench as jasmine.Spy
+    ).and.callFake(() => {
+      callCount++;
+      return (async function* () {
+        yield {
+          stage: OpenWorkbenchResponse_Stage.READY,
+          progressPercentage: 100,
+          message: 'Ready',
+          workbenchId: 'wb-reopened',
+        };
+      })();
+    });
+
+    await service.openWorkbench('my-session', 'my-inspection');
+
+    const [id1, id2] = await Promise.all([
+      service.reopenWorkbench(),
+      service.reopenWorkbench(),
+    ]);
+
+    expect(id1).toBe('wb-reopened');
+    expect(id2).toBe('wb-reopened');
+    expect(callCount).toBe(2); // 1 for initial open, 1 for deduplicated reopen
+  });
+
+  it('should throw error when reopenWorkbench is called without prior openWorkbench', async () => {
+    await expectAsync(service.reopenWorkbench()).toBeRejectedWithError(
+      'No active or previous inspection session available to reopen.',
+    );
+  });
+
+  it('should reset session IDs and expiration signals on closeWorkbench', async () => {
+    async function* mockOpenStream() {
+      yield {
+        stage: OpenWorkbenchResponse_Stage.READY,
+        progressPercentage: 100,
+        message: 'Ready',
+        workbenchId: 'wb-1',
+      };
+    }
+    (
+      mockConnectClient.workbenchClient.openWorkbench as jasmine.Spy
+    ).and.returnValue(mockOpenStream());
+    (
+      mockConnectClient.workbenchClient.closeWorkbench as jasmine.Spy
+    ).and.returnValue(Promise.resolve({ closed: true }));
+
+    await service.openWorkbench('session-1', 'insp-1');
+    await service.closeWorkbench('wb-1');
+
+    await expectAsync(service.reopenWorkbench()).toBeRejectedWithError(
+      'No active or previous inspection session available to reopen.',
+    );
+    expect(service.isWorkbenchExpired()).toBeFalse();
+    expect(service.isReopening()).toBeFalse();
   });
 });

--- a/web/src/app/services/api/workbench/workbench-client.service.ts
+++ b/web/src/app/services/api/workbench/workbench-client.service.ts
@@ -15,6 +15,7 @@
  */
 
 import { Injectable, OnDestroy, computed, inject, signal } from '@angular/core';
+import { ConnectError, Code } from '@connectrpc/connect';
 import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import { UserIdentityService } from 'src/app/services/api/workbench/user-identity.service';
 import {
@@ -83,6 +84,13 @@ export class WorkbenchClientService implements OnDestroy {
     WorkbenchClientService.STRUCT_YAML_CACHE_CAPACITY,
   );
 
+  private currentSessionId: string | null = null;
+  private currentInspectionId: string | null = null;
+  private inFlightReopenPromise: Promise<string | undefined> | null = null;
+
+  private readonly isWorkbenchExpiredSignal = signal<boolean>(false);
+  private readonly isReopeningSignal = signal<boolean>(false);
+
   private readonly indexStateSignal =
     signal<WatchIndexProgressResponse_IndexState>(
       WatchIndexProgressResponse_IndexState.UNSPECIFIED,
@@ -102,6 +110,17 @@ export class WorkbenchClientService implements OnDestroy {
   public readonly isWorkbenchActive = computed(
     () => this.activeWorkbenchIdSignal() !== null,
   );
+
+  /**
+   * Whether the active Workbench session has expired on the backend.
+   */
+  public readonly isWorkbenchExpired =
+    this.isWorkbenchExpiredSignal.asReadonly();
+
+  /**
+   * Whether a Workbench reopen operation is currently in progress.
+   */
+  public readonly isReopening = this.isReopeningSignal.asReadonly();
 
   /**
    * Current index construction state.
@@ -144,9 +163,36 @@ export class WorkbenchClientService implements OnDestroy {
     }
   };
 
+  private readonly visibilityChangeHandler = () => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const id = this.activeWorkbenchIdSignal();
+    if (document.visibilityState === 'hidden') {
+      this.stopHeartbeat();
+    } else if (document.visibilityState === 'visible' && id) {
+      this.startHeartbeat(id);
+      void this.heartbeat(id);
+    }
+  };
+
+  private readonly focusHandler = () => {
+    const id = this.activeWorkbenchIdSignal();
+    if (id && !this.isWorkbenchExpiredSignal()) {
+      void this.heartbeat(id);
+    }
+  };
+
   constructor() {
     if (typeof window !== 'undefined') {
       window.addEventListener('beforeunload', this.unloadHandler);
+      window.addEventListener('focus', this.focusHandler);
+    }
+    if (typeof document !== 'undefined') {
+      document.addEventListener(
+        'visibilitychange',
+        this.visibilityChangeHandler,
+      );
     }
   }
 
@@ -156,6 +202,13 @@ export class WorkbenchClientService implements OnDestroy {
   public ngOnDestroy(): void {
     if (typeof window !== 'undefined') {
       window.removeEventListener('beforeunload', this.unloadHandler);
+      window.removeEventListener('focus', this.focusHandler);
+    }
+    if (typeof document !== 'undefined') {
+      document.removeEventListener(
+        'visibilitychange',
+        this.visibilityChangeHandler,
+      );
     }
     this.stopHeartbeat();
   }
@@ -168,6 +221,9 @@ export class WorkbenchClientService implements OnDestroy {
     inspectionId: string,
     onProgress?: WorkbenchOpenProgressCallback,
   ): Promise<string | undefined> {
+    this.currentSessionId = sessionId;
+    this.currentInspectionId = inspectionId;
+
     const userId = this.userIdService.userId;
     const responseStream = this.connectClient.workbenchClient.openWorkbench({
       userId,
@@ -188,6 +244,7 @@ export class WorkbenchClientService implements OnDestroy {
 
     if (workbenchId) {
       this.structYamlCache.clear();
+      this.isWorkbenchExpiredSignal.set(false);
       this.activeWorkbenchIdSignal.set(workbenchId);
       this.startHeartbeat(workbenchId);
       if (this.indexProgressAbortController) {
@@ -253,6 +310,26 @@ export class WorkbenchClientService implements OnDestroy {
   }
 
   /**
+   * Marks the workbench session as expired and stops heartbeat checks.
+   */
+  private markSessionExpired(): void {
+    if (!this.isWorkbenchExpiredSignal()) {
+      this.isWorkbenchExpiredSignal.set(true);
+      this.stopHeartbeat();
+    }
+  }
+
+  /**
+   * Checks if an error indicates that the backend session has expired (Code.NotFound),
+   * and marks the session as expired if so.
+   */
+  private handleSessionError(e: unknown): void {
+    if (e instanceof ConnectError && e.code === Code.NotFound) {
+      this.markSessionExpired();
+    }
+  }
+
+  /**
    * Sends a heartbeat to refresh the TTL lease of the active Workbench.
    */
   public async heartbeat(workbenchId: string): Promise<boolean> {
@@ -260,11 +337,54 @@ export class WorkbenchClientService implements OnDestroy {
       const res = await this.connectClient.workbenchClient.heartbeatWorkbench({
         workbenchId,
       });
-      return res.active;
+      if (!res.active) {
+        this.markSessionExpired();
+        return false;
+      }
+      return true;
     } catch (e) {
       console.warn(`[WorkbenchClient] Heartbeat failed for ${workbenchId}:`, e);
+      this.handleSessionError(e);
       return false;
     }
+  }
+
+  /**
+   * Reopens an expired Workbench session using the stored session and inspection identifiers.
+   * Concurrent invocations are deduplicated to share a single in-flight reopening promise.
+   *
+   * @param onProgress Optional callback for reporting reopening progress stages.
+   * @returns The restored Workbench ID.
+   */
+  public async reopenWorkbench(
+    onProgress?: WorkbenchOpenProgressCallback,
+  ): Promise<string | undefined> {
+    if (!this.currentSessionId || !this.currentInspectionId) {
+      throw new Error(
+        'No active or previous inspection session available to reopen.',
+      );
+    }
+
+    if (this.inFlightReopenPromise) {
+      return await this.inFlightReopenPromise;
+    }
+
+    this.isReopeningSignal.set(true);
+    this.inFlightReopenPromise = (async () => {
+      try {
+        const workbenchId = await this.openWorkbench(
+          this.currentSessionId!,
+          this.currentInspectionId!,
+          onProgress,
+        );
+        return workbenchId;
+      } finally {
+        this.isReopeningSignal.set(false);
+        this.inFlightReopenPromise = null;
+      }
+    })();
+
+    return await this.inFlightReopenPromise;
   }
 
   /**
@@ -278,6 +398,10 @@ export class WorkbenchClientService implements OnDestroy {
     }
     this.stopHeartbeat();
     this.structYamlCache.clear();
+    this.currentSessionId = null;
+    this.currentInspectionId = null;
+    this.isWorkbenchExpiredSignal.set(false);
+    this.isReopeningSignal.set(false);
     this.activeWorkbenchIdSignal.set(null);
     this.indexStateSignal.set(
       WatchIndexProgressResponse_IndexState.UNSPECIFIED,
@@ -316,13 +440,19 @@ export class WorkbenchClientService implements OnDestroy {
     if (!workbenchId) {
       throw new Error('No active Workbench session found.');
     }
-    const res = await this.connectClient.workbenchClient.readStructYAML({
-      workbenchId,
-      structId,
-    });
-    const yaml = res.yaml ?? '';
-    this.structYamlCache.put(structId, yaml);
-    return yaml;
+
+    try {
+      const res = await this.connectClient.workbenchClient.readStructYAML({
+        workbenchId,
+        structId,
+      });
+      const yaml = res.yaml ?? '';
+      this.structYamlCache.put(structId, yaml);
+      return yaml;
+    } catch (e) {
+      this.handleSessionError(e);
+      throw e;
+    }
   }
 
   /**
@@ -343,39 +473,44 @@ export class WorkbenchClientService implements OnDestroy {
       throw new Error('No active Workbench session found.');
     }
 
-    const responseStream = this.connectClient.workbenchClient.filterTimeline(
-      {
-        workbenchId,
-        timelineQuery: params.timelineQuery ?? '',
-        timelineExclusionQuery: params.timelineExclusionQuery ?? '',
-        logQuery: params.logQuery ?? '',
-        excludeNoLogs: params.excludeNoLogs ?? false,
-      },
-      { signal },
-    );
+    try {
+      const responseStream = this.connectClient.workbenchClient.filterTimeline(
+        {
+          workbenchId,
+          timelineQuery: params.timelineQuery ?? '',
+          timelineExclusionQuery: params.timelineExclusionQuery ?? '',
+          logQuery: params.logQuery ?? '',
+          excludeNoLogs: params.excludeNoLogs ?? false,
+        },
+        { signal },
+      );
 
-    let result: FilterTimelineResult = {};
+      let result: FilterTimelineResult = {};
 
-    for await (const res of responseStream) {
-      if (res.payload.case === 'progress' && res.payload.value) {
-        if (onProgress) {
-          onProgress(
-            res.payload.value.stageName ?? '',
-            res.payload.value.current ?? 0,
-            res.payload.value.total ?? 0,
-          );
+      for await (const res of responseStream) {
+        if (res.payload.case === 'progress' && res.payload.value) {
+          if (onProgress) {
+            onProgress(
+              res.payload.value.stageName ?? '',
+              res.payload.value.current ?? 0,
+              res.payload.value.total ?? 0,
+            );
+          }
+        } else if (res.payload.case === 'result' && res.payload.value) {
+          result = {
+            timelineMode: res.payload.value.timelineMode,
+            timelineBitset: res.payload.value.timelineBitset,
+            logMode: res.payload.value.logMode,
+            logBitset: res.payload.value.logBitset,
+          };
         }
-      } else if (res.payload.case === 'result' && res.payload.value) {
-        result = {
-          timelineMode: res.payload.value.timelineMode,
-          timelineBitset: res.payload.value.timelineBitset,
-          logMode: res.payload.value.logMode,
-          logBitset: res.payload.value.logBitset,
-        };
       }
-    }
 
-    return result;
+      return result;
+    } catch (e) {
+      this.handleSessionError(e);
+      throw e;
+    }
   }
 
   private startHeartbeat(workbenchId: string): void {

--- a/web/src/app/services/api/workbench/workbench-client.service.ts
+++ b/web/src/app/services/api/workbench/workbench-client.service.ts
@@ -170,7 +170,11 @@ export class WorkbenchClientService implements OnDestroy {
     const id = this.activeWorkbenchIdSignal();
     if (document.visibilityState === 'hidden') {
       this.stopHeartbeat();
-    } else if (document.visibilityState === 'visible' && id) {
+    } else if (
+      document.visibilityState === 'visible' &&
+      id &&
+      !this.isWorkbenchExpiredSignal()
+    ) {
       this.startHeartbeat(id);
       void this.heartbeat(id);
     }
@@ -243,6 +247,13 @@ export class WorkbenchClientService implements OnDestroy {
     }
 
     if (workbenchId) {
+      if (
+        this.currentSessionId !== sessionId ||
+        this.currentInspectionId !== inspectionId
+      ) {
+        void this.closeWorkbench(workbenchId);
+        return undefined;
+      }
       this.structYamlCache.clear();
       this.isWorkbenchExpiredSignal.set(false);
       this.activeWorkbenchIdSignal.set(workbenchId);
@@ -297,6 +308,10 @@ export class WorkbenchClientService implements OnDestroy {
         }
       } catch (e) {
         if (abortSignal?.aborted) {
+          return;
+        }
+        this.handleSessionError(e);
+        if (this.isWorkbenchExpiredSignal()) {
           return;
         }
         console.warn(


### PR DESCRIPTION
## Summary

This PR detects backend in-memory Workbench session expiration (e.g. after a 15-minute inactivity sweep) and guides the user to reconnect without losing their frontend inspection state.

## Key Changes

- **Session Expiration Detection**:
  - Periodically sends heartbeat pings to backend (every 5 minutes).
  - Pauses heartbeats when the document is hidden/backgrounded, and sends an immediate health check upon tab focus/visibility.
  - Detects expired sessions proactively via heartbeat response and reactively on RPC errors (`Code.NotFound`).
- **Session Timed Out Dialog (`khi-session-timed-out`)**:
  - Displays a modal dialog when the backend session expires, preventing broken UI states.
  - Offers two clear actions:
    - **Reconnect / Retry**: Invokes `reopenWorkbench()` with live progress reporting via `ProgressDialogStatusUpdator`.
    - **Return to Startup**: Closes the invalid session and navigates back to the startup screen.
- **Orchestration Service**:
  - Introduced `SessionTimeoutDialogService` to monitor `isWorkbenchExpired` signal and manage dialog lifecycle.
- **Unit Tests & Storybook**:
  - Comprehensive unit tests for `SessionTimedOutLayoutComponent`, `SessionTimedOutSmartComponent`, `SessionTimeoutDialogService`, and `WorkbenchClientService`.
  - Added Storybook stories for layout visual states (Default, Reconnecting, ErrorState).