### PR TITLE
perf(web): migrate WebGL timeline rendering to IdBitset and optimize selection resolution

### DIFF
--- a/web/src/app/diff/diff-smart.component.ts
+++ b/web/src/app/diff/diff-smart.component.ts
@@ -168,8 +168,13 @@ export class DiffSmartComponent implements OnInit, OnDestroy {
     }
     const log = this.selectionManager.selectedLog();
     if (log) {
+      const logTimelineIds = new Set(
+        this.inspectionDataStore
+          .inspectionData()
+          ?.timelineStore.getTimelineIdsForLogId(log.id) ?? [],
+      );
       for (const t of this.selectionManager.selectedTimelinesWithChildren()) {
-        if (t.lookupRevisionFromLog(log) || t.lookupEventFromLog(log)) {
+        if (logTimelineIds.has(t.id)) {
           return t;
         }
       }

--- a/web/src/app/log/components/log-list.component.spec.ts
+++ b/web/src/app/log/components/log-list.component.spec.ts
@@ -21,6 +21,7 @@ import { Timeline } from 'src/app/store/domain/timeline';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 import { createMockInspectionData } from 'src/app/store/mock/inspection-data.mock';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 describe('LogListComponent', () => {
   let component: LogListComponent;
@@ -42,7 +43,11 @@ describe('LogListComponent', () => {
 
     // Set required inputs
     fixture.componentRef.setInput('allLogsCount', mockLogs.length);
-    fixture.componentRef.setInput('filteredLogs', mockLogs);
+    fixture.componentRef.setInput('allLogs', mockLogs);
+    fixture.componentRef.setInput(
+      'filteredLogIds',
+      IdBitset.fromAll(mockLogs.map((l) => l.id)),
+    );
     fixture.componentRef.setInput('selectedLogIndex', -1);
     fixture.componentRef.setInput('highlightLogIndices', new Set<number>());
     fixture.componentRef.setInput('selectedTimelinesWithChildren', []);

--- a/web/src/app/log/components/log-list.component.ts
+++ b/web/src/app/log/components/log-list.component.ts
@@ -34,6 +34,7 @@ import { CommonModule } from '@angular/common';
 import { Log } from 'src/app/store/domain/log';
 import { Timeline } from 'src/app/store/domain/timeline';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 import { LogViewLogLineComponent } from './log-view-log-line.component';
 import { IconToggleButtonComponent } from '../../shared/components/icon-toggle-button/icon-toggle-button.component';
 import { bisectLeft } from '../../common/misc-util';
@@ -63,8 +64,10 @@ class LogListScrollingStrategy extends FixedSizeVirtualScrollStrategy {
 export class LogListComponent {
   /** The total number of logs. */
   public readonly allLogsCount = input.required<number>();
-  /** The list of filtered log entries. */
-  public readonly filteredLogs = input.required<ReadonlyDomainElement<Log>[]>();
+  /** The list of all log entries in chronological order. */
+  public readonly allLogs = input.required<ReadonlyDomainElement<Log>[]>();
+  /** The bitset of filtered active log IDs. */
+  public readonly filteredLogIds = input.required<IdBitset>();
   /** The index of the currently selected log. */
   public readonly selectedLogIndex = input.required<number>();
   /** The set of indices of highlighted logs. */
@@ -86,12 +89,38 @@ export class LogListComponent {
   private readonly viewPort = viewChild(CdkVirtualScrollViewport);
 
   protected readonly shownLogs = computed(() => {
-    const logs = this.filteredLogs();
+    const allLogs = this.allLogs();
+    const filterLogIds = this.filteredLogIds();
     const filterByTimeline = this.filterByTimeline();
     const timelines = this.selectedTimelinesWithChildren();
 
-    if (!filterByTimeline || !timelines || timelines.length === 0) return logs;
-    return this.filterLogsWithTimelines(logs, timelines);
+    const timelineFilterActive =
+      filterByTimeline && timelines && timelines.length > 0;
+
+    let timelineLogIndices: Set<number> | null = null;
+    if (timelineFilterActive) {
+      timelineLogIndices = new Set<number>();
+      for (const timeline of timelines) {
+        for (const revision of timeline.revisions) {
+          timelineLogIndices.add(revision.logIndex);
+        }
+        for (const event of timeline.events) {
+          timelineLogIndices.add(event.logIndex);
+        }
+      }
+    }
+
+    const result: ReadonlyDomainElement<Log>[] = [];
+    for (const log of allLogs) {
+      if (!filterLogIds.has(log.id)) {
+        continue;
+      }
+      if (timelineLogIndices && !timelineLogIndices.has(log.logIndex)) {
+        continue;
+      }
+      result.push(log);
+    }
+    return result;
   });
 
   protected readonly shownLogsCount = computed(() => this.shownLogs().length);
@@ -172,28 +201,6 @@ export class LogListComponent {
       // automatically scrolls to the newly selected log.
       this.logSelected.emit(logs[nextArrayIndex]);
     }
-  }
-
-  private filterLogsWithTimelines(
-    logs: ReadonlyDomainElement<Log>[],
-    timelines: ReadonlyDomainElement<Timeline>[],
-  ): ReadonlyDomainElement<Log>[] {
-    const logIndices = new Set<number>();
-    for (const timeline of timelines) {
-      for (const revision of timeline.revisions) {
-        logIndices.add(revision.logIndex);
-      }
-      for (const event of timeline.events) {
-        logIndices.add(event.logIndex);
-      }
-    }
-    const result: ReadonlyDomainElement<Log>[] = [];
-    for (const log of logs) {
-      if (logIndices.has(log.logIndex)) {
-        result.push(log);
-      }
-    }
-    return result;
   }
 
   private searchArrayIndexOfLog(

--- a/web/src/app/log/components/log-list.component.ts
+++ b/web/src/app/log/components/log-list.component.ts
@@ -100,17 +100,17 @@ export class LogListComponent {
 
         for (const timeline of timelines) {
           for (const revision of timeline.revisions) {
-            const log = revision.log;
-            if (!seenLogIds.has(log.id) && filterLogIds.has(log.id)) {
-              seenLogIds.add(log.id);
-              matchedLogs.push(log);
+            const logId = revision.logId;
+            if (!seenLogIds.has(logId) && filterLogIds.has(logId)) {
+              seenLogIds.add(logId);
+              matchedLogs.push(revision.log);
             }
           }
           for (const event of timeline.events) {
-            const log = event.log;
-            if (!seenLogIds.has(log.id) && filterLogIds.has(log.id)) {
-              seenLogIds.add(log.id);
-              matchedLogs.push(log);
+            const logId = event.logId;
+            if (!seenLogIds.has(logId) && filterLogIds.has(logId)) {
+              seenLogIds.add(logId);
+              matchedLogs.push(event.log);
             }
           }
         }

--- a/web/src/app/log/components/log-list.component.ts
+++ b/web/src/app/log/components/log-list.component.ts
@@ -89,36 +89,42 @@ export class LogListComponent {
   private readonly viewPort = viewChild(CdkVirtualScrollViewport);
 
   protected readonly shownLogs = computed(() => {
-    const allLogs = this.allLogs();
-    const filterLogIds = this.filteredLogIds();
     const filterByTimeline = this.filterByTimeline();
-    const timelines = this.selectedTimelinesWithChildren();
+    const filterLogIds = this.filteredLogIds();
 
-    const timelineFilterActive =
-      filterByTimeline && timelines && timelines.length > 0;
+    if (filterByTimeline) {
+      const timelines = this.selectedTimelinesWithChildren();
+      if (timelines && timelines.length > 0) {
+        const seenLogIds = new Set<number>();
+        const matchedLogs: ReadonlyDomainElement<Log>[] = [];
 
-    let timelineLogIndices: Set<number> | null = null;
-    if (timelineFilterActive) {
-      timelineLogIndices = new Set<number>();
-      for (const timeline of timelines) {
-        for (const revision of timeline.revisions) {
-          timelineLogIndices.add(revision.logIndex);
+        for (const timeline of timelines) {
+          for (const revision of timeline.revisions) {
+            const log = revision.log;
+            if (!seenLogIds.has(log.id) && filterLogIds.has(log.id)) {
+              seenLogIds.add(log.id);
+              matchedLogs.push(log);
+            }
+          }
+          for (const event of timeline.events) {
+            const log = event.log;
+            if (!seenLogIds.has(log.id) && filterLogIds.has(log.id)) {
+              seenLogIds.add(log.id);
+              matchedLogs.push(log);
+            }
+          }
         }
-        for (const event of timeline.events) {
-          timelineLogIndices.add(event.logIndex);
-        }
+        matchedLogs.sort((a, b) => a.logIndex - b.logIndex);
+        return matchedLogs;
       }
     }
 
+    const allLogs = this.allLogs();
     const result: ReadonlyDomainElement<Log>[] = [];
     for (const log of allLogs) {
-      if (!filterLogIds.has(log.id)) {
-        continue;
+      if (filterLogIds.has(log.id)) {
+        result.push(log);
       }
-      if (timelineLogIndices && !timelineLogIndices.has(log.logIndex)) {
-        continue;
-      }
-      result.push(log);
     }
     return result;
   });

--- a/web/src/app/log/components/log-list.stories.ts
+++ b/web/src/app/log/components/log-list.stories.ts
@@ -17,6 +17,9 @@
 import { Meta, StoryObj } from '@storybook/angular';
 import { LogListComponent } from './log-list.component';
 import { createMockInspectionData } from 'src/app/store/mock/inspection-data.mock';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
+import { Log } from 'src/app/store/domain/log';
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 
 const meta: Meta<LogListComponent> = {
   title: 'Log/LogList',
@@ -42,17 +45,22 @@ export const Default: Story = {
     }),
   ],
   render: (args, { loaded: { mockData } }) => {
-    const filteredLogs = Array.from(mockData.logStore.logs());
+    const allLogs = Array.from(
+      mockData.logStore.logs(),
+    ) as ReadonlyDomainElement<Log>[];
+    const filteredLogIds = IdBitset.fromAll(allLogs.map((l) => l.id));
     return {
       props: {
         ...args,
-        filteredLogs,
+        allLogs,
+        filteredLogIds,
       },
       template: `
         <div style="height: 500px; border: 1px solid #ccc; position: relative;">
           <khi-log-list
             [allLogsCount]="allLogsCount"
-            [filteredLogs]="filteredLogs"
+            [allLogs]="allLogs"
+            [filteredLogIds]="filteredLogIds"
             [selectedLogIndex]="selectedLogIndex"
             [highlightLogIndices]="highlightLogIndices"
             [selectedTimelinesWithChildren]="selectedTimelinesWithChildren"

--- a/web/src/app/log/log-smart.component.html
+++ b/web/src/app/log/log-smart.component.html
@@ -19,7 +19,8 @@
     <as-split-area size="50">
       <khi-log-list
         [allLogsCount]="allLogsCount()"
-        [filteredLogs]="filteredLogs()"
+        [allLogs]="allLogs()"
+        [filteredLogIds]="filteredLogIds()"
         [selectedLogIndex]="selectedLogIndex()"
         [highlightLogIndices]="highlightLogIndices()"
         [selectedTimelinesWithChildren]="selectedTimelinesWithChildren()"

--- a/web/src/app/log/log-smart.component.ts
+++ b/web/src/app/log/log-smart.component.ts
@@ -182,10 +182,18 @@ export class LogSmartComponent {
         return null;
       }
 
-      const timelines =
-        this.inspectionDataStore.timelineView()?.filteredTimelines() ?? [];
+      const data = this.inspectionDataStore.inspectionData();
+      const filteredTimelineIds = this.inspectionDataStore
+        .timelineView()
+        ?.filteredTimelineIds();
+      const logTimelines =
+        data?.timelineStore.getTimelinesForLogId(log.id) ?? [];
+
       const resourceRefs: ResourceRefAnnotationViewModel[] = [];
-      for (const timeline of timelines) {
+      for (const timeline of logTimelines) {
+        if (filteredTimelineIds && !filteredTimelineIds.has(timeline.id)) {
+          continue;
+        }
         if (
           timeline.lookupEventFromLog(log) !== null ||
           timeline.lookupRevisionFromLog(log) !== null

--- a/web/src/app/log/log-smart.component.ts
+++ b/web/src/app/log/log-smart.component.ts
@@ -36,6 +36,7 @@ import {
   ViewStateService,
 } from 'src/app/services/view-state.service';
 import { StyleOverrideService } from 'src/app/services/style-override.service';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * `LogSmartComponent` is the main container for the log viewing interface.
@@ -99,10 +100,24 @@ export class LogSmartComponent {
   public readonly selectedLog = this.selectionManager.selectedLog;
 
   /**
-   * The list of logs that match the current filter criteria.
+   * The list of all logs in the inspection data.
    */
-  public readonly filteredLogs = computed<ReadonlyDomainElement<Log>[]>(() => {
-    return this.inspectionDataStore.timelineView()?.filteredLogs() ?? [];
+  public readonly allLogs = computed<ReadonlyDomainElement<Log>[]>(() => {
+    const logStore = this.inspectionDataStore.inspectionData()?.logStore;
+    if (!logStore) {
+      return [];
+    }
+    return Array.from(logStore.logs());
+  });
+
+  /**
+   * The bitset of log IDs that match the current filter criteria.
+   */
+  public readonly filteredLogIds = computed<IdBitset>(() => {
+    return (
+      this.inspectionDataStore.timelineView()?.filteredLogIds() ??
+      IdBitset.createEmpty()
+    );
   });
 
   /**

--- a/web/src/app/services/selection-manager.service.ts
+++ b/web/src/app/services/selection-manager.service.ts
@@ -30,12 +30,6 @@ export class SelectionManager {
   // Writable signals representing internal state.
   private readonly selectedLogId = signal<number | null>(null);
   private readonly highlightedLogIds = signal<Set<number>>(new Set<number>());
-  /**
-   * Computes all timelines available in the current inspection data.
-   */
-  private readonly filteredTimelines = computed<
-    ReadonlyDomainElement<Timeline[]>
-  >(() => this.inspectionDataStore.timelineView()?.filteredTimelines() ?? []);
 
   /**
    * Holds the currently selected timeline.
@@ -152,9 +146,7 @@ export class SelectionManager {
     computed<ReadonlyDomainElement<Revision> | null>(() => {
       const revision = this.selectedRevision();
       if (revision === null) return null;
-      const timeline = revision.timeline;
-      const revisionIndex = timeline.revisions.indexOf(revision);
-      return revisionIndex > 0 ? timeline.revisions[revisionIndex - 1] : null;
+      return revision.prev;
     });
 
   /**
@@ -178,14 +170,8 @@ export class SelectionManager {
   >(() => {
     const selectedTimeline = this.selectedTimeline();
     const includeChildren = this.timelineSelectionShouldIncludeChildren();
-    const allTimelines = this.filteredTimelines();
     if (!includeChildren || selectedTimeline === null) return new Set();
-    for (const timeline of allTimelines) {
-      if (timeline === selectedTimeline) {
-        return new Set(timeline.descendants());
-      }
-    }
-    return new Set();
+    return new Set(selectedTimeline.descendants());
   });
 
   /**
@@ -225,40 +211,52 @@ export class SelectionManager {
       return;
     }
 
+    this.selectedLogId.set(log.id);
+
+    const timelineStore =
+      this.inspectionDataStore.inspectionData()?.timelineStore;
+    if (!timelineStore) {
+      this.selectedRevision.set(null);
+      return;
+    }
+
+    const logTimelines = timelineStore.getTimelinesForLogId(log.id);
+    if (logTimelines.length === 0) {
+      this.selectedRevision.set(null);
+      return;
+    }
+
     const currentTimelines = this.selectedTimelinesWithChildren();
 
     // When a timeline is already selected, prioritize searching within that timeline and its children.
     if (currentTimelines.length > 0) {
-      for (const timeline of currentTimelines) {
-        const revision = timeline.lookupRevisionFromLog(log);
-        if (revision) {
-          this.selectedLogId.set(log.id);
-          this.selectedRevision.set(revision);
-          return;
-        }
-        const event = timeline.lookupEventFromLog(log);
-        if (event) {
-          this.selectedLogId.set(log.id);
-          this.selectedRevision.set(null);
-          return;
+      const currentTimelineIds = new Set(currentTimelines.map((t) => t.id));
+      for (const timeline of logTimelines) {
+        if (currentTimelineIds.has(timeline.id)) {
+          const revision = timeline.lookupRevisionFromLog(log);
+          if (revision) {
+            this.selectedRevision.set(revision);
+            return;
+          }
+          const event = timeline.lookupEventFromLog(log);
+          if (event) {
+            this.selectedRevision.set(null);
+            return;
+          }
         }
       }
     }
 
     // When no timeline is selected or the log is not found in the currently selected timelines,
-    // automatically select the first timeline containing the log.
-    this.selectedLogId.set(log.id);
-    for (const timeline of this.filteredTimelines()) {
-      const revision = timeline.lookupRevisionFromLog(log);
-      if (revision) {
+    // automatically select the first visible timeline containing the log.
+    const filteredTimelineIds =
+      this.inspectionDataStore.timelineView()?.filteredTimelineIds();
+
+    for (const timeline of logTimelines) {
+      if (!filteredTimelineIds || filteredTimelineIds.has(timeline.id)) {
         this.selectedTimeline.set(timeline);
+        const revision = timeline.lookupRevisionFromLog(log);
         this.selectedRevision.set(revision);
-        return;
-      }
-      const event = timeline.lookupEventFromLog(log);
-      if (event) {
-        this.selectedTimeline.set(timeline);
-        this.selectedRevision.set(null);
         return;
       }
     }
@@ -302,15 +300,22 @@ export class SelectionManager {
     const log = this.selectedLog();
     const revision = this.selectedRevision();
     const validTimelines = this.selectedTimelinesWithChildren();
+    const validTimelineIds = new Set(validTimelines.map((t) => t.id));
+
+    const timelineStore =
+      this.inspectionDataStore.inspectionData()?.timelineStore;
 
     const isLogValid =
       !log ||
-      validTimelines.some(
-        (t) => t.lookupRevisionFromLog(log) || t.lookupEventFromLog(log),
-      );
+      (timelineStore
+        ? timelineStore
+            .getTimelineIdsForLogId(log.id)
+            .some((id) => validTimelineIds.has(id))
+        : validTimelines.some(
+            (t) => t.lookupRevisionFromLog(log) || t.lookupEventFromLog(log),
+          ));
     const isRevisionValid =
-      !revision ||
-      validTimelines.some((t) => t.lookupRevisionFromLog(revision.log));
+      !revision || validTimelineIds.has(revision.timelineId);
 
     if (!isLogValid) {
       this.selectedLogId.set(null);

--- a/web/src/app/services/selection-manager.service.ts
+++ b/web/src/app/services/selection-manager.service.ts
@@ -249,8 +249,9 @@ export class SelectionManager {
 
     // When no timeline is selected or the log is not found in the currently selected timelines,
     // automatically select the first visible timeline containing the log.
-    const filteredTimelineIds =
-      this.inspectionDataStore.timelineView()?.filteredTimelineIds();
+    const filteredTimelineIds = this.inspectionDataStore
+      .timelineView()
+      ?.filteredTimelineIds();
 
     for (const timeline of logTimelines) {
       if (!filteredTimelineIds || filteredTimelineIds.has(timeline.id)) {

--- a/web/src/app/services/selection-manager.service.ts
+++ b/web/src/app/services/selection-manager.service.ts
@@ -226,33 +226,52 @@ export class SelectionManager {
       return;
     }
 
-    const currentTimelines = this.selectedTimelinesWithChildren();
-
-    // When a timeline is already selected, prioritize searching within that timeline and its children.
-    if (currentTimelines.length > 0) {
-      const currentTimelineIds = new Set(currentTimelines.map((t) => t.id));
-      for (const timeline of logTimelines) {
-        if (currentTimelineIds.has(timeline.id)) {
-          const revision = timeline.lookupRevisionFromLog(log);
-          if (revision) {
-            this.selectedRevision.set(revision);
-            return;
-          }
-          const event = timeline.lookupEventFromLog(log);
-          if (event) {
-            this.selectedRevision.set(null);
-            return;
-          }
-        }
-      }
-    }
-
-    // When no timeline is selected or the log is not found in the currently selected timelines,
-    // automatically select the first visible timeline containing the log.
     const filteredTimelineIds = this.inspectionDataStore
       .timelineView()
       ?.filteredTimelineIds();
 
+    const selectedTimeline = this.selectedTimeline();
+    const currentTimelines = this.selectedTimelinesWithChildren();
+
+    // Priority 1: Check the main selected timeline first if it is visible.
+    if (
+      selectedTimeline &&
+      (!filteredTimelineIds || filteredTimelineIds.has(selectedTimeline.id))
+    ) {
+      const revision = selectedTimeline.lookupRevisionFromLog(log);
+      if (revision) {
+        this.selectedRevision.set(revision);
+        return;
+      }
+      const event = selectedTimeline.lookupEventFromLog(log);
+      if (event) {
+        this.selectedRevision.set(null);
+        return;
+      }
+    }
+
+    // Priority 2: Check descendant timelines of the selected timeline (if visible).
+    if (currentTimelines.length > 1) {
+      for (const timeline of currentTimelines) {
+        if (timeline === selectedTimeline) continue;
+        if (filteredTimelineIds && !filteredTimelineIds.has(timeline.id)) {
+          continue;
+        }
+        const revision = timeline.lookupRevisionFromLog(log);
+        if (revision) {
+          this.selectedRevision.set(revision);
+          return;
+        }
+        const event = timeline.lookupEventFromLog(log);
+        if (event) {
+          this.selectedRevision.set(null);
+          return;
+        }
+      }
+    }
+
+    // Priority 3: When no timeline is selected or the log is not found in the currently selected timelines,
+    // automatically select the first visible timeline containing the log.
     for (const timeline of logTimelines) {
       if (!filteredTimelineIds || filteredTimelineIds.has(timeline.id)) {
         this.selectedTimeline.set(timeline);
@@ -303,20 +322,15 @@ export class SelectionManager {
     const validTimelines = this.selectedTimelinesWithChildren();
     const validTimelineIds = new Set(validTimelines.map((t) => t.id));
 
-    const timelineStore =
-      this.inspectionDataStore.inspectionData()?.timelineStore;
-
-    const isLogValid =
-      !log ||
-      (timelineStore
-        ? timelineStore
-            .getTimelineIdsForLogId(log.id)
-            .some((id) => validTimelineIds.has(id))
-        : validTimelines.some(
-            (t) => t.lookupRevisionFromLog(log) || t.lookupEventFromLog(log),
-          ));
-    const isRevisionValid =
-      !revision || validTimelineIds.has(revision.timelineId);
+    const isLogValid = this.isSelectedLogValid(
+      log,
+      validTimelineIds,
+      validTimelines,
+    );
+    const isRevisionValid = this.isSelectedRevisionValid(
+      revision,
+      validTimelineIds,
+    );
 
     if (!isLogValid) {
       this.selectedLogId.set(null);
@@ -324,5 +338,37 @@ export class SelectionManager {
     } else if (!isRevisionValid) {
       this.selectedRevision.set(null);
     }
+  }
+
+  /**
+   * Checks whether the currently selected log is still valid within the active timeline selection.
+   */
+  private isSelectedLogValid(
+    log: ReadonlyDomainElement<Log> | null,
+    validTimelineIds: Set<number>,
+    validTimelines: ReadonlyDomainElement<Timeline>[],
+  ): boolean {
+    if (!log) return true;
+    const timelineStore =
+      this.inspectionDataStore.inspectionData()?.timelineStore;
+    if (timelineStore) {
+      return timelineStore
+        .getTimelineIdsForLogId(log.id)
+        .some((id) => validTimelineIds.has(id));
+    }
+    return validTimelines.some(
+      (t) => t.lookupRevisionFromLog(log) || t.lookupEventFromLog(log),
+    );
+  }
+
+  /**
+   * Checks whether the currently selected revision is still valid within the active timeline selection.
+   */
+  private isSelectedRevisionValid(
+    revision: ReadonlyDomainElement<Revision> | null,
+    validTimelineIds: Set<number>,
+  ): boolean {
+    if (!revision) return true;
+    return validTimelineIds.has(revision.timelineId);
   }
 }

--- a/web/src/app/services/struct-yaml-prefetch.service.spec.ts
+++ b/web/src/app/services/struct-yaml-prefetch.service.spec.ts
@@ -23,6 +23,7 @@ import { WorkbenchClientService } from 'src/app/services/api/workbench/workbench
 import { Timeline, Revision, Event } from 'src/app/store/domain/timeline';
 import { Log } from 'src/app/store/domain/log';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 describe('StructYamlPrefetchService', () => {
   let service: StructYamlPrefetchService;
@@ -30,7 +31,15 @@ describe('StructYamlPrefetchService', () => {
   let mockSelectedTimeline: WritableSignal<ReadonlyDomainElement<Timeline> | null>;
   let mockSelectedRevision: WritableSignal<ReadonlyDomainElement<Revision> | null>;
   let mockSelectedLog: WritableSignal<ReadonlyDomainElement<Log> | null>;
-  let mockFilteredLogs: WritableSignal<ReadonlyDomainElement<Log>[]>;
+  let mockSelectedTimelinesWithChildren: WritableSignal<
+    ReadonlyDomainElement<Timeline>[]
+  >;
+  let mockFilteredLogIds: WritableSignal<IdBitset>;
+  let mockLogStore: {
+    count: number;
+    getLogIdByIndex: (idx: number) => number;
+    _getBodyStructId: (id: number) => number;
+  };
 
   function createMockLog(
     id: number,
@@ -59,6 +68,8 @@ describe('StructYamlPrefetchService', () => {
       index,
       changedTime,
       structId,
+      logId: log.id,
+      logIndex: log.logIndex,
       log,
       timeline,
     } as unknown as ReadonlyDomainElement<Revision>;
@@ -72,6 +83,8 @@ describe('StructYamlPrefetchService', () => {
     return {
       id,
       timestamp,
+      logId: log.id,
+      logIndex: log.logIndex,
       log,
     } as unknown as ReadonlyDomainElement<Event>;
   }
@@ -95,7 +108,15 @@ describe('StructYamlPrefetchService', () => {
     mockSelectedTimeline = signal<ReadonlyDomainElement<Timeline> | null>(null);
     mockSelectedRevision = signal<ReadonlyDomainElement<Revision> | null>(null);
     mockSelectedLog = signal<ReadonlyDomainElement<Log> | null>(null);
-    mockFilteredLogs = signal<ReadonlyDomainElement<Log>[]>([]);
+    mockSelectedTimelinesWithChildren = signal<
+      ReadonlyDomainElement<Timeline>[]
+    >([]);
+    mockFilteredLogIds = signal<IdBitset>(IdBitset.createEmpty());
+    mockLogStore = {
+      count: 0,
+      getLogIdByIndex: (idx: number) => idx + 1,
+      _getBodyStructId: (id: number) => 200 + (id - 1),
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -110,13 +131,17 @@ describe('StructYamlPrefetchService', () => {
             selectedTimeline: mockSelectedTimeline,
             selectedRevision: mockSelectedRevision,
             selectedLog: mockSelectedLog,
+            selectedTimelinesWithChildren: mockSelectedTimelinesWithChildren,
           },
         },
         {
           provide: InspectionDataStore,
           useValue: {
+            inspectionData: signal({
+              logStore: mockLogStore,
+            }),
             timelineView: signal({
-              filteredLogs: mockFilteredLogs,
+              filteredLogIds: mockFilteredLogIds,
             }),
           },
         },
@@ -264,15 +289,12 @@ describe('StructYamlPrefetchService', () => {
   });
 
   describe('prefetchSurroundingLogs', () => {
-    it('should prefetch logs surrounding the selected log in filteredLogs', () => {
-      const logs: ReadonlyDomainElement<Log>[] = [];
-      for (let i = 0; i < 50; i++) {
-        logs.push(createMockLog(i + 1, i, BigInt(i * 10), 200 + i));
-      }
-      mockFilteredLogs.set(logs);
+    it('should prefetch surrounding logs in LogStore when no timeline is selected', () => {
+      mockLogStore.count = 50;
+      mockFilteredLogIds.set(IdBitset.fromSequential(50));
 
-      // Select log at index 25
-      const selectedLog = logs[25];
+      // Select log at index 25 (id: 26, structId: 225)
+      const selectedLog = createMockLog(26, 25, 250n, 225);
       service.prefetchSurroundingLogs(selectedLog);
 
       expect(mockWorkbenchClient.prefetchStructYAMLs).toHaveBeenCalledTimes(1);
@@ -288,14 +310,39 @@ describe('StructYamlPrefetchService', () => {
       expect(callArgs).not.toContain(246);
     });
 
-    it('should do nothing if selected log is not in filteredLogs', () => {
-      const logs = [createMockLog(1, 0, 100n, 10)];
-      mockFilteredLogs.set(logs);
+    it('should prefetch surrounding items on selected timeline when timeline is selected', () => {
+      const mockTimeline = { id: 1 } as ReadonlyDomainElement<Timeline>;
+      const revisions: ReadonlyDomainElement<Revision>[] = [];
+      for (let i = 0; i < 30; i++) {
+        const log = createMockLog(i + 1, i, BigInt(i * 10), 0);
+        revisions.push(
+          createMockRevision(
+            i + 1,
+            i,
+            BigInt(i * 10),
+            300 + i,
+            log,
+            mockTimeline,
+          ),
+        );
+      }
+      const timeline = createMockTimeline(1, revisions);
+      mockSelectedTimelinesWithChildren.set([timeline]);
+      mockFilteredLogIds.set(IdBitset.fromSequential(30));
 
-      const unlistedLog = createMockLog(99, 99, 9900n, 990);
-      service.prefetchSurroundingLogs(unlistedLog);
+      // Select log at index 15
+      const selectedLog = createMockLog(16, 15, 150n, 0);
+      service.prefetchSurroundingLogs(selectedLog);
 
-      expect(mockWorkbenchClient.prefetchStructYAMLs).not.toHaveBeenCalled();
+      expect(mockWorkbenchClient.prefetchStructYAMLs).toHaveBeenCalledTimes(1);
+      const callArgs =
+        mockWorkbenchClient.prefetchStructYAMLs.calls.mostRecent()
+          .args[0] as number[];
+
+      // Surrounding revisions around index 15 (radius 20): from index 0 to 29 (structIds 300 to 329)
+      expect(callArgs).toContain(300);
+      expect(callArgs).toContain(315);
+      expect(callArgs).toContain(329);
     });
   });
 
@@ -334,7 +381,10 @@ describe('StructYamlPrefetchService', () => {
 
     it('should trigger prefetchSurroundingLogs when selectedLog signal updates', async () => {
       const log = createMockLog(1, 0, 100n, 888);
-      mockFilteredLogs.set([log]);
+      mockLogStore.count = 1;
+      mockLogStore.getLogIdByIndex = () => 1;
+      mockLogStore._getBodyStructId = () => 888;
+      mockFilteredLogIds.set(IdBitset.fromAll([log.id]));
 
       mockSelectedLog.set(log);
       TestBed.flushEffects();

--- a/web/src/app/services/struct-yaml-prefetch.service.spec.ts
+++ b/web/src/app/services/struct-yaml-prefetch.service.spec.ts
@@ -38,7 +38,7 @@ describe('StructYamlPrefetchService', () => {
   let mockLogStore: {
     count: number;
     getLogIdByIndex: (idx: number) => number;
-    _getBodyStructId: (id: number) => number;
+    getBodyStructId: (id: number) => number;
   };
 
   function createMockLog(
@@ -115,7 +115,7 @@ describe('StructYamlPrefetchService', () => {
     mockLogStore = {
       count: 0,
       getLogIdByIndex: (idx: number) => idx + 1,
-      _getBodyStructId: (id: number) => 200 + (id - 1),
+      getBodyStructId: (id: number) => 200 + (id - 1),
     };
 
     TestBed.configureTestingModule({
@@ -383,7 +383,7 @@ describe('StructYamlPrefetchService', () => {
       const log = createMockLog(1, 0, 100n, 888);
       mockLogStore.count = 1;
       mockLogStore.getLogIdByIndex = () => 1;
-      mockLogStore._getBodyStructId = () => 888;
+      mockLogStore.getBodyStructId = () => 888;
       mockFilteredLogIds.set(IdBitset.fromAll([log.id]));
 
       mockSelectedLog.set(log);

--- a/web/src/app/services/struct-yaml-prefetch.service.ts
+++ b/web/src/app/services/struct-yaml-prefetch.service.ts
@@ -32,7 +32,7 @@ interface TimelineItemWithStructId {
 
 interface SurroundingCandidate {
   readonly logIndex: number;
-  readonly structId: number;
+  readonly structIds: readonly number[];
 }
 
 /**
@@ -260,7 +260,7 @@ export class StructYamlPrefetchService {
           timeline.revisions,
           targetLogIndex,
           filteredLogIds,
-          (rev) => [rev.structId, rev.log?.structId ?? 0],
+          (rev) => [rev.structId, logStore.getBodyStructId(rev.logId)],
           backwardCandidates,
           forwardCandidates,
         );
@@ -268,7 +268,7 @@ export class StructYamlPrefetchService {
           timeline.events,
           targetLogIndex,
           filteredLogIds,
-          (evt) => [evt.log?.structId ?? 0],
+          (evt) => [logStore.getBodyStructId(evt.logId)],
           backwardCandidates,
           forwardCandidates,
         );
@@ -317,7 +317,7 @@ export class StructYamlPrefetchService {
       const id = logStore.getLogIdByIndex(i);
       if (filteredLogIds.has(id)) {
         backwardCount++;
-        const structId = logStore._getBodyStructId(id);
+        const structId = logStore.getBodyStructId(id);
         if (structId > 0) {
           structIds.add(structId);
         }
@@ -333,7 +333,7 @@ export class StructYamlPrefetchService {
       const id = logStore.getLogIdByIndex(i);
       if (filteredLogIds.has(id)) {
         forwardCount++;
-        const structId = logStore._getBodyStructId(id);
+        const structId = logStore.getBodyStructId(id);
         if (structId > 0) {
           structIds.add(structId);
         }
@@ -376,10 +376,12 @@ export class StructYamlPrefetchService {
     for (let i = idx - 1; i >= startBackward; i--) {
       const item = items[i];
       if (filteredLogIds.has(item.logId)) {
-        for (const structId of getStructIds(item)) {
-          if (structId > 0) {
-            backwardCandidates.push({ logIndex: item.logIndex, structId });
-          }
+        const candidateStructIds = getStructIds(item).filter((id) => id > 0);
+        if (candidateStructIds.length > 0) {
+          backwardCandidates.push({
+            logIndex: item.logIndex,
+            structIds: candidateStructIds,
+          });
         }
       }
     }
@@ -389,10 +391,12 @@ export class StructYamlPrefetchService {
     for (let i = idx; i < endForward; i++) {
       const item = items[i];
       if (filteredLogIds.has(item.logId)) {
-        for (const structId of getStructIds(item)) {
-          if (structId > 0) {
-            forwardCandidates.push({ logIndex: item.logIndex, structId });
-          }
+        const candidateStructIds = getStructIds(item).filter((id) => id > 0);
+        if (candidateStructIds.length > 0) {
+          forwardCandidates.push({
+            logIndex: item.logIndex,
+            structIds: candidateStructIds,
+          });
         }
       }
     }
@@ -415,7 +419,9 @@ export class StructYamlPrefetchService {
     candidates.sort(compareFn);
     const top = candidates.slice(0, limit);
     for (const item of top) {
-      structIds.add(item.structId);
+      for (const id of item.structIds) {
+        structIds.add(id);
+      }
     }
   }
 }

--- a/web/src/app/services/struct-yaml-prefetch.service.ts
+++ b/web/src/app/services/struct-yaml-prefetch.service.ts
@@ -20,11 +20,18 @@ import { InspectionDataStore } from 'src/app/services/inspection-data-store.serv
 import { WorkbenchClientService } from 'src/app/services/api/workbench/workbench-client.service';
 import { Timeline, Revision } from 'src/app/store/domain/timeline';
 import { Log } from 'src/app/store/domain/log';
+import { LogStore } from 'src/app/store/domain/log-store';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { bisectLeft } from 'src/app/common/misc-util';
 
 interface TimelineItemWithStructId {
   readonly timestamp: bigint;
+  readonly structId: number;
+}
+
+interface SurroundingCandidate {
+  readonly logIndex: number;
   readonly structId: number;
 }
 
@@ -208,50 +215,207 @@ export class StructYamlPrefetchService {
   }
 
   /**
-   * Prefetches the struct IDs of logs surrounding the selected log in the filtered logs list.
+   * Prefetches the struct IDs of logs surrounding the selected log.
    *
    * @param log The currently selected log.
    */
   public prefetchSurroundingLogs(log: ReadonlyDomainElement<Log>): void {
-    const filteredLogs =
-      this.inspectionDataStore.timelineView()?.filteredLogs() ?? [];
-    if (filteredLogs.length === 0) {
+    const data = this.inspectionDataStore.inspectionData();
+    const timelineView = this.inspectionDataStore.timelineView();
+    if (!data || !timelineView) {
       return;
     }
 
+    const logStore = data.logStore;
+    const filteredLogIds = timelineView.filteredLogIds();
+    const selectedTimelines =
+      this.selectionManager.selectedTimelinesWithChildren();
     const targetLogIndex = log.logIndex;
-    const arrayIndex = bisectLeft(
-      filteredLogs,
-      targetLogIndex,
-      (item, target) => item.logIndex - target,
-    );
+    const structIds = new Set<number>();
 
-    const matchIndex =
-      arrayIndex < filteredLogs.length &&
-      filteredLogs[arrayIndex].logIndex === targetLogIndex
-        ? arrayIndex
-        : -1;
-
-    if (matchIndex === -1) {
-      return;
+    // Include the selected log's struct ID if available
+    if (log.structId > 0) {
+      structIds.add(log.structId);
     }
 
-    const [startIndex, endIndex] = this.getSurroundingRange(
-      matchIndex,
-      StructYamlPrefetchService.PREFETCH_SURROUNDING_LOGS_RADIUS,
-      filteredLogs.length,
-    );
+    const radius = StructYamlPrefetchService.PREFETCH_SURROUNDING_LOGS_RADIUS;
 
-    const structIds = new Set<number>();
-    for (let i = startIndex; i < endIndex; i++) {
-      const structId = filteredLogs[i].structId;
-      if (structId > 0) {
-        structIds.add(structId);
+    if (selectedTimelines.length === 0) {
+      // Pass 1: Timeline filter is OFF. Search directly within LogStore around targetLogIndex.
+      this.collectSurroundingLogStoreStructIds(
+        logStore,
+        targetLogIndex,
+        filteredLogIds,
+        radius,
+        structIds,
+      );
+    } else {
+      // Pass 2: Timeline filter is ON.
+      // Collect surrounding items from revisions and events for all selected timelines.
+      const backwardCandidates: SurroundingCandidate[] = [];
+      const forwardCandidates: SurroundingCandidate[] = [];
+
+      for (const timeline of selectedTimelines) {
+        this.collectSurroundingTimelineItemCandidates(
+          timeline.revisions,
+          targetLogIndex,
+          filteredLogIds,
+          (rev) => [rev.structId, rev.log?.structId ?? 0],
+          backwardCandidates,
+          forwardCandidates,
+        );
+        this.collectSurroundingTimelineItemCandidates(
+          timeline.events,
+          targetLogIndex,
+          filteredLogIds,
+          (evt) => [evt.log?.structId ?? 0],
+          backwardCandidates,
+          forwardCandidates,
+        );
       }
+
+      // Add nearest backward candidates (descending logIndex order)
+      this.addTopCandidates(
+        backwardCandidates,
+        (a, b) => b.logIndex - a.logIndex,
+        radius,
+        structIds,
+      );
+
+      // Add nearest forward candidates (ascending logIndex order)
+      this.addTopCandidates(
+        forwardCandidates,
+        (a, b) => a.logIndex - b.logIndex,
+        radius,
+        structIds,
+      );
     }
 
     if (structIds.size > 0) {
       this.workbenchClient.prefetchStructYAMLs(Array.from(structIds));
+    }
+  }
+
+  /**
+   * Scans logStore directly to collect surrounding struct IDs when timeline filter is inactive.
+   *
+   * @param logStore The domain log store.
+   * @param targetLogIndex The chronological log index of the selected log.
+   * @param filteredLogIds The bitset of filtered active log IDs.
+   * @param radius The maximum number of items to scan backwards and forwards.
+   * @param structIds Output set of collected struct IDs.
+   */
+  private collectSurroundingLogStoreStructIds(
+    logStore: LogStore,
+    targetLogIndex: number,
+    filteredLogIds: IdBitset,
+    radius: number,
+    structIds: Set<number>,
+  ): void {
+    let backwardCount = 0;
+    for (let i = targetLogIndex - 1; i >= 0 && backwardCount < radius; i--) {
+      const id = logStore.getLogIdByIndex(i);
+      if (filteredLogIds.has(id)) {
+        backwardCount++;
+        const structId = logStore._getBodyStructId(id);
+        if (structId > 0) {
+          structIds.add(structId);
+        }
+      }
+    }
+
+    let forwardCount = 0;
+    for (
+      let i = targetLogIndex + 1;
+      i < logStore.count && forwardCount < radius;
+      i++
+    ) {
+      const id = logStore.getLogIdByIndex(i);
+      if (filteredLogIds.has(id)) {
+        forwardCount++;
+        const structId = logStore._getBodyStructId(id);
+        if (structId > 0) {
+          structIds.add(structId);
+        }
+      }
+    }
+  }
+
+  /**
+   * Collects surrounding candidate struct IDs from an ordered array of timeline items (revisions or events).
+   *
+   * @param items The chronologically ordered array of timeline items.
+   * @param targetLogIndex The logIndex of the currently selected log.
+   * @param filteredLogIds The bitset of filtered active log IDs.
+   * @param getStructIds A function returning an array of candidate struct IDs for an item.
+   * @param backwardCandidates Output array for items before targetLogIndex.
+   * @param forwardCandidates Output array for items at or after targetLogIndex.
+   */
+  private collectSurroundingTimelineItemCandidates<
+    T extends { readonly logIndex: number; readonly logId: number },
+  >(
+    items: readonly T[],
+    targetLogIndex: number,
+    filteredLogIds: IdBitset,
+    getStructIds: (item: T) => number[],
+    backwardCandidates: SurroundingCandidate[],
+    forwardCandidates: SurroundingCandidate[],
+  ): void {
+    if (items.length === 0) {
+      return;
+    }
+    const idx = bisectLeft(
+      items,
+      targetLogIndex,
+      (item, target) => item.logIndex - target,
+    );
+    const radius = StructYamlPrefetchService.PREFETCH_SURROUNDING_LOGS_RADIUS;
+
+    // Backward items before targetLogIndex
+    const startBackward = Math.max(0, idx - radius);
+    for (let i = idx - 1; i >= startBackward; i--) {
+      const item = items[i];
+      if (filteredLogIds.has(item.logId)) {
+        for (const structId of getStructIds(item)) {
+          if (structId > 0) {
+            backwardCandidates.push({ logIndex: item.logIndex, structId });
+          }
+        }
+      }
+    }
+
+    // Forward items at or after targetLogIndex
+    const endForward = Math.min(items.length, idx + radius);
+    for (let i = idx; i < endForward; i++) {
+      const item = items[i];
+      if (filteredLogIds.has(item.logId)) {
+        for (const structId of getStructIds(item)) {
+          if (structId > 0) {
+            forwardCandidates.push({ logIndex: item.logIndex, structId });
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Sorts candidate items, selects up to the limit, and adds their struct IDs to the output set.
+   *
+   * @param candidates The list of collected candidates.
+   * @param compareFn Comparison function for ordering.
+   * @param limit Maximum number of items to select.
+   * @param structIds Output set of struct IDs.
+   */
+  private addTopCandidates(
+    candidates: SurroundingCandidate[],
+    compareFn: (a: SurroundingCandidate, b: SurroundingCandidate) => number,
+    limit: number,
+    structIds: Set<number>,
+  ): void {
+    candidates.sort(compareFn);
+    const top = candidates.slice(0, limit);
+    for (const item of top) {
+      structIds.add(item.structId);
     }
   }
 }

--- a/web/src/app/store/domain/filter/id-bitset.ts
+++ b/web/src/app/store/domain/filter/id-bitset.ts
@@ -40,7 +40,7 @@ function popcount(v: number): number {
  * and eliminate JavaScript object allocation overhead during timeline and log filtering.
  */
 export class IdBitset {
-  private words: Uint32Array;
+  private _words: Uint32Array;
   private count = 0;
 
   /**
@@ -50,7 +50,14 @@ export class IdBitset {
    */
   constructor(maxId = 1024) {
     const wordCount = Math.ceil((Math.max(0, maxId) + 1) / 32);
-    this.words = new Uint32Array(wordCount);
+    this._words = new Uint32Array(wordCount);
+  }
+
+  /**
+   * Gets the underlying 32-bit word typed array of the bitset.
+   */
+  public get words(): Uint32Array {
+    return this._words;
   }
 
   /**
@@ -62,8 +69,8 @@ export class IdBitset {
   public has(id: number): boolean {
     if (id < 0) return false;
     const wordIdx = id >>> 5;
-    if (wordIdx >= this.words.length) return false;
-    return (this.words[wordIdx] & (1 << (id & 31))) !== 0;
+    if (wordIdx >= this._words.length) return false;
+    return (this._words[wordIdx] & (1 << (id & 31))) !== 0;
   }
 
   /**
@@ -74,12 +81,12 @@ export class IdBitset {
   public add(id: number): void {
     if (id < 0) return;
     const wordIdx = id >>> 5;
-    if (wordIdx >= this.words.length) {
+    if (wordIdx >= this._words.length) {
       this.grow(id);
     }
     const mask = 1 << (id & 31);
-    if ((this.words[wordIdx] & mask) === 0) {
-      this.words[wordIdx] |= mask;
+    if ((this._words[wordIdx] & mask) === 0) {
+      this._words[wordIdx] |= mask;
       this.count++;
     }
   }
@@ -93,10 +100,10 @@ export class IdBitset {
   public delete(id: number): boolean {
     if (id < 0) return false;
     const wordIdx = id >>> 5;
-    if (wordIdx >= this.words.length) return false;
+    if (wordIdx >= this._words.length) return false;
     const mask = 1 << (id & 31);
-    if ((this.words[wordIdx] & mask) !== 0) {
-      this.words[wordIdx] &= ~mask;
+    if ((this._words[wordIdx] & mask) !== 0) {
+      this._words[wordIdx] &= ~mask;
       this.count--;
       return true;
     }
@@ -107,7 +114,7 @@ export class IdBitset {
    * Clears all set bits in the bitset.
    */
   public clear(): void {
-    this.words.fill(0);
+    this._words.fill(0);
     this.count = 0;
   }
 
@@ -125,7 +132,7 @@ export class IdBitset {
    */
   public clone(): IdBitset {
     const cloned = new IdBitset(0);
-    cloned.words = new Uint32Array(this.words);
+    cloned._words = new Uint32Array(this._words);
     cloned.count = this.count;
     return cloned;
   }
@@ -136,8 +143,8 @@ export class IdBitset {
    * @returns An iterator yielding each set ID.
    */
   public *values(): IterableIterator<number> {
-    for (let w = 0; w < this.words.length; w++) {
-      const word = this.words[w];
+    for (let w = 0; w < this._words.length; w++) {
+      const word = this._words[w];
       if (word === 0) continue;
       const base = w * 32;
       for (let b = 0; b < 32; b++) {
@@ -157,10 +164,10 @@ export class IdBitset {
 
   private grow(targetId: number): void {
     const requiredWords = Math.ceil((targetId + 1) / 32);
-    const newWordsCount = Math.max(requiredWords, this.words.length * 2);
+    const newWordsCount = Math.max(requiredWords, this._words.length * 2);
     const newWords = new Uint32Array(newWordsCount);
-    newWords.set(this.words);
-    this.words = newWords;
+    newWords.set(this._words);
+    this._words = newWords;
   }
 
   /**
@@ -195,6 +202,17 @@ export class IdBitset {
   }
 
   /**
+   * Creates an IdBitset containing all IDs from a set.
+   *
+   * @param set - Set of numeric IDs to include in the bitset.
+   * @param maxId - Optional maximum ID to preallocate storage for.
+   * @returns An IdBitset with all specified IDs set.
+   */
+  public static fromSet(set: ReadonlySet<number>, maxId?: number): IdBitset {
+    return IdBitset.fromAll(set, maxId);
+  }
+
+  /**
    * Creates an IdBitset containing all sequential 1-indexed IDs from 1 to totalCount.
    *
    * @param totalCount - The total number of sequential entity IDs (1 to totalCount).
@@ -206,7 +224,7 @@ export class IdBitset {
       return new IdBitset(0);
     }
     const bitset = new IdBitset(count);
-    const words = bitset.words;
+    const words = bitset._words;
     const lastWordIdx = count >>> 5;
 
     if (lastWordIdx === 0) {
@@ -254,12 +272,12 @@ export class IdBitset {
       for (let i = 0; i < len; i++) {
         const wordIdx = indices[i];
         const mask = masks[i];
-        if (wordIdx < bitset.words.length) {
-          const oldWord = bitset.words[wordIdx];
+        if (wordIdx < bitset._words.length) {
+          const oldWord = bitset._words[wordIdx];
           const newWord = oldWord & ~mask;
           if (oldWord !== newWord) {
             bitset.count -= popcount(oldWord ^ newWord);
-            bitset.words[wordIdx] = newWord;
+            bitset._words[wordIdx] = newWord;
           }
         }
       }
@@ -277,14 +295,14 @@ export class IdBitset {
     for (let i = 0; i < len; i++) {
       const wordIdx = indices[i];
       const mask = masks[i];
-      if (wordIdx >= bitset.words.length) {
+      if (wordIdx >= bitset._words.length) {
         bitset.grow((wordIdx + 1) * 32);
       }
-      const oldWord = bitset.words[wordIdx];
+      const oldWord = bitset._words[wordIdx];
       const newWord = oldWord | mask;
       if (oldWord !== newWord) {
         bitset.count += popcount(oldWord ^ newWord);
-        bitset.words[wordIdx] = newWord;
+        bitset._words[wordIdx] = newWord;
       }
     }
     return bitset;
@@ -298,10 +316,10 @@ export class IdBitset {
   public toSparseBitset(): SparseBitset {
     const indices: number[] = [];
     const masks: number[] = [];
-    for (let i = 0; i < this.words.length; i++) {
-      if (this.words[i] !== 0) {
+    for (let i = 0; i < this._words.length; i++) {
+      if (this._words[i] !== 0) {
         indices.push(i);
-        masks.push(this.words[i]);
+        masks.push(this._words[i]);
       }
     }
     return create(SparseBitsetSchema, {

--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -308,5 +308,41 @@ describe('LogStore', () => {
         }),
       ).toThrowError(/Logs are not sorted by timestamp/);
     });
+
+    it('should retrieve log ID by chronological index', () => {
+      const testStore = LogStore.create(internPool, styleStore);
+      // Log IDs (5, 2, 10) are not in chronological order, but timestamps (100n, 200n, 300n) are
+      testStore.addLog({
+        id: 5,
+        ts: 100n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+      });
+      testStore.addLog({
+        id: 2,
+        ts: 200n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+      });
+      testStore.addLog({
+        id: 10,
+        ts: 300n,
+        logTypeId: 1,
+        severityTypeId: 1,
+        summaryStringId: 1,
+      });
+
+      expect(testStore.getLogIdByIndex(0)).toBe(5);
+      expect(testStore.getLogIdByIndex(1)).toBe(2);
+      expect(testStore.getLogIdByIndex(2)).toBe(10);
+      expect(() => testStore.getLogIdByIndex(3)).toThrowError(
+        /Log index 3 out of bounds/,
+      );
+      expect(() => testStore.getLogIdByIndex(-1)).toThrowError(
+        /Log index -1 out of bounds/,
+      );
+    });
   });
 });

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -299,9 +299,11 @@ export class LogStore {
 
   /**
    * Gets the interned struct ID of a log body, or 0 if not stored as a struct.
-   * @note Intended solely for internal retrieval inside the {@link Log} domain adapter.
+   *
+   * @param id The ID of the log.
+   * @returns The struct ID, or 0 if none.
    */
-  public _getBodyStructId(id: number): number {
+  public getBodyStructId(id: number): number {
     const index = this.getIndex(id);
     return this.bodyStructIds[index] ?? 0;
   }

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -248,6 +248,21 @@ export class LogStore {
     }
   }
 
+  /**
+   * Gets the log ID at the specified chronological index.
+   *
+   * @param index The 0-based chronological index.
+   * @returns The log ID.
+   */
+  public getLogIdByIndex(index: number): number {
+    if (index < 0 || index >= this.logCount) {
+      throw new Error(
+        `Log index ${index} out of bounds (count: ${this.logCount})`,
+      );
+    }
+    return this.ids[index];
+  }
+
   // --- Internal getters for Log adapter ---
 
   /**

--- a/web/src/app/store/domain/log.ts
+++ b/web/src/app/store/domain/log.ts
@@ -76,6 +76,6 @@ export class Log {
    * Gets the interned struct ID of the log body, or 0 if not stored as an interned struct.
    */
   get structId(): number {
-    return this.store._getBodyStructId(this.id);
+    return this.store.getBodyStructId(this.id);
   }
 }

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -397,9 +397,27 @@ describe('TimelineStore', () => {
       ]);
 
       logStore.addLogs([
-        { id: 1, ts: 100n, logTypeId: 1, severityTypeId: 1, summaryStringId: 3 },
-        { id: 2, ts: 200n, logTypeId: 1, severityTypeId: 1, summaryStringId: 3 },
-        { id: 3, ts: 300n, logTypeId: 1, severityTypeId: 1, summaryStringId: 3 },
+        {
+          id: 1,
+          ts: 100n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+        {
+          id: 2,
+          ts: 200n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
+        {
+          id: 3,
+          ts: 300n,
+          logTypeId: 1,
+          severityTypeId: 1,
+          summaryStringId: 3,
+        },
       ]);
 
       store.addRevision({

--- a/web/src/app/store/domain/timeline-store.spec.ts
+++ b/web/src/app/store/domain/timeline-store.spec.ts
@@ -388,5 +388,72 @@ describe('TimelineStore', () => {
       const rootChildren = store._getChildIdsForTimeline(1);
       expect(rootChildren.length).toBe(14);
     });
+
+    it('should correctly build and query reverse log indexes', () => {
+      internPool.addStrings([
+        { id: 1, value: 'timeline-1' },
+        { id: 2, value: 'timeline-2' },
+        { id: 3, value: 'summary' },
+      ]);
+
+      logStore.addLogs([
+        { id: 1, ts: 100n, logTypeId: 1, severityTypeId: 1, summaryStringId: 3 },
+        { id: 2, ts: 200n, logTypeId: 1, severityTypeId: 1, summaryStringId: 3 },
+        { id: 3, ts: 300n, logTypeId: 1, severityTypeId: 1, summaryStringId: 3 },
+      ]);
+
+      store.addRevision({
+        id: 10,
+        logId: 1,
+        changedTime: 100n,
+        principalStringId: 1,
+        verbTypeId: 1,
+        stateTypeId: 1,
+      });
+      store.addEvent({ id: 20, logId: 2 });
+      store.addEvent({ id: 21, logId: 1 }); // Log 1 is shared in timeline 2 as an event
+
+      store.addTimeline({
+        id: 100,
+        timelineTypeId: 1,
+        nameStringId: 1,
+        parentTimelineId: 0,
+        revisionIds: [10],
+        eventIds: [],
+      });
+
+      store.addTimeline({
+        id: 200,
+        timelineTypeId: 1,
+        nameStringId: 2,
+        parentTimelineId: 0,
+        revisionIds: [],
+        eventIds: [20, 21],
+      });
+
+      store.shrinkToFit();
+
+      // Query log 1 (appears in timeline 100 as revision 10 and timeline 200 as event 21)
+      expect(store.getTimelineIdsForLogId(1)).toEqual([100, 200]);
+      const timelinesForLog1 = store.getTimelinesForLogId(1);
+      expect(timelinesForLog1.length).toBe(2);
+      expect(timelinesForLog1[0].id).toBe(100);
+      expect(timelinesForLog1[1].id).toBe(200);
+
+      const log1 = logStore.getLog(1);
+      expect(timelinesForLog1[0].lookupRevisionFromLog(log1)?.id).toBe(10);
+      expect(timelinesForLog1[1].lookupEventFromLog(log1)?.id).toBe(21);
+
+      // Query log 2 (appears only in timeline 200 as event 20)
+      expect(store.getTimelineIdsForLogId(2)).toEqual([200]);
+      const timelinesForLog2 = store.getTimelinesForLogId(2);
+      expect(timelinesForLog2.length).toBe(1);
+      const log2 = logStore.getLog(2);
+      expect(timelinesForLog2[0].lookupEventFromLog(log2)?.id).toBe(20);
+
+      // Query log 3 (not in any timeline)
+      expect(store.getTimelineIdsForLogId(3)).toEqual([]);
+      expect(store.getTimelinesForLogId(3)).toEqual([]);
+    });
   });
 });

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -143,6 +143,9 @@ export class TimelineStore {
   private eventLogIds!: Uint32Array;
   private eventIdToIndex: (number | undefined)[] = [];
 
+  // Reverse log indexes
+  private readonly logIdToTimelineIds = new Map<number, number[]>();
+
   private constructor(
     private readonly internPool: InternPoolStore,
     public readonly styleStore: StyleProvider,
@@ -541,7 +544,7 @@ export class TimelineStore {
   }
 
   /**
-   * Rebuilds child timeline relationships based on parentTimelineId.
+   * Rebuilds child timeline relationships and reverse log indexes.
    */
   private rebuildRelationships(): void {
     if (!this.relationshipsDirty) {
@@ -559,7 +562,81 @@ export class TimelineStore {
         }
       }
     }
+
+    this.logIdToTimelineIds.clear();
+
+    for (let tIndex = 0; tIndex < this.timelineCount; tIndex++) {
+      const timelineId = this.timelineIds[tIndex];
+      const revIds = this.timelineRevisionIds[tIndex];
+      if (revIds) {
+        for (let i = 0; i < revIds.length; i++) {
+          const revId = revIds[i];
+          const rIndex = this.revisionIdToIndex[revId];
+          if (rIndex !== undefined) {
+            const logId = this.revisionLogIds[rIndex];
+            if (logId !== 0) {
+              let timelineIds = this.logIdToTimelineIds.get(logId);
+              if (!timelineIds) {
+                timelineIds = [];
+                this.logIdToTimelineIds.set(logId, timelineIds);
+              }
+              if (!timelineIds.includes(timelineId)) {
+                timelineIds.push(timelineId);
+              }
+            }
+          }
+        }
+      }
+
+      const evtIds = this.timelineEventIds[tIndex];
+      if (evtIds) {
+        for (let i = 0; i < evtIds.length; i++) {
+          const evtId = evtIds[i];
+          const eIndex = this.eventIdToIndex[evtId];
+          if (eIndex !== undefined) {
+            const logId = this.eventLogIds[eIndex];
+            if (logId !== 0) {
+              let timelineIds = this.logIdToTimelineIds.get(logId);
+              if (!timelineIds) {
+                timelineIds = [];
+                this.logIdToTimelineIds.set(logId, timelineIds);
+              }
+              if (!timelineIds.includes(timelineId)) {
+                timelineIds.push(timelineId);
+              }
+            }
+          }
+        }
+      }
+    }
+
     this.relationshipsDirty = false;
+  }
+
+  /**
+   * Retrieves timeline IDs associated with a log ID.
+   *
+   * @param logId The ID of the log.
+   * @returns An array of timeline IDs that contain the log.
+   */
+  public getTimelineIdsForLogId(logId: number): readonly number[] {
+    if (this.relationshipsDirty) {
+      this.rebuildRelationships();
+    }
+    return this.logIdToTimelineIds.get(logId) ?? [];
+  }
+
+  /**
+   * Retrieves timeline domain adapters associated with a log ID.
+   *
+   * @param logId The ID of the log.
+   * @returns An array of timeline domain adapters that contain the log.
+   */
+  public getTimelinesForLogId(
+    logId: number,
+  ): readonly ReadonlyDomainElement<Timeline>[] {
+    const ids = this.getTimelineIdsForLogId(logId);
+    return ids.map((id) => this.getTimeline(id));
   }
 
   // --- Timeline Accessors ---

--- a/web/src/app/store/domain/timeline-view.spec.ts
+++ b/web/src/app/store/domain/timeline-view.spec.ts
@@ -149,15 +149,12 @@ describe('TimelineView', () => {
     await waitForFiltering(view);
 
     const timelinesSignal = view.filteredTimelines;
-    const logsSignal = view.filteredLogs;
     const logIdsSignal = view.filteredLogIds;
 
     expect(typeof timelinesSignal).toBe('function');
-    expect(typeof logsSignal).toBe('function');
     expect(typeof logIdsSignal).toBe('function');
 
     expect(timelinesSignal()).toEqual([]);
-    expect(logsSignal()).toEqual([]);
     expect(logIdsSignal().size).toBe(0);
   });
 
@@ -353,7 +350,7 @@ describe('TimelineView', () => {
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 
-  it('should return filteredLogs in chronological order regardless of log ID order', async () => {
+  it('should return filteredLogIds from filter evaluation', async () => {
     const mockLogs = [
       { id: 10, logIndex: 0, timestamp: 100n },
       { id: 2, logIndex: 1, timestamp: 200n },
@@ -365,10 +362,6 @@ describe('TimelineView', () => {
     ]);
     Object.defineProperty(logStoreSpy, 'count', { get: () => 3 });
     logStoreSpy.getLogIdByIndex.and.callFake((index) => mockLogs[index].id);
-    logStoreSpy.getLog.and.callFake((id) => {
-      const found = mockLogs.find((l) => l.id === id);
-      return found as unknown as ReturnType<LogStore['getLog']>;
-    });
 
     const timelineStoreSpy = jasmine.createSpyObj<TimelineStore>(
       'TimelineStore',
@@ -387,7 +380,6 @@ describe('TimelineView', () => {
       'process',
     ]);
     Object.defineProperty(filter, 'priority', { get: () => 10 });
-    // Filter matches IDs 5 and 10 (chronologically index 0 and 2)
     filter.process.and.callFake((ctx) =>
       Promise.resolve({
         ...ctx,
@@ -398,9 +390,10 @@ describe('TimelineView', () => {
     view.addFilter(filter);
     await waitForFiltering(view);
 
-    const filtered = view.filteredLogs();
-    expect(filtered.length).toBe(2);
-    expect(filtered[0].id).toBe(10);
-    expect(filtered[1].id).toBe(5);
+    const filteredIds = view.filteredLogIds();
+    expect(filteredIds.size).toBe(2);
+    expect(filteredIds.has(10)).toBeTrue();
+    expect(filteredIds.has(5)).toBeTrue();
+    expect(filteredIds.has(2)).toBeFalse();
   });
 });

--- a/web/src/app/store/domain/timeline-view.spec.ts
+++ b/web/src/app/store/domain/timeline-view.spec.ts
@@ -352,4 +352,55 @@ describe('TimelineView', () => {
 
     expect(consoleSpy).not.toHaveBeenCalled();
   });
+
+  it('should return filteredLogs in chronological order regardless of log ID order', async () => {
+    const mockLogs = [
+      { id: 10, logIndex: 0, timestamp: 100n },
+      { id: 2, logIndex: 1, timestamp: 200n },
+      { id: 5, logIndex: 2, timestamp: 300n },
+    ];
+    const logStoreSpy = jasmine.createSpyObj<LogStore>('LogStore', [
+      'getLog',
+      'getLogIdByIndex',
+    ]);
+    Object.defineProperty(logStoreSpy, 'count', { get: () => 3 });
+    logStoreSpy.getLogIdByIndex.and.callFake((index) => mockLogs[index].id);
+    logStoreSpy.getLog.and.callFake((id) => {
+      const found = mockLogs.find((l) => l.id === id);
+      return found as unknown as ReturnType<LogStore['getLog']>;
+    });
+
+    const timelineStoreSpy = jasmine.createSpyObj<TimelineStore>(
+      'TimelineStore',
+      ['getTimeline'],
+    );
+    Object.defineProperty(timelineStoreSpy, 'logStore', {
+      get: () => logStoreSpy,
+    });
+    Object.defineProperty(timelineStoreSpy, 'timelines', {
+      get: () => [],
+    });
+
+    const view = new TimelineView(timelineStoreSpy);
+    const filter = jasmine.createSpyObj<LogTimelineFilter>('Filter', [
+      'priority',
+      'process',
+    ]);
+    Object.defineProperty(filter, 'priority', { get: () => 10 });
+    // Filter matches IDs 5 and 10 (chronologically index 0 and 2)
+    filter.process.and.callFake((ctx) =>
+      Promise.resolve({
+        ...ctx,
+        logIds: IdBitset.fromAll([5, 10]),
+      }),
+    );
+
+    view.addFilter(filter);
+    await waitForFiltering(view);
+
+    const filtered = view.filteredLogs();
+    expect(filtered.length).toBe(2);
+    expect(filtered[0].id).toBe(10);
+    expect(filtered[1].id).toBe(5);
+  });
 });

--- a/web/src/app/store/domain/timeline-view.ts
+++ b/web/src/app/store/domain/timeline-view.ts
@@ -15,7 +15,6 @@
  */
 
 import { signal, computed } from '@angular/core';
-import { Log } from 'src/app/store/domain/log';
 import { Timeline } from 'src/app/store/domain/timeline';
 import { TimelineStore } from 'src/app/store/domain/timeline-store';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
@@ -107,23 +106,6 @@ export class TimelineView {
   public readonly filteredTimelineBitset = computed<SparseBitset>(() => {
     const ctx = this.context();
     return ctx.timelineIds.toSparseBitset();
-  });
-
-  /**
-   * Emits the final list of logs that successfully passed the pipeline evaluation.
-   */
-  public readonly filteredLogs = computed<ReadonlyDomainElement<Log>[]>(() => {
-    const ctx = this.context();
-    const logs: ReadonlyDomainElement<Log>[] = [];
-    const logStore = this.store.logStore;
-    const count = logStore.count;
-    for (let i = 0; i < count; i++) {
-      const id = logStore.getLogIdByIndex(i);
-      if (ctx.logIds.has(id)) {
-        logs.push(logStore.getLog(id));
-      }
-    }
-    return logs;
   });
 
   /**

--- a/web/src/app/store/domain/timeline-view.ts
+++ b/web/src/app/store/domain/timeline-view.ts
@@ -109,6 +109,13 @@ export class TimelineView {
   });
 
   /**
+   * Emits the bitset of timeline IDs that successfully passed the pipeline evaluation.
+   */
+  public readonly filteredTimelineIds = computed<IdBitset>(() => {
+    return this.context().timelineIds;
+  });
+
+  /**
    * Emits the bitset of log IDs that successfully passed the pipeline evaluation.
    */
   public readonly filteredLogIds = computed<IdBitset>(() => {

--- a/web/src/app/store/domain/timeline-view.ts
+++ b/web/src/app/store/domain/timeline-view.ts
@@ -115,14 +115,14 @@ export class TimelineView {
   public readonly filteredLogs = computed<ReadonlyDomainElement<Log>[]>(() => {
     const ctx = this.context();
     const logs: ReadonlyDomainElement<Log>[] = [];
-    for (const id of ctx.logIds.values()) {
-      logs.push(this.store.logStore.getLog(id));
+    const logStore = this.store.logStore;
+    const count = logStore.count;
+    for (let i = 0; i < count; i++) {
+      const id = logStore.getLogIdByIndex(i);
+      if (ctx.logIds.has(id)) {
+        logs.push(logStore.getLog(id));
+      }
     }
-    logs.sort((a, b) => {
-      const tsA = a.timestamp ?? 0n;
-      const tsB = b.timestamp ?? 0n;
-      return tsA < tsB ? -1 : tsA > tsB ? 1 : 0;
-    });
     return logs;
   });
 

--- a/web/src/app/store/domain/timeline.spec.ts
+++ b/web/src/app/store/domain/timeline.spec.ts
@@ -852,8 +852,8 @@ describe('Timeline', () => {
     });
   });
 
-  describe('hasLogInEvents, hasLogInRevisions, and hasLog', () => {
-    it('should correctly check if the timeline contains the log using binary search', () => {
+  describe('hasLog', () => {
+    it('should correctly check if the timeline contains the log', () => {
       internPool.addStrings([
         { id: 1, value: 'timeline-label' },
         { id: 2, value: 'user-name' },
@@ -928,16 +928,8 @@ describe('Timeline', () => {
       const log2 = logStore.getLog(2);
       const log3 = logStore.getLog(3);
 
-      expect(timeline.hasLogInRevisions(log1)).toBe(true);
-      expect(timeline.hasLogInEvents(log1)).toBe(false);
       expect(timeline.hasLog(log1)).toBe(true);
-
-      expect(timeline.hasLogInRevisions(log2)).toBe(false);
-      expect(timeline.hasLogInEvents(log2)).toBe(true);
       expect(timeline.hasLog(log2)).toBe(true);
-
-      expect(timeline.hasLogInRevisions(log3)).toBe(false);
-      expect(timeline.hasLogInEvents(log3)).toBe(false);
       expect(timeline.hasLog(log3)).toBe(false);
     });
   });

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -138,6 +138,13 @@ export class Revision {
   }
 
   /**
+   * Gets the ID of the underlying log without instantiating a Log adapter.
+   */
+  get logId(): number {
+    return this.timelineStore._getRevisionLogId(this.id);
+  }
+
+  /**
    * Gets the interned struct ID of the revision body, or 0 if not stored as an interned struct.
    */
   get structId(): number {
@@ -176,6 +183,13 @@ export class Event {
    */
   get timeline(): ReadonlyDomainElement<Timeline> {
     return this.timelineStore.getTimeline(this.timelineId);
+  }
+
+  /**
+   * Gets the ID of the underlying log without instantiating a Log adapter.
+   */
+  get logId(): number {
+    return this.timelineStore._getEventLogId(this.id);
   }
 
   /**

--- a/web/src/app/store/domain/timeline.ts
+++ b/web/src/app/store/domain/timeline.ts
@@ -446,35 +446,17 @@ export class Timeline {
   }
 
   /**
-   * Checks if this timeline contains the specified log within its events using binary search.
-   */
-  public hasLogInEvents(log: ReadonlyDomainElement<Log>): boolean {
-    const events = this.events;
-    const eIdx = bisectLeft(
-      events,
-      log.logIndex,
-      (item, target) => item.logIndex - target,
-    );
-    return eIdx < events.length && events[eIdx].logIndex === log.logIndex;
-  }
-
-  /**
-   * Checks if this timeline contains the specified log within its revisions using binary search.
-   */
-  public hasLogInRevisions(log: ReadonlyDomainElement<Log>): boolean {
-    const revisions = this.revisions;
-    const rIdx = bisectLeft(
-      revisions,
-      log.logIndex,
-      (item, target) => item.logIndex - target,
-    );
-    return rIdx < revisions.length && revisions[rIdx].logIndex === log.logIndex;
-  }
-
-  /**
-   * Checks if this timeline contains the specified log using binary search.
+   * Checks if this timeline contains the specified log.
    */
   public hasLog(log: ReadonlyDomainElement<Log>): boolean {
-    return this.hasLogInEvents(log) || this.hasLogInRevisions(log);
+    if (this.timelineStore) {
+      return this.timelineStore
+        .getTimelineIdsForLogId(log.id)
+        .includes(this.id);
+    }
+    return (
+      this.events.some((e) => e.logIndex === log.logIndex) ||
+      this.revisions.some((r) => r.logIndex === log.logIndex)
+    );
   }
 }

--- a/web/src/app/timeline/components/canvas/glcontextmanager.ts
+++ b/web/src/app/timeline/components/canvas/glcontextmanager.ts
@@ -105,7 +105,9 @@ export class GLContextManager<RenderArgs> {
    * Should be called once after construction.
    */
   async setup() {
-    const gl = this.canvas.getContext('webgl2');
+    const gl = this.canvas.getContext('webgl2', {
+      antialias: false,
+    });
     if (!gl) {
       alert(
         'Failed to obtain the WebGL2 context. Please try reload this page or restart your computer.',

--- a/web/src/app/timeline/components/canvas/glsl-function-tester.spec.ts
+++ b/web/src/app/timeline/components/canvas/glsl-function-tester.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  GLSLDataType,
+  GLSLFunctionTester,
+} from 'src/app/timeline/components/canvas/glsl-function-tester';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
+
+describe('GLSLFunctionTester', () => {
+  let tester: GLSLFunctionTester;
+
+  beforeEach(() => {
+    tester = new GLSLFunctionTester();
+    tester.setup();
+  });
+
+  afterEach(() => {
+    tester.dispose();
+  });
+
+  describe('basic expression evaluation', () => {
+    it('evaluates float arithmetic expressions', async () => {
+      const result = await tester.runExpression<number>({
+        expression: '12.5 + 7.25',
+        returnType: GLSLDataType.Float,
+      });
+      expect(result).toBeCloseTo(19.75, 4);
+    });
+
+    it('evaluates int and uint expressions', async () => {
+      const intResult = await tester.runExpression<number>({
+        expression: '10 - 25',
+        returnType: GLSLDataType.Int,
+      });
+      expect(intResult).toBe(-15);
+
+      const uintResult = await tester.runExpression<number>({
+        expression: '100u * 30u',
+        returnType: GLSLDataType.Uint,
+      });
+      expect(uintResult).toBe(3000);
+    });
+
+    it('evaluates boolean logic expressions', async () => {
+      const trueResult = await tester.runExpression<boolean>({
+        expression: '(5u > 3u) && (10u != 0u)',
+        returnType: GLSLDataType.Bool,
+      });
+      expect(trueResult).toBe(true);
+
+      const falseResult = await tester.runExpression<boolean>({
+        expression: '42.0 < 10.0',
+        returnType: GLSLDataType.Bool,
+      });
+      expect(falseResult).toBe(false);
+    });
+
+    it('evaluates vec2, vec3, and vec4 expressions', async () => {
+      const vec2Result = await tester.runExpression<number[]>({
+        expression: 'vec2(1.5, 2.5) * 2.0',
+        returnType: GLSLDataType.Vec2,
+      });
+      expect(vec2Result[0]).toBeCloseTo(3.0, 4);
+      expect(vec2Result[1]).toBeCloseTo(5.0, 4);
+
+      const vec4Result = await tester.runExpression<number[]>({
+        expression: 'vec4(1.0, 0.5, 0.25, 1.0)',
+        returnType: GLSLDataType.Vec4,
+      });
+      expect(vec4Result).toEqual([1.0, 0.5, 0.25, 1.0]);
+    });
+
+    it('evaluates uvec4 expressions', async () => {
+      const uvec4Result = await tester.runExpression<number[]>({
+        expression: 'uvec4(1u, 2u, 100u, 200u)',
+        returnType: GLSLDataType.UVec4,
+      });
+      expect(uvec4Result).toEqual([1, 2, 100, 200]);
+    });
+
+    it('passes uniforms correctly to expressions', async () => {
+      const result = await tester.runExpression<number>({
+        declarations: 'uniform float u_multiplier;',
+        expression: '10.0 * u_multiplier',
+        returnType: GLSLDataType.Float,
+        uniforms: [
+          {
+            name: 'u_multiplier',
+            setter: (gl, loc) => gl.uniform1f(loc, 3.5),
+          },
+        ],
+      });
+      expect(result).toBeCloseTo(35.0, 4);
+    });
+  });
+
+  describe('shared.glsl functions and constants', () => {
+    it('provides correct mathematical constants PI and SQRT2', async () => {
+      const piResult = await tester.runExpression<number>({
+        expression: 'float(PI)',
+        returnType: GLSLDataType.Float,
+        includes: {
+          '#include "shared.glsl"': 'assets/shared.glsl',
+        },
+      });
+      expect(piResult).toBeCloseTo(Math.PI, 4);
+
+      const sqrt2Result = await tester.runExpression<number>({
+        expression: 'float(SQRT2)',
+        returnType: GLSLDataType.Float,
+        includes: {
+          '#include "shared.glsl"': 'assets/shared.glsl',
+        },
+      });
+      expect(sqrt2Result).toBeCloseTo(Math.SQRT2, 4);
+    });
+
+    it('defines BITSET_TEXTURE_WIDTH as 2048u', async () => {
+      const bitsetWidth = await tester.runExpression<number>({
+        expression: 'BITSET_TEXTURE_WIDTH',
+        returnType: GLSLDataType.Uint,
+        includes: {
+          '#include "shared.glsl"': 'assets/shared.glsl',
+        },
+      });
+      expect(bitsetWidth).toBe(2048);
+    });
+
+    describe('checkBitset function', () => {
+      it('correctly checks bits across word boundaries and multiple texture rows', async () => {
+        const bitset = IdBitset.createEmpty();
+        // Word 0
+        bitset.add(0);
+        bitset.add(1);
+        bitset.add(31);
+        // Word 1
+        bitset.add(32);
+        bitset.add(42);
+        // Word 2047 (last word of row 0: 2047 * 32 = 65504 to 65535)
+        bitset.add(65535);
+        // Word 2048 (first word of row 1: 2048 * 32 = 65536)
+        bitset.add(65536);
+        bitset.add(70000);
+        bitset.add(100000);
+
+        const bitsetTexture = tester.createBitsetTexture(bitset.words, 2048);
+
+        const checkBit = async (id: number): Promise<boolean> => {
+          return tester.runExpression<boolean>({
+            declarations: 'uniform uint u_targetId;',
+            expression: 'checkBitset(u_testBitset, u_targetId)',
+            returnType: GLSLDataType.Bool,
+            includes: {
+              '#include "shared.glsl"': 'assets/shared.glsl',
+            },
+            textures: [
+              {
+                uniformName: 'u_testBitset',
+                unit: 0,
+                texture: bitsetTexture,
+              },
+            ],
+            uniforms: [
+              {
+                name: 'u_targetId',
+                setter: (gl, loc) => gl.uniform1ui(loc, id),
+              },
+            ],
+          });
+        };
+
+        // Assert set bits return true
+        expect(await checkBit(0)).toBe(true);
+        expect(await checkBit(1)).toBe(true);
+        expect(await checkBit(31)).toBe(true);
+        expect(await checkBit(32)).toBe(true);
+        expect(await checkBit(42)).toBe(true);
+        expect(await checkBit(65535)).toBe(true);
+        expect(await checkBit(65536)).toBe(true);
+        expect(await checkBit(70000)).toBe(true);
+        expect(await checkBit(100000)).toBe(true);
+
+        // Assert unset bits return false
+        expect(await checkBit(2)).toBe(false);
+        expect(await checkBit(30)).toBe(false);
+        expect(await checkBit(33)).toBe(false);
+        expect(await checkBit(43)).toBe(false);
+        expect(await checkBit(65534)).toBe(false);
+        expect(await checkBit(65537)).toBe(false);
+        expect(await checkBit(70001)).toBe(false);
+        expect(await checkBit(99999)).toBe(false);
+        expect(await checkBit(100001)).toBe(false);
+      });
+    });
+
+    describe('ViewState UBO integration', () => {
+      it('correctly reads selectedLogIndex and viewport values from ViewState block', async () => {
+        const gl = tester.gl;
+        const uboBuffer = gl.createBuffer()!;
+        const source = new ArrayBuffer(32);
+        const floatView = new Float32Array(source);
+        const uintView = new Uint32Array(source);
+
+        // canvasResolution: vec2(800.0, 600.0) -> offset 0
+        floatView[0] = 800.0;
+        floatView[1] = 600.0;
+        // devicePixelRatio: 2.0 -> offset 8
+        floatView[2] = 2.0;
+        // pixelsPerMs: 0.5 -> offset 12
+        floatView[3] = 0.5;
+        // leftEdgeTime: uvec2(1000u, 500u) -> offset 16
+        uintView[4] = 1000;
+        uintView[5] = 500;
+        // selectedLogIndex: 12345u -> offset 24
+        uintView[6] = 12345;
+        // padding -> offset 28
+        uintView[7] = 0;
+
+        gl.bindBuffer(gl.UNIFORM_BUFFER, uboBuffer);
+        gl.bufferData(gl.UNIFORM_BUFFER, source, gl.STATIC_DRAW);
+        gl.bindBuffer(gl.UNIFORM_BUFFER, null);
+
+        const selectedLogIndex = await tester.runExpression<number>({
+          expression: 'vs.selectedLogIndex',
+          returnType: GLSLDataType.Uint,
+          includes: {
+            '#include "shared.glsl"': 'assets/shared.glsl',
+          },
+          ubos: [
+            {
+              blockName: 'ViewState',
+              bindingPoint: 0,
+              buffer: uboBuffer,
+            },
+          ],
+        });
+        expect(selectedLogIndex).toBe(12345);
+
+        const pixelsPerMs = await tester.runExpression<number>({
+          expression: 'vs.pixelsPerMs',
+          returnType: GLSLDataType.Float,
+          includes: {
+            '#include "shared.glsl"': 'assets/shared.glsl',
+          },
+          ubos: [
+            {
+              blockName: 'ViewState',
+              bindingPoint: 0,
+              buffer: uboBuffer,
+            },
+          ],
+        });
+        expect(pixelsPerMs).toBeCloseTo(0.5, 4);
+
+        gl.deleteBuffer(uboBuffer);
+      });
+    });
+  });
+});

--- a/web/src/app/timeline/components/canvas/glsl-function-tester.ts
+++ b/web/src/app/timeline/components/canvas/glsl-function-tester.ts
@@ -1,0 +1,566 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  GLSLIncludeReplace,
+  WebGLUtil,
+} from 'src/app/timeline/components/canvas/glutil';
+import { WebGLContextLostException } from 'src/app/timeline/components/canvas/glcontextmanager';
+
+/**
+ * Supported GLSL data types for evaluated expressions and output varyings.
+ */
+export enum GLSLDataType {
+  Bool = 'bool',
+  Float = 'float',
+  Int = 'int',
+  Uint = 'uint',
+  Vec2 = 'vec2',
+  Vec3 = 'vec3',
+  Vec4 = 'vec4',
+  IVec2 = 'ivec2',
+  IVec3 = 'ivec3',
+  IVec4 = 'ivec4',
+  UVec2 = 'uvec2',
+  UVec3 = 'uvec3',
+  UVec4 = 'uvec4',
+}
+
+/**
+ * Sampler type for GLSL textures.
+ */
+export enum GLSLSamplerType {
+  Usampler2D = 'usampler2D',
+  Sampler2D = 'sampler2D',
+  Isampler2D = 'isampler2D',
+}
+
+/**
+ * Texture binding configuration for a GLSL test run.
+ */
+export interface GLSLTextureBinding {
+  /** The uniform name for the sampler in the shader. */
+  readonly uniformName: string;
+  /** The WebGL texture unit index to bind (e.g. 0, 1, 2). */
+  readonly unit: number;
+  /** The WebGL texture instance to bind. */
+  readonly texture: WebGLTexture;
+  /** The GLSL sampler type declaration. Defaults to usampler2D. */
+  readonly samplerType?: GLSLSamplerType;
+}
+
+/**
+ * Uniform setter configuration for custom uniform values.
+ */
+export interface GLSLUniformBinding {
+  /** The name of the uniform in the shader. */
+  readonly name: string;
+  /** Callback to set the uniform value on the WebGL context. */
+  readonly setter: (
+    gl: WebGL2RenderingContext,
+    location: WebGLUniformLocation,
+  ) => void;
+}
+
+/**
+ * Uniform Buffer Object binding configuration for a GLSL test run.
+ */
+export interface GLSLUBOBinding {
+  /** The name of the uniform block in the shader. */
+  readonly blockName: string;
+  /** The binding point index to assign to the block. */
+  readonly bindingPoint: number;
+  /** The WebGL buffer containing the UBO data. */
+  readonly buffer: WebGLBuffer;
+}
+
+/**
+ * Options for evaluating a single GLSL expression or function call.
+ */
+export interface GLSLExpressionOptions {
+  /** The GLSL expression to evaluate (e.g. `checkBitset(u_bitset, u_id)`). */
+  readonly expression: string;
+  /** The expected return data type of the expression. */
+  readonly returnType: GLSLDataType;
+  /** Optional header declarations (functions, structs, constants) or includes. */
+  readonly declarations?: string;
+  /** Map of tokens to file paths for GLSL inclusion/replacement (e.g. `#include "shared.glsl"`). */
+  readonly includes?: GLSLIncludeReplace;
+  /** Optional texture bindings. */
+  readonly textures?: readonly GLSLTextureBinding[];
+  /** Optional uniform setters. */
+  readonly uniforms?: readonly GLSLUniformBinding[];
+  /** Optional UBO bindings. */
+  readonly ubos?: readonly GLSLUBOBinding[];
+}
+
+/**
+ * Options for executing a custom vertex shader source with transform feedback.
+ */
+export interface GLSLShaderOptions {
+  /** Full vertex shader source code. */
+  readonly vertexShaderSource: string;
+  /** The name of the output varying capturing the result. */
+  readonly outputVarying: string;
+  /** The data type of the output varying. */
+  readonly returnType: GLSLDataType;
+  /** Map of tokens to file paths for GLSL inclusion/replacement. */
+  readonly includes?: GLSLIncludeReplace;
+  /** Optional texture bindings. */
+  readonly textures?: readonly GLSLTextureBinding[];
+  /** Optional uniform setters. */
+  readonly uniforms?: readonly GLSLUniformBinding[];
+  /** Optional UBO bindings. */
+  readonly ubos?: readonly GLSLUBOBinding[];
+}
+
+/**
+ * Test utility that compiles and executes GLSL shader functions and expressions in WebGL2
+ * using Transform Feedback for exact typed value readback.
+ */
+export class GLSLFunctionTester {
+  private canvas?: HTMLCanvasElement;
+  private glContext?: WebGL2RenderingContext;
+
+  /**
+   * Gets the underlying WebGL2 rendering context.
+   */
+  public get gl(): WebGL2RenderingContext {
+    if (!this.glContext) {
+      throw new Error(
+        'GLSLFunctionTester is not initialized. Call setup() first.',
+      );
+    }
+    return this.glContext;
+  }
+
+  /**
+   * Initializes an offscreen canvas and WebGL2 context for shader testing.
+   */
+  public setup(): void {
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = 1;
+    this.canvas.height = 1;
+    const gl = this.canvas.getContext('webgl2');
+    if (!gl) {
+      throw new WebGLContextLostException(
+        'WebGL2 is not supported in this test environment.',
+      );
+    }
+    this.glContext = gl;
+  }
+
+  /**
+   * Disposes the WebGL2 context and resources.
+   */
+  public dispose(): void {
+    if (this.glContext) {
+      const ext = this.glContext.getExtension('WEBGL_lose_context');
+      if (ext) {
+        ext.loseContext();
+      }
+      this.glContext = undefined;
+    }
+    if (this.canvas) {
+      this.canvas.remove();
+      this.canvas = undefined;
+    }
+  }
+
+  /**
+   * Creates an R32UI 2D texture from raw 32-bit bitset words.
+   *
+   * @param words The 32-bit words array representing the bitset.
+   * @param width The width of the texture in texels (defaults to 2048).
+   * @returns The initialized WebGL texture.
+   */
+  public createBitsetTexture(
+    words: Uint32Array,
+    width: number = 2048,
+  ): WebGLTexture {
+    const gl = this.gl;
+    const height = Math.max(1, Math.ceil(words.length / width));
+    const padded = new Uint32Array(width * height);
+    padded.set(words);
+
+    const texture = gl.createTexture();
+    if (!texture) {
+      throw new WebGLContextLostException('Failed to create bitset texture');
+    }
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.R32UI,
+      width,
+      height,
+      0,
+      gl.RED_INTEGER,
+      gl.UNSIGNED_INT,
+      padded,
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    return texture;
+  }
+
+  /**
+   * Evaluates a GLSL expression and returns the typed result.
+   *
+   * @param options Expression evaluation configuration.
+   * @returns A promise resolving to the evaluated value (boolean, number, or number[]).
+   */
+  public async runExpression<T>(options: GLSLExpressionOptions): Promise<T> {
+    const includeTokens = Object.keys(options.includes ?? {}).join('\n');
+    const declarations = [includeTokens, options.declarations ?? '']
+      .filter(Boolean)
+      .join('\n');
+    const textureUniforms = (options.textures ?? [])
+      .map(
+        (t) =>
+          `uniform highp ${t.samplerType ?? GLSLSamplerType.Usampler2D} ${t.uniformName};`,
+      )
+      .join('\n');
+
+    const varyingType =
+      options.returnType === GLSLDataType.Bool
+        ? GLSLDataType.Uint
+        : options.returnType;
+
+    const assignment =
+      options.returnType === GLSLDataType.Bool
+        ? `out_varying_result = (${options.expression}) ? 1u : 0u;`
+        : `out_varying_result = ${options.expression};`;
+
+    const isIntegerType =
+      options.returnType === GLSLDataType.Bool ||
+      options.returnType === GLSLDataType.Int ||
+      options.returnType === GLSLDataType.Uint ||
+      options.returnType === GLSLDataType.IVec2 ||
+      options.returnType === GLSLDataType.IVec3 ||
+      options.returnType === GLSLDataType.IVec4 ||
+      options.returnType === GLSLDataType.UVec2 ||
+      options.returnType === GLSLDataType.UVec3 ||
+      options.returnType === GLSLDataType.UVec4;
+
+    const qualifier = isIntegerType ? 'flat out' : 'out';
+
+    const vertexShaderSource = `
+#version 300 es
+precision highp float;
+precision highp int;
+
+${declarations}
+${textureUniforms}
+
+${qualifier} ${varyingType} out_varying_result;
+
+void main() {
+  ${assignment}
+}
+`;
+
+    return this.runShader<T>({
+      vertexShaderSource,
+      outputVarying: 'out_varying_result',
+      returnType: options.returnType,
+      includes: options.includes,
+      textures: options.textures,
+      uniforms: options.uniforms,
+      ubos: options.ubos,
+    });
+  }
+
+  /**
+   * Executes a custom vertex shader with transform feedback and reads back the output varying.
+   *
+   * @param options Shader execution configuration.
+   * @returns A promise resolving to the varying result value.
+   */
+  public async runShader<T>(options: GLSLShaderOptions): Promise<T> {
+    const gl = this.gl;
+
+    let vss = options.vertexShaderSource;
+    if (options.includes) {
+      for (const [key, value] of Object.entries(options.includes)) {
+        const fileContent = await WebGLUtil.getShaderString(value);
+        vss = vss.replaceAll(key, fileContent);
+      }
+    }
+    vss = vss.trimStart();
+
+    const vs = gl.createShader(gl.VERTEX_SHADER);
+    if (!vs) {
+      throw new WebGLContextLostException('Failed to create vertex shader');
+    }
+    gl.shaderSource(vs, vss);
+    gl.compileShader(vs);
+    if (!gl.getShaderParameter(vs, gl.COMPILE_STATUS)) {
+      const log = gl.getShaderInfoLog(vs);
+      gl.deleteShader(vs);
+      throw new Error(
+        `GLSL compilation error:\n${log}\n\nShader Source:\n${vss}`,
+      );
+    }
+
+    const fs = gl.createShader(gl.FRAGMENT_SHADER);
+    if (!fs) {
+      gl.deleteShader(vs);
+      throw new WebGLContextLostException('Failed to create fragment shader');
+    }
+    gl.shaderSource(
+      fs,
+      '#version 300 es\nprecision highp float;\nvoid main() {}\n',
+    );
+    gl.compileShader(fs);
+
+    const program = gl.createProgram();
+    if (!program) {
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      throw new WebGLContextLostException('Failed to create WebGL program');
+    }
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+
+    gl.transformFeedbackVaryings(
+      program,
+      [options.outputVarying],
+      gl.SEPARATE_ATTRIBS,
+    );
+
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      const log = gl.getProgramInfoLog(program);
+      gl.deleteProgram(program);
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      throw new Error(`GLSL linking error:\n${log}`);
+    }
+
+    const dummyBuffers: WebGLBuffer[] = [];
+    const activeUniformBlocks = gl.getProgramParameter(
+      program,
+      gl.ACTIVE_UNIFORM_BLOCKS,
+    ) as number;
+    const boundPoints = new Set<number>();
+
+    if (options.ubos) {
+      for (const ubo of options.ubos) {
+        WebGLUtil.setProgramUniformBlockBinding(
+          gl,
+          program,
+          ubo.blockName,
+          ubo.bindingPoint,
+        );
+        gl.bindBufferBase(gl.UNIFORM_BUFFER, ubo.bindingPoint, ubo.buffer);
+        boundPoints.add(ubo.bindingPoint);
+      }
+    }
+
+    let nextBindingPoint = 0;
+    for (let i = 0; i < activeUniformBlocks; i++) {
+      const blockName = gl.getActiveUniformBlockName(program, i);
+      const isBound = options.ubos?.some((u) => u.blockName === blockName);
+      if (!isBound && blockName) {
+        while (boundPoints.has(nextBindingPoint)) {
+          nextBindingPoint++;
+        }
+        const dummyBuffer = gl.createBuffer();
+        if (dummyBuffer) {
+          dummyBuffers.push(dummyBuffer);
+          const blockSize = gl.getActiveUniformBlockParameter(
+            program,
+            i,
+            gl.UNIFORM_BLOCK_DATA_SIZE,
+          ) as number;
+          gl.bindBuffer(gl.UNIFORM_BUFFER, dummyBuffer);
+          gl.bufferData(
+            gl.UNIFORM_BUFFER,
+            Math.max(blockSize, 256),
+            gl.DYNAMIC_DRAW,
+          );
+          gl.uniformBlockBinding(program, i, nextBindingPoint);
+          gl.bindBufferBase(gl.UNIFORM_BUFFER, nextBindingPoint, dummyBuffer);
+          boundPoints.add(nextBindingPoint);
+        }
+      }
+    }
+
+    const typeConfig = this.getTypeConfig(options.returnType);
+    const feedbackBuffer = gl.createBuffer();
+    if (!feedbackBuffer) {
+      gl.deleteProgram(program);
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      throw new WebGLContextLostException('Failed to create feedback buffer');
+    }
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, feedbackBuffer);
+    gl.bufferData(
+      gl.TRANSFORM_FEEDBACK_BUFFER,
+      typeConfig.byteSize,
+      gl.STATIC_READ,
+    );
+
+    const transformFeedback = gl.createTransformFeedback();
+    if (!transformFeedback) {
+      gl.deleteBuffer(feedbackBuffer);
+      gl.deleteProgram(program);
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      throw new WebGLContextLostException(
+        'Failed to create transform feedback object',
+      );
+    }
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, feedbackBuffer);
+
+    gl.useProgram(program);
+
+    if (options.textures) {
+      for (const t of options.textures) {
+        gl.activeTexture(gl.TEXTURE0 + t.unit);
+        gl.bindTexture(gl.TEXTURE_2D, t.texture);
+        gl.bindSampler(t.unit, null);
+        const loc = gl.getUniformLocation(program, t.uniformName);
+        if (loc !== null) {
+          gl.uniform1i(loc, t.unit);
+        }
+      }
+    }
+
+    if (options.uniforms) {
+      for (const u of options.uniforms) {
+        const loc = gl.getUniformLocation(program, u.name);
+        if (loc !== null) {
+          u.setter(gl, loc);
+        }
+      }
+    }
+
+    gl.enable(gl.RASTERIZER_DISCARD);
+    gl.beginTransformFeedback(gl.POINTS);
+    gl.drawArrays(gl.POINTS, 0, 1);
+    gl.endTransformFeedback();
+    gl.disable(gl.RASTERIZER_DISCARD);
+
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, feedbackBuffer);
+
+    const readArray = typeConfig.createArray();
+    gl.getBufferSubData(gl.TRANSFORM_FEEDBACK_BUFFER, 0, readArray);
+
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, null);
+    dummyBuffers.forEach((b) => gl.deleteBuffer(b));
+    gl.deleteTransformFeedback(transformFeedback);
+    gl.deleteBuffer(feedbackBuffer);
+    gl.deleteProgram(program);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+
+    return typeConfig.formatResult(readArray) as T;
+  }
+
+  private getTypeConfig(type: GLSLDataType): {
+    byteSize: number;
+    createArray: () => ArrayBufferView;
+    formatResult: (arr: ArrayBufferView) => unknown;
+  } {
+    switch (type) {
+      case GLSLDataType.Bool:
+        return {
+          byteSize: 4,
+          createArray: () => new Uint32Array(1),
+          formatResult: (arr) => (arr as Uint32Array)[0] !== 0,
+        };
+      case GLSLDataType.Uint:
+        return {
+          byteSize: 4,
+          createArray: () => new Uint32Array(1),
+          formatResult: (arr) => (arr as Uint32Array)[0],
+        };
+      case GLSLDataType.Int:
+        return {
+          byteSize: 4,
+          createArray: () => new Int32Array(1),
+          formatResult: (arr) => (arr as Int32Array)[0],
+        };
+      case GLSLDataType.Float:
+        return {
+          byteSize: 4,
+          createArray: () => new Float32Array(1),
+          formatResult: (arr) => (arr as Float32Array)[0],
+        };
+      case GLSLDataType.Vec2:
+        return {
+          byteSize: 8,
+          createArray: () => new Float32Array(2),
+          formatResult: (arr) => Array.from(arr as Float32Array),
+        };
+      case GLSLDataType.Vec3:
+        return {
+          byteSize: 12,
+          createArray: () => new Float32Array(3),
+          formatResult: (arr) => Array.from(arr as Float32Array),
+        };
+      case GLSLDataType.Vec4:
+        return {
+          byteSize: 16,
+          createArray: () => new Float32Array(4),
+          formatResult: (arr) => Array.from(arr as Float32Array),
+        };
+      case GLSLDataType.IVec2:
+        return {
+          byteSize: 8,
+          createArray: () => new Int32Array(2),
+          formatResult: (arr) => Array.from(arr as Int32Array),
+        };
+      case GLSLDataType.IVec3:
+        return {
+          byteSize: 12,
+          createArray: () => new Int32Array(3),
+          formatResult: (arr) => Array.from(arr as Int32Array),
+        };
+      case GLSLDataType.IVec4:
+        return {
+          byteSize: 16,
+          createArray: () => new Int32Array(4),
+          formatResult: (arr) => Array.from(arr as Int32Array),
+        };
+      case GLSLDataType.UVec2:
+        return {
+          byteSize: 8,
+          createArray: () => new Uint32Array(2),
+          formatResult: (arr) => Array.from(arr as Uint32Array),
+        };
+      case GLSLDataType.UVec3:
+        return {
+          byteSize: 12,
+          createArray: () => new Uint32Array(3),
+          formatResult: (arr) => Array.from(arr as Uint32Array),
+        };
+      case GLSLDataType.UVec4:
+        return {
+          byteSize: 16,
+          createArray: () => new Uint32Array(4),
+          formatResult: (arr) => Array.from(arr as Uint32Array),
+        };
+    }
+  }
+}

--- a/web/src/app/timeline/components/canvas/glutil.ts
+++ b/web/src/app/timeline/components/canvas/glutil.ts
@@ -177,8 +177,21 @@ export class WebGLUtil {
     return shader;
   }
 
-  private static async getShaderString(path: string): Promise<string> {
-    const result = await fetch(path);
+  /**
+   * Fetches the shader source text from the specified path.
+   *
+   * @param path The URL path to the shader source file.
+   * @returns A promise resolving to the shader source code string.
+   */
+  public static async getShaderString(path: string): Promise<string> {
+    const url =
+      path.startsWith('/') || path.startsWith('http') ? path : `/${path}`;
+    const result = await fetch(url);
+    if (!result.ok) {
+      throw new Error(
+        `Failed to load shader file at ${path} (resolved URL: ${url}): HTTP ${result.status} ${result.statusText}`,
+      );
+    }
     return result.text();
   }
 }

--- a/web/src/app/timeline/components/canvas/hittest-shared-resource.spec.ts
+++ b/web/src/app/timeline/components/canvas/hittest-shared-resource.spec.ts
@@ -17,7 +17,7 @@
 import {
   TimelineHitTestSharedResource,
   ScissorRect,
-} from './hittest-shared-resource';
+} from 'src/app/timeline/components/canvas/hittest-shared-resource';
 import { createMockInspectionData } from 'src/app/store/mock/inspection-data.mock';
 
 describe('TimelineHitTestSharedResource', () => {

--- a/web/src/app/timeline/components/canvas/hittest-shared-resource.spec.ts
+++ b/web/src/app/timeline/components/canvas/hittest-shared-resource.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  TimelineHitTestSharedResource,
+  ScissorRect,
+} from './hittest-shared-resource';
+import { createMockInspectionData } from 'src/app/store/mock/inspection-data.mock';
+
+describe('TimelineHitTestSharedResource', () => {
+  let hittestResource: TimelineHitTestSharedResource;
+  let canvas: HTMLCanvasElement;
+  let gl: WebGL2RenderingContext;
+
+  beforeEach(() => {
+    canvas = document.createElement('canvas');
+    canvas.width = 100;
+    canvas.height = 100;
+    const context = canvas.getContext('webgl2');
+    if (!context) {
+      throw new Error('WebGL2 context is not supported in this environment');
+    }
+    gl = context;
+    hittestResource = new TimelineHitTestSharedResource();
+  });
+
+  describe('setup', () => {
+    it('should initialize WebGL framebuffer and texture', () => {
+      hittestResource.setup(gl);
+
+      expect(hittestResource.hittestFBO).toBeTruthy();
+      expect(hittestResource.hittestTexture).toBeTruthy();
+    });
+  });
+
+  describe('beforeRender and afterRender', () => {
+    it('should configure scissor test, clear buffer, and restore state', () => {
+      hittestResource.setup(gl);
+      hittestResource.resize(100, 100);
+
+      const scissorRect: ScissorRect = {
+        x: 10,
+        y: 20,
+        width: 1,
+        height: 1,
+      };
+
+      spyOn(gl, 'enable').and.callThrough();
+      spyOn(gl, 'scissor').and.callThrough();
+      spyOn(gl, 'clearBufferuiv').and.callThrough();
+      spyOn(gl, 'disable').and.callThrough();
+
+      hittestResource.beforeRender(gl, scissorRect);
+
+      expect(gl.enable).toHaveBeenCalledWith(gl.SCISSOR_TEST);
+      expect(gl.scissor).toHaveBeenCalledWith(10, 20, 1, 1);
+      expect(gl.clearBufferuiv).toHaveBeenCalled();
+
+      hittestResource.afterRender(gl);
+
+      expect(gl.disable).toHaveBeenCalledWith(gl.SCISSOR_TEST);
+    });
+  });
+
+  describe('hittest', () => {
+    it('should return hit test result for a given coordinate', async () => {
+      hittestResource.setup(gl);
+      hittestResource.resize(100, 100);
+
+      const mockData = await createMockInspectionData();
+      const mockTimeline = mockData.timelineStore.timelines[0];
+
+      const result = hittestResource.hittest(gl, 10, 20, mockTimeline);
+
+      expect(result.clientX).toBe(10);
+      expect(result.clientY).toBe(20);
+      expect(result.timeline).toBe(mockTimeline);
+    });
+  });
+});

--- a/web/src/app/timeline/components/canvas/hittest-shared-resource.ts
+++ b/web/src/app/timeline/components/canvas/hittest-shared-resource.ts
@@ -35,6 +35,16 @@ export interface HitTestResult {
 }
 
 /**
+ * Defines a rectangular region for WebGL scissor testing.
+ */
+export interface ScissorRect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
  * Shared resource for handling hit testing on timelines using WebGL.
  * It manages a framebuffer object (FBO) and texture to render an index map
  * for efficient retrieval of the object at a specific pixel.
@@ -112,10 +122,13 @@ export class TimelineHitTestSharedResource {
 
   /**
    * Prepares the shared resource for rendering the hit test map.
-   * Binds the FBO and clears the buffers. Resizes the texture if necessary.
+   * Binds the FBO, applies scissor clipping, and clears the buffers within the scissor region.
+   * Resizes the texture if necessary.
+   *
    * @param gl The WebGL2 rendering context.
+   * @param scissorRect Scissor box to restrict clearing and rasterization.
    */
-  beforeRender(gl: WebGL2RenderingContext) {
+  beforeRender(gl: WebGL2RenderingContext, scissorRect: ScissorRect) {
     if (this.sizeUpdated) {
       gl.bindTexture(gl.TEXTURE_2D, this.hittestTexture);
       gl.texImage2D(
@@ -141,16 +154,25 @@ export class TimelineHitTestSharedResource {
       this.sizeUpdated = false;
     }
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.hittestFBO);
+    gl.enable(gl.SCISSOR_TEST);
+    gl.scissor(
+      scissorRect.x,
+      scissorRect.y,
+      scissorRect.width,
+      scissorRect.height,
+    );
     gl.clearBufferuiv(gl.COLOR, 0, this.clearBuffer);
     gl.clear(gl.DEPTH_BUFFER_BIT);
   }
 
   /**
-   * Unbinds the framebuffer after rendering is complete.
+   * Unbinds the framebuffer and disables scissor testing after rendering is complete.
+   *
    * @param gl The WebGL2 rendering context.
    */
   afterRender(gl: WebGL2RenderingContext) {
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.disable(gl.SCISSOR_TEST);
   }
 
   /**

--- a/web/src/app/timeline/components/canvas/timeline-events-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-events-renderer.ts
@@ -19,7 +19,6 @@ import { Timeline } from 'src/app/store/domain/timeline';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { TimelineRendererSharedResource } from './timeline-shared-resource';
 import { IDisposableRenderer, TimelineRect } from './timeline-renderer';
-import { TimelineChartItemHighlight } from '../interaction-model';
 import {
   TimelineChartStyle,
   BASE_ROW_HEIGHT,
@@ -27,7 +26,6 @@ import {
 } from 'src/app/timeline/components/style-model';
 import { RendererConvertUtil } from './convertutil';
 import { StyleStoreLike } from 'src/app/store/domain/style-store';
-import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * Renders timeline events (points in time) using WebGL.
@@ -38,8 +36,6 @@ export class TimelineEventsRenderer implements IDisposableRenderer {
 
   private timeVBO!: WebGLBuffer;
   private intStaticMetaVBO!: WebGLBuffer;
-  private intDynamicMetaVBO!: WebGLBuffer;
-  private intDynamicMetaVBOSource!: Uint32Array;
 
   constructor(
     private timeline: ReadonlyDomainElement<Timeline>,
@@ -49,7 +45,7 @@ export class TimelineEventsRenderer implements IDisposableRenderer {
 
   /**
    * Sets up the WebGL resources (VAO, VBOs) for rendering events.
-   * Calculates and buffers static data (time, type, severity) to the GPU.
+   * Calculates and buffers static data (time, type, severity, logIndex, logId) to the GPU.
    *
    * @param gl The WebGL2 rendering context.
    * @param tmpBuffer Shared temporary buffer for allocations.
@@ -75,25 +71,14 @@ export class TimelineEventsRenderer implements IDisposableRenderer {
     );
     for (let i = 0; i < this.timeline.events.length; i++) {
       const event = this.timeline.events[i];
-      intStaticMetaVBOSource[i * 4] = i;
-      intStaticMetaVBOSource[i * 4 + 1] = event.log.logType.id;
-      intStaticMetaVBOSource[i * 4 + 2] = event.log.severity.id;
-      intStaticMetaVBOSource[i * 4 + 3] = 0;
+      intStaticMetaVBOSource[i * 4] = event.log.logType.id;
+      intStaticMetaVBOSource[i * 4 + 1] = event.log.severity.id;
+      intStaticMetaVBOSource[i * 4 + 2] = event.logIndex;
+      intStaticMetaVBOSource[i * 4 + 3] = event.logId;
     }
     this.intStaticMetaVBO = gl.createBuffer()!;
     gl.bindBuffer(gl.ARRAY_BUFFER, this.intStaticMetaVBO);
     gl.bufferData(gl.ARRAY_BUFFER, intStaticMetaVBOSource, gl.STATIC_DRAW);
-
-    this.intDynamicMetaVBOSource = new Uint32Array(
-      this.timeline.events.length * 4,
-    );
-    this.intDynamicMetaVBO = gl.createBuffer()!;
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.intDynamicMetaVBO);
-    gl.bufferData(
-      gl.ARRAY_BUFFER,
-      this.intDynamicMetaVBOSource,
-      gl.DYNAMIC_DRAW,
-    );
 
     this.eventsVAO = gl.createVertexArray()!;
     gl.bindVertexArray(this.eventsVAO);
@@ -128,53 +113,7 @@ export class TimelineEventsRenderer implements IDisposableRenderer {
     gl.enableVertexAttribArray(
       TimelineEventsSharedResources.VBO_LAYOUT_LOCATION_INT_STATIC_META,
     );
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.intDynamicMetaVBO);
-    gl.vertexAttribIPointer(
-      TimelineEventsSharedResources.VBO_LAYOUT_LOCATION_INT_DYNAMIC_META,
-      4,
-      gl.UNSIGNED_INT,
-      0,
-      0,
-    );
-    gl.vertexAttribDivisor(
-      TimelineEventsSharedResources.VBO_LAYOUT_LOCATION_INT_DYNAMIC_META,
-      1,
-    );
-    gl.enableVertexAttribArray(
-      TimelineEventsSharedResources.VBO_LAYOUT_LOCATION_INT_DYNAMIC_META,
-    );
     gl.bindVertexArray(null);
-    gl.bindBuffer(gl.ARRAY_BUFFER, null);
-  }
-
-  /**
-   * Updates the dynamic buffer with highlight/selection status for each event.
-   * This is called when the user interacts with the timeline.
-   *
-   * @param gl The WebGL rendering context.
-   * @param logElementHighlights Map of log indices to their highlight state.
-   * @param activeLogIds Bitset of log IDs that are currently active (not filtered out).
-   */
-  updateDynamicBuffer(
-    gl: WebGLRenderingContext,
-    logElementHighlights: TimelineChartItemHighlight,
-    activeLogIds: IdBitset,
-  ) {
-    for (let i = 0; i < this.timeline.events.length; i++) {
-      const selectionStatus =
-        logElementHighlights[this.timeline.events[i].logIndex] ?? 0;
-      const filterStatus = activeLogIds.has(this.timeline.events[i].logId)
-        ? 1
-        : 0;
-      this.intDynamicMetaVBOSource[i * 4 + 0] = selectionStatus;
-      this.intDynamicMetaVBOSource[i * 4 + 1] = filterStatus;
-    }
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.intDynamicMetaVBO);
-    gl.bufferData(
-      gl.ARRAY_BUFFER,
-      this.intDynamicMetaVBOSource,
-      gl.DYNAMIC_DRAW,
-    );
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
   }
 
@@ -253,6 +192,20 @@ export class TimelineEventsRenderer implements IDisposableRenderer {
       layerStyleUBO,
     );
 
+    gl.activeTexture(gl.TEXTURE2);
+    gl.bindTexture(
+      gl.TEXTURE_2D,
+      this.timelineSharedResources.filterBitsetTexture,
+    );
+    gl.bindSampler(2, null);
+
+    gl.activeTexture(gl.TEXTURE3);
+    gl.bindTexture(
+      gl.TEXTURE_2D,
+      this.timelineSharedResources.highlightBitsetTexture,
+    );
+    gl.bindSampler(3, null);
+
     gl.drawArraysInstanced(
       gl.TRIANGLE_STRIP,
       0,
@@ -273,7 +226,6 @@ export class TimelineEventsRenderer implements IDisposableRenderer {
     gl.deleteVertexArray(this.eventsVAO);
     gl.deleteBuffer(this.timeVBO);
     gl.deleteBuffer(this.intStaticMetaVBO);
-    gl.deleteBuffer(this.intDynamicMetaVBO);
   }
 }
 
@@ -291,7 +243,6 @@ export class TimelineEventsSharedResources {
 
   public static readonly VBO_LAYOUT_LOCATION_TIME = 0;
   public static readonly VBO_LAYOUT_LOCATION_INT_STATIC_META = 1;
-  public static readonly VBO_LAYOUT_LOCATION_INT_DYNAMIC_META = 2;
 
   public eventsColorProgram!: WebGLProgram;
   public eventsHittestProgram!: WebGLProgram;
@@ -302,7 +253,6 @@ export class TimelineEventsSharedResources {
 
   private styleUpdated = false;
 
-  /**
   /**
    * Initializes shaders and buffers for event rendering.
    *
@@ -336,6 +286,15 @@ export class TimelineEventsSharedResources {
       'EventLayerStyles',
       TimelineEventsSharedResources.UBO_BINDING_EVENT_LAYER_STYLES,
     );
+    gl.useProgram(this.eventsColorProgram);
+    gl.uniform1i(
+      gl.getUniformLocation(this.eventsColorProgram, 'u_filterBitset'),
+      2,
+    );
+    gl.uniform1i(
+      gl.getUniformLocation(this.eventsColorProgram, 'u_highlightBitset'),
+      3,
+    );
 
     this.eventsHittestProgram = await WebGLUtil.compileAndLinkShaders(
       gl,
@@ -364,6 +323,16 @@ export class TimelineEventsSharedResources {
       'EventLayerStyles',
       TimelineEventsSharedResources.UBO_BINDING_EVENT_LAYER_STYLES,
     );
+    gl.useProgram(this.eventsHittestProgram);
+    gl.uniform1i(
+      gl.getUniformLocation(this.eventsHittestProgram, 'u_filterBitset'),
+      2,
+    );
+    gl.uniform1i(
+      gl.getUniformLocation(this.eventsHittestProgram, 'u_highlightBitset'),
+      3,
+    );
+    gl.useProgram(null);
 
     this.eventStylesUBO = gl.createBuffer()!;
     this.layerStyleUBOs.clear();

--- a/web/src/app/timeline/components/canvas/timeline-events-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-events-renderer.ts
@@ -27,6 +27,7 @@ import {
 } from 'src/app/timeline/components/style-model';
 import { RendererConvertUtil } from './convertutil';
 import { StyleStoreLike } from 'src/app/store/domain/style-store';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * Renders timeline events (points in time) using WebGL.
@@ -152,19 +153,17 @@ export class TimelineEventsRenderer implements IDisposableRenderer {
    *
    * @param gl The WebGL rendering context.
    * @param logElementHighlights Map of log indices to their highlight state.
-   * @param activeLogsIndices Set of log indices that are currently active (not filtered out).
+   * @param activeLogIds Bitset of log IDs that are currently active (not filtered out).
    */
   updateDynamicBuffer(
     gl: WebGLRenderingContext,
     logElementHighlights: TimelineChartItemHighlight,
-    activeLogsIndices: Set<number>,
+    activeLogIds: IdBitset,
   ) {
     for (let i = 0; i < this.timeline.events.length; i++) {
       const selectionStatus =
         logElementHighlights[this.timeline.events[i].logIndex] ?? 0;
-      const filterStatus = activeLogsIndices.has(
-        this.timeline.events[i].logIndex,
-      )
+      const filterStatus = activeLogIds.has(this.timeline.events[i].logId)
         ? 1
         : 0;
       this.intDynamicMetaVBOSource[i * 4 + 0] = selectionStatus;

--- a/web/src/app/timeline/components/canvas/timeline-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-renderer.ts
@@ -25,8 +25,9 @@ import { LRUCache } from 'src/app/common/lru-cache';
 import { TimelineRendererSharedResource } from './timeline-shared-resource';
 import {
   HitTestResult,
+  ScissorRect,
   TimelineHitTestSharedResource,
-} from './hittest-shared-resource';
+} from 'src/app/timeline/components/canvas/hittest-shared-resource';
 import {
   TimelineEventsRenderer,
   TimelineEventsSharedResources,
@@ -336,23 +337,9 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
       Math.ceil(Math.max(...this.hitTestRequests.map((r) => r.y))),
     );
 
-    const scissorX = minX;
-    const scissorY = Math.max(0, Math.floor(this.height - maxY - 1));
-    const scissorW = Math.min(
-      this.width - scissorX,
-      Math.max(1, maxX - minX + 1),
-    );
-    const scissorH = Math.min(
-      this.height - scissorY,
-      Math.max(1, maxY - minY + 1),
-    );
+    const scissor = this.calculateHitTestScissorRect(minX, maxX, minY, maxY);
 
-    this.hittestSharedResource.beforeRender(gl, {
-      x: scissorX,
-      y: scissorY,
-      width: scissorW,
-      height: scissorH,
-    });
+    this.hittestSharedResource.beforeRender(gl, scissor);
     this.renderIntersectingItems(minY, maxY, (t, rect) => {
       rect.dpr = 1.0; // hit test buffer is rendered without considering dpr
       if (t.revisions.length > 0) {
@@ -542,5 +529,32 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
     renderer.setup(gl, this.tmpBuffer);
     this.eventRenderers.put(t.id.toString(), renderer);
     return renderer;
+  }
+
+  /**
+   * Calculates the scissor rectangle for hit testing from bounding coordinates.
+   */
+  private calculateHitTestScissorRect(
+    minX: number,
+    maxX: number,
+    minY: number,
+    maxY: number,
+  ): ScissorRect {
+    const scissorX = minX;
+    const scissorY = Math.max(0, Math.floor(this.height - maxY - 1));
+    const scissorW = Math.min(
+      this.width - scissorX,
+      Math.max(1, maxX - minX + 1),
+    );
+    const scissorH = Math.min(
+      this.height - scissorY,
+      Math.max(1, maxY - minY + 1),
+    );
+    return {
+      x: scissorX,
+      y: scissorY,
+      width: scissorW,
+      height: scissorH,
+    };
   }
 }

--- a/web/src/app/timeline/components/canvas/timeline-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-renderer.ts
@@ -38,6 +38,7 @@ import {
   BASE_ROW_HEIGHT,
 } from 'src/app/timeline/components/style-model';
 import { SharedTmpBuffer } from './glutil';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * Interface for renderers that can be disposed.
@@ -139,9 +140,9 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
 
   /**
    * Current filter state of log elements.
-   * When activeLogsIndices not includes a log index, then the log must be shown as disabled.
+   * When activeLogIds does not include a log ID, then the log must be shown as disabled.
    */
-  private activeLogsIndices: Set<number> = new Set();
+  private activeLogIds: IdBitset = IdBitset.createEmpty();
 
   private highlightUpdated = false;
 
@@ -210,18 +211,10 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
     );
     if (this.highlightUpdated) {
       this.iterateRevisionRenderers(gl, (r) =>
-        r.updateDynamicBuffer(
-          gl,
-          this.logElementHighlights,
-          this.activeLogsIndices,
-        ),
+        r.updateDynamicBuffer(gl, this.logElementHighlights, this.activeLogIds),
       );
       this.iterateEventRenderers(gl, (r) =>
-        r.updateDynamicBuffer(
-          gl,
-          this.logElementHighlights,
-          this.activeLogsIndices,
-        ),
+        r.updateDynamicBuffer(gl, this.logElementHighlights, this.activeLogIds),
       );
       this.highlightUpdated = false;
     }
@@ -231,7 +224,6 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
     if (this.hitTestRequests.length > 0) {
       this.processHitTestRequest(gl);
     }
-    gl.finish();
   }
 
   /**
@@ -254,12 +246,13 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
    * @param chartViewModel The new view model to render.
    * @param chartStyle The visual style configuration.
    * @param logElementHighlights The set of highlighted log elements.
+   * @param activeLogIds The bitset of active log IDs.
    */
   update(
     chartViewModel: TimelineChartViewModel,
     chartStyle: TimelineChartStyle,
     logElementHighlights: TimelineChartItemHighlight,
-    activeLogsIndices: Set<number>,
+    activeLogIds: IdBitset,
   ) {
     this.chartViewModel = chartViewModel;
     this.chartStyle = chartStyle;
@@ -267,7 +260,7 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
     this.eventSharedResource.updateChartStyle(chartStyle);
     this.logElementHighlights = logElementHighlights;
     this.highlightUpdated = true;
-    this.activeLogsIndices = activeLogsIndices;
+    this.activeLogIds = activeLogIds;
   }
 
   /**
@@ -303,15 +296,57 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
    * @param gl The WebGL2 rendering context.
    */
   private processHitTestRequest(gl: WebGL2RenderingContext) {
-    if (!this.chartViewModel || !this.chartStyle) return;
-    this.hittestSharedResource.beforeRender(gl);
-    this.iterateRevisionRenderers(gl, (r, rect) => {
-      rect.dpr = 1.0; // hit test buffer is rendered in without considering dpr
-      r.renderHittest(gl, rect);
+    if (
+      !this.chartViewModel ||
+      !this.chartStyle ||
+      this.hitTestRequests.length === 0
+    ) {
+      return;
+    }
+    const minX = Math.max(
+      0,
+      Math.floor(Math.min(...this.hitTestRequests.map((r) => r.x))),
+    );
+    const maxX = Math.min(
+      this.width - 1,
+      Math.ceil(Math.max(...this.hitTestRequests.map((r) => r.x))),
+    );
+    const minY = Math.max(
+      0,
+      Math.floor(Math.min(...this.hitTestRequests.map((r) => r.y))),
+    );
+    const maxY = Math.min(
+      this.height - 1,
+      Math.ceil(Math.max(...this.hitTestRequests.map((r) => r.y))),
+    );
+
+    const scissorX = minX;
+    const scissorY = Math.max(0, Math.floor(this.height - maxY - 1));
+    const scissorW = Math.min(
+      this.width - scissorX,
+      Math.max(1, maxX - minX + 1),
+    );
+    const scissorH = Math.min(
+      this.height - scissorY,
+      Math.max(1, maxY - minY + 1),
+    );
+
+    this.hittestSharedResource.beforeRender(gl, {
+      x: scissorX,
+      y: scissorY,
+      width: scissorW,
+      height: scissorH,
     });
-    this.iterateEventRenderers(gl, (r, rect) => {
-      rect.dpr = 1.0; // hit test buffer is rendered in without considering dpr
-      r.renderHittest(gl, rect);
+    this.renderIntersectingItems(minY, maxY, (t, rect) => {
+      rect.dpr = 1.0; // hit test buffer is rendered without considering dpr
+      if (t.revisions.length > 0) {
+        const revisionRenderer = this.ensureRevisionRenderer(gl, t);
+        revisionRenderer.renderHittest(gl, rect);
+      }
+      if (t.events.length > 0) {
+        const eventRenderer = this.ensureEventRenderer(gl, t);
+        eventRenderer.renderHittest(gl, rect);
+      }
     });
     this.hittestSharedResource.afterRender(gl);
     for (const request of this.hitTestRequests) {
@@ -345,6 +380,39 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
       }
     }
     this.hitTestRequests = [];
+  }
+
+  /**
+   * Iterates through visible timelines whose vertical span intersects [minDomY, maxDomY] and executes a callback.
+   *
+   * @param minDomY The minimum DOM Y coordinate.
+   * @param maxDomY The maximum DOM Y coordinate.
+   * @param onRender Callback to execute for each intersecting timeline.
+   */
+  private renderIntersectingItems(
+    minDomY: number,
+    maxDomY: number,
+    onRender: (t: ReadonlyDomainElement<Timeline>, rect: TimelineRect) => void,
+  ) {
+    if (!this.chartViewModel || !this.chartStyle) return;
+    const drawRect: TimelineRect = {
+      dpr: this.dpr,
+      offsetY: this.height,
+      width: this.width,
+      height: 0,
+    };
+    let domOffsetY = 0;
+    for (const t of this.chartViewModel.timelinesInDrawArea) {
+      const tType =
+        this.chartViewModel.styleStore?.getTimelineType(t.type.id) ?? t.type;
+      const rowHeight = tType.height * BASE_ROW_HEIGHT;
+      drawRect.height = rowHeight;
+      drawRect.offsetY -= rowHeight;
+      if (domOffsetY + rowHeight >= minDomY && domOffsetY <= maxDomY) {
+        onRender(t, drawRect);
+      }
+      domOffsetY += rowHeight;
+    }
   }
 
   /**

--- a/web/src/app/timeline/components/canvas/timeline-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-renderer.ts
@@ -32,7 +32,6 @@ import {
   TimelineEventsSharedResources,
 } from './timeline-events-renderer';
 import { TimelineChartViewModel } from '../timeline-chart.viewmodel';
-import { TimelineChartItemHighlight } from '../interaction-model';
 import {
   TimelineChartStyle,
   BASE_ROW_HEIGHT,
@@ -134,9 +133,14 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
   private hitTestRequests: HitTestRequest[] = [];
 
   /**
-   * Current highlight state of log elements (e.g. selected, hovered).
+   * Index of the currently selected log, or 0xFFFFFFFF if none.
    */
-  private logElementHighlights: TimelineChartItemHighlight = {};
+  private selectedLogIndex = 0xffffffff;
+
+  /**
+   * Bitset of highlighted log indices.
+   */
+  private highlightedLogIndices: IdBitset = IdBitset.createEmpty();
 
   /**
    * Current filter state of log elements.
@@ -144,7 +148,8 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
    */
   private activeLogIds: IdBitset = IdBitset.createEmpty();
 
-  private highlightUpdated = false;
+  private filterBitsetUpdated = true;
+  private highlightBitsetUpdated = true;
 
   /**
    * Sets up the WebGL resources for the renderer.
@@ -189,6 +194,17 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
       this.cachedInspectionDataUniqueID =
         this.chartViewModel.inspectionDataUniqueID;
     }
+    if (this.filterBitsetUpdated) {
+      this.timelineSharedResource.updateFilterBitset(gl, this.activeLogIds);
+      this.filterBitsetUpdated = false;
+    }
+    if (this.highlightBitsetUpdated) {
+      this.timelineSharedResource.updateHighlightBitset(
+        gl,
+        this.highlightedLogIndices,
+      );
+      this.highlightBitsetUpdated = false;
+    }
     gl.viewport(0, 0, this.width, this.height);
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -198,6 +214,7 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
       devicePixelRatio: this.dpr,
       pixelsPerMs: args.pixelsPerMs,
       leftEdgeTime: args.leftEdgeTime,
+      selectedLogIndex: this.selectedLogIndex,
     });
     this.revisionSharedResource.beforeRender(
       gl,
@@ -209,15 +226,6 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
       this.tmpBuffer,
       this.chartViewModel.styleStore,
     );
-    if (this.highlightUpdated) {
-      this.iterateRevisionRenderers(gl, (r) =>
-        r.updateDynamicBuffer(gl, this.logElementHighlights, this.activeLogIds),
-      );
-      this.iterateEventRenderers(gl, (r) =>
-        r.updateDynamicBuffer(gl, this.logElementHighlights, this.activeLogIds),
-      );
-      this.highlightUpdated = false;
-    }
     this.iterateRevisionRenderers(gl, (r, rect) => r.renderColor(gl, rect));
     this.iterateEventRenderers(gl, (r, rect) => r.renderColor(gl, rect));
 
@@ -245,22 +253,30 @@ export class TimelineRenderer implements GLRenderer<TimelineRendererRenderArgs> 
    *
    * @param chartViewModel The new view model to render.
    * @param chartStyle The visual style configuration.
-   * @param logElementHighlights The set of highlighted log elements.
+   * @param selectedLogIndex The index of the selected log, or 0xFFFFFFFF if none.
+   * @param highlightedLogIndices The bitset of highlighted log indices.
    * @param activeLogIds The bitset of active log IDs.
    */
   update(
     chartViewModel: TimelineChartViewModel,
     chartStyle: TimelineChartStyle,
-    logElementHighlights: TimelineChartItemHighlight,
+    selectedLogIndex: number,
+    highlightedLogIndices: IdBitset,
     activeLogIds: IdBitset,
   ) {
     this.chartViewModel = chartViewModel;
     this.chartStyle = chartStyle;
     this.revisionSharedResource.updateChartStyle(chartStyle);
     this.eventSharedResource.updateChartStyle(chartStyle);
-    this.logElementHighlights = logElementHighlights;
-    this.highlightUpdated = true;
-    this.activeLogIds = activeLogIds;
+    this.selectedLogIndex = selectedLogIndex;
+    if (this.highlightedLogIndices !== highlightedLogIndices) {
+      this.highlightedLogIndices = highlightedLogIndices;
+      this.highlightBitsetUpdated = true;
+    }
+    if (this.activeLogIds !== activeLogIds) {
+      this.activeLogIds = activeLogIds;
+      this.filterBitsetUpdated = true;
+    }
   }
 
   /**

--- a/web/src/app/timeline/components/canvas/timeline-revisions-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-revisions-renderer.ts
@@ -30,6 +30,7 @@ import {
 } from 'src/app/timeline/components/style-model';
 import { RendererConvertUtil } from './convertutil';
 import { StyleStoreLike } from 'src/app/store/domain/style-store';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * Renders timeline revisions (horizontal bars representing resource states) using WebGL.
@@ -166,19 +167,17 @@ export class TimelineRevisionsRenderer implements IDisposableRenderer {
    *
    * @param gl The WebGL rendering context.
    * @param logElementHighlights Map of log indices to their highlight state.
-   * @param activeLogsIndices Set of log indices that are currently active (not filtered out).
+   * @param activeLogIds Bitset of log IDs that are currently active (not filtered out).
    */
   updateDynamicBuffer(
     gl: WebGLRenderingContext,
     logElementHighlights: TimelineChartItemHighlight,
-    activeLogsIndices: Set<number>,
+    activeLogIds: IdBitset,
   ) {
     for (let i = 0; i < this.timeline.revisions.length; i++) {
       const selectionStatus =
         logElementHighlights[this.timeline.revisions[i].logIndex] ?? 0;
-      const filterStatus = activeLogsIndices.has(
-        this.timeline.revisions[i].logIndex,
-      )
+      const filterStatus = activeLogIds.has(this.timeline.revisions[i].logId)
         ? 1
         : 0;
       this.intDynamicMetaVBOSource[i * 4 + 0] = selectionStatus;

--- a/web/src/app/timeline/components/canvas/timeline-revisions-renderer.ts
+++ b/web/src/app/timeline/components/canvas/timeline-revisions-renderer.ts
@@ -19,10 +19,7 @@ import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 import { SharedTmpBuffer, WebGLUtil } from './glutil';
 import { TimelineRendererSharedResource } from './timeline-shared-resource';
 import { IDisposableRenderer, TimelineRect } from './timeline-renderer';
-import {
-  TimelineChartItemHighlight,
-  TimelineChartItemHighlightType,
-} from '../interaction-model';
+import { TimelineChartItemHighlightType } from '../interaction-model';
 import {
   TimelineChartStyle,
   BASE_ROW_HEIGHT,
@@ -30,7 +27,6 @@ import {
 } from 'src/app/timeline/components/style-model';
 import { RendererConvertUtil } from './convertutil';
 import { StyleStoreLike } from 'src/app/store/domain/style-store';
-import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * Renders timeline revisions (horizontal bars representing resource states) using WebGL.
@@ -41,8 +37,6 @@ export class TimelineRevisionsRenderer implements IDisposableRenderer {
 
   private timeVBO!: WebGLBuffer;
   private intStaticMetaVBO!: WebGLBuffer;
-  private intDynamicMetaVBO!: WebGLBuffer;
-  private intDynamicMetaVBOSource!: Uint32Array;
 
   constructor(
     private timeline: ReadonlyDomainElement<Timeline>,
@@ -52,7 +46,7 @@ export class TimelineRevisionsRenderer implements IDisposableRenderer {
 
   /**
    * Sets up the WebGL resources (VAO, VBOs) for rendering revisions.
-   * Calculates and buffers static data (time, state metadata) to the GPU.
+   * Calculates and buffers static data (time, state metadata, logIndex, logId) to the GPU.
    *
    * @param gl The WebGL2 rendering context.
    * @param tmpBuffer Shared temporary buffer for allocations.
@@ -89,25 +83,14 @@ export class TimelineRevisionsRenderer implements IDisposableRenderer {
     );
     for (let i = 0; i < this.timeline.revisions.length; i++) {
       const revision = this.timeline.revisions[i];
-      intStaticMetaVBOSource[i * 4] = i;
-      intStaticMetaVBOSource[i * 4 + 1] = revision.state.id;
+      intStaticMetaVBOSource[i * 4] = revision.state.id;
+      intStaticMetaVBOSource[i * 4 + 1] = 0;
       intStaticMetaVBOSource[i * 4 + 2] = revision.logIndex;
-      intStaticMetaVBOSource[i * 4 + 3] = this.timeline.type.id;
+      intStaticMetaVBOSource[i * 4 + 3] = revision.logId;
     }
     this.intStaticMetaVBO = gl.createBuffer()!;
     gl.bindBuffer(gl.ARRAY_BUFFER, this.intStaticMetaVBO);
     gl.bufferData(gl.ARRAY_BUFFER, intStaticMetaVBOSource, gl.STATIC_DRAW);
-
-    this.intDynamicMetaVBOSource = new Uint32Array(
-      this.timeline.revisions.length * 4,
-    );
-    this.intDynamicMetaVBO = gl.createBuffer()!;
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.intDynamicMetaVBO);
-    gl.bufferData(
-      gl.ARRAY_BUFFER,
-      this.intDynamicMetaVBOSource,
-      gl.DYNAMIC_DRAW,
-    );
 
     this.revisionsVAO = gl.createVertexArray()!;
     gl.bindVertexArray(this.revisionsVAO);
@@ -142,53 +125,7 @@ export class TimelineRevisionsRenderer implements IDisposableRenderer {
     gl.enableVertexAttribArray(
       TimelineRevisionsSharedResources.VBO_LAYOUT_LOCATION_INT_STATIC_META,
     );
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.intDynamicMetaVBO);
-    gl.vertexAttribIPointer(
-      TimelineRevisionsSharedResources.VBO_LAYOUT_LOCATION_INT_DYNAMIC_META,
-      4,
-      gl.UNSIGNED_INT,
-      0,
-      0,
-    );
-    gl.vertexAttribDivisor(
-      TimelineRevisionsSharedResources.VBO_LAYOUT_LOCATION_INT_DYNAMIC_META,
-      1,
-    );
-    gl.enableVertexAttribArray(
-      TimelineRevisionsSharedResources.VBO_LAYOUT_LOCATION_INT_DYNAMIC_META,
-    );
     gl.bindVertexArray(null);
-    gl.bindBuffer(gl.ARRAY_BUFFER, null);
-  }
-
-  /**
-   * Updates the dynamic buffer with highlight/selection status for each revision.
-   * This is called when the user interacts with the timeline (hover, select).
-   *
-   * @param gl The WebGL rendering context.
-   * @param logElementHighlights Map of log indices to their highlight state.
-   * @param activeLogIds Bitset of log IDs that are currently active (not filtered out).
-   */
-  updateDynamicBuffer(
-    gl: WebGLRenderingContext,
-    logElementHighlights: TimelineChartItemHighlight,
-    activeLogIds: IdBitset,
-  ) {
-    for (let i = 0; i < this.timeline.revisions.length; i++) {
-      const selectionStatus =
-        logElementHighlights[this.timeline.revisions[i].logIndex] ?? 0;
-      const filterStatus = activeLogIds.has(this.timeline.revisions[i].logId)
-        ? 1
-        : 0;
-      this.intDynamicMetaVBOSource[i * 4 + 0] = selectionStatus;
-      this.intDynamicMetaVBOSource[i * 4 + 1] = filterStatus;
-    }
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.intDynamicMetaVBO);
-    gl.bufferData(
-      gl.ARRAY_BUFFER,
-      this.intDynamicMetaVBOSource,
-      gl.DYNAMIC_DRAW,
-    );
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
   }
 
@@ -278,7 +215,6 @@ export class TimelineRevisionsRenderer implements IDisposableRenderer {
       this.timelineSharedResources.numberMSDFTexture,
     );
     gl.bindSampler(0, this.timelineSharedResources.msdfSampler);
-    gl.uniform1i(gl.getUniformLocation(program, 'numbersMSDFTexture'), 0);
 
     gl.activeTexture(gl.TEXTURE1);
     gl.bindTexture(
@@ -286,7 +222,20 @@ export class TimelineRevisionsRenderer implements IDisposableRenderer {
       this.timelineSharedResources.iconsMSDFTexture,
     );
     gl.bindSampler(1, this.timelineSharedResources.msdfSampler);
-    gl.uniform1i(gl.getUniformLocation(program, 'iconsMSDFTexture'), 1);
+
+    gl.activeTexture(gl.TEXTURE2);
+    gl.bindTexture(
+      gl.TEXTURE_2D,
+      this.timelineSharedResources.filterBitsetTexture,
+    );
+    gl.bindSampler(2, null);
+
+    gl.activeTexture(gl.TEXTURE3);
+    gl.bindTexture(
+      gl.TEXTURE_2D,
+      this.timelineSharedResources.highlightBitsetTexture,
+    );
+    gl.bindSampler(3, null);
 
     gl.drawArraysInstanced(
       gl.TRIANGLE_STRIP,
@@ -308,7 +257,6 @@ export class TimelineRevisionsRenderer implements IDisposableRenderer {
     gl.deleteVertexArray(this.revisionsVAO);
     gl.deleteBuffer(this.timeVBO);
     gl.deleteBuffer(this.intStaticMetaVBO);
-    gl.deleteBuffer(this.intDynamicMetaVBO);
   }
 }
 
@@ -326,7 +274,6 @@ export class TimelineRevisionsSharedResources {
 
   public static readonly VBO_LAYOUT_LOCATION_TIME = 0;
   public static readonly VBO_LAYOUT_LOCATION_INT_STATIC_META = 1;
-  public static readonly VBO_LAYOUT_LOCATION_INT_DYNAMIC_META = 2;
 
   public revisionsColorProgram!: WebGLProgram;
   public revisionsHittestProgram!: WebGLProgram;
@@ -388,6 +335,23 @@ export class TimelineRevisionsSharedResources {
       'RevisionLayerStyles',
       TimelineRevisionsSharedResources.UBO_BINDING_REVISION_LAYER_STYLES,
     );
+    gl.useProgram(this.revisionsColorProgram);
+    gl.uniform1i(
+      gl.getUniformLocation(this.revisionsColorProgram, 'numbersMSDFTexture'),
+      0,
+    );
+    gl.uniform1i(
+      gl.getUniformLocation(this.revisionsColorProgram, 'iconsMSDFTexture'),
+      1,
+    );
+    gl.uniform1i(
+      gl.getUniformLocation(this.revisionsColorProgram, 'u_filterBitset'),
+      2,
+    );
+    gl.uniform1i(
+      gl.getUniformLocation(this.revisionsColorProgram, 'u_highlightBitset'),
+      3,
+    );
 
     this.revisionsHittestProgram = await WebGLUtil.compileAndLinkShaders(
       gl,
@@ -422,6 +386,25 @@ export class TimelineRevisionsSharedResources {
       'RevisionLayerStyles',
       TimelineRevisionsSharedResources.UBO_BINDING_REVISION_LAYER_STYLES,
     );
+    gl.useProgram(this.revisionsHittestProgram);
+    gl.uniform1i(
+      gl.getUniformLocation(this.revisionsHittestProgram, 'numbersMSDFTexture'),
+      0,
+    );
+    gl.uniform1i(
+      gl.getUniformLocation(this.revisionsHittestProgram, 'iconsMSDFTexture'),
+      1,
+    );
+    gl.uniform1i(
+      gl.getUniformLocation(this.revisionsHittestProgram, 'u_filterBitset'),
+      2,
+    );
+    gl.uniform1i(
+      gl.getUniformLocation(this.revisionsHittestProgram, 'u_highlightBitset'),
+      3,
+    );
+    gl.useProgram(null);
+
     this.revisionStylesUBO = gl.createBuffer()!;
     this.layerStyleUBOs.clear();
   }

--- a/web/src/app/timeline/components/canvas/timeline-shared-resource.ts
+++ b/web/src/app/timeline/components/canvas/timeline-shared-resource.ts
@@ -23,6 +23,7 @@ import {
   BMFontConfig,
   IconAtlas,
 } from 'src/app/store/domain/style';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * Represents the state required by shared timeline rendering resources.
@@ -39,6 +40,8 @@ export interface TimelineRendererSharedResourceState {
   pixelsPerMs: number;
   /** The time (in unix milliseconds) at the left edge of the viewport. */
   leftEdgeTime: number;
+  /** The index of the selected log, or 0xFFFFFFFF if none. */
+  selectedLogIndex: number;
 }
 
 /**
@@ -46,12 +49,19 @@ export interface TimelineRendererSharedResourceState {
  * This class manages MSDF textures for text and icons, and updates the shared view state UBO.
  */
 export class TimelineRendererSharedResource {
+  public static readonly BITSET_TEXTURE_WIDTH = 2048;
   public readonly MAX_NUMBER_FONTS = 10;
   public readonly MAX_ICON_FONTS = 128;
 
   /** Uniform Buffer Object for storing the view state (viewport, time). */
   uboViewState!: WebGLBuffer;
   uboViewStateSource!: ArrayBuffer;
+
+  /** Texture containing the R32UI bitset for active filtered log IDs. */
+  filterBitsetTexture!: WebGLTexture;
+
+  /** Texture containing the R32UI bitset for highlighted log indices. */
+  highlightBitsetTexture!: WebGLTexture;
 
   /** Uniform Buffer Object for storing parameters related to the number MSDF font atlas. */
   uboNumberMSDFParamBuffer!: WebGLBuffer;
@@ -92,10 +102,13 @@ export class TimelineRendererSharedResource {
     if (this.uboViewState === null) {
       throw new WebGLContextLostException('Failed to create buffer');
     }
-    this.uboViewStateSource = new ArrayBuffer(32); // 24 + 8 padding
+    this.uboViewStateSource = new ArrayBuffer(32);
     gl.bindBuffer(gl.UNIFORM_BUFFER, this.uboViewState);
     gl.bufferData(gl.UNIFORM_BUFFER, this.uboViewStateSource, gl.DYNAMIC_DRAW);
     gl.bindBuffer(gl.UNIFORM_BUFFER, null);
+
+    this.filterBitsetTexture = this.createBitsetTexture(gl);
+    this.highlightBitsetTexture = this.createBitsetTexture(gl);
 
     this.numberMSDFTexture = await WebGLUtil.loadTexture(
       gl,
@@ -247,10 +260,107 @@ export class TimelineRendererSharedResource {
       RendererConvertUtil.splitTimeToSecondsAndNanoSeconds(state.leftEdgeTime);
     dv.setUint32(16, seconds, true);
     dv.setUint32(20, nanoSeconds, true);
-    dv.setUint32(24, 0, true); // these are paddings for std140
+    dv.setUint32(24, state.selectedLogIndex, true);
     dv.setUint32(28, 0, true);
     gl.bindBuffer(gl.UNIFORM_BUFFER, this.uboViewState);
     gl.bufferData(gl.UNIFORM_BUFFER, this.uboViewStateSource, gl.DYNAMIC_DRAW);
     gl.bindBuffer(gl.UNIFORM_BUFFER, null);
+  }
+
+  /**
+   * Updates the filter bitset texture with active log IDs.
+   *
+   * @param gl The WebGL2 rendering context.
+   * @param bitset The bitset of active log IDs.
+   */
+  public updateFilterBitset(
+    gl: WebGL2RenderingContext,
+    bitset: IdBitset,
+  ): void {
+    this.uploadBitsetTexture(gl, this.filterBitsetTexture, bitset);
+  }
+
+  /**
+   * Updates the highlight bitset texture with highlighted log indices.
+   *
+   * @param gl The WebGL2 rendering context.
+   * @param bitset The bitset of highlighted log indices.
+   */
+  public updateHighlightBitset(
+    gl: WebGL2RenderingContext,
+    bitset: IdBitset,
+  ): void {
+    this.uploadBitsetTexture(gl, this.highlightBitsetTexture, bitset);
+  }
+
+  /**
+   * Creates an R32UI WebGL texture initialized for bitset lookup.
+   *
+   * @param gl The WebGL2 rendering context.
+   * @returns The newly created WebGLTexture.
+   */
+  private createBitsetTexture(gl: WebGL2RenderingContext): WebGLTexture {
+    const texture = gl.createTexture();
+    if (texture === null) {
+      throw new WebGLContextLostException('Failed to create bitset texture');
+    }
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    const initialBuffer = new Uint32Array(
+      TimelineRendererSharedResource.BITSET_TEXTURE_WIDTH,
+    );
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.R32UI,
+      TimelineRendererSharedResource.BITSET_TEXTURE_WIDTH,
+      1,
+      0,
+      gl.RED_INTEGER,
+      gl.UNSIGNED_INT,
+      initialBuffer,
+    );
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    return texture;
+  }
+
+  /**
+   * Uploads an IdBitset into an R32UI texture.
+   *
+   * @param gl The WebGL2 rendering context.
+   * @param texture The target WebGLTexture.
+   * @param bitset The IdBitset to upload.
+   */
+  private uploadBitsetTexture(
+    gl: WebGL2RenderingContext,
+    texture: WebGLTexture,
+    bitset: IdBitset,
+  ): void {
+    const width = TimelineRendererSharedResource.BITSET_TEXTURE_WIDTH;
+    const words = bitset.words;
+    const height = Math.max(1, Math.ceil(words.length / width));
+    let buffer: Uint32Array;
+    if (words.length === width * height) {
+      buffer = words;
+    } else {
+      buffer = new Uint32Array(width * height);
+      buffer.set(words);
+    }
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.R32UI,
+      width,
+      height,
+      0,
+      gl.RED_INTEGER,
+      gl.UNSIGNED_INT,
+      buffer,
+    );
+    gl.bindTexture(gl.TEXTURE_2D, null);
   }
 }

--- a/web/src/app/timeline/components/misc/histogram-cache.spec.ts
+++ b/web/src/app/timeline/components/misc/histogram-cache.spec.ts
@@ -17,6 +17,7 @@
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { LogStore } from 'src/app/store/domain/log-store';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 import { HistogramCache } from './histogram-cache';
 
 enum Severity {
@@ -32,6 +33,7 @@ function createCacheWithLogs(
   minBucketTime: number,
   minTimeMs?: number,
   maxTimeMs?: number,
+  filterLogIds?: IdBitset,
 ): HistogramCache {
   const internPool = InternPoolStore.create();
   const styleStore = new StyleStore();
@@ -67,9 +69,11 @@ function createCacheWithLogs(
   logStore.addLogs(logsDto);
   logStore.shrinkToFit();
   const logs = Array.from(logStore.logs());
+  const logIds = filterLogIds ?? IdBitset.fromSequential(logs.length);
   return new HistogramCache(
     styleStore.severities,
     logs,
+    logIds,
     minBucketTime,
     minTimeMs,
     maxTimeMs,
@@ -197,5 +201,31 @@ describe('HistogramCache', () => {
     // Window 0 (0-1000): 1 log. Total 1. Ratio 1.0.
     expect(result.logRatios[Severity.SeverityError][0]).toBeCloseTo(1.0);
     expect(result.bucketCount).toBe(1);
+  });
+
+  it('should only include logs present in the logIds bitset', () => {
+    // 3 logs with IDs 1, 2, 3
+    const cache = createCacheWithLogs(
+      [
+        { severity: Severity.SeverityError, timeMs: 500 }, // ID 1
+        { severity: Severity.SeverityError, timeMs: 1500 }, // ID 2
+        { severity: Severity.SeverityInfo, timeMs: 2500 }, // ID 3
+      ],
+      1000,
+      undefined,
+      undefined,
+      IdBitset.fromAll([1, 3]), // Include only ID 1 and ID 3
+    );
+
+    const result = cache.getHistogramData(0, 3000, 1000);
+
+    // Total filtered logs: 2 (ID 1 Error, ID 3 Info)
+    expect(result.totalLogCount).toBe(2);
+    // Window 0: 1 Error -> 1/2
+    expect(result.logRatios[Severity.SeverityError][0]).toBeCloseTo(0.5);
+    // Window 1 (ID 2 omitted): 0 -> 0
+    expect(result.logRatios[Severity.SeverityError][1]).toBeCloseTo(0);
+    // Window 2: 1 Info -> 1/2
+    expect(result.logRatios[Severity.SeverityInfo][2]).toBeCloseTo(0.5);
   });
 });

--- a/web/src/app/timeline/components/misc/histogram-cache.ts
+++ b/web/src/app/timeline/components/misc/histogram-cache.ts
@@ -17,6 +17,7 @@
 import { Severity } from 'src/app/store/domain/style';
 import { Log } from 'src/app/store/domain/log';
 import { ReadonlyDomainElement } from 'src/app/store/domain/types';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * Result of the histogram calculation.
@@ -84,6 +85,7 @@ export class HistogramCache {
    *
    * @param severities - The list of severities.
    * @param logs - The list of logs to be indexed.
+   * @param logIds - The bitset of active log IDs to include in the histogram.
    * @param minBucketTime - The resolution of the cache in milliseconds.
    * @param logMinTimeMS - The minimum time of the logs. It will be recalculated from given logs, but this allows user to extend the range.
    * @param logMaxTimeMS - The maximum time of the logs. It will be recalculated from given logs, but this allows user to extend the range.
@@ -91,11 +93,12 @@ export class HistogramCache {
   constructor(
     public readonly severities: readonly ReadonlyDomainElement<Severity>[],
     logs: readonly ReadonlyDomainElement<Log>[],
+    logIds: IdBitset,
     private readonly minBucketTime: number,
     public logMinTimeMS: number = Infinity,
     public logMaxTimeMS: number = -Infinity,
   ) {
-    if (logs.length === 0) {
+    if (logs.length === 0 || logIds.size === 0) {
       this.alignedMinTimeMS = 0;
       this.cumulativeSums = {} as { [severityId: number]: Int32Array };
       this.resultCache = {} as { [severityId: number]: Float32Array };
@@ -107,6 +110,9 @@ export class HistogramCache {
     }
 
     for (const log of logs) {
+      if (!logIds.has(log.id)) {
+        continue;
+      }
       this.logMinTimeMS = Math.min(this.logMinTimeMS, log.legacyTimestampMs);
       this.logMaxTimeMS = Math.max(this.logMaxTimeMS, log.legacyTimestampMs);
     }
@@ -126,6 +132,9 @@ export class HistogramCache {
       this.resultCache[severity.id] = new Float32Array(windowCount);
     }
     for (const log of logs) {
+      if (!logIds.has(log.id)) {
+        continue;
+      }
       const windowIndex =
         (Math.floor(log.legacyTimestampMs / minBucketTime) * minBucketTime -
           this.alignedMinTimeMS) /

--- a/web/src/app/timeline/components/timeline-chart.component.ts
+++ b/web/src/app/timeline/components/timeline-chart.component.ts
@@ -39,10 +39,7 @@ import { HitTestResult } from './canvas/hittest-shared-resource';
 import { RenderingLoopManager } from './canvas/rendering-loop-manager';
 import { TimelineRulerViewModel } from './timeline-ruler.viewmodel';
 import { TimelineChartViewModel } from './timeline-chart.viewmodel';
-import {
-  TimelineChartItemHighlight,
-  TimelineHighlight,
-} from './interaction-model';
+import { TimelineHighlight } from './interaction-model';
 import {
   TimelineRulerStyle,
   TimelineChartStyle,
@@ -127,15 +124,20 @@ export class TimelineChartComponent implements AfterViewInit {
   readonly pixelsPerMs = input<number>(1);
 
   /**
+   * The index of the selected log, or 0xFFFFFFFF if none.
+   */
+  readonly selectedLogIndex = input<number>(0xffffffff);
+
+  /**
+   * Bitset of highlighted log indices.
+   */
+  readonly highlightedLogIndexBitset = input<IdBitset>(IdBitset.createEmpty());
+
+  /**
    * A bitset of log IDs that are currently active (e.g., matching a filter).
    * Inactive logs may be rendered differently (e.g., dimmed).
    */
   readonly activeLogIds = input<IdBitset>(IdBitset.createEmpty());
-
-  /**
-   * Highlights for specific items (logs/events) within the timeline.
-   */
-  readonly timelineChartItemHighlights = input<TimelineChartItemHighlight>({});
 
   /**
    * Emitted when the mouse moves over a timeline item.
@@ -288,7 +290,8 @@ export class TimelineChartComponent implements AfterViewInit {
     const chartViewModel = this.chartViewModel();
     const chartStyle = this.chartStyle();
     const timelineHighlights = this.timelineHighlights();
-    const logElementHighlights = this.timelineChartItemHighlights();
+    const selectedLogIndex = this.selectedLogIndex();
+    const highlightedLogIndexBitset = this.highlightedLogIndexBitset();
     const activeLogIds = this.activeLogIds();
     this.invalidate.set(true);
     if (
@@ -310,7 +313,8 @@ export class TimelineChartComponent implements AfterViewInit {
     this.timelineRenderer.update(
       chartViewModel,
       chartStyle,
-      logElementHighlights,
+      selectedLogIndex,
+      highlightedLogIndexBitset,
       activeLogIds,
     );
   }

--- a/web/src/app/timeline/components/timeline-chart.component.ts
+++ b/web/src/app/timeline/components/timeline-chart.component.ts
@@ -48,6 +48,7 @@ import {
   TimelineChartStyle,
 } from 'src/app/timeline/components/style-model';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 /**
  * Represents a mouse event that occurred on the timeline chart, including hit test results.
@@ -126,10 +127,10 @@ export class TimelineChartComponent implements AfterViewInit {
   readonly pixelsPerMs = input<number>(1);
 
   /**
-   * A set of log indices that are currently active (e.g., matching a filter).
+   * A bitset of log IDs that are currently active (e.g., matching a filter).
    * Inactive logs may be rendered differently (e.g., dimmed).
    */
-  readonly activeLogsIndices = input<Set<number>>(new Set());
+  readonly activeLogIds = input<IdBitset>(IdBitset.createEmpty());
 
   /**
    * Highlights for specific items (logs/events) within the timeline.
@@ -288,7 +289,7 @@ export class TimelineChartComponent implements AfterViewInit {
     const chartStyle = this.chartStyle();
     const timelineHighlights = this.timelineHighlights();
     const logElementHighlights = this.timelineChartItemHighlights();
-    const activeLogsIndices = this.activeLogsIndices();
+    const activeLogIds = this.activeLogIds();
     this.invalidate.set(true);
     if (
       rulerViewModel === undefined ||
@@ -310,7 +311,7 @@ export class TimelineChartComponent implements AfterViewInit {
       chartViewModel,
       chartStyle,
       logElementHighlights,
-      activeLogsIndices,
+      activeLogIds,
     );
   }
 }

--- a/web/src/app/timeline/components/timeline-chart.stories.ts
+++ b/web/src/app/timeline/components/timeline-chart.stories.ts
@@ -40,6 +40,7 @@ import { createMockInspectionData } from 'src/app/store/mock/inspection-data.moc
 import { HistogramCache } from 'src/app/timeline/components/misc/histogram-cache';
 import { getMinTimeSpanForHistogram } from 'src/app/timeline/components/calculator/human-friendly-tick';
 import { RulerViewModelBuilder } from './timeline-ruler.viewmodel';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 @Component({
   selector: 'khi-rendering-loop-starter',
@@ -63,7 +64,7 @@ class RenderingLoopStarter implements OnInit {
         <khi-timeline-chart
           [chartViewModel]="viewModel().chartViewModel"
           [rulerViewModel]="viewModel().rulerViewModel"
-          [activeLogsIndices]="viewModel().activeLogsIndices"
+          [activeLogIds]="viewModel().activeLogIds"
           [leftEdgeTime]="viewModel().leftEdgeTime"
           [pixelsPerMs]="viewModel().pixelsPerMs"
           [rulerStyle]="viewModel().rulerStyle"
@@ -91,7 +92,7 @@ class TimelineChartStoriesComponent {
         ready: false,
         chartViewModel: undefined,
         rulerViewModel: undefined,
-        activeLogsIndices: undefined,
+        activeLogIds: IdBitset.createEmpty(),
         leftEdgeTime: 0,
         pixelsPerMs: 1,
         rulerStyle: undefined,
@@ -138,16 +139,13 @@ class TimelineChartStoriesComponent {
       filteredLogsCache,
     );
 
-    const activeLogsIndices = new Set<number>();
-    for (const log of logsList) {
-      activeLogsIndices.add(log.logIndex);
-    }
+    const activeLogIds = IdBitset.fromAll(logsList.map((log) => log.id));
 
     return {
       ready: true,
       chartViewModel,
       rulerViewModel,
-      activeLogsIndices,
+      activeLogIds,
       leftEdgeTime: startTimeMs - 5000,
       pixelsPerMs: window.innerWidth / (durationMs + 10000),
       rulerStyle: generateDefaultRulerStyle(mockData.styleStore),

--- a/web/src/app/timeline/components/timeline-chart.stories.ts
+++ b/web/src/app/timeline/components/timeline-chart.stories.ts
@@ -35,12 +35,36 @@ import { RenderingLoopManager } from './canvas/rendering-loop-manager';
 import {
   generateDefaultChartStyle,
   generateDefaultRulerStyle,
+  TimelineChartStyle,
+  TimelineRulerStyle,
 } from 'src/app/timeline/components/style-model';
 import { createMockInspectionData } from 'src/app/store/mock/inspection-data.mock';
 import { HistogramCache } from 'src/app/timeline/components/misc/histogram-cache';
 import { getMinTimeSpanForHistogram } from 'src/app/timeline/components/calculator/human-friendly-tick';
-import { RulerViewModelBuilder } from './timeline-ruler.viewmodel';
+import {
+  RulerViewModelBuilder,
+  TimelineRulerViewModel,
+} from './timeline-ruler.viewmodel';
 import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
+import { TimelineChartViewModel } from './timeline-chart.viewmodel';
+
+interface TimelineChartStoryViewModelNotReady {
+  readonly ready: false;
+}
+
+interface TimelineChartStoryViewModelReady {
+  readonly ready: true;
+  readonly chartViewModel: TimelineChartViewModel;
+  readonly rulerViewModel: TimelineRulerViewModel;
+  readonly activeLogIds: IdBitset;
+  readonly leftEdgeTime: number;
+  readonly pixelsPerMs: number;
+  readonly rulerStyle: TimelineRulerStyle;
+  readonly chartStyle: TimelineChartStyle;
+}
+
+type TimelineChartStoryViewModel =
+  TimelineChartStoryViewModelNotReady | TimelineChartStoryViewModelReady;
 
 @Component({
   selector: 'khi-rendering-loop-starter',
@@ -59,16 +83,17 @@ class RenderingLoopStarter implements OnInit {
 
 @Component({
   template: `
-    @if (viewModel().ready) {
+    @let vm = viewModel();
+    @if (vm.ready) {
       <div style="height: 100vh; width: 100vw; display: grid;">
         <khi-timeline-chart
-          [chartViewModel]="viewModel().chartViewModel"
-          [rulerViewModel]="viewModel().rulerViewModel"
-          [activeLogIds]="viewModel().activeLogIds"
-          [leftEdgeTime]="viewModel().leftEdgeTime"
-          [pixelsPerMs]="viewModel().pixelsPerMs"
-          [rulerStyle]="viewModel().rulerStyle"
-          [chartStyle]="viewModel().chartStyle"
+          [chartViewModel]="vm.chartViewModel"
+          [rulerViewModel]="vm.rulerViewModel"
+          [activeLogIds]="vm.activeLogIds"
+          [leftEdgeTime]="vm.leftEdgeTime"
+          [pixelsPerMs]="vm.pixelsPerMs"
+          [rulerStyle]="vm.rulerStyle"
+          [chartStyle]="vm.chartStyle"
           [forceNotReadyToRender]="forceNotReadyToRender()"
         ></khi-timeline-chart>
       </div>
@@ -85,18 +110,11 @@ class TimelineChartStoriesComponent {
     },
   });
 
-  viewModel = computed(() => {
+  viewModel = computed<TimelineChartStoryViewModel>(() => {
     const mockData = this.khiInspectionData.value();
     if (!mockData) {
       return {
         ready: false,
-        chartViewModel: undefined,
-        rulerViewModel: undefined,
-        activeLogIds: IdBitset.createEmpty(),
-        leftEdgeTime: 0,
-        pixelsPerMs: 1,
-        rulerStyle: undefined,
-        chartStyle: undefined,
       };
     }
     const startTimeMs = mockData.metadata!.header!.startTimeUnixSeconds * 1000;
@@ -114,9 +132,11 @@ class TimelineChartStoriesComponent {
       styleStore: mockData.styleStore,
     };
 
+    const allLogIds = IdBitset.fromAll(logsList.map((log) => log.id));
     const allLogsCache = new HistogramCache(
       mockData.styleStore.severities,
       logsList,
+      allLogIds,
       getMinTimeSpanForHistogram(10000, startTimeMs, endTimeMs),
       startTimeMs,
       endTimeMs,
@@ -124,6 +144,7 @@ class TimelineChartStoriesComponent {
     const filteredLogsCache = new HistogramCache(
       mockData.styleStore.severities,
       logsList,
+      allLogIds,
       getMinTimeSpanForHistogram(10000, startTimeMs, endTimeMs),
       startTimeMs,
       endTimeMs,

--- a/web/src/app/timeline/components/timeline-chart.stories.ts
+++ b/web/src/app/timeline/components/timeline-chart.stories.ts
@@ -44,9 +44,9 @@ import { getMinTimeSpanForHistogram } from 'src/app/timeline/components/calculat
 import {
   RulerViewModelBuilder,
   TimelineRulerViewModel,
-} from './timeline-ruler.viewmodel';
+} from 'src/app/timeline/components/timeline-ruler.viewmodel';
 import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
-import { TimelineChartViewModel } from './timeline-chart.viewmodel';
+import { TimelineChartViewModel } from 'src/app/timeline/components/timeline-chart.viewmodel';
 
 interface TimelineChartStoryViewModelNotReady {
   readonly ready: false;

--- a/web/src/app/timeline/components/timeline-frame.component.html
+++ b/web/src/app/timeline/components/timeline-frame.component.html
@@ -66,7 +66,8 @@
         [chartStyle]="chartStyle()"
         [rulerStyle]="rulerStyle()"
         [timelineHighlights]="timelineHighlights()"
-        [timelineChartItemHighlights]="timelineChartItemHighlights()"
+        [selectedLogIndex]="selectedLogIndex()"
+        [highlightedLogIndexBitset]="highlightedLogIndexBitset()"
         [activeLogIds]="filteredLogIds()"
         (mouseMoveOnTimelineItem)="
           handleTimelineChartItemEvent($event, hoverOnTimelineItem)
@@ -143,7 +144,8 @@
           [chartStyle]="chartStyle()"
           [rulerStyle]="rulerStyle()"
           [timelineHighlights]="timelineHighlights()"
-          [timelineChartItemHighlights]="timelineChartItemHighlights()"
+          [selectedLogIndex]="selectedLogIndex()"
+          [highlightedLogIndexBitset]="highlightedLogIndexBitset()"
           [activeLogIds]="filteredLogIds()"
           (mouseMoveOnTimelineItem)="
             handleTimelineChartItemEvent($event, hoverOnTimelineItem)

--- a/web/src/app/timeline/components/timeline-frame.component.html
+++ b/web/src/app/timeline/components/timeline-frame.component.html
@@ -67,7 +67,7 @@
         [rulerStyle]="rulerStyle()"
         [timelineHighlights]="timelineHighlights()"
         [timelineChartItemHighlights]="timelineChartItemHighlights()"
-        [activeLogsIndices]="activeLogsIndices()"
+        [activeLogIds]="filteredLogIds()"
         (mouseMoveOnTimelineItem)="
           handleTimelineChartItemEvent($event, hoverOnTimelineItem)
         "
@@ -144,7 +144,7 @@
           [rulerStyle]="rulerStyle()"
           [timelineHighlights]="timelineHighlights()"
           [timelineChartItemHighlights]="timelineChartItemHighlights()"
-          [activeLogsIndices]="activeLogsIndices()"
+          [activeLogIds]="filteredLogIds()"
           (mouseMoveOnTimelineItem)="
             handleTimelineChartItemEvent($event, hoverOnTimelineItem)
           "

--- a/web/src/app/timeline/components/timeline-frame.component.stories.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.stories.ts
@@ -34,6 +34,7 @@ import {
   generateDefaultRulerStyle,
 } from 'src/app/timeline/components/style-model';
 import { createMockInspectionData } from 'src/app/store/mock/inspection-data.mock';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 function msToNs(ms: number): bigint {
   return BigInt(Math.floor(ms)) * 1000000n;
@@ -72,6 +73,7 @@ function filterTimelineHighlight(
         [timezoneShiftHours]="9"
         [allLogsWithoutFilter]="viewModel().logs"
         [filteredLogs]="viewModel().filteredLogs"
+        [filteredLogIds]="viewModel().filteredLogIds"
         [timelineHoverOverlayRequest]="timelineHoverRequest()"
         [chartStyle]="viewModel().chartStyle!"
         [rulerStyle]="viewModel().rulerStyle!"
@@ -116,6 +118,7 @@ class TimelineFrameStoriesComponent {
         timelines: [],
         logs: [],
         filteredLogs: [],
+        filteredLogIds: IdBitset.createEmpty(),
         minLogTime: 0,
         maxLogTime: 0,
         chartStyle: undefined,
@@ -135,6 +138,7 @@ class TimelineFrameStoriesComponent {
       timelines: data.timelineStore.timelines,
       logs,
       filteredLogs: logs,
+      filteredLogIds: IdBitset.fromAll(logs.map((log) => log.id)),
       minLogTime: minTimeMs,
       maxLogTime: maxTimeMs,
       chartStyle: generateDefaultChartStyle(),

--- a/web/src/app/timeline/components/timeline-frame.component.stories.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.stories.ts
@@ -32,9 +32,14 @@ import {
 import {
   generateDefaultChartStyle,
   generateDefaultRulerStyle,
+  TimelineChartStyle,
+  TimelineRulerStyle,
 } from 'src/app/timeline/components/style-model';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
 import { createMockInspectionData } from 'src/app/store/mock/inspection-data.mock';
 import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
+import { Log } from 'src/app/store/domain/log';
+import { ReadonlyDomainElement } from 'src/app/store/domain/types';
 
 function msToNs(ms: number): bigint {
   return BigInt(Math.floor(ms)) * 1000000n;
@@ -58,26 +63,45 @@ function filterTimelineHighlight(
   );
 }
 
+interface TimelineFrameStoryViewModelNotReady {
+  readonly ready: false;
+}
+
+interface TimelineFrameStoryViewModelReady {
+  readonly ready: true;
+  readonly timelines: readonly ReadonlyDomainElement<Timeline>[];
+  readonly logs: ReadonlyDomainElement<Log>[];
+  readonly filteredLogIds: IdBitset;
+  readonly minLogTime: number;
+  readonly maxLogTime: number;
+  readonly chartStyle: TimelineChartStyle;
+  readonly rulerStyle: TimelineRulerStyle;
+  readonly styleStore: StyleStoreLike;
+}
+
+type TimelineFrameStoryViewModel =
+  TimelineFrameStoryViewModelNotReady | TimelineFrameStoryViewModelReady;
+
 @Component({
   template: `
-    @if (viewModel().ready) {
+    @let vm = viewModel();
+    @if (vm.ready) {
       <khi-timeline-frame
-        [timelines]="viewModel().timelines"
-        [minQueryLogTimeMS]="viewModel().minLogTime"
-        [maxQueryLogTimeMS]="viewModel().maxLogTime"
+        [timelines]="vm.timelines"
+        [minQueryLogTimeMS]="vm.minLogTime"
+        [maxQueryLogTimeMS]="vm.maxLogTime"
         [viewportLeftTimeMS]="viewportLeftTimeMS()"
         [pixelsPerMs]="pixelsPerMs()"
         [timelineHighlights]="timelineHighlights()"
         [timelineChartItemHighlights]="timelineChartItemHighlights()"
         [cursorTimeMS]="timeCursorMS()"
         [timezoneShiftHours]="9"
-        [allLogsWithoutFilter]="viewModel().logs"
-        [filteredLogs]="viewModel().filteredLogs"
-        [filteredLogIds]="viewModel().filteredLogIds"
+        [allLogsWithoutFilter]="vm.logs"
+        [filteredLogIds]="vm.filteredLogIds"
         [timelineHoverOverlayRequest]="timelineHoverRequest()"
-        [chartStyle]="viewModel().chartStyle!"
-        [rulerStyle]="viewModel().rulerStyle!"
-        [styleStore]="viewModel().styleStore!"
+        [chartStyle]="vm.chartStyle"
+        [rulerStyle]="vm.rulerStyle"
+        [styleStore]="vm.styleStore"
         (hoverOnTimeline)="hoverOnTimeline($event)"
         (clickOnTimeline)="clickOnTimeline($event)"
         (hoverOnTimelineItem)="hoverOnTimelineChartItem($event)"
@@ -110,20 +134,11 @@ class TimelineFrameStoriesComponent {
     });
   }
 
-  viewModel = computed(() => {
+  viewModel = computed<TimelineFrameStoryViewModel>(() => {
     const data = this.khiInspectionData.value();
     if (!data) {
       return {
         ready: false,
-        timelines: [],
-        logs: [],
-        filteredLogs: [],
-        filteredLogIds: IdBitset.createEmpty(),
-        minLogTime: 0,
-        maxLogTime: 0,
-        chartStyle: undefined,
-        rulerStyle: undefined,
-        styleStore: undefined,
       };
     }
     const minTimeMs = data.metadata?.header
@@ -137,7 +152,6 @@ class TimelineFrameStoriesComponent {
       ready: true,
       timelines: data.timelineStore.timelines,
       logs,
-      filteredLogs: logs,
       filteredLogIds: IdBitset.fromAll(logs.map((log) => log.id)),
       minLogTime: minTimeMs,
       maxLogTime: maxTimeMs,

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -51,6 +51,7 @@ import { CommonModule } from '@angular/common';
 import { TimelineLegendComponent } from './timeline-legend.component';
 import { Log } from 'src/app/store/domain/log';
 import { HistogramCache } from './misc/histogram-cache';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 import {
   TimelineHoverOverlay,
   TimelineHoverOverlayComponent,
@@ -203,17 +204,10 @@ export class TimelineFrameComponent implements AfterViewInit {
   readonly filteredLogs = input<ReadonlyDomainElement<Log>[]>([]);
 
   /**
-   * The set of indices of non-filtered active logs.
+   * The bitset of filtered active log IDs.
    * Used for showing filtering state on the timeline.
    */
-  readonly activeLogsIndices = computed(() => {
-    const filteredLogs = this.filteredLogs();
-    const set = new Set<number>();
-    for (const log of filteredLogs) {
-      set.add(log.logIndex);
-    }
-    return set;
-  });
+  readonly filteredLogIds = input<IdBitset>(IdBitset.createEmpty());
 
   /**
    * The minimum time span for a single histogram bucket.

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -288,19 +288,14 @@ export class TimelineFrameComponent implements AfterViewInit {
   readonly timelineChartItemHighlights = input<TimelineChartItemHighlight>({});
 
   /**
-   * The index of the log that is currently selected.
+   * The index of the log that is currently selected, or 0xFFFFFFFF if none.
    */
-  readonly selectedLogIndex = computed(() => {
-    const highlights = this.timelineChartItemHighlights();
-    const findResult = Object.entries(highlights).find(([, value]) => {
-      return value === TimelineChartItemHighlightType.Selected;
-    });
-    if (findResult === undefined) {
-      return null;
-    }
-    const [highlightedLogIndex] = findResult;
-    return highlightedLogIndex;
-  });
+  readonly selectedLogIndex = input<number>(0xffffffff);
+
+  /**
+   * Bitset of highlighted log indices.
+   */
+  readonly highlightedLogIndexBitset = input<IdBitset>(IdBitset.createEmpty());
 
   /**
    * Request to show a hover overlay.
@@ -399,11 +394,17 @@ export class TimelineFrameComponent implements AfterViewInit {
    * Returns the actual timeline that contains the currently selected log.
    */
   protected readonly selectedLogTimeline = computed(() => {
-    const logIndexStr = this.selectedLogIndex();
-    if (logIndexStr === null) {
-      return null;
+    let logIndex = this.selectedLogIndex();
+    if (logIndex === 0xffffffff || logIndex === undefined || logIndex < 0) {
+      const highlights = this.timelineChartItemHighlights();
+      const findResult = Object.entries(highlights).find(([, value]) => {
+        return value === TimelineChartItemHighlightType.Selected;
+      });
+      if (findResult === undefined) {
+        return null;
+      }
+      logIndex = Number(findResult[0]);
     }
-    const logIndex = Number(logIndexStr);
     const allLogs = this.allLogsWithoutFilter();
     const log = allLogs[logIndex];
     if (!log) {

--- a/web/src/app/timeline/components/timeline-frame.component.ts
+++ b/web/src/app/timeline/components/timeline-frame.component.ts
@@ -165,7 +165,7 @@ export class TimelineFrameComponent implements AfterViewInit {
   /**
    * The list of timelines to display.
    */
-  readonly timelines = input<ReadonlyDomainElement<Timeline>[]>([]);
+  readonly timelines = input<readonly ReadonlyDomainElement<Timeline>[]>([]);
 
   /**
    * Current set of collapsed timeline IDs.
@@ -198,16 +198,17 @@ export class TimelineFrameComponent implements AfterViewInit {
    */
   readonly allLogsWithoutFilter = input<ReadonlyDomainElement<Log>[]>([]);
   /**
-   * The list of filtered logs.
-   * Used for displaying logs on the timeline.
-   */
-  readonly filteredLogs = input<ReadonlyDomainElement<Log>[]>([]);
-
-  /**
    * The bitset of filtered active log IDs.
    * Used for showing filtering state on the timeline.
    */
   readonly filteredLogIds = input<IdBitset>(IdBitset.createEmpty());
+
+  /**
+   * The bitset of all log IDs.
+   */
+  protected readonly allLogIds = computed(() => {
+    return IdBitset.fromSequential(this.allLogsWithoutFilter().length);
+  });
 
   /**
    * The minimum time span for a single histogram bucket.
@@ -229,9 +230,11 @@ export class TimelineFrameComponent implements AfterViewInit {
   protected readonly allLogsWithoutFilterHistogramCache = computed(() => {
     const minTimeSpanForHistogram = this.minTimeSpanForHistogram();
     const allLogsWithoutFilter = this.allLogsWithoutFilter();
+    const allLogIds = this.allLogIds();
     return new HistogramCache(
       this.styleStore().severities,
       allLogsWithoutFilter,
+      allLogIds,
       minTimeSpanForHistogram,
     );
   });
@@ -243,10 +246,12 @@ export class TimelineFrameComponent implements AfterViewInit {
   protected readonly filteredLogsHistogramCache = computed(() => {
     const minTimeSpanForHistogram = this.minTimeSpanForHistogram();
     const allLogsHistogramCache = this.allLogsWithoutFilterHistogramCache();
-    const filteredLogs = this.filteredLogs();
+    const allLogsWithoutFilter = this.allLogsWithoutFilter();
+    const filteredLogIds = this.filteredLogIds();
     return new HistogramCache(
       this.styleStore().severities,
-      filteredLogs,
+      allLogsWithoutFilter,
+      filteredLogIds,
       minTimeSpanForHistogram,
       allLogsHistogramCache.logMinTimeMS,
       allLogsHistogramCache.logMaxTimeMS,

--- a/web/src/app/timeline/components/timeline-ruler.stories.ts
+++ b/web/src/app/timeline/components/timeline-ruler.stories.ts
@@ -34,6 +34,7 @@ import { LogStore } from 'src/app/store/domain/log-store';
 import { InternPoolStore } from 'src/app/store/domain/intern-pool-store';
 import { StyleStore } from 'src/app/store/domain/style-store';
 import { generateDefaultRulerStyle } from 'src/app/timeline/components/style-model';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 
 @Component({
   selector: 'khi-rendering-loop-starter',
@@ -197,19 +198,22 @@ function generateMockLogs(
 
 function generateViewModel(
   logs: Log[],
-  filteredLogs: Log[] = logs,
+  filterLogIds: IdBitset = IdBitset.fromAll(logs.map((l) => l.id)),
 ): TimelineRulerViewModel {
   const calculator = new RulerViewModelBuilder();
+  const allLogIds = IdBitset.fromAll(logs.map((l) => l.id));
   const allLogsCache = new HistogramCache(
     sharedStyleStore.severities,
     logs,
+    allLogIds,
     1000,
     START_TIME,
     START_TIME + DURATION,
   ); // 1s bucket
   const filteredLogsCache = new HistogramCache(
     sharedStyleStore.severities,
-    filteredLogs,
+    logs,
+    filterLogIds,
     1000,
     START_TIME,
     START_TIME + DURATION,
@@ -230,13 +234,15 @@ function filterLogs(
   rate: number,
 ): {
   allLogs: Log[];
-  filteredLogs: Log[];
+  filteredLogIds: IdBitset;
 } {
   const allLogs = logs;
-  const filteredLogs = logs.filter(() => {
-    return Math.random() < rate;
-  });
-  return { allLogs, filteredLogs };
+  const filteredIds = logs
+    .filter(() => {
+      return Math.random() < rate;
+    })
+    .map((l) => l.id);
+  return { allLogs, filteredLogIds: IdBitset.fromAll(filteredIds) };
 }
 
 export const Default: Story = {
@@ -291,7 +297,7 @@ const filtered = filterLogs(
 );
 export const Filtered: Story = {
   args: {
-    viewModel: generateViewModel(filtered.allLogs, filtered.filteredLogs),
+    viewModel: generateViewModel(filtered.allLogs, filtered.filteredLogIds),
     leftEdgeTime: START_TIME,
     pixelsPerMs: VIEWPORT_WIDTH / DURATION,
   },

--- a/web/src/app/timeline/timeline-smart.component.html
+++ b/web/src/app/timeline/timeline-smart.component.html
@@ -34,6 +34,8 @@
   (viewportLeftTimeMSChange)="onViewportLeftTimeMsChange($event)"
   [timelineHighlights]="timelineHighlights()"
   [timelineChartItemHighlights]="timelineChartItemHighlights()"
+  [selectedLogIndex]="selectedLogIndexForRenderer()"
+  [highlightedLogIndexBitset]="highlightedLogIndexBitset()"
   (hoverOnTimeline)="hoverOnTimeline($event)"
   (clickOnTimeline)="clickOnTimeline($event)"
   (toggleCollapseTimeline)="onToggleCollapseTimeline($event)"

--- a/web/src/app/timeline/timeline-smart.component.html
+++ b/web/src/app/timeline/timeline-smart.component.html
@@ -46,7 +46,6 @@
   [cursorTimeMS]="cursorTimeMs()"
   [timelineHoverOverlayRequest]="timelineHoverOverlayRequest()"
   [allLogsWithoutFilter]="allLogs()"
-  [filteredLogs]="filteredLogs()"
   [filteredLogIds]="filteredLogIds()"
   (mouseEnterChart)="onMouseEnterChart()"
   (mouseLeaveChart)="onMouseLeaveChart()"

--- a/web/src/app/timeline/timeline-smart.component.html
+++ b/web/src/app/timeline/timeline-smart.component.html
@@ -47,6 +47,7 @@
   [timelineHoverOverlayRequest]="timelineHoverOverlayRequest()"
   [allLogsWithoutFilter]="allLogs()"
   [filteredLogs]="filteredLogs()"
+  [filteredLogIds]="filteredLogIds()"
   (mouseEnterChart)="onMouseEnterChart()"
   (mouseLeaveChart)="onMouseLeaveChart()"
   (mouseEnterStickyHeader)="onMouseEnterStickyHeader()"

--- a/web/src/app/timeline/timeline-smart.component.ts
+++ b/web/src/app/timeline/timeline-smart.component.ts
@@ -175,14 +175,6 @@ export class TimelineSmartComponent {
   });
 
   /**
-   * List of logs matching the current filter criteria.
-   * Used for the histogram and log distribution views.
-   */
-  protected readonly filteredLogs = computed(() => {
-    return this.inspectionDataStore.timelineView()?.filteredLogs() ?? [];
-  });
-
-  /**
    * Bitset of log IDs matching the current filter criteria.
    * Used for passing directly to timeline frame WebGL rendering.
    */
@@ -202,7 +194,7 @@ export class TimelineSmartComponent {
     if (header) {
       return header.startTimeUnixSeconds * 1000;
     }
-    const logs = this.filteredLogs();
+    const logs = this.allLogs();
     if (logs.length === 0) {
       return Date.now() - 60 * 60 * 1000;
     }
@@ -218,7 +210,7 @@ export class TimelineSmartComponent {
     if (header) {
       return header.endTimeUnixSeconds * 1000;
     }
-    const logs = this.filteredLogs();
+    const logs = this.allLogs();
     if (logs.length === 0) {
       return Date.now();
     }

--- a/web/src/app/timeline/timeline-smart.component.ts
+++ b/web/src/app/timeline/timeline-smart.component.ts
@@ -43,6 +43,7 @@ import {
 } from 'src/app/timeline/components/style-model';
 import { TimelineChartMouseEvent } from 'src/app/timeline/components/timeline-chart.component';
 import { bisectLeft } from 'src/app/common/misc-util';
+import { IdBitset } from 'src/app/store/domain/filter/id-bitset';
 import { BigIntTimeUtil } from 'src/app/utils/bigint-time-util';
 import { TimelineFilterConfig } from 'src/app/timeline-toolbar/types/filter-config';
 
@@ -179,6 +180,17 @@ export class TimelineSmartComponent {
    */
   protected readonly filteredLogs = computed(() => {
     return this.inspectionDataStore.timelineView()?.filteredLogs() ?? [];
+  });
+
+  /**
+   * Bitset of log IDs matching the current filter criteria.
+   * Used for passing directly to timeline frame WebGL rendering.
+   */
+  protected readonly filteredLogIds = computed(() => {
+    return (
+      this.inspectionDataStore.timelineView()?.filteredLogIds() ??
+      IdBitset.createEmpty()
+    );
   });
 
   /**

--- a/web/src/app/timeline/timeline-smart.component.ts
+++ b/web/src/app/timeline/timeline-smart.component.ts
@@ -380,21 +380,25 @@ export class TimelineSmartComponent {
       return { timeline: currentSelected, targetTimeNs };
     }
 
+    const timelineStore =
+      this.inspectionDataStore.inspectionData()?.timelineStore;
+    const logTimelines = timelineStore
+      ? timelineStore.getTimelinesForLogId(targetLog.id)
+      : [];
+
     if (currentSelected) {
       const descendants = new Set(currentSelected.descendants());
-      const allTimelines = this.filteredTimelines();
-      const descendantMatch = allTimelines.find(
-        (t: ReadonlyDomainElement<Timeline>) =>
-          descendants.has(t) && t.hasLog(targetLog),
-      );
+      const descendantMatch = logTimelines.find((t) => descendants.has(t));
       if (descendantMatch) {
         return { timeline: descendantMatch, targetTimeNs };
       }
     }
 
-    const allTimelines = this.filteredTimelines();
-    const globalMatch = allTimelines.find(
-      (t: ReadonlyDomainElement<Timeline>) => t.hasLog(targetLog),
+    const filteredTimelineIds = this.inspectionDataStore
+      .timelineView()
+      ?.filteredTimelineIds();
+    const globalMatch = logTimelines.find(
+      (t) => !filteredTimelineIds || filteredTimelineIds.has(t.id),
     );
     return globalMatch ? { timeline: globalMatch, targetTimeNs } : null;
   }

--- a/web/src/app/timeline/timeline-smart.component.ts
+++ b/web/src/app/timeline/timeline-smart.component.ts
@@ -267,8 +267,18 @@ export class TimelineSmartComponent {
     return this.selectionManager.selectedLogIndex();
   });
 
+  protected readonly selectedLogIndexForRenderer = computed(() => {
+    return this.selectionManager.selectedLogIndex() ?? 0xffffffff;
+  });
+
   private readonly highlightedLogIndices = computed(() => {
     return this.selectionManager.highlightLogIndices();
+  });
+
+  protected readonly highlightedLogIndexBitset = computed(() => {
+    return IdBitset.fromSet(
+      this.selectionManager.highlightLogIndices() ?? new Set<number>(),
+    );
   });
 
   /**

--- a/web/src/assets/event.vertex.glsl
+++ b/web/src/assets/event.vertex.glsl
@@ -8,8 +8,10 @@ precision highp int;
 // Input attributes from the vertex buffer.
 // instanced rendering is used, so these attributes are per-instance (per-event).
 layout(location = 0) in uvec2 time; // x: start time(s), y: start time(ns). High precision timestamp.
-layout(location = 1) in uvec4 intStaticMeta; // x: eventIndex, y: logType, z: logSeverity. Static metadata.
-layout(location = 2) in uvec4 intDynamicMeta; // x: selectionState. y: filterState Dynamic metadata that can change frequently.
+layout(location = 1) in uvec4 intStaticMeta; // x: logType, y: logSeverity, z: logIndex, w: logId. Static metadata.
+
+uniform highp usampler2D u_filterBitset;
+uniform highp usampler2D u_highlightBitset;
 
 // Outputs to the fragment shader.
 out vec2 uv;                // UV coordinates for the quad (0.0 to 1.0).
@@ -55,29 +57,38 @@ void main(){
   pos.xy = genRotationMatrix2D(PI / 4.0) * pos.xy / SQRT2;
   uvAfterRotation = pos.xy * 0.5 + 0.5;
 
-  // 3. Populate the EventModel to pass data to the fragment shader
-  eventModel.eventIndex = intStaticMeta.x;
-  eventModel.logTypeColor = es.logTypeColors[intStaticMeta.y];
-  eventModel.logSeverityColor = es.logSeverityColors[intStaticMeta.z];
-  eventModel.selectionStatus = intDynamicMeta.x;
-  eventModel.filterStatus = intDynamicMeta.y;
+  // 3. Compute dynamic selection and filter states
+  uint logIndex = intStaticMeta.z;
+  uint logId = intStaticMeta.w;
 
-  // 4. Calculate the screen size of the event
+  bool isSelected = (vs.selectedLogIndex != 0xFFFFFFFFu && logIndex == vs.selectedLogIndex);
+  bool isHovered = (!isSelected && checkBitset(u_highlightBitset, logIndex));
+  uint selectionStatus = isSelected ? 2u : (isHovered ? 1u : 0u);
+  uint filterStatus = checkBitset(u_filterBitset, logId) ? 1u : 0u;
+
+  // 4. Populate the EventModel to pass data to the fragment shader
+  eventModel.eventIndex = uint(gl_InstanceID);
+  eventModel.logTypeColor = es.logTypeColors[intStaticMeta.x];
+  eventModel.logSeverityColor = es.logSeverityColors[intStaticMeta.y];
+  eventModel.selectionStatus = selectionStatus;
+  eventModel.filterStatus = filterStatus;
+
+  // 5. Calculate the screen size of the event
   // If the event is not selected/hovered (selectionStatus < 0.5), it is slightly smaller.
   eventScreenSize = els.timelineHeight - 2.0 * els.verticalPadding * mix(1.0,0.7, step(0.5, float(eventModel.selectionStatus)));
   vec2 scale = vec2(eventScreenSize) / vec2(vs.canvasResolution.x,els.timelineHeight);
 
-  // 5. Calculate the position of the event on the timeline
+  // 6. Calculate the position of the event on the timeline
   ivec2 leftEdgeRelativeTime = ivec2(time.xy - vs.leftEdgeTime);
   // Convert time difference to screen pixels.
   float leftEdgeXScreen = (float(leftEdgeRelativeTime.x) * 1e+3 + float(leftEdgeRelativeTime.y) * 1e-6) * vs.pixelsPerMs;
   // Convert screen pixels to Normalized Device Coordinates (NDC).
   vec2 translation = vec2(leftEdgeXScreen / vs.canvasResolution.x * 2.0 - 1.0,0.0);
 
-  // 6. Apply translation and scaling to the rotated quad
+  // 7. Apply translation and scaling to the rotated quad
   vec3 moved = genTranslationScaleMatrixAffineSpace2D(translation,scale) * vec3(pos.xy,1.0);
 
-  // 7. Calculate final Depth (Z-coordinate) for correct layering
+  // 8. Calculate final Depth (Z-coordinate) for correct layering
   // Importance criteria 1: active > filtered out
   // Importance criteria 2: Selected > Hover > None
   // Importance criteria 3: severity (higher severity -> closer to camera)
@@ -85,7 +96,7 @@ void main(){
   float baseOffset = -0.5;
   float filterPriority = - 0.1 * float(eventModel.filterStatus);
   float selectionPriority = - 0.01 * float(SELECTION_STATE_TO_DEPTH_PRIORITY[eventModel.selectionStatus]);
-  float importancePriority = - 0.001 / float(MAX_LOG_SEVERITY_COUNT) * float(intStaticMeta.z);
+  float importancePriority = - 0.001 / float(MAX_LOG_SEVERITY_COUNT) * float(intStaticMeta.y);
   pos.z = filterPriority + selectionPriority + importancePriority + baseOffset;
 
   gl_Position = vec4(moved.xy,pos.z,1.0);

--- a/web/src/assets/event.vertex.glsl
+++ b/web/src/assets/event.vertex.glsl
@@ -61,7 +61,7 @@ void main(){
   uint logIndex = intStaticMeta.z;
   uint logId = intStaticMeta.w;
 
-  bool isSelected = (vs.selectedLogIndex != 0xFFFFFFFFu && logIndex == vs.selectedLogIndex);
+  bool isSelected = (vs.selectedLogIndex != NO_LOG_INDEX_SELECTED && logIndex == vs.selectedLogIndex);
   bool isHovered = (!isSelected && checkBitset(u_highlightBitset, logIndex));
   uint selectionStatus = isSelected ? 2u : (isHovered ? 1u : 0u);
   uint filterStatus = checkBitset(u_filterBitset, logId) ? 1u : 0u;

--- a/web/src/assets/revision.vertex.glsl
+++ b/web/src/assets/revision.vertex.glsl
@@ -10,8 +10,10 @@ precision highp int;
 
 // Input attributes from the vertex buffer.
 layout(location = 0) in uvec4 time; // x: start time(s), y: start time(ns), z: end time(s), w: end time(ns)
-layout(location = 1) in uvec4 intStaticMeta; // x: revisionIndex, y: revisionState, z: logIndex. Static metadata.
-layout(location = 2) in uvec4 intDynamicMeta; // x: selectionState, y: filterStatus. Dynamic metadata.
+layout(location = 1) in uvec4 intStaticMeta; // x: revisionState, y: 0, z: logIndex, w: logId. Static metadata.
+
+uniform highp usampler2D u_filterBitset;
+uniform highp usampler2D u_highlightBitset;
 
 // Outputs to the fragment shader.
 out vec2 uv;                // UV coordinates for the quad (0.0 to 1.0).
@@ -30,17 +32,26 @@ vec4 genQuadPosition(){
 void main(){
   vec4 pos = genQuadPosition();
   
+  // Compute dynamic selection and filter states
+  uint logIndex = intStaticMeta.z;
+  uint logId = intStaticMeta.w;
+
+  bool isSelected = (vs.selectedLogIndex != 0xFFFFFFFFu && logIndex == vs.selectedLogIndex);
+  bool isHovered = (!isSelected && checkBitset(u_highlightBitset, logIndex));
+  uint selectionStatus = isSelected ? 2u : (isHovered ? 1u : 0u);
+  uint filterStatus = checkBitset(u_filterBitset, logId) ? 1u : 0u;
+
   // Populate the RevisionModel to pass data to the fragment shader.
-  revisionModel.baseColor = rs.baseColors[intStaticMeta.y];
-  revisionModel.iconUVSize = rs.iconUVSize[intStaticMeta.y];
-  revisionModel.alphaTransparency = rs.revisionStyles[intStaticMeta.y].x;
-  revisionModel.borderStripePatten = rs.revisionStyles[intStaticMeta.y].y;
-  revisionModel.bodyStripePattern = rs.revisionStyles[intStaticMeta.y].z;
-  revisionModel.revisionIndex = intStaticMeta.x;
-  revisionModel.revisionState = intStaticMeta.y;
+  revisionModel.baseColor = rs.baseColors[intStaticMeta.x];
+  revisionModel.iconUVSize = rs.iconUVSize[intStaticMeta.x];
+  revisionModel.alphaTransparency = rs.revisionStyles[intStaticMeta.x].x;
+  revisionModel.borderStripePatten = rs.revisionStyles[intStaticMeta.x].y;
+  revisionModel.bodyStripePattern = rs.revisionStyles[intStaticMeta.x].z;
+  revisionModel.revisionIndex = uint(gl_InstanceID);
+  revisionModel.revisionState = intStaticMeta.x;
   revisionModel.logIndex = intStaticMeta.z;
-  revisionModel.selectionStatus = intDynamicMeta.x;
-  revisionModel.filterStatus = intDynamicMeta.y;
+  revisionModel.selectionStatus = selectionStatus;
+  revisionModel.filterStatus = filterStatus;
 
   uv = pos.xy * 0.5 + 0.5;
 

--- a/web/src/assets/revision.vertex.glsl
+++ b/web/src/assets/revision.vertex.glsl
@@ -36,7 +36,7 @@ void main(){
   uint logIndex = intStaticMeta.z;
   uint logId = intStaticMeta.w;
 
-  bool isSelected = (vs.selectedLogIndex != 0xFFFFFFFFu && logIndex == vs.selectedLogIndex);
+  bool isSelected = (vs.selectedLogIndex != NO_LOG_INDEX_SELECTED && logIndex == vs.selectedLogIndex);
   bool isHovered = (!isSelected && checkBitset(u_highlightBitset, logIndex));
   uint selectionStatus = isSelected ? 2u : (isHovered ? 1u : 0u);
   uint filterStatus = checkBitset(u_filterBitset, logId) ? 1u : 0u;

--- a/web/src/assets/shared.glsl
+++ b/web/src/assets/shared.glsl
@@ -5,6 +5,9 @@
 // Bitset texture constant
 #define BITSET_TEXTURE_WIDTH 2048u
 
+// Sentinel value indicating that no log is currently selected.
+#define NO_LOG_INDEX_SELECTED 0xFFFFFFFFu
+
 // ViewState containing the global viewport and time state.
 // This uniform block is shared across all renderers.
 layout(std140) uniform ViewState {
@@ -12,15 +15,18 @@ layout(std140) uniform ViewState {
     float devicePixelRatio; // The ratio of physical pixels to logical pixels.
     float pixelsPerMs; // The current zoom level: pixels per millisecond.
     uvec2 leftEdgeTime; // The timestamp at the left edge of the viewport. x: seconds, y: nanoseconds.
-    uint selectedLogIndex; // The index of the selected log, or 0xFFFFFFFFu if none.
+    uint selectedLogIndex; // The index of the selected log, or NO_LOG_INDEX_SELECTED (0xFFFFFFFFu) if none.
     uint _padding;
 } vs;
 
 // Checks whether a given bit is set in an R32UI bitset texture.
+// id >> 5u is equivalent to integer division by 32 to determine the uint32 word index.
+// id & 31u is equivalent to modulo 32 to determine the bit offset within that word.
+// Texture coordinate is computed via bitwise operations: wordIndex & 2047u for x (mod 2048), wordIndex >> 11u for y (div 2048).
 bool checkBitset(highp usampler2D bitsetTexture, uint id) {
     uint wordIndex = id >> 5u;
     uint bitOffset = id & 31u;
-    ivec2 coord = ivec2(int(wordIndex % BITSET_TEXTURE_WIDTH), int(wordIndex / BITSET_TEXTURE_WIDTH));
+    ivec2 coord = ivec2(int(wordIndex & 2047u), int(wordIndex >> 11u));
     uint word = texelFetch(bitsetTexture, coord, 0).r;
     return (word & (1u << bitOffset)) != 0u;
 }

--- a/web/src/assets/shared.glsl
+++ b/web/src/assets/shared.glsl
@@ -2,6 +2,9 @@
 #define PI 3.141592653589793
 #define SQRT2 1.414213562373095
 
+// Bitset texture constant
+#define BITSET_TEXTURE_WIDTH 2048u
+
 // ViewState containing the global viewport and time state.
 // This uniform block is shared across all renderers.
 layout(std140) uniform ViewState {
@@ -9,4 +12,15 @@ layout(std140) uniform ViewState {
     float devicePixelRatio; // The ratio of physical pixels to logical pixels.
     float pixelsPerMs; // The current zoom level: pixels per millisecond.
     uvec2 leftEdgeTime; // The timestamp at the left edge of the viewport. x: seconds, y: nanoseconds.
+    uint selectedLogIndex; // The index of the selected log, or 0xFFFFFFFFu if none.
+    uint _padding;
 } vs;
+
+// Checks whether a given bit is set in an R32UI bitset texture.
+bool checkBitset(highp usampler2D bitsetTexture, uint id) {
+    uint wordIndex = id >> 5u;
+    uint bitOffset = id & 31u;
+    ivec2 coord = ivec2(int(wordIndex % BITSET_TEXTURE_WIDTH), int(wordIndex / BITSET_TEXTURE_WIDTH));
+    uint word = texelFetch(bitsetTexture, coord, 0).r;
+    return (word & (1u << bitOffset)) != 0u;
+}


### PR DESCRIPTION
## Summary
Significantly accelerates timeline rendering and user interaction by replacing array-based log filtering with compact `IdBitset` representations, offloading dynamic status updates to WebGL shaders, and optimizing timeline/log selection resolution.

## Key Changes
- **IdBitset Migration**:
  - Migrates timeline filter pipeline and log visibility tracking from full object arrays to `IdBitset`.
  - Replaces `filteredLogs` with `allLogs` and `filteredLogIds`.
- **GPU-Accelerated Dynamic Status**:
  - Migrates dynamic highlight/hover/selection status rendering to WebGL R32UI bitset textures and Uniform Buffer Objects (UBO).
  - Eliminates CPU-bound vertex buffer re-allocations during selection/highlight changes.
- **GLSL Shader Testing (`glsl-function-tester.ts`)**:
  - Introduces `GLSLFunctionTester` to unit test WebGL GLSL vertex shader functions directly in Karma/Jasmine tests.
  - Adds hit-test unit tests for shared WebGL resources.
- **Timeline Store & Selection Performance**:
  - Adds reverse index (`logIdToTimelineIds`) in `TimelineStore` for $O(1)$ log-to-timeline lookups.
  - Optimizes `SelectionManager` to resolve selection states using bitset queries.
  - Reduces redundant computations in `LogListComponent` and timeline selection consumers.

## Verification
- `npm test -- --watch=false --browsers=ChromeHeadless` (1,049 tests passed)