### PR TITLE
feat(web): add Connect-RPC retry interceptor and resilient polling/upload/download

### DIFF
--- a/web/src/app/services/api/backend-api.service.spec.ts
+++ b/web/src/app/services/api/backend-api.service.spec.ts
@@ -290,6 +290,40 @@ describe('BackendAPIImpl testing', () => {
     expect(reporterSpy).toHaveBeenCalledWith(100, 100);
   });
 
+  it('retries chunk download when getInspectionDataChunk encounters 502 error', async () => {
+    const fileSize = 10;
+    mockInspectionClient.getInspectionMetadata.and.returnValue(
+      Promise.resolve(
+        create(GetInspectionMetadataResponseSchema, {
+          header: {
+            inspectionType: 'test',
+            inspectionName: 'test',
+            suggestedFilename: 'retry-test.khi',
+            fileSize: BigInt(fileSize),
+          },
+        }),
+      ),
+    );
+
+    let callCount = 0;
+    mockInspectionClient.getInspectionDataChunk.and.callFake(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.reject(new Error('502 Bad Gateway'));
+      }
+      return Promise.resolve(
+        create(GetInspectionDataChunkResponseSchema, {
+          data: new Uint8Array(fileSize),
+        }),
+      );
+    });
+
+    const data = await firstValueFrom(api.getInspectionData('test', () => {}));
+    expect(data.fileName).toEqual('retry-test.khi');
+    expect(data.content.size).toEqual(fileSize);
+    expect(callCount).toBe(2);
+  });
+
   it('respects environment download chunk size and concurrency in getInspectionData', async () => {
     const originalDownload = environment.download;
     try {

--- a/web/src/app/services/api/backend-api.service.ts
+++ b/web/src/app/services/api/backend-api.service.ts
@@ -34,6 +34,7 @@ import {
   catchError,
   concat,
   debounceTime,
+  defer,
   exhaustMap,
   from,
   map,
@@ -41,8 +42,10 @@ import {
   of,
   range,
   reduce,
+  retry,
   shareReplay,
   switchMap,
+  timer,
   withLatestFrom,
 } from 'rxjs';
 import { ViewStateService } from '../view-state.service';
@@ -52,6 +55,11 @@ import { ProgressUtil } from '../progress/progress-util';
 import { ApiPathUtil } from 'src/app/services/api/api-path-util';
 import { ConnectClientService } from 'src/app/services/api/connect-client.service';
 import { resolveDownloadConfig } from 'src/app/services/api/download-config-resolver';
+import {
+  calculateBackoffDelayMs,
+  DEFAULT_CHUNK_MAX_RETRIES,
+  isRetryableError,
+} from 'src/app/services/api/retry-util';
 import { downloadBlob } from 'src/app/utils/download-util';
 import {
   convertMapToParameterValues,
@@ -253,13 +261,24 @@ export class BackendAPIImpl implements BackendAPI {
             return { index, startInBytes, maxSizeInBytes };
           }),
           mergeMap(({ index, startInBytes, maxSizeInBytes }) => {
-            return from(
-              this.connectClient.inspectionClient.getInspectionDataChunk({
-                inspectionId: inspectionID,
-                offsetBytes: BigInt(startInBytes),
-                maxSizeBytes: BigInt(maxSizeInBytes),
-              }),
+            return defer(() =>
+              from(
+                this.connectClient.inspectionClient.getInspectionDataChunk({
+                  inspectionId: inspectionID,
+                  offsetBytes: BigInt(startInBytes),
+                  maxSizeBytes: BigInt(maxSizeInBytes),
+                }),
+              ),
             ).pipe(
+              retry({
+                count: DEFAULT_CHUNK_MAX_RETRIES,
+                delay: (error, retryCount) => {
+                  if (!isRetryableError(error)) {
+                    throw error;
+                  }
+                  return timer(calculateBackoffDelayMs(retryCount));
+                },
+              }),
               map((chunk) => {
                 const blob = new Blob([chunk.data as BlobPart]);
                 chunkLoaded[index] = blob.size;

--- a/web/src/app/services/api/chunked-uploader.spec.ts
+++ b/web/src/app/services/api/chunked-uploader.spec.ts
@@ -87,6 +87,76 @@ describe('executeChunkedUpload', () => {
     ).toBeRejectedWithError('chunk upload failed');
   });
 
+  it('should retry chunk on transient error and complete successfully', async () => {
+    const fileContent = '1234567890abcdef'; // 16 bytes, 4 chunks of 4 bytes
+    const file = new File([fileContent], 'test.txt', { type: 'text/plain' });
+    let failedOnce = false;
+    let offset4Calls = 0;
+
+    await executeChunkedUpload({
+      file,
+      chunkSize: 4,
+      maxRetriesPerChunk: 2,
+      uploadChunk: async (offset) => {
+        if (offset === 4) {
+          offset4Calls++;
+          if (!failedOnce) {
+            failedOnce = true;
+            throw new Error('503 Service Unavailable');
+          }
+        }
+      },
+    });
+
+    expect(failedOnce).toBeTrue();
+    expect(offset4Calls).toBe(2);
+  });
+
+  it('should fail when chunk retries are exhausted', async () => {
+    const fileContent = '1234567890abcdef';
+    const file = new File([fileContent], 'test.txt', { type: 'text/plain' });
+    let callCount = 0;
+
+    await expectAsync(
+      executeChunkedUpload({
+        file,
+        chunkSize: 4,
+        maxRetriesPerChunk: 2,
+        uploadChunk: async (offset) => {
+          if (offset === 0) {
+            callCount++;
+            throw new Error('502 Bad Gateway');
+          }
+        },
+      }),
+    ).toBeRejectedWithError('502 Bad Gateway');
+
+    // 1 initial attempt + 2 retries = 3 calls
+    expect(callCount).toBe(3);
+  });
+
+  it('should fail immediately on non-retryable error without retrying', async () => {
+    const fileContent = '1234567890abcdef';
+    const file = new File([fileContent], 'test.txt', { type: 'text/plain' });
+    let callCount = 0;
+
+    await expectAsync(
+      executeChunkedUpload({
+        file,
+        chunkSize: 4,
+        maxRetriesPerChunk: 3,
+        uploadChunk: async (offset) => {
+          if (offset === 0) {
+            callCount++;
+            throw new Error('400 Bad Request');
+          }
+        },
+      }),
+    ).toBeRejectedWithError('400 Bad Request');
+
+    expect(callCount).toBe(1);
+  });
+
   it('should abort upload when abortSignal is triggered', async () => {
     const fileContent = '1234567890abcdef';
     const file = new File([fileContent], 'test.txt', { type: 'text/plain' });

--- a/web/src/app/services/api/chunked-uploader.ts
+++ b/web/src/app/services/api/chunked-uploader.ts
@@ -15,6 +15,12 @@
  */
 
 import { CancellationError } from 'src/app/store/domain/filter/types';
+import {
+  calculateBackoffDelayMs,
+  DEFAULT_CHUNK_MAX_RETRIES,
+  delayWithSignal,
+  isRetryableError,
+} from 'src/app/services/api/retry-util';
 
 /**
  * Progress callback reporting uploaded bytes and total bytes.
@@ -41,6 +47,9 @@ export interface ChunkUploadExecutorOptions {
 
   /** Optional progress callback invoked as chunks complete. */
   readonly onProgress?: ChunkUploadProgressCallback;
+
+  /** Maximum number of retry attempts per failed chunk upload. Defaults to 10. */
+  readonly maxRetriesPerChunk?: number;
 
   /** Function that uploads a single binary chunk to the remote service. */
   readonly uploadChunk: (
@@ -110,6 +119,9 @@ export async function executeChunkedUpload(
   let uploadedBytes = 0;
   let firstError: unknown = null;
 
+  const maxRetriesPerChunk =
+    options.maxRetriesPerChunk ?? DEFAULT_CHUNK_MAX_RETRIES;
+
   const workerCount = Math.min(maxConcurrency, chunks.length);
   const workers = Array.from({ length: workerCount }, async () => {
     while (true) {
@@ -123,30 +135,52 @@ export async function executeChunkedUpload(
       }
 
       const chunk = chunks[index];
-      try {
-        const sliceBlob = options.file.slice(
-          chunk.offset,
-          chunk.offset + chunk.length,
-        );
-        const buffer = await sliceBlob.arrayBuffer();
-        const data = new Uint8Array(buffer);
-
+      let chunkRetryCount = 0;
+      while (true) {
         if (abortController.signal.aborted || firstError !== null) {
           break;
         }
 
-        await options.uploadChunk(chunk.offset, data, abortController.signal);
+        try {
+          const sliceBlob = options.file.slice(
+            chunk.offset,
+            chunk.offset + chunk.length,
+          );
+          const buffer = await sliceBlob.arrayBuffer();
+          const data = new Uint8Array(buffer);
 
-        uploadedBytes += chunk.length;
-        if (options.onProgress) {
-          options.onProgress(uploadedBytes, totalSize);
+          if (abortController.signal.aborted || firstError !== null) {
+            break;
+          }
+
+          await options.uploadChunk(chunk.offset, data, abortController.signal);
+
+          uploadedBytes += chunk.length;
+          if (options.onProgress) {
+            options.onProgress(uploadedBytes, totalSize);
+          }
+          break;
+        } catch (err) {
+          chunkRetryCount++;
+          if (
+            chunkRetryCount <= maxRetriesPerChunk &&
+            isRetryableError(err) &&
+            !abortController.signal.aborted &&
+            firstError === null
+          ) {
+            const delayMs = calculateBackoffDelayMs(chunkRetryCount);
+            await delayWithSignal(delayMs, abortController.signal);
+            if (!abortController.signal.aborted && firstError === null) {
+              continue;
+            }
+          }
+
+          if (firstError === null) {
+            firstError = err;
+            abortController.abort();
+          }
+          break;
         }
-      } catch (err) {
-        if (firstError === null) {
-          firstError = err;
-          abortController.abort();
-        }
-        break;
       }
     }
   });

--- a/web/src/app/services/api/connect-client.service.spec.ts
+++ b/web/src/app/services/api/connect-client.service.spec.ts
@@ -106,4 +106,31 @@ describe('ConnectClientService', () => {
         originalEnv;
     }
   });
+
+  it('retries unary RPC when encountering 502 Bad Gateway', async () => {
+    let callCount = 0;
+    spyOn(globalThis, 'fetch').and.callFake(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve(
+          new Response('Bad Gateway', {
+            status: 502,
+            headers: { 'content-type': 'text/plain' },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ active: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    });
+
+    const res = await service.workbenchClient.heartbeatWorkbench({
+      workbenchId: 'test-retry',
+    });
+    expect(res.active).toBeTrue();
+    expect(callCount).toBe(2);
+  });
 });

--- a/web/src/app/services/api/connect-client.service.ts
+++ b/web/src/app/services/api/connect-client.service.ts
@@ -26,6 +26,7 @@ import { WorkbenchService } from 'src/app/generated/api/v1/workbench_pb';
 import { InspectionService } from 'src/app/generated/api/v1/inspection_pb';
 import { ApiPathUtil } from 'src/app/services/api/api-path-util';
 import { createLegacyPollingInterceptor } from 'src/app/services/api/legacy-polling.interceptor';
+import { createRetryInterceptor } from 'src/app/services/api/retry.interceptor';
 import { resolveUseBinaryFormat } from 'src/app/services/api/transport-config-resolver';
 
 /**
@@ -38,7 +39,7 @@ export class ConnectClientService {
   private readonly transport = createConnectTransport({
     baseUrl: ApiPathUtil.getServerBaseUrl(),
     useBinaryFormat: resolveUseBinaryFormat(),
-    interceptors: [createLegacyPollingInterceptor()],
+    interceptors: [createRetryInterceptor(), createLegacyPollingInterceptor()],
   });
 
   /**

--- a/web/src/app/services/api/legacy-polling.interceptor.spec.ts
+++ b/web/src/app/services/api/legacy-polling.interceptor.spec.ts
@@ -23,6 +23,8 @@ import {
   MessageInitShape,
 } from '@bufbuild/protobuf';
 import {
+  Code,
+  ConnectError,
   ContextValues,
   createClient,
   createContextValues,
@@ -492,6 +494,197 @@ describe('LegacyPollingInterceptor', () => {
       }
 
       expect(modes).toEqual([FilterResultMode.INCLUDE]);
+    });
+
+    it('survives transient 502 error during OpenWorkbench polling', async () => {
+      let openCalls = 0;
+      const mockTransport = createMockUnaryTransport((methodName) => {
+        if (methodName === 'OpenWorkbenchSync') {
+          openCalls++;
+          if (openCalls === 1) {
+            throw new ConnectError('502 Bad Gateway', Code.Unavailable);
+          }
+          return create(OpenWorkbenchSyncResponseSchema, {
+            jobId: 'job-wb-retry',
+            stage: OpenWorkbenchResponse_Stage.READY,
+            progressPercentage: 100.0,
+            message: 'Workbench ready.',
+            workbenchId: 'wb-retry-1',
+          });
+        }
+        throw new Error(`Unexpected method: ${methodName}`);
+      });
+
+      const interceptor = createLegacyPollingInterceptor(mockTransport, true);
+      const clientTransport = createMockStreamTransport(interceptor);
+      const client = createClient(WorkbenchService, clientTransport);
+      const stages: OpenWorkbenchResponse_Stage[] = [];
+      for await (const res of client.openWorkbench({
+        userId: 'u1',
+        sessionId: 's1',
+        inspectionId: 'i1',
+      })) {
+        stages.push(res.stage);
+      }
+
+      expect(stages).toEqual([OpenWorkbenchResponse_Stage.READY]);
+      expect(openCalls).toBe(2);
+    });
+
+    it('survives transient 503 error during FilterTimeline polling', async () => {
+      let filterCalls = 0;
+      const mockTransport = createMockUnaryTransport((methodName) => {
+        if (methodName === 'FilterTimelineSync') {
+          filterCalls++;
+          if (filterCalls === 1) {
+            throw new ConnectError('503 Service Unavailable', Code.Unavailable);
+          }
+          return create(FilterTimelineSyncResponseSchema, {
+            jobId: 'job-filter-retry',
+            isDone: true,
+            result: create(FilterResultSchema, {
+              timelineMode: FilterResultMode.INCLUDE,
+              logMode: FilterResultMode.INCLUDE,
+            }),
+          });
+        }
+        throw new Error(`Unexpected method: ${methodName}`);
+      });
+
+      const interceptor = createLegacyPollingInterceptor(mockTransport, true);
+      const clientTransport = createMockStreamTransport(interceptor);
+      const client = createClient(WorkbenchService, clientTransport);
+      const modes: FilterResultMode[] = [];
+      for await (const res of client.filterTimeline({
+        workbenchId: 'wb-1',
+      })) {
+        if (res.payload.case === 'result') {
+          modes.push(res.payload.value.timelineMode);
+        }
+      }
+
+      expect(modes).toEqual([FilterResultMode.INCLUDE]);
+      expect(filterCalls).toBe(2);
+    });
+
+    it('aborts OpenWorkbench when consecutive errors exceed limit', async () => {
+      const mockTransport = createMockUnaryTransport((methodName) => {
+        if (methodName === 'OpenWorkbenchSync') {
+          throw new ConnectError('502 Bad Gateway', Code.Unavailable);
+        }
+        throw new Error(`Unexpected method: ${methodName}`);
+      });
+
+      const interceptor = createLegacyPollingInterceptor(mockTransport, true);
+      const clientTransport = createMockStreamTransport(interceptor);
+      const client = createClient(WorkbenchService, clientTransport);
+
+      await expectAsync(
+        (async () => {
+          for await (const res of client.openWorkbench({
+            userId: 'u1',
+            sessionId: 's1',
+            inspectionId: 'i1',
+          })) {
+            expect(res).toBeDefined();
+          }
+        })(),
+      ).toBeRejectedWithError(ConnectError);
+    });
+
+    it('fails immediately on non-retryable error during OpenWorkbench polling', async () => {
+      let openCalls = 0;
+      const mockTransport = createMockUnaryTransport((methodName) => {
+        if (methodName === 'OpenWorkbenchSync') {
+          openCalls++;
+          throw new ConnectError('Invalid argument', Code.InvalidArgument);
+        }
+        throw new Error(`Unexpected method: ${methodName}`);
+      });
+
+      const interceptor = createLegacyPollingInterceptor(mockTransport, true);
+      const clientTransport = createMockStreamTransport(interceptor);
+      const client = createClient(WorkbenchService, clientTransport);
+
+      await expectAsync(
+        (async () => {
+          for await (const res of client.openWorkbench({
+            userId: 'u1',
+            sessionId: 's1',
+            inspectionId: 'i1',
+          })) {
+            expect(res).toBeDefined();
+          }
+        })(),
+      ).toBeRejectedWithError(ConnectError);
+
+      expect(openCalls).toBe(1);
+    });
+
+    it('resets consecutive error counter on success after transient failure', async () => {
+      let openCalls = 0;
+      const mockTransport = createMockUnaryTransport((methodName) => {
+        if (methodName === 'OpenWorkbenchSync') {
+          openCalls++;
+          if (openCalls === 1) {
+            throw new ConnectError('503 Service Unavailable', Code.Unavailable);
+          }
+          if (openCalls === 2) {
+            return create(OpenWorkbenchSyncResponseSchema, {
+              stage: OpenWorkbenchResponse_Stage.INITIALIZING,
+            });
+          }
+          if (openCalls === 3) {
+            throw new ConnectError('503 Service Unavailable', Code.Unavailable);
+          }
+          return create(OpenWorkbenchSyncResponseSchema, {
+            stage: OpenWorkbenchResponse_Stage.READY,
+          });
+        }
+        throw new Error(`Unexpected method: ${methodName}`);
+      });
+
+      const interceptor = createLegacyPollingInterceptor(mockTransport, true);
+      const clientTransport = createMockStreamTransport(interceptor);
+      const client = createClient(WorkbenchService, clientTransport);
+      const stages: OpenWorkbenchResponse_Stage[] = [];
+
+      for await (const res of client.openWorkbench({
+        userId: 'u1',
+        sessionId: 's1',
+        inspectionId: 'i1',
+      })) {
+        stages.push(res.stage);
+      }
+
+      expect(stages).toEqual([
+        OpenWorkbenchResponse_Stage.INITIALIZING,
+        OpenWorkbenchResponse_Stage.READY,
+      ]);
+      expect(openCalls).toBe(4);
+    });
+
+    it('aborts FilterTimeline when consecutive errors exceed limit', async () => {
+      const mockTransport = createMockUnaryTransport((methodName) => {
+        if (methodName === 'FilterTimelineSync') {
+          throw new ConnectError('503 Service Unavailable', Code.Unavailable);
+        }
+        throw new Error(`Unexpected method: ${methodName}`);
+      });
+
+      const interceptor = createLegacyPollingInterceptor(mockTransport, true);
+      const clientTransport = createMockStreamTransport(interceptor);
+      const client = createClient(WorkbenchService, clientTransport);
+
+      await expectAsync(
+        (async () => {
+          for await (const res of client.filterTimeline({
+            workbenchId: 'wb-1',
+          })) {
+            expect(res).toBeDefined();
+          }
+        })(),
+      ).toBeRejectedWithError(ConnectError);
     });
   });
 });

--- a/web/src/app/services/api/legacy-polling.interceptor.ts
+++ b/web/src/app/services/api/legacy-polling.interceptor.ts
@@ -53,7 +53,17 @@ import {
   WorkbenchService,
 } from 'src/app/generated/api/v1/workbench_pb';
 import { ApiPathUtil } from 'src/app/services/api/api-path-util';
+import { createRetryInterceptor } from 'src/app/services/api/retry.interceptor';
+import {
+  delayWithSignal,
+  isRetryableError,
+} from 'src/app/services/api/retry-util';
 import { environment } from 'src/environments/environment';
+
+/**
+ * Maximum number of consecutive transient errors tolerated during polling before aborting.
+ */
+export const MAX_CONSECUTIVE_POLL_ERRORS = 5;
 
 /**
  * Checks whether legacy polling mode is enabled via URL query parameter or environment configuration.
@@ -89,27 +99,6 @@ async function getFirstMessage<T>(iterable: AsyncIterable<T>): Promise<T> {
 }
 
 /**
- * Delays execution for the specified milliseconds, resolving early if the signal is aborted.
- */
-function delay(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal?.aborted) {
-      resolve();
-      return;
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
-
-/**
  * Adapts WatchPopup streaming RPC to unary PullPopup calls.
  */
 async function* adaptWatchPopup(
@@ -137,7 +126,7 @@ async function* adaptWatchPopup(
         return;
       }
     }
-    await delay(500, req.signal);
+    await delayWithSignal(500, req.signal);
   }
 }
 
@@ -160,7 +149,7 @@ async function* adaptWatchServerStat(
         return;
       }
     }
-    await delay(1000, req.signal);
+    await delayWithSignal(1000, req.signal);
   }
 }
 
@@ -183,7 +172,7 @@ async function* adaptWatchInspections(
         return;
       }
     }
-    await delay(500, req.signal);
+    await delayWithSignal(500, req.signal);
   }
 }
 
@@ -222,7 +211,7 @@ async function* adaptWatchIndexProgress(
         return;
       }
     }
-    await delay(500, req.signal);
+    await delayWithSignal(500, req.signal);
   }
 }
 
@@ -236,27 +225,47 @@ async function* adaptOpenWorkbench(
   const wbClient = createClient(WorkbenchService, transport);
   const input = (await getFirstMessage(req.message)) as OpenWorkbenchRequest;
   let jobId = '';
+  let consecutiveErrors = 0;
   try {
     while (!req.signal.aborted) {
-      const res = await wbClient.openWorkbenchSync(
-        {
-          userId: input.userId,
-          sessionId: input.sessionId,
-          inspectionId: input.inspectionId,
-          jobId,
-        },
-        { signal: req.signal },
-      );
-      jobId = res.jobId;
-      yield create(OpenWorkbenchResponseSchema, {
-        stage: res.stage,
-        progressPercentage: res.progressPercentage,
-        message: res.message,
-        workbenchId: res.workbenchId,
-      });
-      if (res.stage === OpenWorkbenchResponse_Stage.READY) {
-        return;
+      try {
+        const res = await wbClient.openWorkbenchSync(
+          {
+            userId: input.userId,
+            sessionId: input.sessionId,
+            inspectionId: input.inspectionId,
+            jobId,
+          },
+          { signal: req.signal },
+        );
+        consecutiveErrors = 0;
+        jobId = res.jobId;
+        yield create(OpenWorkbenchResponseSchema, {
+          stage: res.stage,
+          progressPercentage: res.progressPercentage,
+          message: res.message,
+          workbenchId: res.workbenchId,
+        });
+        if (res.stage === OpenWorkbenchResponse_Stage.READY) {
+          return;
+        }
+      } catch (err) {
+        if (req.signal.aborted) {
+          return;
+        }
+        consecutiveErrors++;
+        if (
+          consecutiveErrors > MAX_CONSECUTIVE_POLL_ERRORS ||
+          !isRetryableError(err)
+        ) {
+          throw err;
+        }
+        console.warn(
+          `[LegacyPolling] OpenWorkbenchSync transient error (${consecutiveErrors}/${MAX_CONSECUTIVE_POLL_ERRORS}):`,
+          err,
+        );
       }
+      await delayWithSignal(300, req.signal);
     }
   } finally {
     if (req.signal.aborted && jobId) {
@@ -279,60 +288,56 @@ async function* adaptFilterTimeline(
   const wbClient = createClient(WorkbenchService, transport);
   const input = (await getFirstMessage(req.message)) as FilterTimelineRequest;
   let jobId = '';
+  let consecutiveErrors = 0;
   try {
-    const initialRes = await wbClient.filterTimelineSync(
-      {
-        workbenchId: input.workbenchId,
-        timelineQuery: input.timelineQuery,
-        timelineExclusionQuery: input.timelineExclusionQuery,
-        logQuery: input.logQuery,
-        excludeNoLogs: input.excludeNoLogs,
-        jobId: '',
-      },
-      { signal: req.signal },
-    );
-    jobId = initialRes.jobId;
-    if (initialRes.progress) {
-      yield create(FilterTimelineResponseSchema, {
-        payload: { case: 'progress', value: initialRes.progress },
-      });
-    }
-    if (initialRes.isDone) {
-      if (initialRes.errorMessage) {
-        throw new Error(initialRes.errorMessage);
-      }
-      if (initialRes.result) {
-        yield create(FilterTimelineResponseSchema, {
-          payload: { case: 'result', value: initialRes.result },
-        });
-      }
-      return;
-    }
-
     while (!req.signal.aborted) {
-      const pollRes = await wbClient.filterTimelineSync(
-        {
-          workbenchId: input.workbenchId,
-          jobId,
-        },
-        { signal: req.signal },
-      );
-      if (pollRes.progress) {
-        yield create(FilterTimelineResponseSchema, {
-          payload: { case: 'progress', value: pollRes.progress },
-        });
-      }
-      if (pollRes.isDone) {
-        if (pollRes.errorMessage) {
-          throw new Error(pollRes.errorMessage);
-        }
-        if (pollRes.result) {
+      try {
+        const pollRes = await wbClient.filterTimelineSync(
+          {
+            workbenchId: input.workbenchId,
+            timelineQuery: jobId ? '' : input.timelineQuery,
+            timelineExclusionQuery: jobId ? '' : input.timelineExclusionQuery,
+            logQuery: jobId ? '' : input.logQuery,
+            excludeNoLogs: jobId ? false : input.excludeNoLogs,
+            jobId,
+          },
+          { signal: req.signal },
+        );
+        consecutiveErrors = 0;
+        jobId = pollRes.jobId;
+        if (pollRes.progress) {
           yield create(FilterTimelineResponseSchema, {
-            payload: { case: 'result', value: pollRes.result },
+            payload: { case: 'progress', value: pollRes.progress },
           });
         }
-        return;
+        if (pollRes.isDone) {
+          if (pollRes.errorMessage) {
+            throw new Error(pollRes.errorMessage);
+          }
+          if (pollRes.result) {
+            yield create(FilterTimelineResponseSchema, {
+              payload: { case: 'result', value: pollRes.result },
+            });
+          }
+          return;
+        }
+      } catch (err) {
+        if (req.signal.aborted) {
+          return;
+        }
+        consecutiveErrors++;
+        if (
+          consecutiveErrors > MAX_CONSECUTIVE_POLL_ERRORS ||
+          !isRetryableError(err)
+        ) {
+          throw err;
+        }
+        console.warn(
+          `[LegacyPolling] FilterTimelineSync transient error (${consecutiveErrors}/${MAX_CONSECUTIVE_POLL_ERRORS}):`,
+          err,
+        );
       }
+      await delayWithSignal(300, req.signal);
     }
   } finally {
     if (req.signal.aborted && jobId) {
@@ -368,6 +373,7 @@ export function createLegacyPollingInterceptor(
     createConnectTransport({
       baseUrl: ApiPathUtil.getServerBaseUrl(),
       useBinaryFormat: environment.production,
+      interceptors: [createRetryInterceptor()],
     });
 
   return (next) => async (req) => {

--- a/web/src/app/services/api/retry-util.spec.ts
+++ b/web/src/app/services/api/retry-util.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Code, ConnectError } from '@connectrpc/connect';
+import {
+  calculateBackoffDelayMs,
+  DEFAULT_CHUNK_MAX_RETRIES,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_RETRY_BASE_DELAY_MS,
+  DEFAULT_RETRY_MAX_DELAY_MS,
+  delayWithSignal,
+  isRetryableError,
+} from 'src/app/services/api/retry-util';
+import { CancellationError } from 'src/app/store/domain/filter/types';
+
+describe('retry-util', () => {
+  describe('constants', () => {
+    it('defines expected default retry settings', () => {
+      expect(DEFAULT_MAX_RETRIES).toBe(3);
+      expect(DEFAULT_CHUNK_MAX_RETRIES).toBe(10);
+      expect(DEFAULT_RETRY_BASE_DELAY_MS).toBe(500);
+      expect(DEFAULT_RETRY_MAX_DELAY_MS).toBe(3000);
+    });
+  });
+
+  describe('isRetryableError', () => {
+    it('returns false for null or undefined', () => {
+      expect(isRetryableError(null)).toBeFalse();
+      expect(isRetryableError(undefined)).toBeFalse();
+    });
+
+    it('returns false for CancellationError and DOMException AbortError', () => {
+      expect(isRetryableError(new CancellationError('Aborted'))).toBeFalse();
+      expect(
+        isRetryableError(
+          new DOMException('The user aborted a request', 'AbortError'),
+        ),
+      ).toBeFalse();
+    });
+
+    it('returns false for ConnectError with Code.Canceled', () => {
+      const err = new ConnectError('User canceled', Code.Canceled);
+      expect(isRetryableError(err)).toBeFalse();
+    });
+
+    it('returns true for ConnectError with Code.Unavailable', () => {
+      const err = new ConnectError(
+        'Service temporarily unavailable',
+        Code.Unavailable,
+      );
+      expect(isRetryableError(err)).toBeTrue();
+    });
+
+    it('returns true for ConnectError containing 502/503/504 in message', () => {
+      const err502 = new ConnectError('HTTP 502 Bad Gateway', Code.Unknown);
+      const err503 = new ConnectError(
+        'HTTP 503 Service Unavailable',
+        Code.Unknown,
+      );
+      const err504 = new ConnectError('HTTP 504 Gateway Timeout', Code.Unknown);
+      expect(isRetryableError(err502)).toBeTrue();
+      expect(isRetryableError(err503)).toBeTrue();
+      expect(isRetryableError(err504)).toBeTrue();
+    });
+
+    it('returns false for non-transient ConnectError codes', () => {
+      const notFound = new ConnectError('Resource not found', Code.NotFound);
+      const invalid = new ConnectError('Invalid input', Code.InvalidArgument);
+      const internal = new ConnectError('Internal server panic', Code.Internal);
+      expect(isRetryableError(notFound)).toBeFalse();
+      expect(isRetryableError(invalid)).toBeFalse();
+      expect(isRetryableError(internal)).toBeFalse();
+    });
+
+    it('returns true for TypeError network failure errors', () => {
+      const fetchFailed = new TypeError('Failed to fetch');
+      const networkError = new TypeError(
+        'NetworkError when attempting to fetch resource.',
+      );
+      expect(isRetryableError(fetchFailed)).toBeTrue();
+      expect(isRetryableError(networkError)).toBeTrue();
+    });
+
+    it('returns false for unrelated TypeError', () => {
+      const typeErr = new TypeError('Cannot read properties of undefined');
+      expect(isRetryableError(typeErr)).toBeFalse();
+    });
+
+    it('returns true for generic Error mentioning 502/503/504', () => {
+      expect(
+        isRetryableError(new Error('upstream server returned 502 Bad Gateway')),
+      ).toBeTrue();
+      expect(isRetryableError(new Error('503 Service Unavailable'))).toBeTrue();
+    });
+
+    it('returns false for generic unrelated Error', () => {
+      expect(isRetryableError(new Error('Syntax error'))).toBeFalse();
+    });
+  });
+
+  describe('calculateBackoffDelayMs', () => {
+    it('calculates exponential delay without jitter', () => {
+      expect(calculateBackoffDelayMs(1, 500, 3000, false)).toBe(500);
+      expect(calculateBackoffDelayMs(2, 500, 3000, false)).toBe(1000);
+      expect(calculateBackoffDelayMs(3, 500, 3000, false)).toBe(2000);
+      expect(calculateBackoffDelayMs(4, 500, 3000, false)).toBe(3000); // capped at max
+    });
+
+    it('includes jitter within expected range', () => {
+      const delay = calculateBackoffDelayMs(1, 500, 3000, true);
+      expect(delay).toBeGreaterThanOrEqual(500);
+      expect(delay).toBeLessThanOrEqual(500 + 250);
+    });
+  });
+
+  describe('delayWithSignal', () => {
+    it('resolves immediately if signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const start = Date.now();
+      await delayWithSignal(1000, controller.signal);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(100);
+    });
+
+    it('resolves early if signal fires during delay', async () => {
+      const controller = new AbortController();
+      const start = Date.now();
+      const delayPromise = delayWithSignal(2000, controller.signal);
+      setTimeout(() => controller.abort(), 50);
+      await delayPromise;
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it('resolves after specified time when not aborted', async () => {
+      const start = Date.now();
+      await delayWithSignal(50);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(40);
+    });
+  });
+});

--- a/web/src/app/services/api/retry-util.spec.ts
+++ b/web/src/app/services/api/retry-util.spec.ts
@@ -124,6 +124,13 @@ describe('retry-util', () => {
       expect(delay).toBeGreaterThanOrEqual(500);
       expect(delay).toBeLessThanOrEqual(500 + 250);
     });
+
+    it('never exceeds maxDelayMs when jitter is added', () => {
+      for (let i = 0; i < 20; i++) {
+        const delay = calculateBackoffDelayMs(10, 500, 3000, true);
+        expect(delay).toBeLessThanOrEqual(3000);
+      }
+    });
   });
 
   describe('delayWithSignal', () => {

--- a/web/src/app/services/api/retry-util.ts
+++ b/web/src/app/services/api/retry-util.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Code, ConnectError } from '@connectrpc/connect';
+import { CancellationError } from 'src/app/store/domain/filter/types';
+
+/**
+ * Default base delay in milliseconds before the first retry attempt.
+ */
+export const DEFAULT_RETRY_BASE_DELAY_MS = 500;
+
+/**
+ * Default maximum delay in milliseconds between retry attempts.
+ */
+export const DEFAULT_RETRY_MAX_DELAY_MS = 3000;
+
+/**
+ * Default maximum number of retry attempts for standard RPCs.
+ */
+export const DEFAULT_MAX_RETRIES = 3;
+
+/**
+ * Default maximum number of retry attempts for chunked upload and download operations.
+ */
+export const DEFAULT_CHUNK_MAX_RETRIES = 10;
+
+/**
+ * Checks whether an error represents a transient failure that can be safely retried.
+ *
+ * Transient errors include:
+ * - ConnectError with Code.Unavailable (covers HTTP 502, 503, 504 and network drops)
+ * - Browser fetch network errors (TypeError with fetch message)
+ *
+ * Explicit cancellations (AbortError, Code.Canceled, CancellationError) are not retryable.
+ *
+ * @param error The caught error to evaluate.
+ * @returns True if the error is retryable, false otherwise.
+ */
+export function isRetryableError(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+
+  if (error instanceof CancellationError) {
+    return false;
+  }
+
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return false;
+  }
+
+  if (error instanceof ConnectError) {
+    if (error.code === Code.Canceled) {
+      return false;
+    }
+    if (error.code === Code.Unavailable) {
+      return true;
+    }
+    const message = error.message;
+    if (
+      message.includes('502') ||
+      message.includes('503') ||
+      message.includes('504') ||
+      message.includes('Bad Gateway') ||
+      message.includes('Service Unavailable') ||
+      message.includes('Gateway Timeout')
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  if (error instanceof TypeError) {
+    const message = error.message.toLowerCase();
+    if (
+      message.includes('failed to fetch') ||
+      message.includes('networkerror') ||
+      message.includes('network error') ||
+      message.includes('load failed')
+    ) {
+      return true;
+    }
+  }
+
+  if (error instanceof Error) {
+    const message = error.message;
+    if (
+      message.includes('502') ||
+      message.includes('503') ||
+      message.includes('504') ||
+      message.includes('Bad Gateway') ||
+      message.includes('Service Unavailable') ||
+      message.includes('Gateway Timeout')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Calculates the exponential backoff delay in milliseconds for a retry attempt.
+ *
+ * @param retryCount The current retry attempt index (1-indexed: 1, 2, 3...).
+ * @param baseDelayMs Initial delay before the first retry attempt.
+ * @param maxDelayMs Upper bound for the calculated delay.
+ * @param addJitter Whether to append a small random jitter to avoid thundering herds.
+ * @returns Delay duration in milliseconds.
+ */
+export function calculateBackoffDelayMs(
+  retryCount: number,
+  baseDelayMs: number = DEFAULT_RETRY_BASE_DELAY_MS,
+  maxDelayMs: number = DEFAULT_RETRY_MAX_DELAY_MS,
+  addJitter: boolean = true,
+): number {
+  const attemptFactor = Math.max(0, retryCount - 1);
+  const exponentialDelay = Math.min(
+    maxDelayMs,
+    baseDelayMs * Math.pow(2, attemptFactor),
+  );
+  if (!addJitter) {
+    return exponentialDelay;
+  }
+  const jitterMs = Math.random() * (baseDelayMs * 0.5);
+  return Math.min(maxDelayMs + baseDelayMs * 0.5, exponentialDelay + jitterMs);
+}
+
+/**
+ * Delays execution for the specified milliseconds, resolving early if the AbortSignal fires.
+ *
+ * @param ms Delay duration in milliseconds.
+ * @param signal Optional AbortSignal to cancel waiting immediately.
+ */
+export function delayWithSignal(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/web/src/app/services/api/retry-util.ts
+++ b/web/src/app/services/api/retry-util.ts
@@ -136,7 +136,7 @@ export function calculateBackoffDelayMs(
     return exponentialDelay;
   }
   const jitterMs = Math.random() * (baseDelayMs * 0.5);
-  return Math.min(maxDelayMs + baseDelayMs * 0.5, exponentialDelay + jitterMs);
+  return Math.min(maxDelayMs, exponentialDelay + jitterMs);
 }
 
 /**

--- a/web/src/app/services/api/retry.interceptor.spec.ts
+++ b/web/src/app/services/api/retry.interceptor.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DescMethodStreaming,
+  DescMethodUnary,
+  DescService,
+  Message,
+} from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+  StreamRequest,
+  StreamResponse,
+  UnaryRequest,
+  UnaryResponse,
+} from '@connectrpc/connect';
+import {
+  createRetryInterceptor,
+  DEFAULT_RETRYABLE_METHODS,
+} from 'src/app/services/api/retry.interceptor';
+
+describe('retry.interceptor', () => {
+  function createMockUnaryRequest(
+    methodName: string,
+    signal?: AbortSignal,
+  ): UnaryRequest {
+    const service: DescService = {
+      typeName: 'khi.api.v1.TestService',
+      methods: {},
+    } as unknown as DescService;
+
+    const method: DescMethodUnary = {
+      name: methodName,
+      methodKind: 'unary',
+      parent: service,
+    } as unknown as DescMethodUnary;
+
+    return {
+      stream: false,
+      service,
+      method,
+      url: `http://localhost/${methodName}`,
+      requestMethod: 'POST',
+      signal: signal ?? new AbortController().signal,
+      header: new Headers(),
+      contextValues: createContextValues(),
+      message: {} as Message,
+    };
+  }
+
+  function createMockStreamRequest(methodName: string): StreamRequest {
+    const service: DescService = {
+      typeName: 'khi.api.v1.TestService',
+      methods: {},
+    } as unknown as DescService;
+
+    const method: DescMethodStreaming = {
+      name: methodName,
+      methodKind: 'server_streaming',
+      parent: service,
+    } as unknown as DescMethodStreaming;
+
+    return {
+      stream: true,
+      service,
+      method,
+      url: `http://localhost/${methodName}`,
+      requestMethod: 'POST',
+      signal: new AbortController().signal,
+      header: new Headers(),
+      contextValues: createContextValues(),
+      message: (async function* () {})(),
+    };
+  }
+
+  it('passes through streaming requests unchanged', async () => {
+    const interceptor = createRetryInterceptor({ maxRetries: 3 });
+    const req = createMockStreamRequest('WatchInspections');
+    let called = false;
+    const next = async (
+      r: StreamRequest | UnaryRequest,
+    ): Promise<StreamResponse | UnaryResponse> => {
+      called = true;
+      return {
+        stream: true,
+        service: r.service,
+        method: r.method,
+        header: new Headers(),
+        trailer: new Headers(),
+        message: (async function* () {})(),
+      } as StreamResponse;
+    };
+
+    await interceptor(next)(req);
+    expect(called).toBeTrue();
+  });
+
+  it('does not retry non-retryable methods', async () => {
+    const interceptor = createRetryInterceptor({
+      maxRetries: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 2,
+    });
+    const req = createMockUnaryRequest('CreateInspection');
+    let callCount = 0;
+    const next = async () => {
+      callCount++;
+      throw new ConnectError('503 Service Unavailable', Code.Unavailable);
+    };
+
+    await expectAsync(interceptor(next)(req)).toBeRejectedWithError(
+      ConnectError,
+    );
+    expect(callCount).toBe(1);
+  });
+
+  it('retries retryable method on Code.Unavailable and succeeds when transient error resolves', async () => {
+    const interceptor = createRetryInterceptor({
+      maxRetries: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 5,
+    });
+    const req = createMockUnaryRequest('ReadStructYAMLs');
+    let callCount = 0;
+    const mockResponse: UnaryResponse = {
+      stream: false,
+      service: req.service,
+      method: req.method,
+      header: new Headers(),
+      trailer: new Headers(),
+      message: {} as Message,
+    };
+
+    const next = async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new ConnectError('HTTP 502 Bad Gateway', Code.Unavailable);
+      }
+      return mockResponse;
+    };
+
+    const res = await interceptor(next)(req);
+    expect(callCount).toBe(2);
+    expect(res).toBe(mockResponse);
+  });
+
+  it('throws error after exhausting maxRetries', async () => {
+    const interceptor = createRetryInterceptor({
+      maxRetries: 2,
+      baseDelayMs: 1,
+      maxDelayMs: 5,
+    });
+    const req = createMockUnaryRequest('ReadStructYAMLs');
+    let callCount = 0;
+
+    const next = async () => {
+      callCount++;
+      throw new ConnectError('503 Service Unavailable', Code.Unavailable);
+    };
+
+    await expectAsync(interceptor(next)(req)).toBeRejectedWithError(
+      ConnectError,
+    );
+    // Initial call + 2 retries = 3 calls
+    expect(callCount).toBe(3);
+  });
+
+  it('does not retry non-retryable errors like InvalidArgument', async () => {
+    const interceptor = createRetryInterceptor({
+      maxRetries: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 5,
+    });
+    const req = createMockUnaryRequest('ReadStructYAMLs');
+    let callCount = 0;
+
+    const next = async () => {
+      callCount++;
+      throw new ConnectError('Invalid arguments', Code.InvalidArgument);
+    };
+
+    await expectAsync(interceptor(next)(req)).toBeRejectedWithError(
+      ConnectError,
+    );
+    expect(callCount).toBe(1);
+  });
+
+  it('passes through directly if request signal is already aborted before execution', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const interceptor = createRetryInterceptor({ maxRetries: 3 });
+    const req = createMockUnaryRequest('ReadStructYAMLs', controller.signal);
+    let callCount = 0;
+    const next = async () => {
+      callCount++;
+      return { stream: false } as UnaryResponse;
+    };
+
+    await interceptor(next)(req);
+    expect(callCount).toBe(1);
+  });
+
+  it('aborts immediately during delayWithSignal and does not issue subsequent retries', async () => {
+    const controller = new AbortController();
+    const interceptor = createRetryInterceptor({
+      maxRetries: 3,
+      baseDelayMs: 1000,
+      maxDelayMs: 2000,
+    });
+    const req = createMockUnaryRequest('ReadStructYAMLs', controller.signal);
+    let callCount = 0;
+
+    const next = async () => {
+      callCount++;
+      throw new ConnectError('503 Service Unavailable', Code.Unavailable);
+    };
+
+    const interceptorPromise = interceptor(next)(req);
+    // Abort shortly after entering delayWithSignal
+    setTimeout(() => controller.abort(), 20);
+
+    await expectAsync(interceptorPromise).toBeRejectedWithError(ConnectError);
+    expect(callCount).toBe(1);
+  });
+
+  it('stops retry if request signal is aborted inside next()', async () => {
+    const controller = new AbortController();
+    const interceptor = createRetryInterceptor({
+      maxRetries: 3,
+      baseDelayMs: 50,
+      maxDelayMs: 100,
+    });
+    const req = createMockUnaryRequest('ReadStructYAMLs', controller.signal);
+    let callCount = 0;
+
+    const next = async () => {
+      callCount++;
+      controller.abort();
+      throw new ConnectError('502 Bad Gateway', Code.Unavailable);
+    };
+
+    await expectAsync(interceptor(next)(req)).toBeRejected();
+    expect(callCount).toBe(1);
+  });
+
+  it('contains expected default retryable methods', () => {
+    expect(DEFAULT_RETRYABLE_METHODS.has('ReadStructYAMLs')).toBeTrue();
+    expect(DEFAULT_RETRYABLE_METHODS.has('OpenWorkbenchSync')).toBeTrue();
+    expect(DEFAULT_RETRYABLE_METHODS.has('FilterTimelineSync')).toBeTrue();
+    expect(DEFAULT_RETRYABLE_METHODS.has('ValidateTimelineQuery')).toBeTrue();
+    expect(DEFAULT_RETRYABLE_METHODS.has('ValidateLogQuery')).toBeTrue();
+    expect(DEFAULT_RETRYABLE_METHODS.has('GetInspectionDataChunk')).toBeFalse();
+    expect(DEFAULT_RETRYABLE_METHODS.has('UploadFileChunk')).toBeFalse();
+    expect(DEFAULT_RETRYABLE_METHODS.has('UploadInspectionChunk')).toBeFalse();
+    expect(DEFAULT_RETRYABLE_METHODS.has('CreateInspection')).toBeFalse();
+    expect(DEFAULT_RETRYABLE_METHODS.has('RunInspection')).toBeFalse();
+  });
+});

--- a/web/src/app/services/api/retry.interceptor.spec.ts
+++ b/web/src/app/services/api/retry.interceptor.spec.ts
@@ -33,6 +33,7 @@ import {
   createRetryInterceptor,
   DEFAULT_RETRYABLE_METHODS,
 } from 'src/app/services/api/retry.interceptor';
+import { CancellationError } from 'src/app/store/domain/filter/types';
 
 describe('retry.interceptor', () => {
   function createMockUnaryRequest(
@@ -234,7 +235,9 @@ describe('retry.interceptor', () => {
     // Abort shortly after entering delayWithSignal
     setTimeout(() => controller.abort(), 20);
 
-    await expectAsync(interceptorPromise).toBeRejectedWithError(ConnectError);
+    await expectAsync(interceptorPromise).toBeRejectedWith(
+      jasmine.any(CancellationError),
+    );
     expect(callCount).toBe(1);
   });
 
@@ -254,7 +257,9 @@ describe('retry.interceptor', () => {
       throw new ConnectError('502 Bad Gateway', Code.Unavailable);
     };
 
-    await expectAsync(interceptor(next)(req)).toBeRejected();
+    await expectAsync(interceptor(next)(req)).toBeRejectedWith(
+      jasmine.any(CancellationError),
+    );
     expect(callCount).toBe(1);
   });
 

--- a/web/src/app/services/api/retry.interceptor.ts
+++ b/web/src/app/services/api/retry.interceptor.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Interceptor } from '@connectrpc/connect';
+import {
+  calculateBackoffDelayMs,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_RETRY_BASE_DELAY_MS,
+  DEFAULT_RETRY_MAX_DELAY_MS,
+  delayWithSignal,
+  isRetryableError,
+} from 'src/app/services/api/retry-util';
+
+/**
+ * Set of unary RPC method names that are idempotent and safe to retry automatically upon transient errors.
+ * Chunk-level operations (GetInspectionDataChunk, UploadFileChunk, UploadInspectionChunk) are handled
+ * with higher retry limits by their dedicated uploader/downloader managers and excluded here to prevent double retries.
+ */
+export const DEFAULT_RETRYABLE_METHODS: ReadonlySet<string> = new Set([
+  'GetInspectionTypes',
+  'GetInspections',
+  'GetInspectionMetadata',
+  'GetInspectionFeatures',
+  'ReadStructYAMLs',
+  'GetArchitectureGraph',
+  'HeartbeatWorkbench',
+  'PullIndexProgress',
+  'PullServerStat',
+  'PullPopup',
+  'PullInspections',
+  'OpenWorkbenchSync',
+  'FilterTimelineSync',
+  'ValidateTimelineQuery',
+  'ValidateLogQuery',
+]);
+
+/**
+ * Configuration options for the Connect-RPC retry interceptor.
+ */
+export interface RetryInterceptorOptions {
+  /** Maximum number of retry attempts before giving up. Defaults to 3. */
+  readonly maxRetries?: number;
+
+  /** Base delay in milliseconds before the first retry attempt. Defaults to 500. */
+  readonly baseDelayMs?: number;
+
+  /** Maximum backoff delay in milliseconds. Defaults to 3000. */
+  readonly maxDelayMs?: number;
+
+  /** Set of RPC method names allowed to be retried. Defaults to DEFAULT_RETRYABLE_METHODS. */
+  readonly retryableMethods?: ReadonlySet<string>;
+}
+
+/**
+ * Creates a Connect-RPC interceptor that automatically retries idempotent unary RPCs on transient failures.
+ *
+ * Catches transient errors (such as HTTP 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout,
+ * and network connection drops) and executes exponential backoff retries.
+ *
+ * @param options Optional configuration for retry attempts, delays, and allowed method list.
+ * @returns A Connect-RPC Interceptor.
+ */
+export function createRetryInterceptor(
+  options?: RetryInterceptorOptions,
+): Interceptor {
+  const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = options?.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+  const maxDelayMs = options?.maxDelayMs ?? DEFAULT_RETRY_MAX_DELAY_MS;
+  const retryableMethods =
+    options?.retryableMethods ?? DEFAULT_RETRYABLE_METHODS;
+
+  return (next) => async (req) => {
+    // Only intercept and retry unary calls; streaming calls manage their own lifecycle
+    if (req.stream) {
+      return next(req);
+    }
+
+    const isMethodAllowed = retryableMethods.has(req.method.name);
+    if (!isMethodAllowed) {
+      return next(req);
+    }
+
+    let retryCount = 0;
+    while (true) {
+      if (req.signal?.aborted) {
+        return next(req);
+      }
+
+      try {
+        return await next(req);
+      } catch (err) {
+        retryCount++;
+        if (
+          retryCount > maxRetries ||
+          !isRetryableError(err) ||
+          req.signal?.aborted
+        ) {
+          throw err;
+        }
+
+        const delayMs = calculateBackoffDelayMs(
+          retryCount,
+          baseDelayMs,
+          maxDelayMs,
+        );
+        await delayWithSignal(delayMs, req.signal);
+
+        if (req.signal?.aborted) {
+          throw err;
+        }
+      }
+    }
+  };
+}

--- a/web/src/app/services/api/retry.interceptor.ts
+++ b/web/src/app/services/api/retry.interceptor.ts
@@ -23,6 +23,7 @@ import {
   delayWithSignal,
   isRetryableError,
 } from 'src/app/services/api/retry-util';
+import { CancellationError } from 'src/app/store/domain/filter/types';
 
 /**
  * Set of unary RPC method names that are idempotent and safe to retry automatically upon transient errors.
@@ -102,12 +103,12 @@ export function createRetryInterceptor(
       try {
         return await next(req);
       } catch (err) {
+        if (req.signal?.aborted) {
+          throw new CancellationError('The operation was aborted.');
+        }
+
         retryCount++;
-        if (
-          retryCount > maxRetries ||
-          !isRetryableError(err) ||
-          req.signal?.aborted
-        ) {
+        if (retryCount > maxRetries || !isRetryableError(err)) {
           throw err;
         }
 
@@ -119,7 +120,7 @@ export function createRetryInterceptor(
         await delayWithSignal(delayMs, req.signal);
 
         if (req.signal?.aborted) {
-          throw err;
+          throw new CancellationError('The operation was aborted.');
         }
       }
     }


### PR DESCRIPTION
## Summary

Adds automatic retry mechanisms across Connect-RPC unary calls, chunked file upload/download, and legacy polling to handle transient failures (HTTP 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout, and network connection drops).

### Key Changes

1. **Retry Interceptor (`retry.interceptor.ts`)**:
   - Implements `createRetryInterceptor` with exponential backoff and jitter.
   - Automatically retries idempotent unary RPCs on transient errors (`Code.Unavailable` and fetch errors).
   - Prevents double retries on chunked operations by delegating chunk-specific retries to their respective managers.
2. **Chunked Uploader (`chunked-uploader.ts`)**:
   - Retries failed chunk uploads up to 10 attempts (`DEFAULT_CHUNK_MAX_RETRIES = 10`) with backoff.
   - Fails immediately on non-retryable errors (e.g., 400 Bad Request) without unnecessary retries.
3. **Chunked Download (`backend-api.service.ts`)**:
   - Retries `getInspectionDataChunk` downloads up to 10 attempts (`DEFAULT_CHUNK_MAX_RETRIES = 10`) using RxJS `retry` and exponential backoff.
4. **Legacy Polling Interceptor (`legacy-polling.interceptor.ts`)**:
   - Reuses common `delayWithSignal` utility.
   - Tolerates up to 5 consecutive transient errors during `OpenWorkbench` and `FilterTimeline` polling before giving up.
   - Resets error counters upon successful poll response and aborts immediately on non-retryable errors.
5. **Unit Tests**:
   - Comprehensive test suite covering retry limits, exponential backoff with jitter, non-retryable errors, pre-aborted requests, and mid-delay cancellation.

## Verification

- `make test-web`: All 1,048 tests passed (`TOTAL: 1048 SUCCESS`).
- `make lint-web`: 0 issues.
- `make build-storybook`: Succeeded.
- `make build-web`: Succeeded.
- `make pre-commit`: Succeeded with 0 issues.