### PR TITLE
feat(parser,store): stream v6 chunks directly into dynamic stores and introduce StructStore

### DIFF
--- a/web/src/app/parser/README.md
+++ b/web/src/app/parser/README.md
@@ -105,16 +105,16 @@ The data lifecycle is divided into two distinct phases: **Phase 1 (Parsing)** wh
    - The parser identifies the chunk type and looks up how to handle it in the version-specific registry.
 
 2. **`ParserBlueprint` and `ChunkDefinition`**
-   - Each file version (e.g., v6) defines a blueprint that maps chunk IDs to their corresponding Protobuf decoding logic and `IDataAssembler`.
+   - Each file version (e.g., v6) defines a blueprint that maps chunk IDs to their corresponding Protobuf decoding logic and `DataAssembler`.
 
-3. **`IDataAssembler`**
-   - Receives decoded Protobuf objects (`ingest`) as the file streams.
-   - Extracts necessary information, cross-references data, and constructs Domain Models.
-   - Assemblers are executed in a strict **Priority Order** during the assembly phase. For example, the `InterningPoolAssembler` runs first so that resolved strings are available when the `LogAssembler` runs.
+3. **`DataAssembler`**
+   - Injected with `InspectionDataBuilder` upon creation.
+   - Streams decoded Protobuf objects directly into domain stores during `ingest()`, avoiding intermediate in-memory array buffering.
+   - Provides an optional `finalize()` hook executed in priority order for any post-streaming data linking (e.g. associating timeline items to timelines).
 
 4. **`InspectionDataBuilder`**
    - Acts as the temporary mutable context during the parsing phase.
-   - Assemblers push their constructed Domain Models into this builder.
+   - Houses the domain stores and applies compaction (`shrinkToFit`) upon `build()`.
 
 5. **Optimized Domain Stores (`/domain`)**
    - Stores pre-sort Domain Models by timestamp and provide high-performance query methods (like binary search) to ensure the UI remains fast and responsive even when exploring massive datasets.
@@ -127,13 +127,15 @@ To maintain the Three-Tier Data Model, this directory is organized as follows:
 web/src/app/
  ├── store/            # Application Model (Domain Stores and Models)
  │    └── domain/      # Highly optimized domain stores built by assemblers
- │         ├── string-pool-store.ts
+ │         ├── intern-pool-store.ts
  │         ├── log-store.ts
- │         └── timeline-store.ts
+ │         ├── timeline-store.ts
+ │         ├── struct-store.ts
+ │         └── buffer-util.ts
  │
  └── parser/           # Core logic for KHI file parsing
       ├── core/        # Version-agnostic orchestrator and interfaces
-      │    ├── interfaces.ts       # IDataAssembler, ParserBlueprint, ChunkDefinition
+      │    ├── interfaces.ts       # DataAssembler, ParserBlueprint, ChunkDefinition
       │    ├── binary-reader.ts    # Utility to read chunks from ArrayBuffer
       │    ├── file-parser.ts      # KHIFileParser (Main orchestrator)
       │    └── builder.ts          # InspectionDataBuilder
@@ -141,13 +143,7 @@ web/src/app/
       ├── errors/      # Custom error definitions for the parsing phase
       │    └── parser-errors.ts    # KHIInvalidFileError, KHIDataAssemblyError, etc.
       │
-      ├── blueprints/  # Version-specific blueprints and the main registry
-      │    ├── registry.ts         # VERSION_REGISTRY
-      │    └── v6-blueprint.ts     # Blueprint mapping chunk IDs to v6 assemblers
-      │
-      └── assemblers/  # Version-specific chunk assemblers
-           └── v6/
-                ├── interning-pool-assembler.ts
-                ├── log-assembler.ts
-                └── ...
+      └── v6/          # Version 6 specific blueprint and assemblers
+           ├── blueprint.ts        # V6_BLUEPRINT and V6 chunk assemblers
+           └── blueprint.spec.ts   # Blueprint and assembler unit tests
 ```

--- a/web/src/app/parser/core/builder.spec.ts
+++ b/web/src/app/parser/core/builder.spec.ts
@@ -29,6 +29,7 @@ import {
   TimelineType,
   RevisionStateStyle,
 } from 'src/app/store/domain/style';
+import { StructValueKind } from 'src/app/store/domain/struct-store';
 
 describe('InspectionDataBuilder (Core)', () => {
   let builder: InspectionDataBuilder;
@@ -128,11 +129,11 @@ describe('InspectionDataBuilder (Core)', () => {
     };
 
     const result = await builder
-      .addStrings([{ id: 1, value: 'summary_value' }])
-      .addLogs(rawLogs)
-      .addTimelines(rawTimelines)
-      .addRevisions(rawRevisions)
-      .addEvents(rawEvents)
+      .addString({ id: 1, value: 'summary_value' })
+      .addLog(rawLogs[0])
+      .addTimeline(rawTimelines[0])
+      .addRevision(rawRevisions[0])
+      .addEvent(rawEvents[0])
       .addSeverities([rawSeverity])
       .addLogTypes([rawLogType])
       .addVerbs([rawVerb])
@@ -146,5 +147,78 @@ describe('InspectionDataBuilder (Core)', () => {
     const l = result.logStore.getLog(100);
     expect(l.id).toBe(100);
     expect(l.timestamp).toBe(1234n);
+  });
+
+  it('should stream single elements and handle structStore', async () => {
+    builder
+      .addString({ id: 1, value: 'meta\0key' })
+      .addString({ id: 2, value: 'val' })
+      .addFieldPathSet({ id: 1, fieldPathStringIds: [1] })
+      .addStruct({
+        id: 10,
+        fieldPathSetId: 1,
+        values: [{ kind: StructValueKind.String, stringId: 2 }],
+      })
+      .addLog({
+        id: 1,
+        ts: 100n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 2,
+        bodyStructId: 10,
+      })
+      .addRevision({
+        id: 50,
+        logId: 1,
+        changedTime: 100n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+        resourceBodyStructId: 10,
+      })
+      .addEvent({
+        id: 60,
+        logId: 1,
+      })
+      .addTimeline({
+        id: 5,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [50],
+        eventIds: [60],
+      });
+
+    const result = await builder.build();
+    expect(result.structStore.count).toBe(1);
+    expect(result.structStore.getStruct(10)).toEqual({
+      meta: {
+        key: 'val',
+      },
+    });
+    expect(result.logStore.count).toBe(1);
+    expect(result.timelineStore.count).toBe(1);
+  });
+
+  it('should handle build() when no elements are added', async () => {
+    const result = await builder.build();
+    expect(result.internPool.count).toBe(0);
+    expect(result.structStore.count).toBe(0);
+    expect(result.logStore.count).toBe(0);
+    expect(result.timelineStore.count).toBe(0);
+  });
+
+  it('should support single addition of FieldPathSet and Struct', async () => {
+    builder.addString({ id: 1, value: 'prop' });
+    builder.addFieldPathSet({ id: 1, fieldPathStringIds: [1] });
+    builder.addStruct({
+      id: 10,
+      fieldPathSetId: 1,
+      values: [{ kind: StructValueKind.Int64, value: 42n }],
+    });
+
+    const result = await builder.build();
+    expect(result.structStore.count).toBe(1);
+    expect(result.structStore.getStruct(10)).toEqual({ prop: 42 });
   });
 });

--- a/web/src/app/parser/core/builder.ts
+++ b/web/src/app/parser/core/builder.ts
@@ -28,6 +28,11 @@ import {
   EventDTO,
 } from 'src/app/store/domain/timeline-store';
 import {
+  FieldPathSetDTO,
+  StructDTO,
+  StructStore,
+} from 'src/app/store/domain/struct-store';
+import {
   LogType,
   RevisionState,
   Severity,
@@ -42,70 +47,88 @@ import {
 
 /**
  * Core InspectionDataBuilder for compiling raw store inputs.
- * Collects components in a version-decoupled form.
+ * Directly populates domain stores incrementally during file ingestion.
  */
 export class InspectionDataBuilder {
+  private readonly internPool = InternPoolStore.create();
   private readonly styleStore = new StyleStore();
+  private readonly logStore: LogStore;
+  private readonly timelineStore: TimelineStore;
+  private readonly structStore: StructStore;
+
   private readonly metadataStore: MetadataStore = {
     header: undefined,
     queries: [],
   };
 
-  private readonly rawStrings: StringEntryDTO[] = [];
-  private readonly rawLogs: LogDTO[] = [];
-  private readonly rawTimelines: TimelineDTO[] = [];
-  private readonly rawRevisions: RevisionDTO[] = [];
-  private readonly rawEvents: EventDTO[] = [];
-
   private iconAtlasPromise?: Promise<void>;
 
   /**
-   * Adds interned strings to the pool.
+   * Initializes the InspectionDataBuilder with linked domain stores.
    */
-  public addStrings(strings: Iterable<StringEntryDTO>): this {
-    for (const s of strings) {
-      this.rawStrings.push(s);
-    }
+  constructor() {
+    this.logStore = LogStore.create(this.internPool, this.styleStore);
+    this.timelineStore = TimelineStore.create(
+      this.internPool,
+      this.styleStore,
+      this.logStore,
+    );
+    this.structStore = StructStore.create(this.internPool);
+  }
+
+  /**
+   * Adds an interned string entry to the pool.
+   */
+  public addString(entry: StringEntryDTO): this {
+    this.internPool.addString(entry);
     return this;
   }
 
   /**
-   * Adds domain raw logs.
+   * Adds a single domain log entry.
    */
-  public addLogs(logs: Iterable<LogDTO>): this {
-    for (const log of logs) {
-      this.rawLogs.push(log);
-    }
+  public addLog(log: LogDTO): this {
+    this.logStore.addLog(log);
     return this;
   }
 
   /**
-   * Adds domain raw timelines.
+   * Adds a single timeline definition.
    */
-  public addTimelines(timelines: Iterable<TimelineDTO>): this {
-    for (const timeline of timelines) {
-      this.rawTimelines.push(timeline);
-    }
+  public addTimeline(timeline: TimelineDTO): this {
+    this.timelineStore.addTimeline(timeline);
     return this;
   }
 
   /**
-   * Adds domain raw revisions.
+   * Adds a single revision.
    */
-  public addRevisions(revisions: Iterable<RevisionDTO>): this {
-    for (const revision of revisions) {
-      this.rawRevisions.push(revision);
-    }
+  public addRevision(revision: RevisionDTO): this {
+    this.timelineStore.addRevision(revision);
     return this;
   }
 
   /**
-   * Adds domain raw events.
+   * Adds a single event.
    */
-  public addEvents(events: Iterable<EventDTO>): this {
-    for (const event of events) {
-      this.rawEvents.push(event);
-    }
+  public addEvent(event: EventDTO): this {
+    this.timelineStore.addEvent(event);
+    return this;
+  }
+
+  /**
+   * Adds a FieldPathSet to the struct store.
+   */
+  public addFieldPathSet(set: FieldPathSetDTO): this {
+    this.structStore.addFieldPathSet(set);
+    return this;
+  }
+
+  /**
+   * Adds an InternedStruct to the struct store.
+   */
+  public addStruct(struct: StructDTO): this {
+    this.structStore.addStruct(struct);
     return this;
   }
 
@@ -154,65 +177,47 @@ export class InspectionDataBuilder {
    */
   public setIconAtlas(dto: IconAtlasDTO): this {
     this.iconAtlasPromise = this.styleStore.setIconAtlas(dto);
-    this.iconAtlasPromise.catch(() => {}); // Prevents the unhandled rejection. Error will be thrown in the build method to actually await the promise.
+    this.iconAtlasPromise.catch(() => {}); // Prevents unhandled rejection.
     return this;
   }
 
   /**
    * Sets the primary inspection metadata header.
    */
-  public setMetadataHeader(header: InspectionHeader): void {
+  public setMetadataHeader(header: InspectionHeader): this {
     this.metadataStore.header = header;
+    return this;
   }
 
   /**
    * Adds saved inspection queries to the collection.
    */
-  public addMetadataQueries(queries: Iterable<InspectionQuery>): void {
+  public addMetadataQueries(queries: Iterable<InspectionQuery>): this {
     for (const q of queries) {
       this.metadataStore.queries.push(q);
     }
+    return this;
   }
 
   /**
-   * Retrieves the StyleStore instance managed by this builder.
-   */
-  public getStyleStore(): StyleStore {
-    return this.styleStore;
-  }
-
-  /**
-   * Instantiates data store contexts returning root inspection model.
+   * Compacts all domain stores and returns the completed InspectionData.
    */
   public async build(): Promise<InspectionData> {
-    const internPool = InternPoolStore.initialize(this.rawStrings);
-    const logStore = LogStore.initialize(
-      internPool,
-      this.styleStore,
-      this.rawLogs,
-      this.rawLogs.length,
-    );
-    const timelineStore = TimelineStore.initialize(
-      internPool,
-      this.styleStore,
-      logStore,
-      this.rawTimelines,
-      this.rawTimelines.length,
-      this.rawRevisions,
-      this.rawRevisions.length,
-      this.rawEvents,
-      this.rawEvents.length,
-    );
+    this.internPool.shrinkToFit();
+    this.logStore.shrinkToFit();
+    this.timelineStore.shrinkToFit();
+    this.structStore.shrinkToFit();
 
     if (this.iconAtlasPromise) {
       await this.iconAtlasPromise;
     }
 
     return {
-      internPool,
+      internPool: this.internPool,
       styleStore: this.styleStore,
-      logStore,
-      timelineStore,
+      logStore: this.logStore,
+      timelineStore: this.timelineStore,
+      structStore: this.structStore,
       metadata: this.metadataStore,
     };
   }

--- a/web/src/app/parser/core/file-parser.spec.ts
+++ b/web/src/app/parser/core/file-parser.spec.ts
@@ -15,11 +15,14 @@
  */
 
 import { KHIFileParser } from 'src/app/parser/core/file-parser';
-import { KHIChunkDecodeError } from 'src/app/parser/errors/parser-errors';
+import {
+  KHIChunkDecodeError,
+  KHIInvalidFileError,
+} from 'src/app/parser/errors/parser-errors';
 import {
   ParserBlueprint,
   ChunkDefinition,
-  IDataAssembler,
+  DataAssembler,
 } from 'src/app/parser/core/interfaces';
 import { ProgressReporter } from 'src/app/services/progress/progress-interface';
 
@@ -41,18 +44,18 @@ describe('KHIFileParser', () => {
     return new Uint8Array(compressedBuffer);
   }
 
-  let mockAssembler1: jasmine.SpyObj<IDataAssembler<string>>;
-  let mockAssembler2: jasmine.SpyObj<IDataAssembler<number>>;
+  let mockAssembler1: jasmine.SpyObj<Required<DataAssembler<string>>>;
+  let mockAssembler2: jasmine.SpyObj<Required<DataAssembler<number>>>;
   let registry: Record<number, ParserBlueprint>;
 
   beforeEach(() => {
-    mockAssembler1 = jasmine.createSpyObj('IDataAssembler', [
+    mockAssembler1 = jasmine.createSpyObj('DataAssembler', [
       'ingest',
-      'assembleInto',
+      'finalize',
     ]);
-    mockAssembler2 = jasmine.createSpyObj('IDataAssembler', [
+    mockAssembler2 = jasmine.createSpyObj('DataAssembler', [
       'ingest',
-      'assembleInto',
+      'finalize',
     ]);
 
     const blueprint: ParserBlueprint = new Map<
@@ -140,15 +143,15 @@ describe('KHIFileParser', () => {
     expect(mockAssembler1.ingest).toHaveBeenCalledWith('hello');
     expect(mockAssembler2.ingest).toHaveBeenCalledWith(42);
 
-    expect(mockAssembler1.assembleInto).toHaveBeenCalled();
-    expect(mockAssembler2.assembleInto).toHaveBeenCalled();
-    expect(mockAssembler2.assembleInto).toHaveBeenCalledBefore(
-      mockAssembler1.assembleInto,
+    expect(mockAssembler1.finalize).toHaveBeenCalled();
+    expect(mockAssembler2.finalize).toHaveBeenCalled();
+    expect(mockAssembler2.finalize).toHaveBeenCalledBefore(
+      mockAssembler1.finalize,
     );
   });
 
   it('should throw KHIDataAssemblyError if assembler fails during assembly', async () => {
-    mockAssembler1.assembleInto.and.throwError('Assembly failed');
+    mockAssembler1.finalize.and.throwError('Assembly failed');
     const parser = new KHIFileParser(registry);
 
     const data1 = new TextEncoder().encode('hello');
@@ -258,8 +261,8 @@ describe('KHIFileParser', () => {
     expect(result).toBeDefined();
     expect(mockAssembler1.ingest).toHaveBeenCalledWith('hello');
     expect(mockAssembler2.ingest).toHaveBeenCalledWith(42);
-    expect(mockAssembler1.assembleInto).toHaveBeenCalled();
-    expect(mockAssembler2.assembleInto).toHaveBeenCalled();
+    expect(mockAssembler1.finalize).toHaveBeenCalled();
+    expect(mockAssembler2.finalize).toHaveBeenCalled();
   });
 
   it('should accurately report chunkIndex in decode error when unhandled chunks are skipped', async () => {
@@ -295,5 +298,61 @@ describe('KHIFileParser', () => {
       KHIChunkDecodeError,
       /Failed to decode chunk \(typeId: 2, index: 1, offset: \d+\) in version 6\./,
     );
+  });
+
+  it('should throw KHIInvalidFileError for empty buffer', async () => {
+    const parser = new KHIFileParser(registry);
+    const emptyBuffer = new ArrayBuffer(0);
+
+    await expectAsync(parser.parse(emptyBuffer)).toBeRejectedWithError(
+      KHIInvalidFileError,
+      /Empty KHI file buffer was given/,
+    );
+  });
+
+  it('should throw Error for truncated buffer smaller than header', async () => {
+    const parser = new KHIFileParser(registry);
+    const truncatedBuffer = new ArrayBuffer(2);
+
+    await expectAsync(parser.parse(truncatedBuffer)).toBeRejectedWithError(
+      Error,
+      /Buffer too small to contain header/,
+    );
+  });
+
+  it('should stream multiple chunks of the same type to the same assembler instance', async () => {
+    const parser = new KHIFileParser(registry);
+
+    const chunkA = new TextEncoder().encode('first');
+    const compressedA = await compressData(chunkA);
+
+    const chunkB = new TextEncoder().encode('second');
+    const compressedB = await compressData(chunkB);
+
+    const bufferSize = 4 + 8 + compressedA.length + 8 + compressedB.length;
+    const buffer = new ArrayBuffer(bufferSize);
+    const dv = new DataView(buffer);
+    const uint8View = new Uint8Array(buffer);
+
+    uint8View.set([75, 72, 73, 6], 0);
+
+    // Chunk 0: Type 1
+    dv.setUint32(4, compressedA.length, true);
+    dv.setUint32(8, 1, true);
+    uint8View.set(compressedA, 12);
+
+    // Chunk 1: Type 1 again
+    const offset1 = 12 + compressedA.length;
+    dv.setUint32(offset1, compressedB.length, true);
+    dv.setUint32(offset1 + 4, 1, true);
+    uint8View.set(compressedB, offset1 + 8);
+
+    await parser.parse(buffer);
+
+    expect(mockAssembler1.ingest).toHaveBeenCalledTimes(2);
+    expect(mockAssembler1.ingest).toHaveBeenCalledWith('first');
+    expect(mockAssembler1.ingest).toHaveBeenCalledWith('second');
+    // finalize should still be called only once
+    expect(mockAssembler1.finalize).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/app/parser/core/file-parser.ts
+++ b/web/src/app/parser/core/file-parser.ts
@@ -21,10 +21,7 @@ import {
   KHIChunkDecodeError,
   KHIDataAssemblyError,
 } from 'src/app/parser/errors/parser-errors';
-import {
-  IDataAssembler,
-  ParserBlueprint,
-} from 'src/app/parser/core/interfaces';
+import { DataAssembler, ParserBlueprint } from 'src/app/parser/core/interfaces';
 import { BinaryReader } from 'src/app/parser/core/binary-reader';
 import { InspectionDataBuilder } from 'src/app/parser/core/builder';
 import { ProgressReporter } from 'src/app/services/progress/progress-interface';
@@ -85,9 +82,10 @@ export class KHIFileParser {
       );
     }
 
-    const activeAssemblers = new Map<number, IDataAssembler<unknown>>();
+    const builder = new InspectionDataBuilder();
+    const activeAssemblers = new Map<number, DataAssembler<unknown>>();
     for (const [typeId, definition] of blueprint.entries()) {
-      activeAssemblers.set(typeId, definition.createAssembler());
+      activeAssemblers.set(typeId, definition.createAssembler(builder));
     }
 
     let chunkIndex = 0;
@@ -143,15 +141,14 @@ export class KHIFileParser {
       chunkIndex++;
     }
 
-    // 4. Priority-Based Assembly Phase
+    // 4. Priority-Based Finalization Phase
     progressReporter?.reportProgress(KHIFileParser.PROGRESS_ASSEMBLY_START);
-    progressReporter?.reportMessage('Preparing data assembly...');
+    progressReporter?.reportMessage('Preparing data finalization...');
     const executedDefinitions = Array.from(executedTypeIds).map((typeId) =>
       blueprint.get(typeId)!,
     );
     executedDefinitions.sort((a, b) => a.priority - b.priority);
 
-    const builder = new InspectionDataBuilder();
     let defIndex = 0;
     for (const def of executedDefinitions) {
       const assembler = activeAssemblers.get(def.typeId)!;
@@ -163,9 +160,9 @@ export class KHIFileParser {
             executedDefinitions.length,
       );
       progressReporter?.reportProgress(assemblyPercent);
-      progressReporter?.reportMessage(`Assembling ${def.label}...`);
+      progressReporter?.reportMessage(`Finalizing ${def.label}...`);
       try {
-        assembler.assembleInto(builder);
+        assembler.finalize?.();
       } catch (error) {
         throw new KHIDataAssemblyError({
           version,

--- a/web/src/app/parser/core/interfaces.ts
+++ b/web/src/app/parser/core/interfaces.ts
@@ -17,18 +17,18 @@
 import { InspectionDataBuilder } from 'src/app/parser/core/builder';
 
 /**
- * Stateful assembler that collects decoded Protobufs and mutates the final model.
+ * Stateful assembler that processes decoded Protobufs and streams data into stores.
  */
-export interface IDataAssembler<TProto = unknown> {
+export interface DataAssembler<TProto = unknown> {
   /**
    * Ingests a decoded Protobuf chunk. Called multiple times if chunks are split.
    */
   ingest(proto: TProto): void;
 
   /**
-   * Integrates the ingested data into the final InspectionData model.
+   * Optional finalization hook called after all chunks have been ingested.
    */
-  assembleInto(builder: InspectionDataBuilder): void;
+  finalize?(): void;
 }
 
 /**
@@ -45,9 +45,11 @@ export interface ChunkDefinition<TProto = unknown> {
    */
   readonly decode: (bytes: Uint8Array) => TProto;
   /**
-   * Factory method for the stateful assembler.
+   * Factory method for the stateful assembler, binding it to the session's builder.
    */
-  readonly createAssembler: () => IDataAssembler<TProto>;
+  readonly createAssembler: (
+    builder: InspectionDataBuilder,
+  ) => DataAssembler<TProto>;
   /**
    * Execution priority for dependency resolution (Lower number = executed first).
    */

--- a/web/src/app/parser/v6/blueprint.spec.ts
+++ b/web/src/app/parser/v6/blueprint.spec.ts
@@ -67,11 +67,26 @@ describe('V6_BLUEPRINT', () => {
     expect(V6_BLUEPRINT.get(V6ChunkType.Log)!.priority).toBe(100);
     expect(V6_BLUEPRINT.get(V6ChunkType.Timeline)!.priority).toBe(100);
   });
+
+  it('should create assemblers bound to builder', () => {
+    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
+      'InspectionDataBuilder',
+      ['addLog'],
+    );
+    for (const def of V6_BLUEPRINT.values()) {
+      const assembler = def.createAssembler(builder);
+      expect(assembler).toBeDefined();
+    }
+  });
 });
 
 describe('V6InternPoolAssembler', () => {
-  it('should ingest strings and assemble them into builder', () => {
-    const assembler = new V6InternPoolAssembler();
+  it('should ingest strings, field path sets, and structs directly into builder', () => {
+    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
+      'InspectionDataBuilder',
+      ['addString', 'addFieldPathSet', 'addStruct'],
+    );
+    const assembler = new V6InternPoolAssembler(builder);
     const mockChunk = create(InterningPoolChunkSchema, {
       strings: [
         create(InternStringSchema, { id: 1, value: 'foo' }),
@@ -94,22 +109,27 @@ describe('V6InternPoolAssembler', () => {
 
     assembler.ingest(mockChunk);
 
-    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
-      'InspectionDataBuilder',
-      ['addStrings'],
-    );
-    assembler.assembleInto(builder);
-
-    expect(builder.addStrings).toHaveBeenCalledWith([
-      { id: 1, value: 'foo' },
-      { id: 2, value: 'bar' },
-    ]);
+    expect(builder.addString).toHaveBeenCalledWith({ id: 1, value: 'foo' });
+    expect(builder.addString).toHaveBeenCalledWith({ id: 2, value: 'bar' });
+    expect(builder.addFieldPathSet).toHaveBeenCalledWith({
+      id: 10,
+      fieldPathStringIds: [1, 2],
+    });
+    expect(builder.addStruct).toHaveBeenCalledWith({
+      id: 100,
+      fieldPathSetId: 10,
+      values: [],
+    });
   });
 });
 
 describe('V6LogAssembler', () => {
-  it('should ingest logs and assemble them into builder', () => {
-    const assembler = new V6LogAssembler();
+  it('should ingest logs directly into builder', () => {
+    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
+      'InspectionDataBuilder',
+      ['addLog'],
+    );
+    const assembler = new V6LogAssembler(builder);
     const mockChunk = create(LogChunkSchema, {
       logs: [
         create(LogSchema, {
@@ -125,28 +145,30 @@ describe('V6LogAssembler', () => {
 
     assembler.ingest(mockChunk);
 
-    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
-      'InspectionDataBuilder',
-      ['addLogs'],
-    );
-    assembler.assembleInto(builder);
-
-    expect(builder.addLogs).toHaveBeenCalledWith([
-      {
-        id: 100,
-        ts: 123000000456n,
-        logTypeId: 10,
-        severityTypeId: 20,
-        summaryStringId: 30,
-        bodyStructId: 5,
-      },
-    ]);
+    expect(builder.addLog).toHaveBeenCalledWith({
+      id: 100,
+      ts: 123000000456n,
+      logTypeId: 10,
+      severityTypeId: 20,
+      summaryStringId: 30,
+      bodyStructId: 5,
+    });
   });
 });
 
 describe('V6StyleAssembler', () => {
-  it('should ingest timeline styles and assemble them into builder', () => {
-    const assembler = new V6StyleAssembler();
+  it('should ingest timeline styles directly into builder', () => {
+    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
+      'InspectionDataBuilder',
+      [
+        'addSeverities',
+        'addVerbs',
+        'addLogTypes',
+        'addRevisionStates',
+        'addTimelineTypes',
+      ],
+    );
+    const assembler = new V6StyleAssembler(builder);
     const mockChunk = create(TimelineStyleChunkSchema, {
       severities: [
         create(SeveritySchema, {
@@ -166,18 +188,6 @@ describe('V6StyleAssembler', () => {
 
     assembler.ingest(mockChunk);
 
-    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
-      'InspectionDataBuilder',
-      [
-        'addSeverities',
-        'addVerbs',
-        'addLogTypes',
-        'addRevisionStates',
-        'addTimelineTypes',
-      ],
-    );
-    assembler.assembleInto(builder);
-
     expect(builder.addSeverities).toHaveBeenCalledWith([
       {
         id: 1,
@@ -191,7 +201,18 @@ describe('V6StyleAssembler', () => {
   });
 
   it('should correctly extract ArrayBuffer slices for iconAtlas with subarray views', () => {
-    const assembler = new V6StyleAssembler();
+    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
+      'InspectionDataBuilder',
+      [
+        'addSeverities',
+        'addVerbs',
+        'addLogTypes',
+        'addRevisionStates',
+        'addTimelineTypes',
+        'setIconAtlas',
+      ],
+    );
+    const assembler = new V6StyleAssembler(builder);
 
     // Create Uint8Array views with non-zero byteOffset inside a shared ArrayBuffer
     const fullBuffer = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer;
@@ -213,19 +234,6 @@ describe('V6StyleAssembler', () => {
 
     assembler.ingest(mockChunk);
 
-    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
-      'InspectionDataBuilder',
-      [
-        'addSeverities',
-        'addVerbs',
-        'addLogTypes',
-        'addRevisionStates',
-        'addTimelineTypes',
-        'setIconAtlas',
-      ],
-    );
-    assembler.assembleInto(builder);
-
     expect(builder.setIconAtlas).toHaveBeenCalledTimes(1);
     const passedAtlas = builder.setIconAtlas.calls.mostRecent().args[0];
 
@@ -241,8 +249,12 @@ describe('V6StyleAssembler', () => {
 });
 
 describe('V6TimelineAssembler', () => {
-  it('should ingest timelines and timeline items and assemble them into builder', () => {
-    const assembler = new V6TimelineAssembler();
+  it('should ingest timeline items and link timelines on finalize', () => {
+    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
+      'InspectionDataBuilder',
+      ['addRevision', 'addEvent', 'addTimeline'],
+    );
+    const assembler = new V6TimelineAssembler(builder);
     const mockChunk = create(TimelineChunkSchema, {
       timelineItems: [
         create(TimelineItemsSchema, {
@@ -278,46 +290,41 @@ describe('V6TimelineAssembler', () => {
 
     assembler.ingest(mockChunk);
 
-    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
-      'InspectionDataBuilder',
-      ['addRevisions', 'addEvents', 'addTimelines'],
-    );
-    assembler.assembleInto(builder);
+    expect(builder.addRevision).toHaveBeenCalledWith({
+      id: 1,
+      logId: 10,
+      changedTime: 1000000000n,
+      principalStringId: 5,
+      verbTypeId: 2,
+      stateTypeId: 3,
+      resourceBodyStructId: 99,
+      fieldAnnotations: [],
+    });
+    expect(builder.addEvent).toHaveBeenCalledWith({
+      id: 1,
+      logId: 20,
+    });
 
-    expect(builder.addRevisions).toHaveBeenCalledWith([
-      {
-        id: 1,
-        logId: 10,
-        changedTime: 1000000000n,
-        principalStringId: 5,
-        verbTypeId: 2,
-        stateTypeId: 3,
-        resourceBodyStructId: 99,
-        fieldAnnotations: [],
-      },
-    ]);
-    expect(builder.addEvents).toHaveBeenCalledWith([
-      {
-        id: 1,
-        logId: 20,
-      },
-    ]);
-    expect(builder.addTimelines).toHaveBeenCalledWith([
-      {
-        id: 1,
-        timelineTypeId: 10,
-        nameStringId: 20,
-        parentTimelineId: 0,
-        revisionIds: [1],
-        eventIds: [1],
-      },
-    ]);
+    assembler.finalize();
+
+    expect(builder.addTimeline).toHaveBeenCalledWith({
+      id: 1,
+      timelineTypeId: 10,
+      nameStringId: 20,
+      parentTimelineId: 0,
+      revisionIds: [1],
+      eventIds: [1],
+    });
   });
 });
 
 describe('V6MetadataAssembler', () => {
-  it('should ingest metadata chunk and decode oneof items into builder', () => {
-    const assembler = new V6MetadataAssembler();
+  it('should ingest metadata chunk and decode oneof items directly into builder', () => {
+    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
+      'InspectionDataBuilder',
+      ['setMetadataHeader', 'addMetadataQueries'],
+    );
+    const assembler = new V6MetadataAssembler(builder);
 
     const headerPayload = {
       inspectionType: 'type-a',
@@ -356,12 +363,6 @@ describe('V6MetadataAssembler', () => {
     });
 
     assembler.ingest(mockChunk);
-
-    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
-      'InspectionDataBuilder',
-      ['setMetadataHeader', 'addMetadataQueries'],
-    );
-    assembler.assembleInto(builder);
 
     expect(builder.setMetadataHeader).toHaveBeenCalledWith({
       inspectionType: 'type-a',

--- a/web/src/app/parser/v6/blueprint.ts
+++ b/web/src/app/parser/v6/blueprint.ts
@@ -17,7 +17,7 @@
 import { fromBinary } from '@bufbuild/protobuf';
 import {
   ChunkDefinition,
-  IDataAssembler,
+  DataAssembler,
   ParserBlueprint,
 } from 'src/app/parser/core/interfaces';
 import { InspectionDataBuilder } from 'src/app/parser/core/builder';
@@ -38,90 +38,113 @@ import {
 } from 'src/app/generated/khifile/v6/style_pb';
 import {
   HDRColor4 as DomainHDRColor4,
-  LogType as DomainLogType,
-  RevisionState as DomainRevisionState,
   RevisionStateStyle as DomainRevisionStateStyle,
-  Severity as DomainSeverity,
-  TimelineType as DomainTimelineType,
-  Verb as DomainVerb,
 } from 'src/app/store/domain/style';
 import {
   Timeline,
   TimelineChunk,
   TimelineChunkSchema,
 } from 'src/app/generated/khifile/v6/timeline_pb';
-import { StringEntryDTO } from 'src/app/store/domain/intern-pool-store';
-import { LogDTO } from 'src/app/store/domain/log-store';
+import { TimelineDTO } from 'src/app/store/domain/timeline-store';
 import {
-  EventDTO,
-  RevisionDTO,
-  TimelineDTO,
-} from 'src/app/store/domain/timeline-store';
-import { IconAtlasDTO } from 'src/app/store/domain/style-store';
+  StructValueDTO,
+  StructValueKind,
+} from 'src/app/store/domain/struct-store';
+import { InternedValue } from 'src/app/generated/khifile/shared_pb';
 
 /**
  * Assembler for the file metadata chunk.
  */
-export class V6MetadataAssembler implements IDataAssembler<MetadataChunk> {
-  private readonly chunks: MetadataChunk[] = [];
+export class V6MetadataAssembler implements DataAssembler<MetadataChunk> {
+  constructor(private readonly builder: InspectionDataBuilder) {}
 
   /**
-   * Ingests a decoded metadata chunk.
+   * Ingests a decoded metadata chunk directly into the inspection data builder.
    */
   ingest(proto: MetadataChunk): void {
-    this.chunks.push(proto);
-  }
-
-  /**
-   * Integrates metadata into the final builder.
-   */
-  assembleInto(builder: InspectionDataBuilder): void {
-    for (const chunk of this.chunks) {
-      for (const item of chunk.metadata) {
-        if (item.payload.case === 'header') {
-          const h = item.payload.value;
-          builder.setMetadataHeader({
-            inspectionType: h.inspectionType,
-            inspectionName: h.inspectionName,
-            inspectTimeUnixSeconds: Number(h.inspectTimeUnixSeconds),
-            startTimeUnixSeconds: Number(h.startTimeUnixSeconds),
-            endTimeUnixSeconds: Number(h.endTimeUnixSeconds),
-            suggestedFilename: h.suggestedFilename,
-            fileSize: Number(h.fileSize),
-          });
-        } else if (item.payload.case === 'query') {
-          const queries = item.payload.value.queries.map((q) => ({
-            id: q.id,
-            name: q.name,
-            query: q.query,
-          }));
-          builder.addMetadataQueries(queries);
-        }
+    for (const item of proto.metadata) {
+      if (item.payload.case === 'header') {
+        const h = item.payload.value;
+        this.builder.setMetadataHeader({
+          inspectionType: h.inspectionType,
+          inspectionName: h.inspectionName,
+          inspectTimeUnixSeconds: Number(h.inspectTimeUnixSeconds),
+          startTimeUnixSeconds: Number(h.startTimeUnixSeconds),
+          endTimeUnixSeconds: Number(h.endTimeUnixSeconds),
+          suggestedFilename: h.suggestedFilename,
+          fileSize: Number(h.fileSize),
+        });
+      } else if (item.payload.case === 'query') {
+        const queries = item.payload.value.queries.map((q) => ({
+          id: q.id,
+          name: q.name,
+          query: q.query,
+        }));
+        this.builder.addMetadataQueries(queries);
       }
     }
+  }
+}
+
+function mapStructValue(iv: InternedValue): StructValueDTO {
+  switch (iv.kind.case) {
+    case 'nullValue':
+      return { kind: StructValueKind.Null };
+    case 'boolValue':
+      return { kind: StructValueKind.Bool, value: iv.kind.value };
+    case 'int64Value':
+      return { kind: StructValueKind.Int64, value: iv.kind.value };
+    case 'doubleValue':
+      return { kind: StructValueKind.Double, value: iv.kind.value };
+    case 'stringValue':
+      return { kind: StructValueKind.String, stringId: iv.kind.value };
+    case 'structId':
+      return { kind: StructValueKind.StructId, structId: iv.kind.value };
+    case 'structValue':
+      return { kind: StructValueKind.StructId, structId: iv.kind.value.id };
+    case 'listValue':
+      return {
+        kind: StructValueKind.List,
+        values: iv.kind.value.values.map(mapStructValue),
+      };
+    case 'timestampValue':
+      return {
+        kind: StructValueKind.Timestamp,
+        timestampNs:
+          BigInt(iv.kind.value.seconds) * 1_000_000_000n +
+          BigInt(iv.kind.value.nanos),
+      };
+    default:
+      return { kind: StructValueKind.Null };
   }
 }
 
 /**
  * Assembler for the interning pool chunk.
  */
-export class V6InternPoolAssembler implements IDataAssembler<InterningPoolChunk> {
-  private readonly strings: StringEntryDTO[] = [];
+export class V6InternPoolAssembler implements DataAssembler<InterningPoolChunk> {
+  constructor(private readonly builder: InspectionDataBuilder) {}
 
   /**
-   * Ingests a decoded interning pool chunk.
+   * Ingests a decoded interning pool chunk directly into the inspection data builder.
    */
   ingest(proto: InterningPoolChunk): void {
     for (const s of proto.strings) {
-      this.strings.push({ id: s.id, value: s.value });
+      this.builder.addString({ id: s.id, value: s.value });
     }
-  }
-
-  /**
-   * Integrates pooled strings into the final builder.
-   */
-  assembleInto(builder: InspectionDataBuilder): void {
-    builder.addStrings(this.strings);
+    for (const fps of proto.fieldPathSets) {
+      this.builder.addFieldPathSet({
+        id: fps.id,
+        fieldPathStringIds: fps.fieldPathStringIds,
+      });
+    }
+    for (const st of proto.structs) {
+      this.builder.addStruct({
+        id: st.id,
+        fieldPathSetId: st.fieldPathSetId,
+        values: st.values.map(mapStructValue),
+      });
+    }
   }
 }
 
@@ -149,70 +172,75 @@ function mapRevisionStyle(
 /**
  * Assembler for the timeline style chunk.
  */
-export class V6StyleAssembler implements IDataAssembler<TimelineStyleChunk> {
-  private readonly severities: DomainSeverity[] = [];
-  private readonly verbs: DomainVerb[] = [];
-  private readonly logTypes: DomainLogType[] = [];
-  private readonly revisionStates: DomainRevisionState[] = [];
-  private readonly timelineTypes: DomainTimelineType[] = [];
-  private iconAtlas?: IconAtlasDTO;
+export class V6StyleAssembler implements DataAssembler<TimelineStyleChunk> {
+  constructor(private readonly builder: InspectionDataBuilder) {}
 
   /**
-   * Ingests a decoded timeline style chunk.
+   * Ingests a decoded timeline style chunk directly into the inspection data builder.
    */
   ingest(proto: TimelineStyleChunk): void {
-    for (const s of proto.severities) {
-      this.severities.push({
-        id: s.id,
-        label: s.label,
-        shortLabel: s.shortLabel,
-        backgroundColor: mapColor(s.backgroundColor),
-        foregroundColor: mapColor(s.foregroundColor),
-        order: s.order,
-      });
+    if (proto.severities.length > 0) {
+      this.builder.addSeverities(
+        proto.severities.map((s) => ({
+          id: s.id,
+          label: s.label,
+          shortLabel: s.shortLabel,
+          backgroundColor: mapColor(s.backgroundColor),
+          foregroundColor: mapColor(s.foregroundColor),
+          order: s.order,
+        })),
+      );
     }
-    for (const v of proto.verbs) {
-      this.verbs.push({
-        id: v.id,
-        label: v.label,
-        backgroundColor: mapColor(v.backgroundColor),
-        foregroundColor: mapColor(v.foregroundColor),
-        visible: v.visible,
-      });
+    if (proto.verbs.length > 0) {
+      this.builder.addVerbs(
+        proto.verbs.map((v) => ({
+          id: v.id,
+          label: v.label,
+          backgroundColor: mapColor(v.backgroundColor),
+          foregroundColor: mapColor(v.foregroundColor),
+          visible: v.visible,
+        })),
+      );
     }
-    for (const lt of proto.logTypes) {
-      this.logTypes.push({
-        id: lt.id,
-        label: lt.label,
-        description: lt.description,
-        backgroundColor: mapColor(lt.backgroundColor),
-        foregroundColor: mapColor(lt.foregroundColor),
-      });
+    if (proto.logTypes.length > 0) {
+      this.builder.addLogTypes(
+        proto.logTypes.map((lt) => ({
+          id: lt.id,
+          label: lt.label,
+          description: lt.description,
+          backgroundColor: mapColor(lt.backgroundColor),
+          foregroundColor: mapColor(lt.foregroundColor),
+        })),
+      );
     }
-    for (const rs of proto.revisionStates) {
-      this.revisionStates.push({
-        id: rs.id,
-        label: rs.label,
-        icon: rs.icon,
-        description: rs.description,
-        backgroundColor: mapColor(rs.backgroundColor),
-        style: mapRevisionStyle(rs.style),
-      });
+    if (proto.revisionStates.length > 0) {
+      this.builder.addRevisionStates(
+        proto.revisionStates.map((rs) => ({
+          id: rs.id,
+          label: rs.label,
+          icon: rs.icon,
+          description: rs.description,
+          backgroundColor: mapColor(rs.backgroundColor),
+          style: mapRevisionStyle(rs.style),
+        })),
+      );
     }
-    for (const tt of proto.timelineTypes) {
-      this.timelineTypes.push({
-        id: tt.id,
-        label: tt.label,
-        description: tt.description,
-        icon: tt.icon,
-        backgroundColor: mapColor(tt.backgroundColor),
-        foregroundColor: mapColor(tt.foregroundColor),
-        typeChipBackgroundColor: mapColor(tt.typeChipBackgroundColor),
-        typeChipForegroundColor: mapColor(tt.typeChipForegroundColor),
-        visible: tt.visible,
-        sortPriority: tt.sortPriority,
-        height: tt.height,
-      });
+    if (proto.timelineTypes.length > 0) {
+      this.builder.addTimelineTypes(
+        proto.timelineTypes.map((tt) => ({
+          id: tt.id,
+          label: tt.label,
+          description: tt.description,
+          icon: tt.icon,
+          backgroundColor: mapColor(tt.backgroundColor),
+          foregroundColor: mapColor(tt.foregroundColor),
+          typeChipBackgroundColor: mapColor(tt.typeChipBackgroundColor),
+          typeChipForegroundColor: mapColor(tt.typeChipForegroundColor),
+          visible: tt.visible,
+          sortPriority: tt.sortPriority,
+          height: tt.height,
+        })),
+      );
     }
     if (proto.iconAtlas) {
       const msdfIconImage = proto.iconAtlas.msdfIconImage.map((u) =>
@@ -226,25 +254,11 @@ export class V6StyleAssembler implements IDataAssembler<TimelineStyleChunk> {
       const nameToCodepoints = new Map<string, string>(
         Object.entries(proto.iconAtlas.nameToCodepoints),
       );
-      this.iconAtlas = {
+      this.builder.setIconAtlas({
         msdfIconImage,
         bmfontJson,
         nameToCodepoints,
-      };
-    }
-  }
-
-  /**
-   * Integrates timeline styles into the final builder.
-   */
-  assembleInto(builder: InspectionDataBuilder): void {
-    builder.addSeverities(this.severities);
-    builder.addVerbs(this.verbs);
-    builder.addLogTypes(this.logTypes);
-    builder.addRevisionStates(this.revisionStates);
-    builder.addTimelineTypes(this.timelineTypes);
-    if (this.iconAtlas) {
-      builder.setIconAtlas(this.iconAtlas);
+      });
     }
   }
 }
@@ -252,18 +266,18 @@ export class V6StyleAssembler implements IDataAssembler<TimelineStyleChunk> {
 /**
  * Assembler for the log chunk.
  */
-export class V6LogAssembler implements IDataAssembler<LogChunk> {
-  private readonly logs: LogDTO[] = [];
+export class V6LogAssembler implements DataAssembler<LogChunk> {
+  constructor(private readonly builder: InspectionDataBuilder) {}
 
   /**
-   * Ingests a decoded log chunk.
+   * Ingests a decoded log chunk directly into the inspection data builder.
    */
   ingest(proto: LogChunk): void {
     for (const log of proto.logs) {
       const ts = log.ts
         ? BigInt(log.ts.seconds) * 1_000_000_000n + BigInt(log.ts.nanos)
         : 0n;
-      this.logs.push({
+      this.builder.addLog({
         id: log.id,
         ts,
         logTypeId: log.logTypeId,
@@ -273,22 +287,13 @@ export class V6LogAssembler implements IDataAssembler<LogChunk> {
       });
     }
   }
-
-  /**
-   * Integrates logs into the final builder.
-   */
-  assembleInto(builder: InspectionDataBuilder): void {
-    builder.addLogs(this.logs);
-  }
 }
 
 /**
  * Assembler for the timeline chunk.
  */
-export class V6TimelineAssembler implements IDataAssembler<TimelineChunk> {
+export class V6TimelineAssembler implements DataAssembler<TimelineChunk> {
   private readonly rawTimelines: Timeline[] = [];
-  private readonly revisions: RevisionDTO[] = [];
-  private readonly events: EventDTO[] = [];
   private readonly itemsMap = new Map<
     number,
     { revisionIds: number[]; eventIds: number[] }
@@ -297,11 +302,13 @@ export class V6TimelineAssembler implements IDataAssembler<TimelineChunk> {
   private nextRevisionId = 1;
   private nextEventId = 1;
 
+  constructor(private readonly builder: InspectionDataBuilder) {}
+
   /**
-   * Ingests a decoded timeline chunk.
+   * Ingests a decoded timeline chunk directly into the inspection data builder.
    */
   ingest(proto: TimelineChunk): void {
-    // 1. Process timelineItems
+    // 1. Process timelineItems: stream revisions and events directly to builder
     for (const items of proto.timelineItems) {
       if (this.itemsMap.has(items.id)) {
         throw new Error(`Duplicate timelineItems id: ${items.id}`);
@@ -313,7 +320,7 @@ export class V6TimelineAssembler implements IDataAssembler<TimelineChunk> {
           ? BigInt(r.changedTime.seconds) * 1_000_000_000n +
             BigInt(r.changedTime.nanos)
           : 0n;
-        this.revisions.push({
+        this.builder.addRevision({
           id,
           logId: r.logId,
           changedTime,
@@ -345,7 +352,7 @@ export class V6TimelineAssembler implements IDataAssembler<TimelineChunk> {
       const eventIds: number[] = [];
       for (const e of items.events) {
         const id = this.nextEventId++;
-        this.events.push({
+        this.builder.addEvent({
           id,
           logId: e.logId,
         });
@@ -362,13 +369,9 @@ export class V6TimelineAssembler implements IDataAssembler<TimelineChunk> {
   }
 
   /**
-   * Integrates timelines into the final builder.
+   * Links timeline items to timelines and flattens into the inspection data builder.
    */
-  assembleInto(builder: InspectionDataBuilder): void {
-    builder.addRevisions(this.revisions);
-    builder.addEvents(this.events);
-
-    // 1. Build flat TimelineDTO list with items linked
+  finalize(): void {
     const linkedTimelines: TimelineDTO[] = [];
     for (const t of this.rawTimelines) {
       const items = this.itemsMap.get(t.timelineItemsId) ?? {
@@ -385,7 +388,9 @@ export class V6TimelineAssembler implements IDataAssembler<TimelineChunk> {
       });
     }
 
-    builder.addTimelines(linkedTimelines);
+    for (const timeline of linkedTimelines) {
+      this.builder.addTimeline(timeline);
+    }
   }
 }
 
@@ -427,7 +432,7 @@ export const V6_BLUEPRINT: ParserBlueprint = new Map<
     {
       typeId: V6ChunkType.Metadata,
       decode: (bytes) => fromBinary(MetadataChunkSchema, bytes),
-      createAssembler: () => new V6MetadataAssembler(),
+      createAssembler: (builder) => new V6MetadataAssembler(builder),
       priority: 5,
       label: 'metadata',
     },
@@ -437,7 +442,7 @@ export const V6_BLUEPRINT: ParserBlueprint = new Map<
     {
       typeId: V6ChunkType.InterningPool,
       decode: (bytes) => fromBinary(InterningPoolChunkSchema, bytes),
-      createAssembler: () => new V6InternPoolAssembler(),
+      createAssembler: (builder) => new V6InternPoolAssembler(builder),
       priority: 10,
       label: 'interningPool',
     },
@@ -447,7 +452,7 @@ export const V6_BLUEPRINT: ParserBlueprint = new Map<
     {
       typeId: V6ChunkType.TimelineStyle,
       decode: (bytes) => fromBinary(TimelineStyleChunkSchema, bytes),
-      createAssembler: () => new V6StyleAssembler(),
+      createAssembler: (builder) => new V6StyleAssembler(builder),
       priority: 20,
       label: 'timelineStyle',
     },
@@ -457,7 +462,7 @@ export const V6_BLUEPRINT: ParserBlueprint = new Map<
     {
       typeId: V6ChunkType.Log,
       decode: (bytes) => fromBinary(LogChunkSchema, bytes),
-      createAssembler: () => new V6LogAssembler(),
+      createAssembler: (builder) => new V6LogAssembler(builder),
       priority: 100,
       label: 'log',
     },
@@ -467,7 +472,7 @@ export const V6_BLUEPRINT: ParserBlueprint = new Map<
     {
       typeId: V6ChunkType.Timeline,
       decode: (bytes) => fromBinary(TimelineChunkSchema, bytes),
-      createAssembler: () => new V6TimelineAssembler(),
+      createAssembler: (builder) => new V6TimelineAssembler(builder),
       priority: 100,
       label: 'timeline',
     },

--- a/web/src/app/services/selection-manager.service.spec.ts
+++ b/web/src/app/services/selection-manager.service.spec.ts
@@ -22,6 +22,7 @@ import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { LogStore } from 'src/app/store/domain/log-store';
 import { TimelineStore } from 'src/app/store/domain/timeline-store';
+import { StructStore } from 'src/app/store/domain/struct-store';
 
 describe('SelectionManager', () => {
   let service: SelectionManager;
@@ -37,7 +38,7 @@ describe('SelectionManager', () => {
     dataStore = TestBed.inject(InspectionDataStore);
     service = TestBed.inject(SelectionManager);
 
-    const internPool = InternPoolStore.initialize();
+    const internPool = InternPoolStore.create();
     const styleStore = new StyleStore();
 
     styleStore.addSeverities([
@@ -146,93 +147,92 @@ describe('SelectionManager', () => {
       { id: 6, value: 'system:serviceaccount:kube-system:generic' },
     ]);
 
-    logStore = LogStore.initialize(
-      internPool,
-      styleStore,
-      [
-        {
-          id: 1,
-          ts: 1700000000000000000n,
-          logTypeId: 2,
-          severityTypeId: 1,
-          summaryStringId: 5,
-        },
-      ],
-      1,
-    );
+    logStore = LogStore.create(internPool, styleStore, 1);
+    logStore.addLogs([
+      {
+        id: 1,
+        ts: 1700000000000000000n,
+        logTypeId: 2,
+        severityTypeId: 1,
+        summaryStringId: 5,
+      },
+    ]);
+    logStore.shrinkToFit();
 
-    timelineStore = TimelineStore.initialize(
+    timelineStore = TimelineStore.create(
       internPool,
       styleStore,
       logStore,
-      [
-        {
-          id: 1,
-          timelineTypeId: 1,
-          nameStringId: 1,
-          parentTimelineId: 0,
-          revisionIds: [],
-          eventIds: [],
-        },
-        {
-          id: 2,
-          timelineTypeId: 2,
-          nameStringId: 2,
-          parentTimelineId: 1,
-          revisionIds: [],
-          eventIds: [],
-        },
-        {
-          id: 3,
-          timelineTypeId: 3,
-          nameStringId: 3,
-          parentTimelineId: 2,
-          revisionIds: [],
-          eventIds: [],
-        },
-        {
-          id: 4,
-          timelineTypeId: 4,
-          nameStringId: 4,
-          parentTimelineId: 3,
-          revisionIds: [1],
-          eventIds: [1],
-        },
-        {
-          id: 5,
-          timelineTypeId: 1,
-          nameStringId: 1,
-          parentTimelineId: 0,
-          revisionIds: [],
-          eventIds: [],
-        },
-      ],
       5,
-      [
-        {
-          id: 1,
-          logId: 1,
-          changedTime: 1700000000000000000n,
-          principalStringId: 6,
-          verbTypeId: 1,
-          stateTypeId: 1,
-        },
-      ],
       1,
-      [
-        {
-          id: 1,
-          logId: 1,
-        },
-      ],
       1,
     );
+    timelineStore.addRevisions([
+      {
+        id: 1,
+        logId: 1,
+        changedTime: 1700000000000000000n,
+        principalStringId: 6,
+        verbTypeId: 1,
+        stateTypeId: 1,
+      },
+    ]);
+    timelineStore.addEvents([
+      {
+        id: 1,
+        logId: 1,
+      },
+    ]);
+    timelineStore.addTimelines([
+      {
+        id: 1,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [],
+      },
+      {
+        id: 2,
+        timelineTypeId: 2,
+        nameStringId: 2,
+        parentTimelineId: 1,
+        revisionIds: [],
+        eventIds: [],
+      },
+      {
+        id: 3,
+        timelineTypeId: 3,
+        nameStringId: 3,
+        parentTimelineId: 2,
+        revisionIds: [],
+        eventIds: [],
+      },
+      {
+        id: 4,
+        timelineTypeId: 4,
+        nameStringId: 4,
+        parentTimelineId: 3,
+        revisionIds: [1],
+        eventIds: [1],
+      },
+      {
+        id: 5,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [],
+      },
+    ]);
+    timelineStore.shrinkToFit();
 
     const mockData: InspectionData = {
       internPool,
       styleStore,
       logStore,
       timelineStore,
+      structStore: StructStore.create(internPool),
     };
     dataStore.setNewInspectionData(mockData);
   });

--- a/web/src/app/store/domain/buffer-util.spec.ts
+++ b/web/src/app/store/domain/buffer-util.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BufferLayoutBuilder,
+  nextCapacity,
+  reallocateBuffer,
+  reallocateUint32Array,
+} from 'src/app/store/domain/buffer-util';
+
+describe('buffer-util', () => {
+  describe('nextCapacity', () => {
+    it('returns initialCapacity when currentCapacity is zero and minCapacity is small', () => {
+      expect(nextCapacity(0, 10, 1024)).toBe(1024);
+    });
+
+    it('uses default initialCapacity of 1024 when omitted', () => {
+      expect(nextCapacity(0, 10)).toBe(1024);
+    });
+
+    it('handles negative currentCapacity by treating it as zero', () => {
+      expect(nextCapacity(-1, 10)).toBe(1024);
+    });
+
+    it('returns minCapacity when currentCapacity is zero and minCapacity exceeds initialCapacity', () => {
+      expect(nextCapacity(0, 2048, 1024)).toBe(2048);
+    });
+
+    it('doubles current capacity when double exceeds minCapacity', () => {
+      expect(nextCapacity(1024, 1500)).toBe(2048);
+    });
+
+    it('doubles capacity even when minCapacity is less than or equal to currentCapacity', () => {
+      expect(nextCapacity(1024, 1024)).toBe(2048);
+      expect(nextCapacity(1024, 500)).toBe(2048);
+    });
+
+    it('doubles repeatedly until capacity satisfies minCapacity', () => {
+      expect(nextCapacity(1024, 5000)).toBe(8192);
+    });
+  });
+
+  describe('reallocateBuffer', () => {
+    it('allocates a new buffer and copies old data up to bytesToCopy', () => {
+      const oldBuffer = new ArrayBuffer(16);
+      const oldView = new Uint8Array(oldBuffer);
+      for (let i = 0; i < 16; i++) {
+        oldView[i] = i + 1;
+      }
+
+      const newBuffer = reallocateBuffer(oldBuffer, 32, 16);
+      expect(newBuffer.byteLength).toBe(32);
+
+      const newView = new Uint8Array(newBuffer);
+      for (let i = 0; i < 16; i++) {
+        expect(newView[i]).toBe(i + 1);
+      }
+      for (let i = 16; i < 32; i++) {
+        expect(newView[i]).toBe(0);
+      }
+    });
+
+    it('defaults bytesToCopy to min(old.byteLength, newByteLength) when omitted', () => {
+      const oldBuffer = new ArrayBuffer(16);
+      const oldView = new Uint8Array(oldBuffer);
+      for (let i = 0; i < 16; i++) {
+        oldView[i] = i + 1;
+      }
+
+      const expandedBuffer = reallocateBuffer(oldBuffer, 24);
+      expect(expandedBuffer.byteLength).toBe(24);
+      const expandedView = new Uint8Array(expandedBuffer);
+      for (let i = 0; i < 16; i++) {
+        expect(expandedView[i]).toBe(i + 1);
+      }
+
+      const shrunkBuffer = reallocateBuffer(oldBuffer, 8);
+      expect(shrunkBuffer.byteLength).toBe(8);
+      const shrunkView = new Uint8Array(shrunkBuffer);
+      for (let i = 0; i < 8; i++) {
+        expect(shrunkView[i]).toBe(i + 1);
+      }
+    });
+
+    it('handles shrinking buffers properly', () => {
+      const oldBuffer = new ArrayBuffer(16);
+      const oldView = new Uint8Array(oldBuffer);
+      for (let i = 0; i < 16; i++) {
+        oldView[i] = i + 1;
+      }
+
+      const newBuffer = reallocateBuffer(oldBuffer, 8, 8);
+      expect(newBuffer.byteLength).toBe(8);
+
+      const newView = new Uint8Array(newBuffer);
+      for (let i = 0; i < 8; i++) {
+        expect(newView[i]).toBe(i + 1);
+      }
+    });
+
+    it('creates a zero-filled buffer when bytesToCopy is zero', () => {
+      const oldBuffer = new ArrayBuffer(16);
+      new Uint8Array(oldBuffer).fill(0xff);
+
+      const newBuffer = reallocateBuffer(oldBuffer, 16, 0);
+      expect(newBuffer.byteLength).toBe(16);
+      const view = new Uint8Array(newBuffer);
+      for (let i = 0; i < 16; i++) {
+        expect(view[i]).toBe(0);
+      }
+    });
+
+    it('handles shrinking to zero byteLength', () => {
+      const oldBuffer = new ArrayBuffer(16);
+      new Uint8Array(oldBuffer).fill(0x42);
+
+      const newBuffer = reallocateBuffer(oldBuffer, 0, 0);
+      expect(newBuffer.byteLength).toBe(0);
+    });
+  });
+
+  describe('BufferLayoutBuilder', () => {
+    it('calculates sequential field offsets with default 4-byte alignment', () => {
+      const builder = new BufferLayoutBuilder();
+      const offset1 = builder.addField(10, 4);
+      const offset2 = builder.addField(10, 4);
+
+      expect(offset1).toBe(0);
+      expect(offset2).toBe(40);
+      expect(builder.totalBytes).toBe(80);
+    });
+
+    it('aligns offsets to specified alignment boundaries', () => {
+      const builder = new BufferLayoutBuilder();
+      // 5 items of 2 bytes = 10 bytes (offset 0..10)
+      const offset16 = builder.addField(5, 2, 2);
+      expect(offset16).toBe(0);
+      // Next field requires 8-byte alignment, 10 aligned to 8 is 16
+      const offset64 = builder.addField(2, 8, 8);
+      expect(offset64).toBe(16);
+      expect(builder.totalBytes).toBe(32);
+    });
+
+    it('handles capacity of 0 correctly', () => {
+      const builder = new BufferLayoutBuilder();
+      const offset1 = builder.addField(0, 4);
+      const offset2 = builder.addField(0, 8, 8);
+
+      expect(offset1).toBe(0);
+      expect(offset2).toBe(0);
+      expect(builder.totalBytes).toBe(0);
+    });
+  });
+
+  describe('reallocateUint32Array', () => {
+    it('reallocates Uint32Array and copies existing elements', () => {
+      const oldArr = new Uint32Array([10, 20, 30]);
+      const newArr = reallocateUint32Array(oldArr, 5);
+
+      expect(newArr.length).toBe(5);
+      expect(newArr[0]).toBe(10);
+      expect(newArr[1]).toBe(20);
+      expect(newArr[2]).toBe(30);
+      expect(newArr[3]).toBe(0);
+      expect(newArr[4]).toBe(0);
+    });
+
+    it('reallocates Uint32Array with specific copyLength', () => {
+      const oldArr = new Uint32Array([10, 20, 30, 40]);
+      const newArr = reallocateUint32Array(oldArr, 6, 2);
+
+      expect(newArr.length).toBe(6);
+      expect(newArr[0]).toBe(10);
+      expect(newArr[1]).toBe(20);
+      expect(newArr[2]).toBe(0);
+    });
+
+    it('handles shrinking Uint32Array', () => {
+      const oldArr = new Uint32Array([10, 20, 30, 40]);
+      const newArr = reallocateUint32Array(oldArr, 2);
+
+      expect(newArr.length).toBe(2);
+      expect(newArr[0]).toBe(10);
+      expect(newArr[1]).toBe(20);
+    });
+  });
+});

--- a/web/src/app/store/domain/buffer-util.ts
+++ b/web/src/app/store/domain/buffer-util.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { align } from 'src/app/common/memory-util';
+import { allocateBuffer } from 'src/app/store/domain/types';
+
+/**
+ * Calculates the next capacity using exponential growth (doubling).
+ *
+ * @param currentCapacity The current buffer capacity in elements.
+ * @param minCapacity The minimum required capacity in elements.
+ * @param initialCapacity The fallback initial capacity if currentCapacity is zero.
+ * @returns The new capacity greater than or equal to minCapacity.
+ */
+export function nextCapacity(
+  currentCapacity: number,
+  minCapacity: number,
+  initialCapacity = 1024,
+): number {
+  if (currentCapacity <= 0) {
+    return Math.max(initialCapacity, minCapacity);
+  }
+  let cap = currentCapacity * 2;
+  while (cap < minCapacity) {
+    cap *= 2;
+  }
+  return cap;
+}
+
+/**
+ * Helper to compute sequential byte offsets with alignment in compound ArrayBuffers.
+ */
+export class BufferLayoutBuilder {
+  private currentOffset = 0;
+
+  /**
+   * Adds an aligned field slot with the specified element count and byte size.
+   * @param capacity The number of elements in the field view.
+   * @param bytesPerElement The byte size of each element.
+   * @param alignment The required byte boundary alignment (defaults to bytesPerElement).
+   * @returns The starting byte offset for the field view.
+   */
+  public addField(
+    capacity: number,
+    bytesPerElement: number,
+    alignment: number = bytesPerElement,
+  ): number {
+    this.currentOffset = align(this.currentOffset, alignment);
+    const start = this.currentOffset;
+    this.currentOffset += capacity * bytesPerElement;
+    return start;
+  }
+
+  /**
+   * Gets the total byte length required for all fields added so far.
+   */
+  public get totalBytes(): number {
+    return this.currentOffset;
+  }
+}
+
+/**
+ * Allocates a new ArrayBuffer of the requested byte size and copies existing content into it.
+ *
+ * @param oldBuffer The previous buffer containing existing data.
+ * @param newByteLength The total byte length of the new buffer.
+ * @param bytesToCopy The number of valid bytes to copy from the previous buffer. Defaults to all bytes that fit.
+ * @returns The newly allocated and populated ArrayBuffer.
+ */
+export function reallocateBuffer(
+  oldBuffer: ArrayBuffer,
+  newByteLength: number,
+  bytesToCopy: number = Math.min(oldBuffer.byteLength, newByteLength),
+): ArrayBuffer {
+  const newBuffer = allocateBuffer(newByteLength);
+  const copyLength = Math.min(bytesToCopy, newByteLength);
+  if (copyLength > 0 && oldBuffer.byteLength > 0) {
+    new Uint8Array(newBuffer).set(new Uint8Array(oldBuffer, 0, copyLength));
+  }
+  return newBuffer;
+}
+
+/**
+ * Reallocates a Uint32Array to a new element length, copying elements up to copyLength.
+ *
+ * @param oldArray The current Uint32Array.
+ * @param newLength The new element capacity.
+ * @param copyLength The number of active elements to copy from oldArray.
+ * @returns The newly allocated Uint32Array.
+ */
+export function reallocateUint32Array(
+  oldArray: Uint32Array,
+  newLength: number,
+  copyLength: number = Math.min(oldArray.length, newLength),
+): Uint32Array {
+  const newArray = new Uint32Array(newLength);
+  if (copyLength > 0) {
+    newArray.set(oldArray.subarray(0, copyLength));
+  }
+  return newArray;
+}

--- a/web/src/app/store/domain/inspection-data.ts
+++ b/web/src/app/store/domain/inspection-data.ts
@@ -19,6 +19,7 @@ import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { TimelineStore } from 'src/app/store/domain/timeline-store';
 import { MetadataStore } from 'src/app/store/domain/metadata-store';
+import { StructStore } from 'src/app/store/domain/struct-store';
 
 /**
  * Represents the complete domain model for v6 file format or later.
@@ -49,6 +50,11 @@ export interface InspectionData {
    * Timeline store provides efficient access for timeline data.
    */
   readonly timelineStore: TimelineStore;
+
+  /**
+   * Struct store provides efficient access for structured body data.
+   */
+  readonly structStore: StructStore;
 
   /**
    * Accumulated arbitrary file metadata.

--- a/web/src/app/store/domain/intern-pool-store.spec.ts
+++ b/web/src/app/store/domain/intern-pool-store.spec.ts
@@ -20,7 +20,7 @@ describe('InternPoolStore', () => {
   let store: InternPoolStore;
 
   beforeEach(() => {
-    store = InternPoolStore.initialize();
+    store = InternPoolStore.create();
   });
 
   it('should add and get strings from the pool', () => {
@@ -40,15 +40,14 @@ describe('InternPoolStore', () => {
   });
 
   it('should split buffer if the string size exceeds maxBufferSize', () => {
-    const smallStore = InternPoolStore.initialize(
-      [
-        { id: 1, value: 'abcdefgh' }, // 8 bytes -> fits in 1st buffer
-        { id: 2, value: 'ijklmnop' }, // 8 bytes -> exceeds remaining 2 bytes, goes to 2nd buffer
-        { id: 3, value: 'qrstuvwxyz12345' }, // 15 bytes -> exceeds 10 bytes maxBufferSize, allocated standalone
-        { id: 4, value: 'abc' }, // 3 bytes -> fits in next buffer
-      ],
-      10,
-    );
+    const smallStore = InternPoolStore.create(4, 10);
+    smallStore.addStrings([
+      { id: 1, value: 'abcdefgh' }, // 8 bytes -> fits in 1st buffer
+      { id: 2, value: 'ijklmnop' }, // 8 bytes -> exceeds remaining 2 bytes, goes to 2nd buffer
+      { id: 3, value: 'qrstuvwxyz12345' }, // 15 bytes -> exceeds 10 bytes maxBufferSize, allocated standalone
+      { id: 4, value: 'abc' }, // 3 bytes -> fits in next buffer
+    ]);
+    smallStore.shrinkToFit();
 
     expect(smallStore.getString(1)).toBe('abcdefgh');
     expect(smallStore.getString(2)).toBe('ijklmnop');
@@ -62,16 +61,67 @@ describe('InternPoolStore', () => {
     expect(store.getString(2000)).toBe('large-id-string');
   });
 
-  describe('ArrayBuffer allocation', () => {
-    it('should allocate ArrayBuffer and perform operations successfully', () => {
-      const fallbackStore = InternPoolStore.initialize();
-      fallbackStore.addStrings([
-        { id: 10, value: 'fallback-string-1' },
-        { id: 20, value: 'fallback-string-2' },
-      ]);
+  it('should correctly encode and decode multi-byte UTF-8 strings including emojis', () => {
+    store.addStrings([
+      { id: 1, value: 'こんにちは世界' },
+      { id: 2, value: 'Kubernetes 🚀 クラスタ' },
+      { id: 3, value: '' },
+    ]);
 
-      expect(fallbackStore.getString(10)).toBe('fallback-string-1');
-      expect(fallbackStore.getString(20)).toBe('fallback-string-2');
+    expect(store.getString(1)).toBe('こんにちは世界');
+    expect(store.getString(2)).toBe('Kubernetes 🚀 クラスタ');
+    expect(store.getString(3)).toBe('');
+  });
+
+  describe('create and dynamic methods', () => {
+    it('should create an empty store and allow adding strings with addString', () => {
+      const emptyStore = InternPoolStore.create();
+      expect(emptyStore.count).toBe(0);
+      expect(emptyStore.maxStringId).toBe(0);
+
+      emptyStore.addString({ id: 1, value: 'hello' });
+      emptyStore.addString({ id: 5, value: 'world' });
+
+      expect(emptyStore.count).toBe(2);
+      expect(emptyStore.maxStringId).toBe(5);
+      expect(emptyStore.getString(1)).toBe('hello');
+      expect(emptyStore.getString(5)).toBe('world');
+    });
+
+    it('should handle multiple buffer expansions starting from capacity 1', () => {
+      const dynamicStore = InternPoolStore.create(1);
+      for (let i = 1; i <= 50; i++) {
+        dynamicStore.addString({ id: i, value: `str-${i}` });
+      }
+
+      expect(dynamicStore.count).toBe(50);
+      expect(dynamicStore.maxStringId).toBe(50);
+      for (let i = 1; i <= 50; i++) {
+        expect(dynamicStore.getString(i)).toBe(`str-${i}`);
+      }
+    });
+
+    it('should not double-count duplicate additions for the same string ID', () => {
+      const dynamicStore = InternPoolStore.create();
+      dynamicStore.addString({ id: 1, value: 'v1' });
+      dynamicStore.addString({ id: 1, value: 'v2' });
+
+      expect(dynamicStore.count).toBe(1);
+      expect(dynamicStore.getString(1)).toBe('v2');
+    });
+
+    it('should shrink metadataBuffer to fit string count', () => {
+      const emptyStore = InternPoolStore.create(2048);
+      emptyStore.addString({ id: 10, value: 'test' });
+      expect(emptyStore.count).toBe(1);
+      expect(emptyStore.maxStringId).toBe(10);
+
+      emptyStore.shrinkToFit();
+
+      expect(emptyStore.getString(10)).toBe('test');
+      expect(() => emptyStore.getString(11)).toThrowError(
+        'String ID 11 not found in pool',
+      );
     });
   });
 });

--- a/web/src/app/store/domain/intern-pool-store.ts
+++ b/web/src/app/store/domain/intern-pool-store.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import {
+  BufferLayoutBuilder,
+  nextCapacity,
+} from 'src/app/store/domain/buffer-util';
+import { allocateBuffer } from 'src/app/store/domain/types';
+
 /**
  * Represents an entry in the interned string pool.
  */
@@ -27,9 +33,6 @@ export interface StringEntryDTO {
    */
   readonly value: string;
 }
-
-import { align } from 'src/app/common/memory-util';
-import { allocateBuffer } from 'src/app/store/domain/types';
 
 interface InternPoolStoreLayout {
   readonly bufferIndicesOffset: number;
@@ -82,74 +85,164 @@ export class InternPoolStore {
 
   private static readonly INITIAL_CAPACITY = 1024;
 
+  private _maxStringId = 0;
+  private stringCount = 0;
+
   // Private constructor
-  private constructor(private readonly maxBufferSize: number) {
-    const layout = this.calculateOffsets(InternPoolStore.INITIAL_CAPACITY);
+  private constructor(
+    initialCapacity: number,
+    private readonly maxBufferSize: number,
+  ) {
+    const layout = this.calculateOffsets(initialCapacity);
     this.metadataBuffer = allocateBuffer(layout.totalBytes);
     this.bufferIndices = new Uint16Array(
       this.metadataBuffer,
       layout.bufferIndicesOffset,
-      InternPoolStore.INITIAL_CAPACITY,
+      initialCapacity,
     );
     this.offsets = new Uint32Array(
       this.metadataBuffer,
       layout.offsetsOffset,
-      InternPoolStore.INITIAL_CAPACITY,
+      initialCapacity,
     );
     this.lengths = new Uint32Array(
       this.metadataBuffer,
       layout.lengthsOffset,
-      InternPoolStore.INITIAL_CAPACITY,
+      initialCapacity,
     );
   }
 
   /**
-   * Initializes a new InternPoolStore instance with interned strings.
-   * @param strings An iterable of objects containing id and value.
+   * Creates an empty InternPoolStore instance.
+   *
+   * @param initialCapacity The initial capacity of the metadata buffer.
    * @param maxBufferSize The maximum capacity of each buffer segment in bytes.
+   * @returns A new empty InternPoolStore instance.
    */
-  public static initialize(
-    strings: Iterable<StringEntryDTO> = [],
+  public static create(
+    initialCapacity: number = InternPoolStore.INITIAL_CAPACITY,
     maxBufferSize: number = 100 * 1024 * 1024,
   ): InternPoolStore {
-    const store = new InternPoolStore(maxBufferSize);
-    store.addStrings(strings);
-    return store;
+    return new InternPoolStore(initialCapacity, maxBufferSize);
+  }
+
+  /**
+   * Returns the count of unique strings stored in the pool.
+   */
+  public get count(): number {
+    return this.stringCount;
+  }
+
+  /**
+   * Returns the highest string ID encountered.
+   */
+  public get maxStringId(): number {
+    return this._maxStringId;
+  }
+
+  /**
+   * Adds a single string entry to the pool.
+   *
+   * @param entry An object containing id and value.
+   */
+  public addString(entry: StringEntryDTO): void {
+    const { id, value } = entry;
+    const encoded = this.encoder.encode(value);
+    this.ensureCapacity(id + 1);
+
+    if (
+      this.currentBufferIndex === -1 ||
+      this.maxBufferSize - this.currentOffset < encoded.length
+    ) {
+      const newSize = Math.max(this.maxBufferSize, encoded.length);
+      const buffer = allocateBuffer(newSize);
+      this.buffers.push(new Uint8Array(buffer));
+      this.currentBufferIndex = this.buffers.length - 1;
+      this.currentOffset = 0;
+    }
+
+    const activeBuffer = this.buffers[this.currentBufferIndex];
+    activeBuffer.set(encoded, this.currentOffset);
+
+    if (this.bufferIndices[id] === 0) {
+      this.stringCount++;
+    }
+
+    this.bufferIndices[id] = this.currentBufferIndex + 1;
+    this.offsets[id] = this.currentOffset;
+    this.lengths[id] = encoded.length;
+
+    this.currentOffset += encoded.length;
+    if (id > this._maxStringId) {
+      this._maxStringId = id;
+    }
   }
 
   /**
    * Adds multiple strings to the pool.
+   *
    * @param strings An iterable of objects containing id and value.
    */
   public addStrings(strings: Iterable<StringEntryDTO>): void {
-    for (const { id, value } of strings) {
-      const encoded = this.encoder.encode(value);
-      this.ensureCapacity(id + 1);
-
-      if (
-        this.currentBufferIndex === -1 ||
-        this.maxBufferSize - this.currentOffset < encoded.length
-      ) {
-        const newSize = Math.max(this.maxBufferSize, encoded.length);
-        const buffer = allocateBuffer(newSize);
-        this.buffers.push(new Uint8Array(buffer));
-        this.currentBufferIndex = this.buffers.length - 1;
-        this.currentOffset = 0;
+    if (Array.isArray(strings)) {
+      let maxId = this._maxStringId;
+      for (const entry of strings) {
+        if (entry.id > maxId) {
+          maxId = entry.id;
+        }
       }
+      this.ensureCapacity(maxId + 1);
+    }
+    for (const entry of strings) {
+      this.addString(entry);
+    }
+  }
 
-      const activeBuffer = this.buffers[this.currentBufferIndex];
-      activeBuffer.set(encoded, this.currentOffset);
+  private reallocate(newCapacity: number): void {
+    const layout = this.calculateOffsets(newCapacity);
+    const newMetadataBuffer = allocateBuffer(layout.totalBytes);
+    const newBufferIndices = new Uint16Array(
+      newMetadataBuffer,
+      layout.bufferIndicesOffset,
+      newCapacity,
+    );
+    const newOffsets = new Uint32Array(
+      newMetadataBuffer,
+      layout.offsetsOffset,
+      newCapacity,
+    );
+    const newLengths = new Uint32Array(
+      newMetadataBuffer,
+      layout.lengthsOffset,
+      newCapacity,
+    );
 
-      this.bufferIndices[id] = this.currentBufferIndex + 1;
-      this.offsets[id] = this.currentOffset;
-      this.lengths[id] = encoded.length;
+    const copyLen = Math.min(this.bufferIndices.length, newCapacity);
+    if (copyLen > 0) {
+      newBufferIndices.set(this.bufferIndices.subarray(0, copyLen));
+      newOffsets.set(this.offsets.subarray(0, copyLen));
+      newLengths.set(this.lengths.subarray(0, copyLen));
+    }
 
-      this.currentOffset += encoded.length;
+    this.metadataBuffer = newMetadataBuffer;
+    this.bufferIndices = newBufferIndices;
+    this.offsets = newOffsets;
+    this.lengths = newLengths;
+  }
+
+  /**
+   * Shrinks metadataBuffer to the minimal required size based on the current count.
+   */
+  public shrinkToFit(): void {
+    const neededCapacity = this._maxStringId + 1;
+    if (neededCapacity < this.bufferIndices.length && neededCapacity > 0) {
+      this.reallocate(neededCapacity);
     }
   }
 
   /**
    * Retrieves a string value by its ID from the pool.
+   *
    * @param id The ID of the string.
    * @returns The string value.
    * @throws Error if the ID is not found in the pool.
@@ -173,61 +266,27 @@ export class InternPoolStore {
     return this.decoder.decode(bytes);
   }
 
+  /**
+   * Ensures metadata buffer has at least minCapacity slots.
+   *
+   * @param minCapacity The required minimum capacity.
+   */
   private ensureCapacity(minCapacity: number): void {
     if (minCapacity <= this.bufferIndices.length) {
       return;
     }
 
-    let newCapacity = this.bufferIndices.length * 2;
-    while (newCapacity < minCapacity) {
-      newCapacity *= 2;
-    }
-
-    const layout = this.calculateOffsets(newCapacity);
-    const newMetadataBuffer = allocateBuffer(layout.totalBytes);
-    const newBufferIndices = new Uint16Array(
-      newMetadataBuffer,
-      layout.bufferIndicesOffset,
-      newCapacity,
-    );
-    const newOffsets = new Uint32Array(
-      newMetadataBuffer,
-      layout.offsetsOffset,
-      newCapacity,
-    );
-    const newLengths = new Uint32Array(
-      newMetadataBuffer,
-      layout.lengthsOffset,
-      newCapacity,
-    );
-
-    newBufferIndices.set(this.bufferIndices);
-    newOffsets.set(this.offsets);
-    newLengths.set(this.lengths);
-
-    this.metadataBuffer = newMetadataBuffer;
-    this.bufferIndices = newBufferIndices;
-    this.offsets = newOffsets;
-    this.lengths = newLengths;
+    const newCapacity = nextCapacity(this.bufferIndices.length, minCapacity);
+    this.reallocate(newCapacity);
   }
 
   private calculateOffsets(capacity: number): InternPoolStoreLayout {
-    let currentOffset = 0;
-
-    const bufferIndicesOffset = currentOffset;
-    currentOffset += capacity * 2; // Uint16Array: 2 bytes per element
-
-    const offsetsOffset = align(currentOffset, 4); // Uint32Array: 4-byte aligned
-    currentOffset = offsetsOffset + capacity * 4;
-
-    const lengthsOffset = align(currentOffset, 4); // Uint32Array: 4-byte aligned
-    currentOffset = lengthsOffset + capacity * 4;
-
+    const builder = new BufferLayoutBuilder();
     return {
-      bufferIndicesOffset,
-      offsetsOffset,
-      lengthsOffset,
-      totalBytes: currentOffset,
+      bufferIndicesOffset: builder.addField(capacity, 2),
+      offsetsOffset: builder.addField(capacity, 4, 4),
+      lengthsOffset: builder.addField(capacity, 4, 4),
+      totalBytes: builder.totalBytes,
     };
   }
 }

--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -26,9 +26,9 @@ describe('LogStore', () => {
   const mockColor = { r: 0, g: 0, b: 0, a: 1 };
 
   beforeEach(() => {
-    internPool = InternPoolStore.initialize();
+    internPool = InternPoolStore.create();
     styleStore = new StyleStore();
-    store = LogStore.initialize(internPool, styleStore, [], 0);
+    store = LogStore.create(internPool, styleStore, 0);
 
     // Avoid errors of missing keys in basic tests
     styleStore.addSeverities([
@@ -106,9 +106,11 @@ describe('LogStore', () => {
       { id: 4, ts: 1010n, logTypeId: 4, severityTypeId: 4, summaryStringId: 4 },
     ];
 
-    expect(() =>
-      LogStore.initialize(internPool, styleStore, logs, 4),
-    ).not.toThrow();
+    expect(() => {
+      const s = LogStore.create(internPool, styleStore, 4);
+      s.addLogs(logs);
+      s.shrinkToFit();
+    }).not.toThrow();
   });
 
   it('should throw error if logs are out of timestamp order', () => {
@@ -117,9 +119,10 @@ describe('LogStore', () => {
       { id: 2, ts: 999n, logTypeId: 2, severityTypeId: 2, summaryStringId: 2 },
     ];
 
-    expect(() =>
-      LogStore.initialize(internPool, styleStore, logs, 2),
-    ).toThrowError(/Logs are not sorted by timestamp/);
+    expect(() => {
+      const s = LogStore.create(internPool, styleStore, 2);
+      s.addLogs(logs);
+    }).toThrowError(/Logs are not sorted by timestamp/);
   });
 
   it('should fetch log entries and handle incorrect id lookups', () => {
@@ -167,7 +170,9 @@ describe('LogStore', () => {
       },
     ];
 
-    store = LogStore.initialize(internPool, styleStore, logs, 2);
+    store = LogStore.create(internPool, styleStore, 2);
+    store.addLogs(logs);
+    store.shrinkToFit();
 
     const logObj = store.getLog(55);
     expect(logObj.id).toBe(55);
@@ -191,7 +196,9 @@ describe('LogStore', () => {
       { id: 2, ts: 1005n, logTypeId: 2, severityTypeId: 2, summaryStringId: 2 },
     ];
 
-    store = LogStore.initialize(internPool, styleStore, logs, 2);
+    store = LogStore.create(internPool, styleStore, 2);
+    store.addLogs(logs);
+    store.shrinkToFit();
 
     expect(store.count).toBe(2);
 
@@ -201,27 +208,105 @@ describe('LogStore', () => {
     expect(iteratedLogs[1].id).toBe(2);
   });
 
-  describe('ArrayBuffer allocation', () => {
-    it('should allocate ArrayBuffer and perform operations successfully', () => {
-      const logs: LogDTO[] = [
-        {
-          id: 1,
-          ts: 1000n,
+  describe('create and dynamic methods', () => {
+    it('should create an empty store and add logs dynamically', () => {
+      const dynamicStore = LogStore.create(internPool, styleStore, 1);
+      expect(dynamicStore.count).toBe(0);
+
+      dynamicStore.addLog({
+        id: 10,
+        ts: 100n,
+        logTypeId: 100,
+        severityTypeId: 10,
+        summaryStringId: 1,
+      });
+      dynamicStore.addLog({
+        id: 20,
+        ts: 200n,
+        logTypeId: 100,
+        severityTypeId: 10,
+        summaryStringId: 2,
+        bodyStructId: 42,
+      });
+
+      expect(dynamicStore.count).toBe(2);
+      expect(dynamicStore.getLog(10).timestamp).toBe(100n);
+      expect(dynamicStore.getLog(20).timestamp).toBe(200n);
+      expect(dynamicStore.getLog(20).structId).toBe(42);
+
+      dynamicStore.shrinkToFit();
+      expect(dynamicStore.count).toBe(2);
+      expect(dynamicStore.getLog(10).timestamp).toBe(100n);
+      expect(dynamicStore.getLog(20).timestamp).toBe(200n);
+    });
+
+    it('should handle multiple buffer expansions starting from capacity 1 and preserve all fields', () => {
+      for (let i = 1; i <= 20; i++) {
+        internPool.addString({ id: i, value: `summary_${i}` });
+      }
+
+      const dynamicStore = LogStore.create(internPool, styleStore, 1);
+      for (let i = 1; i <= 20; i++) {
+        dynamicStore.addLog({
+          id: i,
+          ts: BigInt(i * 10),
+          logTypeId: ((i - 1) % 4) + 1,
+          severityTypeId: ((i - 1) % 4) + 1,
+          summaryStringId: i,
+          bodyStructId: i * 100,
+        });
+      }
+
+      expect(dynamicStore.count).toBe(20);
+      for (let i = 1; i <= 20; i++) {
+        const log = dynamicStore.getLog(i);
+        expect(log.id).toBe(i);
+        expect(log.timestamp).toBe(BigInt(i * 10));
+        expect(log.summary).toBe(`summary_${i}`);
+        expect(log.logType.label).toBe(`L${((i - 1) % 4) + 1}`);
+        expect(log.severity.label).toBe(`S${((i - 1) % 4) + 1}`);
+        expect(log.structId).toBe(i * 100);
+      }
+
+      dynamicStore.shrinkToFit();
+      // Should be idempotent on multiple calls
+      dynamicStore.shrinkToFit();
+      expect(dynamicStore.count).toBe(20);
+      for (let i = 1; i <= 20; i++) {
+        const log = dynamicStore.getLog(i);
+        expect(log.id).toBe(i);
+        expect(log.timestamp).toBe(BigInt(i * 10));
+        expect(log.summary).toBe(`summary_${i}`);
+        expect(log.structId).toBe(i * 100);
+      }
+    });
+
+    it('should handle shrinkToFit on an empty store with capacity 0', () => {
+      const emptyStore = LogStore.create(internPool, styleStore, 0);
+      emptyStore.shrinkToFit();
+      expect(emptyStore.count).toBe(0);
+      expect(() => emptyStore.getLog(1)).toThrowError(/Log ID 1 not found/);
+    });
+
+    it('should throw error when adding unsorted logs', () => {
+      const dynamicStore = LogStore.create(internPool, styleStore);
+      dynamicStore.addLog({
+        id: 1,
+        ts: 200n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+      });
+
+      expect(() =>
+        dynamicStore.addLog({
+          id: 2,
+          ts: 100n,
           logTypeId: 1,
           severityTypeId: 1,
           summaryStringId: 1,
-        },
-      ];
-      const fallbackStore = LogStore.initialize(
-        internPool,
-        styleStore,
-        logs,
-        1,
-      );
-
-      expect(fallbackStore.count).toBe(1);
-      const log = fallbackStore.getLog(1);
-      expect(log.id).toBe(1);
+        }),
+      ).toThrowError(/Logs are not sorted by timestamp/);
     });
   });
 });

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -17,7 +17,10 @@
 import { Log } from 'src/app/store/domain/log';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { LogType, Severity, StyleProvider } from 'src/app/store/domain/style';
-import { align } from 'src/app/common/memory-util';
+import {
+  BufferLayoutBuilder,
+  nextCapacity,
+} from 'src/app/store/domain/buffer-util';
 import {
   ReadonlyDomainElement,
   allocateBuffer,
@@ -38,11 +41,20 @@ export interface LogDTO {
   readonly bodyStructId?: number;
 }
 
+interface LogStoreLayout {
+  readonly idsOffset: number;
+  readonly logTypeIdsOffset: number;
+  readonly severityIdsOffset: number;
+  readonly summaryStringIdsOffset: number;
+  readonly bodyStructIdsOffset: number;
+  readonly timestampsOffset: number;
+  readonly totalBytes: number;
+}
+
 /**
  * Store for managing and retrieving logs efficiently.
  */
 export class LogStore {
-  private metadataBuffer!: ArrayBuffer;
   private ids!: Uint32Array;
   private timestamps!: BigUint64Array;
   private logTypeIds!: Uint32Array;
@@ -52,111 +64,158 @@ export class LogStore {
 
   private idToIndex: (number | undefined)[] = [];
 
+  private logCount = 0;
+  private previousTimestamp = 0n;
+
   private constructor(
     private readonly internPool: InternPoolStore,
     private readonly styleStore: StyleProvider,
   ) {}
 
   /**
-   * Initializes a new LogStore instance with the raw logs.
-   * Assumes logs are already sorted by timestamp.
+   * Creates an empty LogStore instance.
+   *
    * @param internPool The intern pool store.
    * @param styleStore The style provider.
-   * @param logs The iterable of raw logs.
-   * @param count The total number of logs.
+   * @param initialCapacity The initial capacity for log metadata.
+   * @returns A new empty LogStore instance.
    */
-  public static initialize(
+  public static create(
     internPool: InternPoolStore,
     styleStore: StyleProvider,
-    logs: Iterable<LogDTO>,
-    count: number,
+    initialCapacity = 1024,
   ): LogStore {
     const store = new LogStore(internPool, styleStore);
-    store.load(logs, count);
+    if (initialCapacity > 0) {
+      store.ensureCapacity(initialCapacity);
+    }
     return store;
   }
 
-  private allocateMetadata(capacity: number): void {
-    let currentOffset = 0;
-    const idsOffset = currentOffset;
-    currentOffset += capacity * 4;
+  /**
+   * Appends multiple logs to the store.
+   * Logs must be in non-decreasing timestamp order.
+   *
+   * @param logs An iterable of LogDTO objects.
+   */
+  public addLogs(logs: Iterable<LogDTO>): void {
+    if (Array.isArray(logs)) {
+      this.ensureCapacity(this.logCount + logs.length);
+    }
+    for (const log of logs) {
+      this.addLog(log);
+    }
+  }
 
-    const logTypeIdsOffset = currentOffset;
-    currentOffset += capacity * 4;
+  private calculateOffsets(capacity: number): LogStoreLayout {
+    const builder = new BufferLayoutBuilder();
+    return {
+      idsOffset: builder.addField(capacity, 4),
+      logTypeIdsOffset: builder.addField(capacity, 4),
+      severityIdsOffset: builder.addField(capacity, 4),
+      summaryStringIdsOffset: builder.addField(capacity, 4),
+      bodyStructIdsOffset: builder.addField(capacity, 4),
+      timestampsOffset: builder.addField(capacity, 8, 8),
+      totalBytes: builder.totalBytes,
+    };
+  }
 
-    const severityIdsOffset = currentOffset;
-    currentOffset += capacity * 4;
+  private reallocate(newCap: number): void {
+    const layout = this.calculateOffsets(newCap);
+    const newMetadataBuffer = allocateBuffer(layout.totalBytes);
 
-    const summaryStringIdsOffset = currentOffset;
-    currentOffset += capacity * 4;
-
-    const bodyStructIdsOffset = currentOffset;
-    currentOffset += capacity * 4;
-
-    const timestampsOffset = align(currentOffset, 8);
-    currentOffset = timestampsOffset + capacity * 8;
-
-    const totalBytes = currentOffset;
-    this.metadataBuffer = allocateBuffer(totalBytes);
-
-    this.ids = new Uint32Array(this.metadataBuffer, idsOffset, capacity);
-    this.logTypeIds = new Uint32Array(
-      this.metadataBuffer,
-      logTypeIdsOffset,
-      capacity,
+    const newIds = new Uint32Array(newMetadataBuffer, layout.idsOffset, newCap);
+    const newLogTypeIds = new Uint32Array(
+      newMetadataBuffer,
+      layout.logTypeIdsOffset,
+      newCap,
     );
-    this.severityIds = new Uint32Array(
-      this.metadataBuffer,
-      severityIdsOffset,
-      capacity,
+    const newSeverityIds = new Uint32Array(
+      newMetadataBuffer,
+      layout.severityIdsOffset,
+      newCap,
     );
-    this.summaryStringIds = new Uint32Array(
-      this.metadataBuffer,
-      summaryStringIdsOffset,
-      capacity,
+    const newSummaryStringIds = new Uint32Array(
+      newMetadataBuffer,
+      layout.summaryStringIdsOffset,
+      newCap,
     );
-    this.bodyStructIds = new Uint32Array(
-      this.metadataBuffer,
-      bodyStructIdsOffset,
-      capacity,
+    const newBodyStructIds = new Uint32Array(
+      newMetadataBuffer,
+      layout.bodyStructIdsOffset,
+      newCap,
     );
-    this.timestamps = new BigUint64Array(
-      this.metadataBuffer,
-      timestampsOffset,
-      capacity,
+    const newTimestamps = new BigUint64Array(
+      newMetadataBuffer,
+      layout.timestampsOffset,
+      newCap,
     );
+
+    if (this.logCount > 0 && this.ids) {
+      newIds.set(this.ids.subarray(0, this.logCount));
+      newLogTypeIds.set(this.logTypeIds.subarray(0, this.logCount));
+      newSeverityIds.set(this.severityIds.subarray(0, this.logCount));
+      newSummaryStringIds.set(this.summaryStringIds.subarray(0, this.logCount));
+      newBodyStructIds.set(this.bodyStructIds.subarray(0, this.logCount));
+      newTimestamps.set(this.timestamps.subarray(0, this.logCount));
+    }
+
+    this.ids = newIds;
+    this.logTypeIds = newLogTypeIds;
+    this.severityIds = newSeverityIds;
+    this.summaryStringIds = newSummaryStringIds;
+    this.bodyStructIds = newBodyStructIds;
+    this.timestamps = newTimestamps;
   }
 
   /**
-   * Initializes the store with the raw logs.
-   * Assumes logs are already sorted by timestamp.
-   * @param logs The iterable of raw logs.
-   * @param count The total number of logs.
+   * Ensures the metadata buffer has at least minCapacity slots.
+   *
+   * @param minCapacity The required minimum capacity.
    */
-  private load(logs: Iterable<LogDTO>, count: number): void {
-    this.allocateMetadata(count);
-    this.idToIndex = [];
-
-    let index = 0;
-    let prevTs = 0n;
-    for (const log of logs) {
-      if (index > 0 && log.ts < prevTs) {
-        throw new Error(
-          `Logs are not sorted by timestamp at index ${index}: timestamp ${log.ts} < ${prevTs}`,
-        );
-      }
-      prevTs = log.ts;
-
-      this.ids[index] = log.id;
-      this.timestamps[index] = log.ts;
-      this.logTypeIds[index] = log.logTypeId;
-      this.severityIds[index] = log.severityTypeId;
-      this.summaryStringIds[index] = log.summaryStringId;
-      this.bodyStructIds[index] = log.bodyStructId ?? 0;
-
-      this.idToIndex[log.id] = index;
-      index++;
+  private ensureCapacity(minCapacity: number): void {
+    const currentCap = this.ids ? this.ids.length : 0;
+    if (minCapacity > currentCap) {
+      this.reallocate(nextCapacity(currentCap, minCapacity));
     }
+  }
+
+  /**
+   * Shrinks metadataBuffer to the minimal required size based on the current log count.
+   */
+  public shrinkToFit(): void {
+    const currentCap = this.ids ? this.ids.length : 0;
+    if (this.logCount < currentCap) {
+      this.reallocate(this.logCount);
+    }
+  }
+
+  /**
+   * Appends a single log to the store.
+   * Logs must be added in non-decreasing timestamp order.
+   *
+   * @param log The raw LogDTO to add.
+   */
+  public addLog(log: LogDTO): void {
+    if (this.logCount > 0 && log.ts < this.previousTimestamp) {
+      throw new Error(
+        `Logs are not sorted by timestamp at index ${this.logCount}: timestamp ${log.ts} < ${this.previousTimestamp}`,
+      );
+    }
+    this.previousTimestamp = log.ts;
+
+    this.ensureCapacity(this.logCount + 1);
+
+    const index = this.logCount;
+    this.ids[index] = log.id;
+    this.timestamps[index] = log.ts;
+    this.logTypeIds[index] = log.logTypeId;
+    this.severityIds[index] = log.severityTypeId;
+    this.summaryStringIds[index] = log.summaryStringId;
+    this.bodyStructIds[index] = log.bodyStructId ?? 0;
+
+    this.idToIndex[log.id] = index;
+    this.logCount++;
   }
 
   /**
@@ -177,14 +236,14 @@ export class LogStore {
    * Gets the total number of logs.
    */
   public get count(): number {
-    return this.ids.length;
+    return this.logCount;
   }
 
   /**
    * Returns an iterator for all logs in the store.
    */
   public *logs(): IterableIterator<ReadonlyDomainElement<Log>> {
-    for (let i = 0; i < this.ids.length; i++) {
+    for (let i = 0; i < this.logCount; i++) {
       yield new Log(this.ids[i], this);
     }
   }
@@ -225,8 +284,9 @@ export class LogStore {
 
   /**
    * Gets the interned struct ID of a log body, or 0 if not stored as a struct.
+   * @note Intended solely for internal retrieval inside the {@link Log} domain adapter.
    */
-  public getBodyStructId(id: number): number {
+  public _getBodyStructId(id: number): number {
     const index = this.getIndex(id);
     return this.bodyStructIds[index] ?? 0;
   }

--- a/web/src/app/store/domain/log.ts
+++ b/web/src/app/store/domain/log.ts
@@ -76,6 +76,6 @@ export class Log {
    * Gets the interned struct ID of the log body, or 0 if not stored as an interned struct.
    */
   get structId(): number {
-    return this.store.getBodyStructId(this.id);
+    return this.store._getBodyStructId(this.id);
   }
 }

--- a/web/src/app/store/domain/struct-store.spec.ts
+++ b/web/src/app/store/domain/struct-store.spec.ts
@@ -1,0 +1,333 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import {
+  StructStore,
+  StructValueKind,
+} from 'src/app/store/domain/struct-store';
+
+describe('StructStore', () => {
+  let internPool: InternPoolStore;
+  let structStore: StructStore;
+
+  beforeEach(() => {
+    internPool = InternPoolStore.create();
+    structStore = StructStore.create(internPool);
+  });
+
+  it('decodes simple struct value variants correctly', () => {
+    internPool.addStrings([
+      { id: 1, value: 'a' },
+      { id: 2, value: 'b' },
+      { id: 3, value: 'c' },
+      { id: 4, value: 'd' },
+      { id: 5, value: 'e' },
+      { id: 6, value: 'f' },
+      { id: 100, value: 'resolved_value' },
+    ]);
+
+    structStore.addFieldPathSet({
+      id: 10,
+      fieldPathStringIds: [1, 2, 3, 4, 5, 6],
+    });
+
+    structStore.addStruct({
+      id: 1,
+      fieldPathSetId: 10,
+      values: [
+        { kind: StructValueKind.Null },
+        { kind: StructValueKind.Int64, value: 123n },
+        { kind: StructValueKind.Double, value: 3.14 },
+        { kind: StructValueKind.Bool, value: true },
+        { kind: StructValueKind.String, stringId: 100 },
+        {
+          kind: StructValueKind.Timestamp,
+          timestampNs: 1_000_000_000_500n,
+        },
+      ],
+    });
+
+    expect(structStore.count).toBe(1);
+
+    const result = structStore.getStruct(1);
+    expect(result).toEqual({
+      a: null,
+      b: 123,
+      c: 3.14,
+      d: true,
+      e: 'resolved_value',
+      f: 1_000_000_000_500n,
+    });
+  });
+
+  it('decodes flattened keys with \\0 separators into nested objects', () => {
+    internPool.addStrings([
+      { id: 1, value: 'metadata\0name' },
+      { id: 2, value: 'metadata\0labels\0env' },
+      { id: 10, value: 'frontend-pod' },
+      { id: 11, value: 'production' },
+    ]);
+
+    structStore.addFieldPathSet({
+      id: 20,
+      fieldPathStringIds: [1, 2],
+    });
+
+    structStore.addStruct({
+      id: 5,
+      fieldPathSetId: 20,
+      values: [
+        { kind: StructValueKind.String, stringId: 10 },
+        { kind: StructValueKind.String, stringId: 11 },
+      ],
+    });
+
+    const result = structStore.getStruct(5);
+    expect(result).toEqual({
+      metadata: {
+        name: 'frontend-pod',
+        labels: {
+          env: 'production',
+        },
+      },
+    });
+  });
+
+  it('decodes recursive nested structs and list value variants', () => {
+    internPool.addStrings([
+      { id: 1, value: 'nested' },
+      { id: 2, value: 'elements' },
+      { id: 3, value: 'key' },
+      { id: 10, value: 'leaf' },
+    ]);
+
+    structStore.addFieldPathSet({
+      id: 30,
+      fieldPathStringIds: [1, 2],
+    });
+    structStore.addFieldPathSet({
+      id: 31,
+      fieldPathStringIds: [3],
+    });
+
+    // Nested struct (id: 100)
+    structStore.addStruct({
+      id: 100,
+      fieldPathSetId: 31,
+      values: [{ kind: StructValueKind.String, stringId: 10 }],
+    });
+
+    // Parent struct (id: 200)
+    structStore.addStruct({
+      id: 200,
+      fieldPathSetId: 30,
+      values: [
+        { kind: StructValueKind.StructId, structId: 100 },
+        {
+          kind: StructValueKind.List,
+          values: [
+            { kind: StructValueKind.Int64, value: 10n },
+            { kind: StructValueKind.Bool, value: false },
+          ],
+        },
+      ],
+    });
+
+    const result = structStore.getStruct(200);
+    expect(result).toEqual({
+      nested: {
+        key: 'leaf',
+      },
+      elements: [10, false],
+    });
+  });
+
+  it('returns null for nonexistent or uninitialized struct IDs', () => {
+    expect(structStore.getStruct(0)).toBeNull();
+    expect(structStore.getStruct(999)).toBeNull();
+    expect(structStore.getStruct(-1)).toBeNull();
+  });
+
+  it('dynamically expands buffer and shrinks to fit correctly', () => {
+    const smallStore = StructStore.create(internPool, 2);
+    internPool.addStrings([{ id: 1, value: 'field' }]);
+
+    smallStore.addFieldPathSet({
+      id: 1,
+      fieldPathStringIds: [1],
+    });
+
+    for (let i = 1; i <= 20; i++) {
+      smallStore.addStruct({
+        id: i,
+        fieldPathSetId: 1,
+        values: [{ kind: StructValueKind.Int64, value: BigInt(i * 10) }],
+      });
+    }
+
+    expect(smallStore.count).toBe(20);
+    smallStore.shrinkToFit();
+
+    expect(smallStore.count).toBe(20);
+    expect(smallStore.getStruct(1)).toEqual({ field: 10 });
+    expect(smallStore.getStruct(20)).toEqual({ field: 200 });
+  });
+
+  it('preserves int64 as bigint when value exceeds MAX_SAFE_INTEGER', () => {
+    internPool.addStrings([
+      { id: 1, value: 'safe' },
+      { id: 2, value: 'unsafe' },
+      { id: 3, value: 'negative_unsafe' },
+    ]);
+    structStore.addFieldPathSet({
+      id: 1,
+      fieldPathStringIds: [1, 2, 3],
+    });
+
+    const safeValue = BigInt(Number.MAX_SAFE_INTEGER);
+    const unsafeValue = BigInt(Number.MAX_SAFE_INTEGER) + 100n;
+    const negativeUnsafe = BigInt(Number.MIN_SAFE_INTEGER) - 100n;
+
+    structStore.addStruct({
+      id: 1,
+      fieldPathSetId: 1,
+      values: [
+        { kind: StructValueKind.Int64, value: safeValue },
+        { kind: StructValueKind.Int64, value: unsafeValue },
+        { kind: StructValueKind.Int64, value: negativeUnsafe },
+      ],
+    });
+
+    const result = structStore.getStruct(1);
+    expect(result).toEqual({
+      safe: Number.MAX_SAFE_INTEGER,
+      unsafe: unsafeValue,
+      negative_unsafe: negativeUnsafe,
+    });
+  });
+
+  it('handles payload buffer expansion beyond initial 64KB', () => {
+    internPool.addStrings([{ id: 1, value: 'num' }]);
+    structStore.addFieldPathSet({
+      id: 1,
+      fieldPathStringIds: [1],
+    });
+
+    // Each struct with a double adds tag (1) + alignment (7) + double (8) = 16 bytes.
+    // 5000 structs = ~80KB, which exceeds initial 64KB (65536 bytes) payloadBuffer.
+    for (let i = 1; i <= 5000; i++) {
+      structStore.addStruct({
+        id: i,
+        fieldPathSetId: 1,
+        values: [{ kind: StructValueKind.Double, value: i * 0.5 }],
+      });
+    }
+
+    expect(structStore.count).toBe(5000);
+    expect(structStore.getStruct(1)).toEqual({ num: 0.5 });
+    expect(structStore.getStruct(2500)).toEqual({ num: 1250 });
+    expect(structStore.getStruct(5000)).toEqual({ num: 2500 });
+
+    structStore.shrinkToFit();
+    // Idempotent
+    structStore.shrinkToFit();
+    expect(structStore.count).toBe(5000);
+    expect(structStore.getStruct(5000)).toEqual({ num: 2500 });
+  });
+
+  it('handles empty struct with no values', () => {
+    structStore.addFieldPathSet({
+      id: 1,
+      fieldPathStringIds: [],
+    });
+    structStore.addStruct({
+      id: 1,
+      fieldPathSetId: 1,
+      values: [],
+    });
+
+    expect(structStore.count).toBe(1);
+    expect(structStore.getStruct(1)).toEqual({});
+  });
+
+  it('handles fieldPathsBuffer dynamic expansion beyond initial capacity', () => {
+    const stringIds: number[] = [];
+    for (let i = 1; i <= 1500; i++) {
+      internPool.addString({ id: i, value: `key_${i}` });
+      stringIds.push(i);
+    }
+
+    // 1500 fields exceeds INITIAL_CAPACITY of 1024
+    structStore.addFieldPathSet({
+      id: 1,
+      fieldPathStringIds: stringIds,
+    });
+
+    const values = stringIds.map((_, idx) => ({
+      kind: StructValueKind.Int64 as const,
+      value: BigInt(idx),
+    }));
+
+    structStore.addStruct({
+      id: 1,
+      fieldPathSetId: 1,
+      values,
+    });
+
+    structStore.shrinkToFit();
+
+    const result = structStore.getStruct(1);
+    expect(result).not.toBeNull();
+    expect(result!['key_1']).toBe(0);
+    expect(result!['key_1500']).toBe(1499);
+  });
+
+  it('handles empty lists and nested lists in struct values', () => {
+    internPool.addStrings([
+      { id: 1, value: 'emptyList' },
+      { id: 2, value: 'nestedList' },
+    ]);
+
+    structStore.addFieldPathSet({
+      id: 1,
+      fieldPathStringIds: [1, 2],
+    });
+
+    structStore.addStruct({
+      id: 1,
+      fieldPathSetId: 1,
+      values: [
+        { kind: StructValueKind.List, values: [] },
+        {
+          kind: StructValueKind.List,
+          values: [
+            {
+              kind: StructValueKind.List,
+              values: [{ kind: StructValueKind.String, stringId: 1 }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = structStore.getStruct(1);
+    expect(result).toEqual({
+      emptyList: [],
+      nestedList: [['emptyList']],
+    });
+  });
+});

--- a/web/src/app/store/domain/struct-store.spec.ts
+++ b/web/src/app/store/domain/struct-store.spec.ts
@@ -330,4 +330,47 @@ describe('StructStore', () => {
       nestedList: [['emptyList']],
     });
   });
+
+  it('safely ignores field paths attempting prototype pollution or containing empty segments', () => {
+    internPool.addStrings([
+      { id: 1, value: '__proto__\0polluted' },
+      { id: 2, value: 'constructor\0prototype\0polluted' },
+      { id: 3, value: 'safe\0prototype\0polluted' },
+      { id: 4, value: 'valid\0key' },
+      { id: 5, value: 'valid\0' }, // trailing empty segment
+      { id: 6, value: '\0empty_leading' }, // leading empty segment
+      { id: 10, value: 'attack_value' },
+      { id: 11, value: 'legit_value' },
+    ]);
+
+    structStore.addFieldPathSet({
+      id: 1,
+      fieldPathStringIds: [1, 2, 3, 4, 5, 6],
+    });
+
+    structStore.addStruct({
+      id: 1,
+      fieldPathSetId: 1,
+      values: [
+        { kind: StructValueKind.String, stringId: 10 },
+        { kind: StructValueKind.String, stringId: 10 },
+        { kind: StructValueKind.String, stringId: 10 },
+        { kind: StructValueKind.String, stringId: 11 },
+        { kind: StructValueKind.String, stringId: 10 },
+        { kind: StructValueKind.String, stringId: 10 },
+      ],
+    });
+
+    const result = structStore.getStruct(1);
+    expect(result).toEqual({
+      valid: {
+        key: 'legit_value',
+      },
+    });
+
+    // Ensure global Object.prototype was not polluted
+    expect(
+      (Object.prototype as Record<string, unknown>)['polluted'],
+    ).toBeUndefined();
+  });
 });

--- a/web/src/app/store/domain/struct-store.ts
+++ b/web/src/app/store/domain/struct-store.ts
@@ -22,6 +22,9 @@ import {
 } from 'src/app/store/domain/buffer-util';
 import { allocateBuffer } from 'src/app/store/domain/types';
 
+const MIN_SAFE_INTEGER_BI = BigInt(Number.MIN_SAFE_INTEGER);
+const MAX_SAFE_INTEGER_BI = BigInt(Number.MAX_SAFE_INTEGER);
+
 /**
  * Separator used when flattening nested object keys in InternedStruct.
  */
@@ -368,7 +371,7 @@ export class StructStore {
     const fieldOffset = this.fieldPathSetOffsets[fieldPathSetId] ?? 0;
 
     let currentPos = startOffset;
-    const root: Record<string, unknown> = {};
+    const root: Record<string, unknown> = Object.create(null);
 
     for (let i = 0; i < fieldCount; i++) {
       const stringId = this.fieldPathsBuffer[fieldOffset + i];
@@ -398,8 +401,7 @@ export class StructStore {
         );
         const numVal = Number(bigVal);
         const isSafe =
-          bigVal >= BigInt(Number.MIN_SAFE_INTEGER) &&
-          bigVal <= BigInt(Number.MAX_SAFE_INTEGER);
+          bigVal >= MIN_SAFE_INTEGER_BI && bigVal <= MAX_SAFE_INTEGER_BI;
         return [isSafe ? numVal : bigVal, pos + 8];
       }
       case ValueTag.Double: {
@@ -457,15 +459,27 @@ export class StructStore {
     value: unknown,
   ): void {
     const parts = fullPath.split(FIELD_PATH_SEPARATOR);
+
+    for (const part of parts) {
+      if (
+        part.length === 0 ||
+        part === '__proto__' ||
+        part === 'constructor' ||
+        part === 'prototype'
+      ) {
+        return;
+      }
+    }
+
     let current = target;
     for (let i = 0; i < parts.length - 1; i++) {
       const part = parts[i];
       if (
-        !(part in current) ||
+        !Object.hasOwn(current, part) ||
         typeof current[part] !== 'object' ||
         current[part] === null
       ) {
-        current[part] = {};
+        current[part] = Object.create(null);
       }
       current = current[part] as Record<string, unknown>;
     }

--- a/web/src/app/store/domain/struct-store.ts
+++ b/web/src/app/store/domain/struct-store.ts
@@ -1,0 +1,594 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
+import {
+  nextCapacity,
+  reallocateBuffer,
+  reallocateUint32Array,
+} from 'src/app/store/domain/buffer-util';
+import { allocateBuffer } from 'src/app/store/domain/types';
+
+/**
+ * Separator used when flattening nested object keys in InternedStruct.
+ */
+const FIELD_PATH_SEPARATOR = '\x00';
+
+/**
+ * Binary tags for value kinds in the flat struct byte stream.
+ */
+const enum ValueTag {
+  Null = 0,
+  BoolFalse = 1,
+  BoolTrue = 2,
+  Int64 = 3,
+  Double = 4,
+  StringId = 5,
+  StructId = 6,
+  List = 7,
+  TimestampNs = 8,
+}
+
+/**
+ * Kind discriminator for StructValue.
+ */
+export enum StructValueKind {
+  Null = 'null',
+  Int64 = 'int64',
+  Double = 'double',
+  String = 'string',
+  Bool = 'bool',
+  StructId = 'structId',
+  List = 'list',
+  Timestamp = 'timestamp',
+}
+
+/**
+ * Null variant of StructValueDTO.
+ */
+export interface StructNullValueDTO {
+  readonly kind: StructValueKind.Null;
+}
+
+/**
+ * Int64 variant of StructValueDTO.
+ */
+export interface StructInt64ValueDTO {
+  readonly kind: StructValueKind.Int64;
+  readonly value: bigint;
+}
+
+/**
+ * Double variant of StructValueDTO.
+ */
+export interface StructDoubleValueDTO {
+  readonly kind: StructValueKind.Double;
+  readonly value: number;
+}
+
+/**
+ * String variant of StructValueDTO.
+ */
+export interface StructStringValueDTO {
+  readonly kind: StructValueKind.String;
+  readonly stringId: number;
+}
+
+/**
+ * Boolean variant of StructValueDTO.
+ */
+export interface StructBoolValueDTO {
+  readonly kind: StructValueKind.Bool;
+  readonly value: boolean;
+}
+
+/**
+ * StructId reference variant of StructValueDTO.
+ */
+export interface StructStructIdValueDTO {
+  readonly kind: StructValueKind.StructId;
+  readonly structId: number;
+}
+
+/**
+ * List variant of StructValueDTO.
+ */
+export interface StructListValueDTO {
+  readonly kind: StructValueKind.List;
+  readonly values: readonly StructValueDTO[];
+}
+
+/**
+ * Timestamp variant of StructValueDTO.
+ */
+export interface StructTimestampValueDTO {
+  readonly kind: StructValueKind.Timestamp;
+  readonly timestampNs: bigint;
+}
+
+/**
+ * Variant value types for structured data in InternedStruct.
+ */
+export type StructValueDTO =
+  | StructNullValueDTO
+  | StructInt64ValueDTO
+  | StructDoubleValueDTO
+  | StructStringValueDTO
+  | StructBoolValueDTO
+  | StructStructIdValueDTO
+  | StructListValueDTO
+  | StructTimestampValueDTO;
+
+/**
+ * Raw FieldPathSet DTO from the assembler.
+ */
+export interface FieldPathSetDTO {
+  readonly id: number;
+  readonly fieldPathStringIds: readonly number[];
+}
+
+/**
+ * Raw Struct DTO from the assembler.
+ */
+export interface StructDTO {
+  readonly id: number;
+  readonly fieldPathSetId: number;
+  readonly values: readonly StructValueDTO[];
+}
+
+/**
+ * Store for managing structured data (InternedStruct) using flat ArrayBuffers.
+ */
+export class StructStore {
+  // Field path set storage
+  private fieldPathSetOffsets: Uint32Array;
+  private fieldPathSetLengths: Uint32Array;
+  private fieldPathsBuffer: Uint32Array;
+  private fieldPathsWriteOffset = 0;
+  private maxFieldPathSetId = 0;
+
+  // Struct indexing
+  private structOffsets: Uint32Array;
+  private structFieldPathSetIds: Uint32Array;
+  private maxStructId = 0;
+  private structCount = 0;
+
+  // Binary payload storage
+  private payloadBuffer: Uint8Array;
+  private payloadDataView: DataView;
+  private payloadWriteOffset = 0;
+
+  private static readonly INITIAL_CAPACITY = 1024;
+  private static readonly INITIAL_PAYLOAD_BYTES = 64 * 1024;
+
+  private constructor(
+    private readonly internPool: InternPoolStore,
+
+    initialCapacity = StructStore.INITIAL_CAPACITY,
+  ) {
+    this.fieldPathSetOffsets = new Uint32Array(initialCapacity);
+    this.fieldPathSetLengths = new Uint32Array(initialCapacity);
+    this.fieldPathsBuffer = new Uint32Array(initialCapacity * 8);
+
+    this.structOffsets = new Uint32Array(initialCapacity);
+    this.structFieldPathSetIds = new Uint32Array(initialCapacity);
+
+    const rawPayloadBuffer = allocateBuffer(StructStore.INITIAL_PAYLOAD_BYTES);
+    this.payloadBuffer = new Uint8Array(rawPayloadBuffer);
+    this.payloadDataView = new DataView(rawPayloadBuffer);
+  }
+
+  /**
+   * Creates an empty StructStore instance.
+   *
+   * @param internPool The intern pool store for string resolution.
+   * @param initialCapacity The initial capacity for struct index tables.
+   * @returns A new StructStore instance.
+   */
+  public static create(
+    internPool: InternPoolStore,
+    initialCapacity = StructStore.INITIAL_CAPACITY,
+  ): StructStore {
+    return new StructStore(internPool, initialCapacity);
+  }
+
+  /**
+   * Gets the total number of structs stored.
+   */
+  public get count(): number {
+    return this.structCount;
+  }
+
+  /**
+   * Appends a FieldPathSet to the store.
+   *
+   * @param set The FieldPathSetDTO to add.
+   */
+  public addFieldPathSet(set: FieldPathSetDTO): void {
+    this.ensureFieldPathSetCapacity(set.id + 1);
+    this.ensureFieldPathsBufferCapacity(
+      this.fieldPathsWriteOffset + set.fieldPathStringIds.length,
+    );
+
+    this.fieldPathSetOffsets[set.id] = this.fieldPathsWriteOffset;
+    this.fieldPathSetLengths[set.id] = set.fieldPathStringIds.length;
+
+    for (let i = 0; i < set.fieldPathStringIds.length; i++) {
+      this.fieldPathsBuffer[this.fieldPathsWriteOffset + i] =
+        set.fieldPathStringIds[i];
+    }
+    this.fieldPathsWriteOffset += set.fieldPathStringIds.length;
+
+    if (set.id > this.maxFieldPathSetId) {
+      this.maxFieldPathSetId = set.id;
+    }
+  }
+
+  /**
+   * Appends a Struct to the store, writing its values into the flat payload byte stream.
+   *
+   * @param struct The StructDTO to add.
+   */
+  public addStruct(struct: StructDTO): void {
+    this.ensureStructCapacity(struct.id + 1);
+
+    // Offset + 1 so that offset 0 indicates unset/empty
+    const startOffset = this.payloadWriteOffset + 1;
+    this.structOffsets[struct.id] = startOffset;
+    this.structFieldPathSetIds[struct.id] = struct.fieldPathSetId;
+
+    for (const val of struct.values) {
+      this.writeValue(val);
+    }
+
+    if (struct.id > this.maxStructId) {
+      this.maxStructId = struct.id;
+    }
+    this.structCount++;
+  }
+
+  private writeValue(val: StructValueDTO): void {
+    switch (val.kind) {
+      case StructValueKind.Null: {
+        this.ensurePayloadCapacity(this.payloadWriteOffset + 1);
+        this.payloadBuffer[this.payloadWriteOffset++] = ValueTag.Null;
+        break;
+      }
+      case StructValueKind.Bool: {
+        this.ensurePayloadCapacity(this.payloadWriteOffset + 1);
+        this.payloadBuffer[this.payloadWriteOffset++] = val.value
+          ? ValueTag.BoolTrue
+          : ValueTag.BoolFalse;
+        break;
+      }
+      case StructValueKind.Int64: {
+        this.ensurePayloadCapacity(this.payloadWriteOffset + 9);
+        this.payloadBuffer[this.payloadWriteOffset++] = ValueTag.Int64;
+        this.payloadDataView.setBigInt64(
+          this.payloadWriteOffset,
+          val.value,
+          /* littleEndian= */ true,
+        );
+        this.payloadWriteOffset += 8;
+        break;
+      }
+      case StructValueKind.Double: {
+        this.ensurePayloadCapacity(this.payloadWriteOffset + 9);
+        this.payloadBuffer[this.payloadWriteOffset++] = ValueTag.Double;
+        this.payloadDataView.setFloat64(
+          this.payloadWriteOffset,
+          val.value,
+          /* littleEndian= */ true,
+        );
+        this.payloadWriteOffset += 8;
+        break;
+      }
+      case StructValueKind.String: {
+        this.ensurePayloadCapacity(this.payloadWriteOffset + 5);
+        this.payloadBuffer[this.payloadWriteOffset++] = ValueTag.StringId;
+        this.payloadDataView.setUint32(
+          this.payloadWriteOffset,
+          val.stringId,
+          /* littleEndian= */ true,
+        );
+        this.payloadWriteOffset += 4;
+        break;
+      }
+      case StructValueKind.StructId: {
+        this.ensurePayloadCapacity(this.payloadWriteOffset + 5);
+        this.payloadBuffer[this.payloadWriteOffset++] = ValueTag.StructId;
+        this.payloadDataView.setUint32(
+          this.payloadWriteOffset,
+          val.structId,
+          /* littleEndian= */ true,
+        );
+        this.payloadWriteOffset += 4;
+        break;
+      }
+      case StructValueKind.List: {
+        this.ensurePayloadCapacity(this.payloadWriteOffset + 5);
+        this.payloadBuffer[this.payloadWriteOffset++] = ValueTag.List;
+        this.payloadDataView.setUint32(
+          this.payloadWriteOffset,
+          val.values.length,
+          /* littleEndian= */ true,
+        );
+        this.payloadWriteOffset += 4;
+        for (const item of val.values) {
+          this.writeValue(item);
+        }
+        break;
+      }
+      case StructValueKind.Timestamp: {
+        this.ensurePayloadCapacity(this.payloadWriteOffset + 9);
+        this.payloadBuffer[this.payloadWriteOffset++] = ValueTag.TimestampNs;
+        this.payloadDataView.setBigInt64(
+          this.payloadWriteOffset,
+          val.timestampNs,
+          /* littleEndian= */ true,
+        );
+        this.payloadWriteOffset += 8;
+        break;
+      }
+    }
+  }
+
+  /**
+   * Retrieves and decodes a struct by ID into a nested JavaScript object on-demand.
+   *
+   * @param id The unique struct ID.
+   * @returns Decoded nested object, or null if not found.
+   */
+  public getStruct(id: number): Record<string, unknown> | null {
+    if (id <= 0 || id > this.maxStructId) {
+      return null;
+    }
+
+    const storedOffset = this.structOffsets[id];
+    if (storedOffset === 0) {
+      return null;
+    }
+
+    const startOffset = storedOffset - 1;
+    const fieldPathSetId = this.structFieldPathSetIds[id];
+    const fieldCount = this.fieldPathSetLengths[fieldPathSetId] ?? 0;
+    const fieldOffset = this.fieldPathSetOffsets[fieldPathSetId] ?? 0;
+
+    let currentPos = startOffset;
+    const root: Record<string, unknown> = {};
+
+    for (let i = 0; i < fieldCount; i++) {
+      const stringId = this.fieldPathsBuffer[fieldOffset + i];
+      const fullPath = this.internPool.getString(stringId);
+      const [val, nextPos] = this.readValue(currentPos);
+      currentPos = nextPos;
+
+      this.setPathValue(root, fullPath, val);
+    }
+
+    return root;
+  }
+
+  private readValue(pos: number): [unknown, number] {
+    const tag: ValueTag = this.payloadBuffer[pos++];
+    switch (tag) {
+      case ValueTag.Null:
+        return [null, pos];
+      case ValueTag.BoolFalse:
+        return [false, pos];
+      case ValueTag.BoolTrue:
+        return [true, pos];
+      case ValueTag.Int64: {
+        const bigVal = this.payloadDataView.getBigInt64(
+          pos,
+          /* littleEndian= */ true,
+        );
+        const numVal = Number(bigVal);
+        const isSafe =
+          bigVal >= BigInt(Number.MIN_SAFE_INTEGER) &&
+          bigVal <= BigInt(Number.MAX_SAFE_INTEGER);
+        return [isSafe ? numVal : bigVal, pos + 8];
+      }
+      case ValueTag.Double: {
+        const dVal = this.payloadDataView.getFloat64(
+          pos,
+          /* littleEndian= */ true,
+        );
+        return [dVal, pos + 8];
+      }
+      case ValueTag.StringId: {
+        const strId = this.payloadDataView.getUint32(
+          pos,
+          /* littleEndian= */ true,
+        );
+        const resolved = this.internPool.getString(strId);
+        return [resolved, pos + 4];
+      }
+      case ValueTag.StructId: {
+        const structId = this.payloadDataView.getUint32(
+          pos,
+          /* littleEndian= */ true,
+        );
+        const nested = this.getStruct(structId);
+        return [nested, pos + 4];
+      }
+      case ValueTag.List: {
+        const count = this.payloadDataView.getUint32(
+          pos,
+          /* littleEndian= */ true,
+        );
+        let listPos = pos + 4;
+        const list: unknown[] = [];
+        for (let i = 0; i < count; i++) {
+          const [item, nextPos] = this.readValue(listPos);
+          list.push(item);
+          listPos = nextPos;
+        }
+        return [list, listPos];
+      }
+      case ValueTag.TimestampNs: {
+        const tsNs = this.payloadDataView.getBigInt64(
+          pos,
+          /* littleEndian= */ true,
+        );
+        return [tsNs, pos + 8];
+      }
+      default:
+        throw new Error(`Unknown ValueTag: ${tag} at offset ${pos - 1}`);
+    }
+  }
+
+  private setPathValue(
+    target: Record<string, unknown>,
+    fullPath: string,
+    value: unknown,
+  ): void {
+    const parts = fullPath.split(FIELD_PATH_SEPARATOR);
+    let current = target;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (
+        !(part in current) ||
+        typeof current[part] !== 'object' ||
+        current[part] === null
+      ) {
+        current[part] = {};
+      }
+      current = current[part] as Record<string, unknown>;
+    }
+    current[parts[parts.length - 1]] = value;
+  }
+
+  /**
+   * Ensures capacity for the FieldPathSet index tables.
+   */
+  private ensureFieldPathSetCapacity(minCapacity: number): void {
+    if (minCapacity <= this.fieldPathSetOffsets.length) {
+      return;
+    }
+    const newCap = nextCapacity(this.fieldPathSetOffsets.length, minCapacity);
+    this.fieldPathSetOffsets = reallocateUint32Array(
+      this.fieldPathSetOffsets,
+      newCap,
+    );
+    this.fieldPathSetLengths = reallocateUint32Array(
+      this.fieldPathSetLengths,
+      newCap,
+    );
+  }
+
+  /**
+   * Ensures capacity for the contiguous field paths buffer.
+   */
+  private ensureFieldPathsBufferCapacity(minCapacity: number): void {
+    if (minCapacity <= this.fieldPathsBuffer.length) {
+      return;
+    }
+    const newCap = nextCapacity(this.fieldPathsBuffer.length, minCapacity);
+    this.fieldPathsBuffer = reallocateUint32Array(
+      this.fieldPathsBuffer,
+      newCap,
+      this.fieldPathsWriteOffset,
+    );
+  }
+
+  /**
+   * Ensures capacity for the struct index tables.
+   */
+  private ensureStructCapacity(minCapacity: number): void {
+    if (minCapacity <= this.structOffsets.length) {
+      return;
+    }
+    const newCap = nextCapacity(this.structOffsets.length, minCapacity);
+    this.structOffsets = reallocateUint32Array(this.structOffsets, newCap);
+    this.structFieldPathSetIds = reallocateUint32Array(
+      this.structFieldPathSetIds,
+      newCap,
+    );
+  }
+
+  /**
+   * Ensures capacity for the binary payload buffer.
+   */
+  private ensurePayloadCapacity(minByteLength: number): void {
+    if (minByteLength <= this.payloadBuffer.byteLength) {
+      return;
+    }
+    const newBytes = nextCapacity(
+      this.payloadBuffer.byteLength,
+      minByteLength,
+      StructStore.INITIAL_PAYLOAD_BYTES,
+    );
+    const newBuffer = reallocateBuffer(
+      this.payloadBuffer.buffer as ArrayBuffer,
+      newBytes,
+      this.payloadWriteOffset,
+    );
+    this.payloadBuffer = new Uint8Array(newBuffer);
+    this.payloadDataView = new DataView(newBuffer);
+  }
+
+  /**
+   * Shrinks all buffers and index arrays to minimal required lengths.
+   */
+  public shrinkToFit(): void {
+    const neededSetCap = this.maxFieldPathSetId + 1;
+    if (neededSetCap < this.fieldPathSetOffsets.length && neededSetCap > 0) {
+      this.fieldPathSetOffsets = reallocateUint32Array(
+        this.fieldPathSetOffsets,
+        neededSetCap,
+        neededSetCap,
+      );
+      this.fieldPathSetLengths = reallocateUint32Array(
+        this.fieldPathSetLengths,
+        neededSetCap,
+        neededSetCap,
+      );
+    }
+
+    if (this.fieldPathsWriteOffset < this.fieldPathsBuffer.length) {
+      this.fieldPathsBuffer = reallocateUint32Array(
+        this.fieldPathsBuffer,
+        this.fieldPathsWriteOffset,
+        this.fieldPathsWriteOffset,
+      );
+    }
+
+    const neededStructCap = this.maxStructId + 1;
+    if (neededStructCap < this.structOffsets.length && neededStructCap > 0) {
+      this.structOffsets = reallocateUint32Array(
+        this.structOffsets,
+        neededStructCap,
+        neededStructCap,
+      );
+      this.structFieldPathSetIds = reallocateUint32Array(
+        this.structFieldPathSetIds,
+        neededStructCap,
+        neededStructCap,
+      );
+    }
+
+    if (this.payloadWriteOffset < this.payloadBuffer.byteLength) {
+      const newBuffer = reallocateBuffer(
+        this.payloadBuffer.buffer as ArrayBuffer,
+        this.payloadWriteOffset,
+        this.payloadWriteOffset,
+      );
+      this.payloadBuffer = new Uint8Array(newBuffer);
+      this.payloadDataView = new DataView(newBuffer);
+    }
+  }
+}

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -33,20 +33,10 @@ describe('TimelineStore', () => {
   const mockColor = { r: 0, g: 0, b: 0, a: 1 };
 
   beforeEach(() => {
-    internPool = InternPoolStore.initialize();
+    internPool = InternPoolStore.create();
     styleStore = new StyleStore();
-    logStore = LogStore.initialize(internPool, styleStore, [], 0);
-    store = TimelineStore.initialize(
-      internPool,
-      styleStore,
-      logStore,
-      [],
-      0,
-      [],
-      0,
-      [],
-      0,
-    );
+    logStore = LogStore.create(internPool, styleStore, 0);
+    store = TimelineStore.create(internPool, styleStore, logStore);
 
     styleStore.addTimelineTypes([
       {
@@ -116,7 +106,9 @@ describe('TimelineStore', () => {
     const logs = [
       { id: 1, ts: 10n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
     ];
-    logStore = LogStore.initialize(internPool, styleStore, logs, 1);
+    logStore = LogStore.create(internPool, styleStore, 1);
+    logStore.addLogs(logs);
+    logStore.shrinkToFit();
 
     const rawTimelines: TimelineDTO[] = [
       {
@@ -148,17 +140,11 @@ describe('TimelineStore', () => {
       },
     ];
 
-    store = TimelineStore.initialize(
-      internPool,
-      styleStore,
-      logStore,
-      rawTimelines,
-      1,
-      rawRevisions,
-      1,
-      rawEvents,
-      1,
-    );
+    store = TimelineStore.create(internPool, styleStore, logStore, 1, 1, 1);
+    store.addRevisions(rawRevisions);
+    store.addEvents(rawEvents);
+    store.addTimelines(rawTimelines);
+    store.shrinkToFit();
 
     const t = store.getTimeline(10);
     expect(t.id).toBe(10);
@@ -198,17 +184,9 @@ describe('TimelineStore', () => {
       },
     ];
 
-    store = TimelineStore.initialize(
-      internPool,
-      styleStore,
-      logStore,
-      rawTimelines,
-      2,
-      [],
-      0,
-      [],
-      0,
-    );
+    store = TimelineStore.create(internPool, styleStore, logStore, 2);
+    store.addTimelines(rawTimelines);
+    store.shrinkToFit();
 
     const timeline = store.getTimeline(2);
     const computedPath = timeline.path;
@@ -249,17 +227,9 @@ describe('TimelineStore', () => {
       },
     ];
 
-    store = TimelineStore.initialize(
-      internPool,
-      styleStore,
-      logStore,
-      rawTimelines,
-      2,
-      [],
-      0,
-      [],
-      0,
-    );
+    store = TimelineStore.create(internPool, styleStore, logStore, 2);
+    store.addTimelines(rawTimelines);
+    store.shrinkToFit();
 
     const childIds = store._getChildIdsForTimeline(10);
     expect(childIds.length).toBe(1);
@@ -271,33 +241,152 @@ describe('TimelineStore', () => {
     );
   });
 
-  describe('ArrayBuffer allocation', () => {
-    it('should allocate ArrayBuffer and perform operations successfully', () => {
-      const timelines: TimelineDTO[] = [
-        {
-          id: 1,
-          timelineTypeId: 1,
-          nameStringId: 1,
-          parentTimelineId: 0,
-          revisionIds: [],
-          eventIds: [],
-        },
-      ];
-      const fallbackStore = TimelineStore.initialize(
+  describe('create and dynamic methods', () => {
+    it('should dynamically add revisions, events, and timelines and shrink to fit', () => {
+      const dynamicStore = TimelineStore.create(
         internPool,
         styleStore,
         logStore,
-        timelines,
         1,
-        [],
+        1,
+        1,
+      );
+      expect(dynamicStore.count).toBe(0);
+      expect(dynamicStore.revisionCount).toBe(0);
+      expect(dynamicStore.eventCount).toBe(0);
+
+      dynamicStore.addRevision({
+        id: 101,
+        logId: 1,
+        changedTime: 500n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+        resourceBodyStructId: 10,
+        fieldAnnotations: [],
+      });
+
+      dynamicStore.addEvent({
+        id: 201,
+        logId: 2,
+      });
+
+      dynamicStore.addTimeline({
+        id: 1,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [101],
+        eventIds: [201],
+      });
+
+      dynamicStore.addTimeline({
+        id: 2,
+        timelineTypeId: 1,
+        nameStringId: 2,
+        parentTimelineId: 1,
+        revisionIds: [],
+        eventIds: [],
+      });
+
+      expect(dynamicStore.count).toBe(2);
+      expect(dynamicStore.revisionCount).toBe(1);
+      expect(dynamicStore.eventCount).toBe(1);
+
+      // Verify lazy relationship rebuild even without calling shrinkToFit
+      const childIdsBeforeShrink = dynamicStore._getChildIdsForTimeline(1);
+      expect(childIdsBeforeShrink).toEqual([2]);
+
+      dynamicStore.shrinkToFit();
+
+      expect(dynamicStore.count).toBe(2);
+      expect(dynamicStore.revisionCount).toBe(1);
+      expect(dynamicStore.eventCount).toBe(1);
+
+      const t1 = dynamicStore.getTimeline(1);
+      expect(t1.id).toBe(1);
+      const t2 = dynamicStore.getTimeline(2);
+      expect(t2.id).toBe(2);
+
+      const childIds = dynamicStore._getChildIdsForTimeline(1);
+      expect(childIds).toEqual([2]);
+    });
+
+    it('should handle shrinkToFit on an empty store with capacity 0', () => {
+      const emptyStore = TimelineStore.create(
+        internPool,
+        styleStore,
+        logStore,
         0,
-        [],
+        0,
         0,
       );
+      emptyStore.shrinkToFit();
+      expect(emptyStore.count).toBe(0);
+      expect(emptyStore.revisionCount).toBe(0);
+      expect(emptyStore.eventCount).toBe(0);
+    });
 
-      expect(fallbackStore.timelines.length).toBe(1);
-      const timeline = fallbackStore.getTimeline(1);
-      expect(timeline.id).toBe(1);
+    it('should handle multiple buffer expansions across all views from capacity 1 and preserve domain relationships', () => {
+      const localLogStore = LogStore.create(internPool, styleStore, 15);
+      for (let i = 1; i <= 15; i++) {
+        localLogStore.addLog({
+          id: i,
+          ts: BigInt(i * 100),
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 1,
+        });
+      }
+
+      const store = TimelineStore.create(
+        internPool,
+        styleStore,
+        localLogStore,
+        1,
+        1,
+        1,
+      );
+      for (let i = 1; i <= 15; i++) {
+        store.addRevision({
+          id: i,
+          logId: i,
+          changedTime: BigInt(i * 100),
+          principalStringId: 1,
+          verbTypeId: 1,
+          stateTypeId: 1,
+          resourceBodyStructId: i * 10,
+        });
+        store.addEvent({ id: i, logId: i });
+        store.addTimeline({
+          id: i,
+          timelineTypeId: 1,
+          nameStringId: 1,
+          parentTimelineId: i > 1 ? 1 : 0,
+          revisionIds: [i],
+          eventIds: [i],
+        });
+      }
+
+      expect(store.count).toBe(15);
+      expect(store.revisionCount).toBe(15);
+      expect(store.eventCount).toBe(15);
+
+      store.shrinkToFit();
+
+      for (let i = 1; i <= 15; i++) {
+        const t = store.getTimeline(i);
+        expect(t.id).toBe(i);
+        expect(t.revisions.length).toBe(1);
+        expect(t.revisions[0].id).toBe(i);
+        expect(t.revisions[0].structId).toBe(i * 10);
+        expect(t.revisions[0].log.timestamp).toBe(BigInt(i * 100));
+        expect(t.events.length).toBe(1);
+        expect(t.events[0].id).toBe(i);
+      }
+
+      const rootChildren = store._getChildIdsForTimeline(1);
+      expect(rootChildren.length).toBe(14);
     });
   });
 });

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -27,7 +27,10 @@ import {
   Verb,
   StyleProvider,
 } from 'src/app/store/domain/style';
-import { align } from 'src/app/common/memory-util';
+import {
+  BufferLayoutBuilder,
+  nextCapacity,
+} from 'src/app/store/domain/buffer-util';
 import { LogStore } from 'src/app/store/domain/log-store';
 import {
   DomainFieldAnnotation,
@@ -47,14 +50,16 @@ export interface TimelineDTO {
   readonly eventIds: readonly number[];
 }
 
+export interface MutatingWebhookAnnotationDTO {
+  readonly configurationStringId: number;
+  readonly webhookStringId: number;
+  readonly round: number;
+  readonly index: number;
+}
+
 export interface FieldAnnotationDTO {
   readonly fieldPathStringId: number;
-  readonly mutatingWebhook?: {
-    readonly configurationStringId: number;
-    readonly webhookStringId: number;
-    readonly round: number;
-    readonly index: number;
-  };
+  readonly mutatingWebhook?: MutatingWebhookAnnotationDTO;
 }
 
 /**
@@ -80,20 +85,18 @@ export interface EventDTO {
 }
 
 interface TimelineStoreLayout {
-  timelineIds: number;
-  timelineTypeIds: number;
-  timelineNameStringIds: number;
-  timelineParentIds: number;
-  revisionIds: number;
-  revisionLogIds: number;
-  revisionChangedTimes: number;
-  revisionPrincipalStringIds: number;
-  revisionVerbTypeIds: number;
-  revisionStateTypeIds: number;
-  revisionBodyStructIds: number;
-  eventIds: number;
-  eventLogIds: number;
-  totalBytes: number;
+  readonly timelineIdsOffset: number;
+  readonly timelineTypeIdsOffset: number;
+  readonly timelineNameStringIdsOffset: number;
+  readonly timelineParentIdsOffset: number;
+  readonly revisionLogIdsOffset: number;
+  readonly revisionPrincipalStringIdsOffset: number;
+  readonly revisionVerbTypeIdsOffset: number;
+  readonly revisionStateTypeIdsOffset: number;
+  readonly revisionBodyStructIdsOffset: number;
+  readonly revisionChangedTimesOffset: number;
+  readonly eventLogIdsOffset: number;
+  readonly totalBytes: number;
 }
 
 /**
@@ -101,6 +104,14 @@ interface TimelineStoreLayout {
  */
 export class TimelineStore {
   private metadataBuffer!: ArrayBuffer;
+  private timelineCapacity = 0;
+  private revisionCapacity = 0;
+  private eventCapacity = 0;
+
+  private timelineCount = 0;
+  private _revisionCount = 0;
+  private _eventCount = 0;
+  private relationshipsDirty = true;
 
   // Timeline views
   private timelineIds!: Uint32Array;
@@ -112,25 +123,23 @@ export class TimelineStore {
   private readonly timelineEventIds: Uint32Array[] = [];
   private readonly timelineChildrenIds: number[][] = [];
   private readonly timelinesList: ReadonlyDomainElement<Timeline>[] = [];
-  private timelineIdToIndex: { [tid: number]: number } = {};
+  private timelineIdToIndex: (number | undefined)[] = [];
 
   // Revision views
-  private revisionIds!: Uint32Array;
   private revisionLogIds!: Uint32Array;
   private revisionChangedTimes!: BigUint64Array;
   private revisionPrincipalStringIds!: Uint32Array;
   private revisionVerbTypeIds!: Uint32Array;
   private revisionStateTypeIds!: Uint32Array;
   private revisionBodyStructIds!: Uint32Array;
-  private revisionFieldAnnotations: (
+  private readonly revisionFieldAnnotations: (
     readonly FieldAnnotationDTO[] | undefined
   )[] = [];
-  private revisionIdToIndex: { [rid: number]: number } = {};
+  private revisionIdToIndex: (number | undefined)[] = [];
 
   // Event views
-  private eventIds!: Uint32Array;
   private eventLogIds!: Uint32Array;
-  private eventIdToIndex: { [eid: number]: number } = {};
+  private eventIdToIndex: (number | undefined)[] = [];
 
   private constructor(
     private readonly internPool: InternPoolStore,
@@ -139,247 +148,410 @@ export class TimelineStore {
   ) {}
 
   /**
-   * Initializes a new TimelineStore instance with the raw timelines, revisions, and events.
+   * Creates an empty TimelineStore instance with initial capacities.
    *
    * @param internPool Intern pool store for string interning.
    * @param styleStore Style provider for styling information.
    * @param logStore Log store providing log references.
-   * @param timelines Iterable of raw timelines.
-   * @param timelineCount Total number of timelines.
-   * @param revisions Iterable of raw revisions.
-   * @param revisionCount Total number of revisions.
-   * @param events Iterable of raw events.
-   * @param eventCount Total number of events.
-   * @returns An initialized TimelineStore instance.
+   * @param initialTimelineCapacity Initial capacity for timelines.
+   * @param initialRevisionCapacity Initial capacity for revisions.
+   * @param initialEventCapacity Initial capacity for events.
+   * @returns A new empty TimelineStore instance.
    */
-  public static initialize(
+  public static create(
     internPool: InternPoolStore,
     styleStore: StyleProvider,
     logStore: LogStore,
-    timelines: Iterable<TimelineDTO>,
-    timelineCount: number,
-    revisions: Iterable<RevisionDTO>,
-    revisionCount: number,
-    events: Iterable<EventDTO>,
-    eventCount: number,
+    initialTimelineCapacity = 1024,
+    initialRevisionCapacity = 1024,
+    initialEventCapacity = 1024,
   ): TimelineStore {
     const store = new TimelineStore(internPool, styleStore, logStore);
-    store.load(
-      timelines,
-      timelineCount,
-      revisions,
-      revisionCount,
-      events,
-      eventCount,
+    store.ensureCapacity(
+      Math.max(initialTimelineCapacity, 1),
+      Math.max(initialRevisionCapacity, 1),
+      Math.max(initialEventCapacity, 1),
     );
     return store;
   }
 
-  private allocateMetadata(
-    timelineCapacity: number,
-    revisionCapacity: number,
-    eventCapacity: number,
-  ): void {
-    const layout = this.calculateOffsets(
-      timelineCapacity,
-      revisionCapacity,
-      eventCapacity,
+  /**
+   * Gets the total number of timelines.
+   */
+  public get count(): number {
+    return this.timelineCount;
+  }
+
+  /**
+   * Gets the total number of revisions.
+   */
+  public get revisionCount(): number {
+    return this._revisionCount;
+  }
+
+  /**
+   * Gets the total number of events.
+   */
+  public get eventCount(): number {
+    return this._eventCount;
+  }
+
+  /**
+   * Ensures timeline metadata has at least minCapacity slots.
+   */
+  private ensureTimelineCapacity(minCapacity: number): void {
+    this.ensureCapacity(minCapacity, this.revisionCapacity, this.eventCapacity);
+  }
+
+  /**
+   * Ensures revision metadata has at least minCapacity slots.
+   */
+  private ensureRevisionCapacity(minCapacity: number): void {
+    this.ensureCapacity(this.timelineCapacity, minCapacity, this.eventCapacity);
+  }
+
+  /**
+   * Ensures event metadata has at least minCapacity slots.
+   */
+  private ensureEventCapacity(minCapacity: number): void {
+    this.ensureCapacity(
+      this.timelineCapacity,
+      this.revisionCapacity,
+      minCapacity,
     );
-    this.metadataBuffer = allocateBuffer(layout.totalBytes);
-    this.applyViews(layout, timelineCapacity, revisionCapacity, eventCapacity);
   }
 
   private calculateOffsets(
-    tCap: number,
-    rCap: number,
-    eCap: number,
+    timelineCapacity: number,
+    revisionCapacity: number,
+    eventCapacity: number,
   ): TimelineStoreLayout {
-    let offset = 0;
-
-    const timelineIds = offset;
-    offset += tCap * 4;
-
-    const timelineTypeIds = offset;
-    offset += tCap * 4;
-
-    const timelineNameStringIds = offset;
-    offset += tCap * 4;
-
-    const timelineParentIds = offset;
-    offset += tCap * 4;
-
-    const revisionIds = align(offset, 4);
-    offset = revisionIds + rCap * 4;
-
-    const revisionLogIds = offset;
-    offset += rCap * 4;
-
-    const revisionPrincipalStringIds = offset;
-    offset += rCap * 4;
-
-    const revisionVerbTypeIds = offset;
-    offset += rCap * 4;
-
-    const revisionStateTypeIds = offset;
-    offset += rCap * 4;
-
-    const revisionBodyStructIds = offset;
-    offset += rCap * 4;
-
-    const revisionChangedTimes = align(offset, 8);
-    offset = revisionChangedTimes + rCap * 8;
-
-    const eventIds = align(offset, 4);
-    offset = eventIds + eCap * 4;
-
-    const eventLogIds = offset;
-    offset += eCap * 4;
-
+    const builder = new BufferLayoutBuilder();
     return {
-      timelineIds,
-      timelineTypeIds,
-      timelineNameStringIds,
-      timelineParentIds,
-      revisionIds,
-      revisionLogIds,
-      revisionPrincipalStringIds,
-      revisionVerbTypeIds,
-      revisionStateTypeIds,
-      revisionBodyStructIds,
-      revisionChangedTimes,
-      eventIds,
-      eventLogIds,
-      totalBytes: offset,
+      timelineIdsOffset: builder.addField(timelineCapacity, 4),
+      timelineTypeIdsOffset: builder.addField(timelineCapacity, 4),
+      timelineNameStringIdsOffset: builder.addField(timelineCapacity, 4),
+      timelineParentIdsOffset: builder.addField(timelineCapacity, 4),
+      revisionLogIdsOffset: builder.addField(revisionCapacity, 4, 4),
+      revisionPrincipalStringIdsOffset: builder.addField(revisionCapacity, 4),
+      revisionVerbTypeIdsOffset: builder.addField(revisionCapacity, 4),
+      revisionStateTypeIdsOffset: builder.addField(revisionCapacity, 4),
+      revisionBodyStructIdsOffset: builder.addField(revisionCapacity, 4),
+      revisionChangedTimesOffset: builder.addField(revisionCapacity, 8, 8),
+      eventLogIdsOffset: builder.addField(eventCapacity, 4, 4),
+      totalBytes: builder.totalBytes,
     };
   }
 
   private applyViews(
     layout: TimelineStoreLayout,
-    tCap: number,
-    rCap: number,
-    eCap: number,
+    timelineCapacity: number,
+    revisionCapacity: number,
+    eventCapacity: number,
   ): void {
     const buffer = this.metadataBuffer;
-    this.timelineIds = new Uint32Array(buffer, layout.timelineIds, tCap);
+    this.timelineIds = new Uint32Array(
+      buffer,
+      layout.timelineIdsOffset,
+      timelineCapacity,
+    );
     this.timelineTypeIds = new Uint32Array(
       buffer,
-      layout.timelineTypeIds,
-      tCap,
+      layout.timelineTypeIdsOffset,
+      timelineCapacity,
     );
     this.timelineNameStringIds = new Uint32Array(
       buffer,
-      layout.timelineNameStringIds,
-      tCap,
+      layout.timelineNameStringIdsOffset,
+      timelineCapacity,
     );
     this.timelineParentIds = new Uint32Array(
       buffer,
-      layout.timelineParentIds,
-      tCap,
+      layout.timelineParentIdsOffset,
+      timelineCapacity,
     );
 
-    this.revisionIds = new Uint32Array(buffer, layout.revisionIds, rCap);
-    this.revisionLogIds = new Uint32Array(buffer, layout.revisionLogIds, rCap);
+    this.revisionLogIds = new Uint32Array(
+      buffer,
+      layout.revisionLogIdsOffset,
+      revisionCapacity,
+    );
     this.revisionPrincipalStringIds = new Uint32Array(
       buffer,
-      layout.revisionPrincipalStringIds,
-      rCap,
+      layout.revisionPrincipalStringIdsOffset,
+      revisionCapacity,
     );
     this.revisionVerbTypeIds = new Uint32Array(
       buffer,
-      layout.revisionVerbTypeIds,
-      rCap,
+      layout.revisionVerbTypeIdsOffset,
+      revisionCapacity,
     );
     this.revisionStateTypeIds = new Uint32Array(
       buffer,
-      layout.revisionStateTypeIds,
-      rCap,
+      layout.revisionStateTypeIdsOffset,
+      revisionCapacity,
     );
     this.revisionBodyStructIds = new Uint32Array(
       buffer,
-      layout.revisionBodyStructIds,
-      rCap,
+      layout.revisionBodyStructIdsOffset,
+      revisionCapacity,
     );
     this.revisionChangedTimes = new BigUint64Array(
       buffer,
-      layout.revisionChangedTimes,
-      rCap,
+      layout.revisionChangedTimesOffset,
+      revisionCapacity,
     );
 
-    this.eventIds = new Uint32Array(buffer, layout.eventIds, eCap);
-    this.eventLogIds = new Uint32Array(buffer, layout.eventLogIds, eCap);
+    this.eventLogIds = new Uint32Array(
+      buffer,
+      layout.eventLogIdsOffset,
+      eventCapacity,
+    );
+  }
+
+  private reallocate(
+    newTimelineCapacity: number,
+    newRevisionCapacity: number,
+    newEventCapacity: number,
+  ): void {
+    const layout = this.calculateOffsets(
+      newTimelineCapacity,
+      newRevisionCapacity,
+      newEventCapacity,
+    );
+    const newBuffer = allocateBuffer(layout.totalBytes);
+
+    const prevTimelineIds = this.timelineIds;
+    const prevTimelineTypeIds = this.timelineTypeIds;
+    const prevTimelineNameStringIds = this.timelineNameStringIds;
+    const prevTimelineParentIds = this.timelineParentIds;
+
+    const prevRevisionLogIds = this.revisionLogIds;
+    const prevRevisionPrincipalStringIds = this.revisionPrincipalStringIds;
+    const prevRevisionVerbTypeIds = this.revisionVerbTypeIds;
+    const prevRevisionStateTypeIds = this.revisionStateTypeIds;
+    const prevRevisionBodyStructIds = this.revisionBodyStructIds;
+    const prevRevisionChangedTimes = this.revisionChangedTimes;
+
+    const prevEventLogIds = this.eventLogIds;
+
+    this.metadataBuffer = newBuffer;
+    this.timelineCapacity = newTimelineCapacity;
+    this.revisionCapacity = newRevisionCapacity;
+    this.eventCapacity = newEventCapacity;
+    this.applyViews(
+      layout,
+      newTimelineCapacity,
+      newRevisionCapacity,
+      newEventCapacity,
+    );
+
+    if (this.timelineCount > 0 && prevTimelineIds) {
+      this.timelineIds.set(prevTimelineIds.subarray(0, this.timelineCount));
+      this.timelineTypeIds.set(
+        prevTimelineTypeIds.subarray(0, this.timelineCount),
+      );
+      this.timelineNameStringIds.set(
+        prevTimelineNameStringIds.subarray(0, this.timelineCount),
+      );
+      this.timelineParentIds.set(
+        prevTimelineParentIds.subarray(0, this.timelineCount),
+      );
+    }
+
+    if (this._revisionCount > 0 && prevRevisionLogIds) {
+      this.revisionLogIds.set(
+        prevRevisionLogIds.subarray(0, this._revisionCount),
+      );
+      this.revisionPrincipalStringIds.set(
+        prevRevisionPrincipalStringIds.subarray(0, this._revisionCount),
+      );
+      this.revisionVerbTypeIds.set(
+        prevRevisionVerbTypeIds.subarray(0, this._revisionCount),
+      );
+      this.revisionStateTypeIds.set(
+        prevRevisionStateTypeIds.subarray(0, this._revisionCount),
+      );
+      this.revisionBodyStructIds.set(
+        prevRevisionBodyStructIds.subarray(0, this._revisionCount),
+      );
+      this.revisionChangedTimes.set(
+        prevRevisionChangedTimes.subarray(0, this._revisionCount),
+      );
+    }
+
+    if (this._eventCount > 0 && prevEventLogIds) {
+      this.eventLogIds.set(prevEventLogIds.subarray(0, this._eventCount));
+    }
   }
 
   /**
-   * Loads the raw timelines, revisions, and events into allocated metadata.
+   * Ensures metadata buffer has at least the specified capacities for all views.
    */
-  private load(
-    timelines: Iterable<TimelineDTO>,
-    timelineCount: number,
-    revisions: Iterable<RevisionDTO>,
-    revisionCount: number,
-    events: Iterable<EventDTO>,
-    eventCount: number,
+  private ensureCapacity(
+    minTimelineCapacity: number,
+    minRevisionCapacity: number,
+    minEventCapacity: number,
   ): void {
-    this.allocateMetadata(timelineCount, revisionCount, eventCount);
-
-    this.timelineRevisionIds.length = 0;
-    this.timelineEventIds.length = 0;
-    this.timelinesList.length = 0;
-    this.timelineChildrenIds.length = 0;
-    this.revisionFieldAnnotations.length = revisionCount;
-    this.timelineIdToIndex = {};
-    this.revisionIdToIndex = {};
-    this.eventIdToIndex = {};
-
-    // Load timelines
-    let tIndex = 0;
-    for (const t of timelines) {
-      this.timelineIds[tIndex] = t.id;
-      this.timelineTypeIds[tIndex] = t.timelineTypeId;
-      this.timelineNameStringIds[tIndex] = t.nameStringId;
-      this.timelineParentIds[tIndex] = t.parentTimelineId;
-
-      this.timelineRevisionIds[tIndex] = new Uint32Array(t.revisionIds);
-      this.timelineEventIds[tIndex] = new Uint32Array(t.eventIds);
-      this.timelineChildrenIds[tIndex] = [];
-
-      this.timelineIdToIndex[t.id] = tIndex;
-      this.timelinesList.push(new Timeline(t.id, this));
-      tIndex++;
+    if (
+      minTimelineCapacity <= this.timelineCapacity &&
+      minRevisionCapacity <= this.revisionCapacity &&
+      minEventCapacity <= this.eventCapacity
+    ) {
+      return;
     }
 
-    // Build child timeline relationships
-    for (const t of timelines) {
-      if (t.parentTimelineId !== 0) {
-        const pIndex = this.getTimelineIndex(t.parentTimelineId);
-        this.timelineChildrenIds[pIndex].push(t.id);
+    const newTCap =
+      minTimelineCapacity > this.timelineCapacity
+        ? nextCapacity(this.timelineCapacity, minTimelineCapacity)
+        : this.timelineCapacity;
+    const newRCap =
+      minRevisionCapacity > this.revisionCapacity
+        ? nextCapacity(this.revisionCapacity, minRevisionCapacity)
+        : this.revisionCapacity;
+    const newECap =
+      minEventCapacity > this.eventCapacity
+        ? nextCapacity(this.eventCapacity, minEventCapacity)
+        : this.eventCapacity;
+
+    this.reallocate(newTCap, newRCap, newECap);
+  }
+
+  /**
+   * Shrinks the metadataBuffer to fit exact counts of timelines, revisions, and events.
+   */
+  public shrinkToFit(): void {
+    this.rebuildRelationships();
+    if (
+      this.timelineCount === this.timelineCapacity &&
+      this._revisionCount === this.revisionCapacity &&
+      this._eventCount === this.eventCapacity
+    ) {
+      return;
+    }
+
+    this.reallocate(this.timelineCount, this._revisionCount, this._eventCount);
+  }
+
+  /**
+   * Appends a single timeline to the store.
+   *
+   * @param timeline The raw TimelineDTO to add.
+   */
+  public addTimeline(timeline: TimelineDTO): void {
+    this.ensureTimelineCapacity(this.timelineCount + 1);
+    const tIndex = this.timelineCount;
+    this.timelineIds[tIndex] = timeline.id;
+    this.timelineTypeIds[tIndex] = timeline.timelineTypeId;
+    this.timelineNameStringIds[tIndex] = timeline.nameStringId;
+    this.timelineParentIds[tIndex] = timeline.parentTimelineId;
+
+    this.timelineRevisionIds[tIndex] = new Uint32Array(timeline.revisionIds);
+    this.timelineEventIds[tIndex] = new Uint32Array(timeline.eventIds);
+    this.timelineChildrenIds[tIndex] = [];
+
+    this.timelineIdToIndex[timeline.id] = tIndex;
+    this.timelinesList.push(new Timeline(timeline.id, this));
+    this.timelineCount++;
+    this.relationshipsDirty = true;
+  }
+
+  /**
+   * Appends multiple timelines to the store.
+   *
+   * @param timelines An iterable of raw TimelineDTOs to add.
+   */
+  public addTimelines(timelines: Iterable<TimelineDTO>): void {
+    if (Array.isArray(timelines)) {
+      this.ensureTimelineCapacity(this.timelineCount + timelines.length);
+    }
+    for (const timeline of timelines) {
+      this.addTimeline(timeline);
+    }
+  }
+
+  /**
+   * Appends a single revision to the store.
+   *
+   * @param revision The raw RevisionDTO to add.
+   */
+  public addRevision(revision: RevisionDTO): void {
+    this.ensureRevisionCapacity(this._revisionCount + 1);
+    const rIndex = this._revisionCount;
+    this.revisionLogIds[rIndex] = revision.logId;
+    this.revisionChangedTimes[rIndex] = revision.changedTime;
+    this.revisionPrincipalStringIds[rIndex] = revision.principalStringId;
+    this.revisionVerbTypeIds[rIndex] = revision.verbTypeId;
+    this.revisionStateTypeIds[rIndex] = revision.stateTypeId;
+    this.revisionBodyStructIds[rIndex] = revision.resourceBodyStructId ?? 0;
+    this.revisionFieldAnnotations[rIndex] = revision.fieldAnnotations;
+
+    this.revisionIdToIndex[revision.id] = rIndex;
+    this._revisionCount++;
+  }
+
+  /**
+   * Appends multiple revisions to the store.
+   *
+   * @param revisions An iterable of raw RevisionDTOs to add.
+   */
+  public addRevisions(revisions: Iterable<RevisionDTO>): void {
+    if (Array.isArray(revisions)) {
+      this.ensureRevisionCapacity(this._revisionCount + revisions.length);
+    }
+    for (const revision of revisions) {
+      this.addRevision(revision);
+    }
+  }
+
+  /**
+   * Appends a single event to the store.
+   *
+   * @param event The raw EventDTO to add.
+   */
+  public addEvent(event: EventDTO): void {
+    this.ensureEventCapacity(this._eventCount + 1);
+    const eIndex = this._eventCount;
+    this.eventLogIds[eIndex] = event.logId;
+
+    this.eventIdToIndex[event.id] = eIndex;
+    this._eventCount++;
+  }
+
+  /**
+   * Appends multiple events to the store.
+   *
+   * @param events An iterable of raw EventDTOs to add.
+   */
+  public addEvents(events: Iterable<EventDTO>): void {
+    if (Array.isArray(events)) {
+      this.ensureEventCapacity(this._eventCount + events.length);
+    }
+    for (const event of events) {
+      this.addEvent(event);
+    }
+  }
+
+  /**
+   * Rebuilds child timeline relationships based on parentTimelineId.
+   */
+  private rebuildRelationships(): void {
+    if (!this.relationshipsDirty) {
+      return;
+    }
+    for (let i = 0; i < this.timelineCount; i++) {
+      this.timelineChildrenIds[i] = [];
+    }
+    for (let i = 0; i < this.timelineCount; i++) {
+      const parentId = this.timelineParentIds[i];
+      if (parentId !== 0) {
+        const pIndex = this.timelineIdToIndex[parentId];
+        if (pIndex !== undefined) {
+          this.timelineChildrenIds[pIndex].push(this.timelineIds[i]);
+        }
       }
     }
-
-    // Load revisions
-    let rIndex = 0;
-    for (const r of revisions) {
-      this.revisionIds[rIndex] = r.id;
-      this.revisionLogIds[rIndex] = r.logId;
-      this.revisionChangedTimes[rIndex] = r.changedTime;
-      this.revisionPrincipalStringIds[rIndex] = r.principalStringId;
-      this.revisionVerbTypeIds[rIndex] = r.verbTypeId;
-      this.revisionStateTypeIds[rIndex] = r.stateTypeId;
-      this.revisionBodyStructIds[rIndex] = r.resourceBodyStructId ?? 0;
-      this.revisionFieldAnnotations[rIndex] = r.fieldAnnotations;
-
-      this.revisionIdToIndex[r.id] = rIndex;
-      rIndex++;
-    }
-
-    // Load events
-    let eIndex = 0;
-    for (const e of events) {
-      this.eventIds[eIndex] = e.id;
-      this.eventLogIds[eIndex] = e.logId;
-      this.eventIdToIndex[e.id] = eIndex;
-      eIndex++;
-    }
+    this.relationshipsDirty = false;
   }
 
   // --- Timeline Accessors ---
@@ -494,6 +666,9 @@ export class TimelineStore {
    * @note Intended solely for internal retrieval inside the {@link Timeline} domain adapter.
    */
   public _getChildIdsForTimeline(id: number): readonly number[] {
+    if (this.relationshipsDirty) {
+      this.rebuildRelationships();
+    }
     return this.timelineChildrenIds[this.getTimelineIndex(id)] ?? [];
   }
 
@@ -555,8 +730,9 @@ export class TimelineStore {
 
   /**
    * Gets the interned struct ID of a revision body, or 0 if not stored as a struct.
+   * @note Intended solely for internal retrieval inside the {@link Revision} domain adapter.
    */
-  public getRevisionBodyStructId(id: number): number {
+  public _getRevisionBodyStructId(id: number): number {
     const index = this.getRevisionIndex(id);
     return this.revisionBodyStructIds[index] ?? 0;
   }

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -38,6 +38,8 @@ import {
   allocateBuffer,
 } from 'src/app/store/domain/types';
 
+const EMPTY_UINT32_ARRAY = new Uint32Array(0);
+
 /**
  * Raw timeline object interface from the assembler.
  */
@@ -446,8 +448,14 @@ export class TimelineStore {
     this.timelineNameStringIds[tIndex] = timeline.nameStringId;
     this.timelineParentIds[tIndex] = timeline.parentTimelineId;
 
-    this.timelineRevisionIds[tIndex] = new Uint32Array(timeline.revisionIds);
-    this.timelineEventIds[tIndex] = new Uint32Array(timeline.eventIds);
+    this.timelineRevisionIds[tIndex] =
+      timeline.revisionIds.length > 0
+        ? new Uint32Array(timeline.revisionIds)
+        : EMPTY_UINT32_ARRAY;
+    this.timelineEventIds[tIndex] =
+      timeline.eventIds.length > 0
+        ? new Uint32Array(timeline.eventIds)
+        : EMPTY_UINT32_ARRAY;
     this.timelineChildrenIds[tIndex] = [];
 
     this.timelineIdToIndex[timeline.id] = tIndex;

--- a/web/src/app/store/domain/timeline.spec.ts
+++ b/web/src/app/store/domain/timeline.spec.ts
@@ -24,6 +24,40 @@ import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { LogStore, LogDTO } from 'src/app/store/domain/log-store';
 
+function createTimelineStore(
+  internPool: InternPoolStore,
+  styleStore: StyleStore,
+  logStore: LogStore,
+  timelines: TimelineDTO[] = [],
+  revisions: RevisionDTO[] = [],
+  events: EventDTO[] = [],
+): TimelineStore {
+  const store = TimelineStore.create(
+    internPool,
+    styleStore,
+    logStore,
+    timelines.length,
+    revisions.length,
+    events.length,
+  );
+  store.addRevisions(revisions);
+  store.addEvents(events);
+  store.addTimelines(timelines);
+  store.shrinkToFit();
+  return store;
+}
+
+function createLogStore(
+  internPool: InternPoolStore,
+  styleStore: StyleStore,
+  logs: LogDTO[] = [],
+): LogStore {
+  const store = LogStore.create(internPool, styleStore, logs.length);
+  store.addLogs(logs);
+  store.shrinkToFit();
+  return store;
+}
+
 describe('Timeline', () => {
   let internPool: InternPoolStore;
   let styleStore: StyleStore;
@@ -33,20 +67,10 @@ describe('Timeline', () => {
   const mockColor = { r: 0, g: 0, b: 0, a: 1 };
 
   beforeEach(() => {
-    internPool = InternPoolStore.initialize();
+    internPool = InternPoolStore.create();
     styleStore = new StyleStore();
-    logStore = LogStore.initialize(internPool, styleStore, [], 0);
-    timelineStore = TimelineStore.initialize(
-      internPool,
-      styleStore,
-      logStore,
-      [],
-      0,
-      [],
-      0,
-      [],
-      0,
-    );
+    logStore = createLogStore(internPool, styleStore);
+    timelineStore = createTimelineStore(internPool, styleStore, logStore);
 
     styleStore.addTimelineTypes([
       {
@@ -120,16 +144,11 @@ describe('Timeline', () => {
           eventIds: [],
         },
       ];
-      timelineStore = TimelineStore.initialize(
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        1,
-        [],
-        0,
-        [],
-        0,
       );
       const timeline = timelineStore.getTimeline(10);
       expect(timeline.id).toBe(10);
@@ -149,16 +168,11 @@ describe('Timeline', () => {
           eventIds: [],
         },
       ];
-      timelineStore = TimelineStore.initialize(
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        1,
-        [],
-        0,
-        [],
-        0,
       );
       const timeline = timelineStore.getTimeline(10);
       expect(timeline.name).toBe('timeline-label');
@@ -205,17 +219,13 @@ describe('Timeline', () => {
         },
       ];
 
-      logStore = LogStore.initialize(internPool, styleStore, rawLogs, 1);
-      timelineStore = TimelineStore.initialize(
+      logStore = createLogStore(internPool, styleStore, rawLogs);
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        1,
         rawRevisions,
-        1,
-        [],
-        0,
       );
 
       const timeline = timelineStore.getTimeline(10);
@@ -266,17 +276,14 @@ describe('Timeline', () => {
         },
       ];
 
-      logStore = LogStore.initialize(internPool, styleStore, rawLogs, 1);
-      timelineStore = TimelineStore.initialize(
+      logStore = createLogStore(internPool, styleStore, rawLogs);
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        1,
         [],
-        0,
         rawEvents,
-        1,
       );
 
       const timeline = timelineStore.getTimeline(10);
@@ -324,16 +331,11 @@ describe('Timeline', () => {
         },
       ];
 
-      timelineStore = TimelineStore.initialize(
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        3,
-        [],
-        0,
-        [],
-        0,
       );
 
       const parent = timelineStore.getTimeline(10);
@@ -426,17 +428,14 @@ describe('Timeline', () => {
         },
       ];
 
-      logStore = LogStore.initialize(internPool, styleStore, rawLogs, 4);
-      timelineStore = TimelineStore.initialize(
+      logStore = createLogStore(internPool, styleStore, rawLogs);
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        1,
         rawRevisions,
-        2,
         rawEvents,
-        2,
       );
 
       const timeline = timelineStore.getTimeline(10);
@@ -527,17 +526,13 @@ describe('Timeline', () => {
         },
       ];
 
-      logStore = LogStore.initialize(internPool, styleStore, rawLogs, 2);
-      timelineStore = TimelineStore.initialize(
+      logStore = createLogStore(internPool, styleStore, rawLogs);
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        2,
         rawRevisions,
-        2,
-        [],
-        0,
       );
 
       const timeline = timelineStore.getTimeline(10);
@@ -585,16 +580,11 @@ describe('Timeline', () => {
         },
       ];
 
-      timelineStore = TimelineStore.initialize(
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        1,
-        [],
-        0,
-        [],
-        0,
       );
 
       const parent = timelineStore.getTimeline(10);
@@ -628,16 +618,11 @@ describe('Timeline', () => {
         },
       ];
 
-      timelineStore = TimelineStore.initialize(
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        2,
-        [],
-        0,
-        [],
-        0,
       );
 
       const child = timelineStore.getTimeline(20);
@@ -702,17 +687,13 @@ describe('Timeline', () => {
           },
         ];
 
-        logStore = LogStore.initialize(internPool, styleStore, rawLogs, 2);
-        timelineStore = TimelineStore.initialize(
+        logStore = createLogStore(internPool, styleStore, rawLogs);
+        timelineStore = createTimelineStore(
           internPool,
           styleStore,
           logStore,
           rawTimelines,
-          1,
           rawRevisions,
-          2,
-          [],
-          0,
         );
 
         const timeline = timelineStore.getTimeline(10);
@@ -778,17 +759,13 @@ describe('Timeline', () => {
           },
         ];
 
-        logStore = LogStore.initialize(internPool, styleStore, rawLogs, 2);
-        timelineStore = TimelineStore.initialize(
+        logStore = createLogStore(internPool, styleStore, rawLogs);
+        timelineStore = createTimelineStore(
           internPool,
           styleStore,
           logStore,
           rawTimelines,
-          1,
           rawRevisions,
-          2,
-          [],
-          0,
         );
 
         const timeline = timelineStore.getTimeline(10);
@@ -854,17 +831,14 @@ describe('Timeline', () => {
           },
         ];
 
-        logStore = LogStore.initialize(internPool, styleStore, rawLogs, 1);
-        timelineStore = TimelineStore.initialize(
+        logStore = createLogStore(internPool, styleStore, rawLogs);
+        timelineStore = createTimelineStore(
           internPool,
           styleStore,
           logStore,
           rawTimelines,
-          1,
           [],
-          0,
           rawEvents,
-          1,
         );
 
         const timeline = timelineStore.getTimeline(10);
@@ -939,17 +913,14 @@ describe('Timeline', () => {
         },
       ];
 
-      logStore = LogStore.initialize(internPool, styleStore, rawLogs, 3);
-      timelineStore = TimelineStore.initialize(
+      logStore = createLogStore(internPool, styleStore, rawLogs);
+      timelineStore = createTimelineStore(
         internPool,
         styleStore,
         logStore,
         rawTimelines,
-        1,
         rawRevisions,
-        1,
         rawEvents,
-        1,
       );
 
       const timeline = timelineStore.getTimeline(10);

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -141,7 +141,7 @@ export class Revision {
    * Gets the interned struct ID of the revision body, or 0 if not stored as an interned struct.
    */
   get structId(): number {
-    return this.timelineStore.getRevisionBodyStructId(this.id);
+    return this.timelineStore._getRevisionBodyStructId(this.id);
   }
 
   /**

--- a/web/src/app/store/mock/inspection-data.mock.ts
+++ b/web/src/app/store/mock/inspection-data.mock.ts
@@ -17,6 +17,7 @@
 import { InspectionData } from 'src/app/store/domain/inspection-data';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
+import { StructStore } from 'src/app/store/domain/struct-store';
 import { LogStore } from 'src/app/store/domain/log-store';
 import {
   TimelineStore,
@@ -319,7 +320,9 @@ export async function createMockInspectionData(): Promise<InspectionData> {
     stringsToRegister.push({ id, value: `sub-${i}` });
   }
 
-  const internPool = InternPoolStore.initialize(stringsToRegister);
+  const internPool = InternPoolStore.create(stringsToRegister.length);
+  internPool.addStrings(stringsToRegister);
+  internPool.shrinkToFit();
 
   // --- 3. Define Mock Entities ---
   const timestampString = '2026-05-13T09:00:00Z';
@@ -725,24 +728,22 @@ export async function createMockInspectionData(): Promise<InspectionData> {
     eventIdsMap.get(subId)!.push(currentEventId);
   }
 
-  const logStore = LogStore.initialize(
-    internPool,
-    styleStore,
-    mockLogs,
-    mockLogs.length,
-  );
+  const logStore = LogStore.create(internPool, styleStore, mockLogs.length);
+  logStore.addLogs(mockLogs);
+  logStore.shrinkToFit();
 
-  const timelineStore = TimelineStore.initialize(
+  const timelineStore = TimelineStore.create(
     internPool,
     styleStore,
     logStore,
-    timelines,
     timelines.length,
-    mockRevisions,
     mockRevisions.length,
-    mockEvents,
     mockEvents.length,
   );
+  timelineStore.addRevisions(mockRevisions);
+  timelineStore.addEvents(mockEvents);
+  timelineStore.addTimelines(timelines);
+  timelineStore.shrinkToFit();
 
   // --- 4. Define Header Metadata ---
   const metadata: MetadataStore = {
@@ -758,11 +759,14 @@ export async function createMockInspectionData(): Promise<InspectionData> {
     queries: [],
   };
 
+  const structStore = StructStore.create(internPool);
+
   return {
     internPool,
     styleStore,
     logStore,
     timelineStore,
+    structStore,
     metadata,
   };
 }

--- a/web/src/app/timeline/components/misc/histogram-cache.spec.ts
+++ b/web/src/app/timeline/components/misc/histogram-cache.spec.ts
@@ -33,7 +33,7 @@ function createCacheWithLogs(
   minTimeMs?: number,
   maxTimeMs?: number,
 ): HistogramCache {
-  const internPool = InternPoolStore.initialize();
+  const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
 
   styleStore.addSeverities([
@@ -63,12 +63,9 @@ function createCacheWithLogs(
     summaryStringId: 0,
   }));
 
-  const logStore = LogStore.initialize(
-    internPool,
-    styleStore,
-    logsDto,
-    logsDto.length,
-  );
+  const logStore = LogStore.create(internPool, styleStore, logsDto.length);
+  logStore.addLogs(logsDto);
+  logStore.shrinkToFit();
   const logs = Array.from(logStore.logs());
   return new HistogramCache(
     styleStore.severities,

--- a/web/src/app/timeline/components/timeline-index.stories.ts
+++ b/web/src/app/timeline/components/timeline-index.stories.ts
@@ -66,7 +66,7 @@ export default meta;
 type Story = StoryObj<TimelineIndexComponent>;
 
 function createTimelines(): Timeline[] {
-  const internPool = InternPoolStore.initialize();
+  const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
   styleStore.addTimelineTypes([
     {
@@ -215,18 +215,17 @@ function createTimelines(): Timeline[] {
     },
   ];
 
-  const logStore = LogStore.initialize(internPool, styleStore, [], 0);
-  const timelineStore = TimelineStore.initialize(
+  const logStore = LogStore.create(internPool, styleStore, 0);
+  const timelineStore = TimelineStore.create(
     internPool,
     styleStore,
     logStore,
-    timelinesData,
     timelinesData.length,
-    [],
-    0,
-    [],
-    0,
+    1,
+    1,
   );
+  timelineStore.addTimelines(timelinesData);
+  timelineStore.shrinkToFit();
 
   return timelineStore.timelines as Timeline[];
 }

--- a/web/src/app/timeline/components/timeline-legend.stories.ts
+++ b/web/src/app/timeline/components/timeline-legend.stories.ts
@@ -37,7 +37,7 @@ export default meta;
 type Story = StoryObj<TimelineLegendComponent>;
 
 function createMockTimeline(isKind: boolean): Timeline {
-  const internPool = InternPoolStore.initialize();
+  const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
 
   internPool.addStrings([
@@ -152,18 +152,17 @@ function createMockTimeline(isKind: boolean): Timeline {
         eventIds: [],
       },
     ];
-    const logStore = LogStore.initialize(internPool, styleStore, [], 0);
-    const timelineStore = TimelineStore.initialize(
+    const logStore = LogStore.create(internPool, styleStore, 0);
+    const timelineStore = TimelineStore.create(
       internPool,
       styleStore,
       logStore,
-      timelineData,
       1,
-      [],
-      0,
-      [],
-      0,
+      1,
+      1,
     );
+    timelineStore.addTimelines(timelineData);
+    timelineStore.shrinkToFit();
     return timelineStore.getTimeline(1) as Timeline;
   } else {
     const timelineData = [
@@ -249,23 +248,21 @@ function createMockTimeline(isKind: boolean): Timeline {
         body: undefined,
       },
     ];
-    const logStore = LogStore.initialize(
-      internPool,
-      styleStore,
-      logsData,
-      logsData.length,
-    );
-    const timelineStore = TimelineStore.initialize(
+    const logStore = LogStore.create(internPool, styleStore, logsData.length);
+    logStore.addLogs(logsData);
+    logStore.shrinkToFit();
+    const timelineStore = TimelineStore.create(
       internPool,
       styleStore,
       logStore,
-      timelineData,
-      1,
-      revisionsData,
-      4,
-      eventsData,
-      3,
+      timelineData.length,
+      revisionsData.length,
+      eventsData.length,
     );
+    timelineStore.addRevisions(revisionsData);
+    timelineStore.addEvents(eventsData);
+    timelineStore.addTimelines(timelineData);
+    timelineStore.shrinkToFit();
     return timelineStore.getTimeline(1) as Timeline;
   }
 }

--- a/web/src/app/timeline/components/timeline-ruler.stories.ts
+++ b/web/src/app/timeline/components/timeline-ruler.stories.ts
@@ -150,7 +150,7 @@ function generateMockLogs(
   count: number,
   severityRatio: { [severity in MockSeverity]?: number },
 ): Log[] {
-  const internPool = InternPoolStore.initialize();
+  const internPool = InternPoolStore.create();
 
   const culmativeRatios: number[] = [];
   const severitiesList = [
@@ -189,12 +189,9 @@ function generateMockLogs(
     });
   }
   logDataList.sort((a, b) => Number(a.ts - b.ts));
-  const logStore = LogStore.initialize(
-    internPool,
-    sharedStyleStore,
-    logDataList,
-    count,
-  );
+  const logStore = LogStore.create(internPool, sharedStyleStore, count);
+  logStore.addLogs(logDataList);
+  logStore.shrinkToFit();
   return Array.from(logStore.logs()) as Log[];
 }
 


### PR DESCRIPTION
## Summary

This PR migrates KHI web frontend data stores and v6 parser assemblers from batch array ingestion to dynamic streaming ingestion, and introduces `StructStore` to drastically reduce peak memory usage during large inspection file parsing:

1. **Dynamic Streaming Stores**:
   - `LogStore`, `TimelineStore`, and `InternPoolStore` now support progressive streaming ingestion (`create()`, `add*()`, `shrinkToFit()`).
   - Memory buffers dynamically resize and shrink to fit exact element counts upon completion.
   - Offsets across compound buffers are unified using `BufferLayoutBuilder`.
   - Removed unused write-only arrays (`revisionIds`, `eventIds`) from `TimelineStore` metadata buffer.

2. **`StructStore` for Interned Structs**:
   - Stores interned protobuf `Struct` payloads in a compact contiguous binary format.
   - Decodes values lazily on-demand when requested by the UI (e.g. log inspection dialog, YAML viewer).
   - Supports null, int64, double, bool, string, timestamp, nested structs, and lists.

3. **Streaming Data Assemblers**:
   - `DataAssembler` interface and `V6_BLUEPRINT` assemblers stream decoded chunks directly to `InspectionDataBuilder` during `ingest()`, avoiding large intermediate array allocations.
   - Two-phase lifecycle with priority-based `finalize()` hook for cross-chunk entity relationships.
   - `InspectionDataBuilder` is streamlined to single-item additions (`addLog`, `addTimeline`, `addRevision`, `addEvent`, etc.).

4. **Testing & Verification**:
   - Added unit tests for `BufferLayoutBuilder`, `reallocateBuffer`, `StructStore`, `LogStore`, `TimelineStore`, `InternPoolStore`, and `KHIFileParser`.
   - Verified that all 958 web unit tests pass.
   - Formatted and linted with zero errors (`make pre-commit`, `make lint-web`, `make build-storybook`).