### PR TITLE
perf(core): optimize orderedMapNode reader access and release raw logs after ingestion

### DIFF
--- a/pkg/common/structured/ordered.go
+++ b/pkg/common/structured/ordered.go
@@ -93,4 +93,9 @@ func (o *orderedMapNode) Children() NodeChildrenIterator {
 	}
 }
 
+// Unwrap returns the inner wrapped Node.
+func (o *orderedMapNode) Unwrap() Node {
+	return o.inner
+}
+
 var _ Node = (*orderedMapNode)(nil)

--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -77,6 +77,11 @@ func (n *NodeReader) GetNode(path FieldPath) (Node, error) {
 	}
 	currentNode := n.Node
 	for i := 0; i < len(path.segments); i++ {
+		// Unwrap orderedMapNode if present since key ordering is not relevant for direct field lookup.
+		if ordered, ok := currentNode.(*orderedMapNode); ok {
+			currentNode = ordered.Unwrap()
+		}
+
 		// Fast-path: direct handle lookup on StandardMapNode without allocating closures.
 		if mapNode, ok := currentNode.(*StandardMapNode); ok {
 			child, found := mapNode.GetChildByHandle(path.handles[i])

--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -77,6 +77,10 @@ func (n *NodeReader) GetNode(path FieldPath) (Node, error) {
 	}
 	currentNode := n.Node
 	for i := 0; i < len(path.segments); i++ {
+		if currentNode == nil {
+			return nil, ErrFieldNotFound
+		}
+
 		// Unwrap orderedMapNode if present since key ordering is not relevant for direct field lookup.
 		if ordered, ok := currentNode.(*orderedMapNode); ok {
 			currentNode = ordered.Unwrap()

--- a/pkg/common/structured/reader_test.go
+++ b/pkg/common/structured/reader_test.go
@@ -372,3 +372,34 @@ nested:
 		})
 	}
 }
+
+func TestNodeReader_NilChildHandling(t *testing.T) {
+	testCases := []struct {
+		name    string
+		reader  *NodeReader
+		path    FieldPath
+		wantErr error
+	}{
+		{
+			name:    "nil reader node returns ErrFieldNotFound",
+			reader:  NewNodeReader(nil),
+			path:    CompileFieldPath("a.b.c"),
+			wantErr: ErrFieldNotFound,
+		},
+		{
+			name:    "map containing nil child returns ErrFieldNotFound on subpath",
+			reader:  NewNodeReader(NewStandardMap([]string{"a"}, []Node{nil})),
+			path:    CompileFieldPath("a.b"),
+			wantErr: ErrFieldNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.reader.GetNode(tc.path)
+			if err != tc.wantErr {
+				t.Errorf("GetNode() error mismatch (-want %v, +got %v)", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/pkg/common/structured/reader_test.go
+++ b/pkg/common/structured/reader_test.go
@@ -324,3 +324,51 @@ nested:
 		t.Errorf("ReadStringOrDefault() fallback mismatch: want %q, got %q", "default", got)
 	}
 }
+
+func TestNodeReader_WithOrderedMapNode(t *testing.T) {
+	yamlData := `
+zebra: "last_alphabetical"
+alpha: "first_alphabetical"
+nested:
+  beta: "inner_beta"
+`
+	node, err := FromYAML(yamlData)
+	if err != nil {
+		t.Fatalf("failed to parse YAML: %v", err)
+	}
+
+	// Wrap root node with WithKeyOrder
+	ordered := WithKeyOrder(node, "zebra", "alpha")
+	reader := NewNodeReader(ordered)
+
+	testCases := []struct {
+		name string
+		path FieldPath
+		want string
+	}{
+		{
+			name: "read zebra field from ordered node",
+			path: CompileFieldPath("zebra"),
+			want: "last_alphabetical",
+		},
+		{
+			name: "read alpha field from ordered node",
+			path: CompileFieldPath("alpha"),
+			want: "first_alphabetical",
+		},
+		{
+			name: "read nested field from ordered node",
+			path: CompileFieldPath("nested.beta"),
+			want: "inner_beta",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reader.ReadStringOrDefault(tc.path, "")
+			if got != tc.want {
+				t.Errorf("ReadStringOrDefault() mismatch (-want %q, +got %q)", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/core/init/default/debug.go
+++ b/pkg/core/init/default/debug.go
@@ -16,6 +16,9 @@ package defaultinit
 
 import (
 	"log/slog"
+	"os"
+	"runtime"
+	"runtime/pprof"
 
 	"cloud.google.com/go/profiler"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/constants"
@@ -68,6 +71,38 @@ var DebugFeaturesInitializer = &coreinit.Initializer{
 			)
 			otel.SetTracerProvider(tp)
 			slog.Info("Cloud Trace is enabled")
+		}
+		if *debugParams.CPUProfile != "" {
+			f, err := os.Create(*debugParams.CPUProfile)
+			if err != nil {
+				return err
+			}
+			if err := pprof.StartCPUProfile(f); err != nil {
+				f.Close()
+				return err
+			}
+			slog.Info("CPU profiling is enabled", "file", *debugParams.CPUProfile)
+			ctx.OnTerminate(func() error {
+				pprof.StopCPUProfile()
+				return f.Close()
+			})
+		}
+		if *debugParams.MemProfile != "" {
+			memProfilePath := *debugParams.MemProfile
+			slog.Info("Memory profiling is enabled", "file", memProfilePath)
+			ctx.OnTerminate(func() error {
+				f, err := os.Create(memProfilePath)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				runtime.GC()
+				if err := pprof.WriteHeapProfile(f); err != nil {
+					return err
+				}
+				slog.Info("Memory profile written", "file", memProfilePath)
+				return nil
+			})
 		}
 		return nil
 	},

--- a/pkg/core/inspection/taskbase/grouped_logingester_task.go
+++ b/pkg/core/inspection/taskbase/grouped_logingester_task.go
@@ -69,15 +69,14 @@ func (SinglePassGroupedIngesterBase[T]) PreProcessLogByGroup(ctx context.Context
 }
 
 // NewGroupedLogIngesterTask returns a task that ingests log metadata into the KHI v6 builder using group-sequential processing.
-func NewGroupedLogIngesterTask[T any](taskID taskid.TaskImplementationID[[]*log.Log], ingester GroupedLogIngester[T], labels ...coretask.LabelOpt) coretask.Task[[]*log.Log] {
+func NewGroupedLogIngesterTask[T any](taskID taskid.TaskImplementationID[struct{}], ingester GroupedLogIngester[T], labels ...coretask.LabelOpt) coretask.Task[struct{}] {
 	rawLogTaskID := ingester.RawLogTask()
 	groupedLogTaskID := ingester.GroupedLogTask()
 	dependencies := append([]taskid.UntypedTaskReference{rawLogTaskID, groupedLogTaskID}, ingester.Dependencies()...)
-	return NewProgressReportableInspectionTask(taskID, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*log.Log, error) {
+	return NewProgressReportableInspectionTask(taskID, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (struct{}, error) {
 		if taskMode == inspectioncore_contract.TaskModeDryRun {
-			return []*log.Log{}, nil
+			return struct{}{}, nil
 		}
-		logs := coretask.GetTaskResult(ctx, rawLogTaskID)
 		groupedLogs := coretask.GetTaskResult(ctx, groupedLogTaskID)
 		builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
 
@@ -181,10 +180,10 @@ func NewGroupedLogIngesterTask[T any](taskID taskid.TaskImplementationID[[]*log.
 		progressUpdator.Done()
 
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return struct{}{}, ctx.Err()
 		}
 		if sharedErr != nil {
-			return nil, sharedErr
+			return struct{}{}, sharedErr
 		}
 
 		slog.DebugContext(ctx, fmt.Sprintf("GroupedLogIngesterTask %s finished: processed %d logs (skipped %d logs)", taskID.String(), totalLogCount, skippedLogCount.Load()))
@@ -195,7 +194,7 @@ func NewGroupedLogIngesterTask[T any](taskID taskid.TaskImplementationID[[]*log.
 				attribute.String("log_count", fmt.Sprintf("%d", totalLogCount)),
 			)
 		}
-		return logs, nil
+		return struct{}{}, nil
 	}, append([]coretask.LabelOpt{
 		// Tasks modifying history must be dependent from SerializerTask.
 		coretask.NewSubsequentTaskRefsTaskLabel(inspectioncore_contract.SerializerTaskID.Ref())}, labels...)...)

--- a/pkg/core/inspection/taskbase/grouped_logingester_task_test.go
+++ b/pkg/core/inspection/taskbase/grouped_logingester_task_test.go
@@ -158,7 +158,7 @@ func TestNewGroupedLogIngesterTask(t *testing.T) {
 				processFn: processFn,
 			}
 
-			tid := taskid.NewDefaultImplementationID[[]*log.Log]("test-grouped-ingester")
+			tid := taskid.NewDefaultImplementationID[struct{}]("test-grouped-ingester")
 			task := NewGroupedLogIngesterTask(tid, ingester)
 
 			ctx := context.Background()
@@ -172,7 +172,7 @@ func TestNewGroupedLogIngesterTask(t *testing.T) {
 				cancel()
 			}
 
-			result, _, err := inspectiontest.RunInspectionTask(
+			_, _, err := inspectiontest.RunInspectionTask(
 				ctx,
 				task,
 				inspectioncore_contract.TaskModeRun,
@@ -189,10 +189,6 @@ func TestNewGroupedLogIngesterTask(t *testing.T) {
 					t.Fatalf("unexpected error message: got %q, want %q", err.Error(), tc.wantErrMsg)
 				}
 				return
-			}
-
-			if len(result) != len(tc.rawLogs) {
-				t.Fatalf("unexpected result count: got %d, want %d", len(result), len(tc.rawLogs))
 			}
 
 			// Verify ingestion.
@@ -235,7 +231,7 @@ func TestNewGroupedLogIngesterTask_ErrorHandling(t *testing.T) {
 		},
 	}
 
-	tid := taskid.NewDefaultImplementationID[[]*log.Log]("test-grouped-ingester-error")
+	tid := taskid.NewDefaultImplementationID[struct{}]("test-grouped-ingester-error")
 	task := NewGroupedLogIngesterTask(tid, ingester)
 
 	builder := khifilev6.NewBuilder()

--- a/pkg/core/inspection/taskbase/logingester_task.go
+++ b/pkg/core/inspection/taskbase/logingester_task.go
@@ -47,18 +47,18 @@ type LogIngester interface {
 }
 
 // NewLogIngesterTask returns a task that ingests log metadata into the KHI v6 builder.
-func NewLogIngesterTask(taskID taskid.TaskImplementationID[[]*log.Log], ingester LogIngester, labels ...coretask.LabelOpt) coretask.Task[[]*log.Log] {
+func NewLogIngesterTask(taskID taskid.TaskImplementationID[struct{}], ingester LogIngester, labels ...coretask.LabelOpt) coretask.Task[struct{}] {
 	rawLogTaskID := ingester.RawLogTask()
 	dependencies := append([]taskid.UntypedTaskReference{rawLogTaskID}, ingester.Dependencies()...)
-	return NewProgressReportableInspectionTask(taskID, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*log.Log, error) {
+	return NewProgressReportableInspectionTask(taskID, dependencies, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) (struct{}, error) {
 		if taskMode == inspectioncore_contract.TaskModeDryRun {
-			return []*log.Log{}, nil
+			return struct{}{}, nil
 		}
 		logs := coretask.GetTaskResult(ctx, rawLogTaskID)
 		builder := khictx.MustGetValue(ctx, inspectioncore_contract.Builder)
 
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return struct{}{}, err
 		}
 
 		concurrency := runtime.GOMAXPROCS(0)
@@ -134,10 +134,10 @@ func NewLogIngesterTask(taskID taskid.TaskImplementationID[[]*log.Log], ingester
 		progressUpdator.Done()
 
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return struct{}{}, ctx.Err()
 		}
 		if sharedErr != nil {
-			return nil, sharedErr
+			return struct{}{}, sharedErr
 		}
 
 		slog.DebugContext(ctx, fmt.Sprintf("LogIngesterTask %s finished: processed %d logs (skipped %d logs)", taskID.String(), len(logs), skippedLogCount.Load()))
@@ -148,7 +148,7 @@ func NewLogIngesterTask(taskID taskid.TaskImplementationID[[]*log.Log], ingester
 				attribute.String("log_count", fmt.Sprintf("%d", len(logs))),
 			)
 		}
-		return logs, nil
+		return struct{}{}, nil
 	}, append([]coretask.LabelOpt{
 		// Tasks modifying history must be dependent from SerializerTask.
 		coretask.NewSubsequentTaskRefsTaskLabel(inspectioncore_contract.SerializerTaskID.Ref())}, labels...)...)

--- a/pkg/core/inspection/taskbase/logingester_task_test.go
+++ b/pkg/core/inspection/taskbase/logingester_task_test.go
@@ -138,7 +138,7 @@ func TestLogIngesterTask(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			tid := taskid.NewDefaultImplementationID[[]*log.Log]("mock-log-ingester")
+			tid := taskid.NewDefaultImplementationID[struct{}]("mock-log-ingester")
 
 			ctx := context.Background()
 			ctx = inspectiontest.WithDefaultTestInspectionTaskContext(ctx)
@@ -146,6 +146,7 @@ func TestLogIngesterTask(t *testing.T) {
 			var cancel context.CancelFunc
 			if tc.cancelContext || tc.cancelMidWay {
 				ctx, cancel = context.WithCancel(ctx)
+				defer cancel()
 			}
 			if tc.cancelContext {
 				cancel()

--- a/pkg/core/inspection/taskbase/mapper_task.go
+++ b/pkg/core/inspection/taskbase/mapper_task.go
@@ -71,7 +71,7 @@ func (r *TimelineMapperResult) Merge(other TimelineMapperResult) {
 // LogToTimelineMapper defines the interface for mapping logs to timeline elements (events or revisions) in KHI file v6 format.
 type LogToTimelineMapper[T any] interface {
 	// LogIngesterTask is one of prerequisite task of LogToTimelineMapper ingesting logs before processing with this mapper.
-	LogIngesterTask() taskid.TaskReference[[]*log.Log]
+	LogIngesterTask() taskid.TaskReference[struct{}]
 	// Dependencies are the additional references used in timeline mapper.
 	Dependencies() []taskid.UntypedTaskReference
 	// GroupedLogTask returns a reference to the task that provides the grouped logs.

--- a/pkg/core/inspection/taskbase/mapper_task_test.go
+++ b/pkg/core/inspection/taskbase/mapper_task_test.go
@@ -38,7 +38,7 @@ var (
 )
 
 var mockLogToTimelineMapperPrevTaskID = taskid.NewDefaultImplementationID[LogGroupMap]("mock-timeline-mapper-prev")
-var mockLogSerializerPrevTaskID = taskid.NewDefaultImplementationID[[]*log.Log]("mock-timeline-mapper-prev-log-serializer")
+var mockLogSerializerPrevTaskID = taskid.NewDefaultImplementationID[struct{}]("mock-timeline-mapper-prev-log-serializer")
 
 type mockLogToTimelineMapperGroupData struct {
 	ProcessedLogs int
@@ -53,7 +53,7 @@ func (m *mockLogToTimelineMapper) GroupedLogTask() taskid.TaskReference[LogGroup
 	return mockLogToTimelineMapperPrevTaskID.Ref()
 }
 
-func (m *mockLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *mockLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return mockLogSerializerPrevTaskID.Ref()
 }
 

--- a/pkg/parameters/debug.go
+++ b/pkg/parameters/debug.go
@@ -45,6 +45,11 @@ type DebugParameters struct {
 	// CloudTraceProject
 	// The GCP project ID where the trace sends the data to.
 	CloudTraceProject *string
+
+	// MemProfile is the destination file path of memory pprof profile written on exit.
+	MemProfile *string
+	// CPUProfile is the destination file path of CPU pprof profile written on exit.
+	CPUProfile *string
 }
 
 // PostProcess implements ParameterStore.
@@ -67,6 +72,8 @@ func (d *DebugParameters) Prepare() error {
 	d.NoColor = flag.Bool("no-color", false, "If this flag is set, KHI prints logs without color.", "")
 	d.CloudTrace = flag.Bool("cloud-trace", false, "If this flag is set, KHI sends traces to Cloud Trace.", "")
 	d.CloudTraceProject = flag.String("cloud-trace-project-id", "", "The GCP project ID where the trace sends the data to.", "")
+	d.MemProfile = flag.String("memprofile", "", "The destination file path of memory pprof profile written on exit.", "")
+	d.CPUProfile = flag.String("cpuprofile", "", "The destination file path of CPU pprof profile written on exit.", "")
 	return nil
 }
 

--- a/pkg/parameters/debug_test.go
+++ b/pkg/parameters/debug_test.go
@@ -43,6 +43,8 @@ func TestDebugParameters(t *testing.T) {
 				NoColor:           testutil.P(false),
 				CloudTrace:        testutil.P(false),
 				CloudTraceProject: testutil.P(""),
+				MemProfile:        testutil.P(""),
+				CPUProfile:        testutil.P(""),
 			},
 		},
 		{
@@ -59,6 +61,8 @@ func TestDebugParameters(t *testing.T) {
 				NoColor:           testutil.P(false),
 				CloudTrace:        testutil.P(true),
 				CloudTraceProject: testutil.P("my-project"),
+				MemProfile:        testutil.P(""),
+				CPUProfile:        testutil.P(""),
 			},
 		},
 	}

--- a/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper.go
@@ -114,7 +114,7 @@ type ManifestLogToTimelineMapper[T any] interface {
 	// TaskID returns the task ID.
 	TaskID() taskid.TaskImplementationID[inspectiontaskbase.TimelineMapperResult]
 	// LogIngesterTask returns the task reference for the log ingester task.
-	LogIngesterTask() taskid.TaskReference[[]*log.Log]
+	LogIngesterTask() taskid.TaskReference[struct{}]
 	// GroupedLogTask returns the task reference for the grouped log task.
 	GroupedLogTask() taskid.TaskReference[ResourceManifestLogGroupMap]
 	// Dependencies returns additional task dependencies of the mapper.

--- a/pkg/task/inspection/commonlogk8saudit/contract/taskid.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/taskid.go
@@ -36,7 +36,7 @@ var K8sAuditLogExtractorRef = taskid.NewTaskReference[K8sAuditLogExtractor](Task
 var K8sAuditLogParserTailRef = taskid.NewTaskReference[struct{}](TaskIDPrefix + "k8s-auditlog-parser-tail")
 
 // K8sAuditLogIngesterTaskID is the task ID for the task to serialize the k8s audit log.
-var K8sAuditLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "k8s-auditlog-ingester")
+var K8sAuditLogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "k8s-auditlog-ingester")
 
 // SuccessLogFilterTaskID is the task ID for the task to filter success logs.
 var SuccessLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "success-log-filter")

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
@@ -28,7 +28,6 @@ import (
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
@@ -87,7 +86,7 @@ func (c *conditionLogToTimelineMapperTaskSetting) GroupedLogTask() taskid.TaskRe
 }
 
 // LogIngesterTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapper.
-func (c *conditionLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (c *conditionLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return commonlogk8saudit_contract.K8sAuditLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task.go
@@ -24,7 +24,6 @@ import (
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
@@ -72,7 +71,7 @@ func (c *containerLogToTimelineMapperTaskSetting) GroupedLogTask() taskid.TaskRe
 }
 
 // LogIngesterTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapper.
-func (c *containerLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (c *containerLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return commonlogk8saudit_contract.K8sAuditLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
@@ -84,7 +83,7 @@ func (e *endpointResourceLogToTimelineMapperTaskSetting) GroupedLogTask() taskid
 }
 
 // LogIngesterTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapper.
-func (e *endpointResourceLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (e *endpointResourceLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return commonlogk8saudit_contract.K8sAuditLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/errormapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/errormapper_task.go
@@ -55,7 +55,7 @@ func (e *nonSuccessLogLogToTimelineMapperTaskSetting) GroupedLogTask() taskid.Ta
 }
 
 // LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (e *nonSuccessLogLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (e *nonSuccessLogLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return commonlogk8saudit_contract.K8sAuditLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/namespacerequestmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/namespacerequestmapper_task.go
@@ -21,7 +21,6 @@ import (
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 )
 
@@ -41,7 +40,7 @@ func (n *namespaceRequestLogToTimelineMapperTaskSetting) GroupedLogTask() taskid
 }
 
 // LogIngesterTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapper.
-func (n *namespaceRequestLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (n *namespaceRequestLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return commonlogk8saudit_contract.K8sAuditLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task.go
@@ -23,7 +23,6 @@ import (
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 )
 
@@ -53,7 +52,7 @@ func (r *resourceOwnerReferenceTimelineMapperTaskSetting) GroupedLogTask() taski
 }
 
 // LogIngesterTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapper.
-func (r *resourceOwnerReferenceTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (r *resourceOwnerReferenceTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return commonlogk8saudit_contract.K8sAuditLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
@@ -91,7 +90,7 @@ func (c *podPhaseLogToTimelineMapperTaskSetting) GroupedLogTask() taskid.TaskRef
 }
 
 // LogIngesterTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapper.
-func (c *podPhaseLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (c *podPhaseLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return commonlogk8saudit_contract.K8sAuditLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper.go
@@ -25,7 +25,6 @@ import (
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
-	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 )
 
@@ -102,7 +101,7 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSetting) GroupedLogTask() taskid
 }
 
 // LogIngesterTask implements commonlogk8saudit_contract.ManifestLogToTimelineMapper.
-func (r *ResourceRevisionLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (r *ResourceRevisionLogToTimelineMapperTaskSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return commonlogk8saudit_contract.K8sAuditLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/taskid.go
@@ -72,7 +72,7 @@ var ComposerLogsTailTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleC
 var AirflowSchedulerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GoogleCloudComposerTaskIDPrefix + "grouper-scheduler")
 
 // AirflowSchedulerLogIngesterTaskID is the task id for the task that ingests Airflow scheduler logs.
-var AirflowSchedulerLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "ingester-scheduler")
+var AirflowSchedulerLogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudComposerTaskIDPrefix + "ingester-scheduler")
 
 // AirflowSchedulerLogToTimelineMapperTaskID is the task id for the task that maps Airflow scheduler logs to timeline events.
 var AirflowSchedulerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GoogleCloudComposerTaskIDPrefix + "mapper-scheduler")
@@ -84,7 +84,7 @@ var AirflowDagProcessorManagerLogSorterTaskID = taskid.NewDefaultImplementationI
 var AirflowDagProcessorManagerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GoogleCloudComposerTaskIDPrefix + "grouper-dag-processor-manager")
 
 // AirflowDagProcessorManagerLogIngesterTaskID is the task id for the task that ingests Airflow DAG processor manager logs.
-var AirflowDagProcessorManagerLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "ingester-dag-processor-manager")
+var AirflowDagProcessorManagerLogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudComposerTaskIDPrefix + "ingester-dag-processor-manager")
 
 // AirflowDagProcessorManagerLogToTimelineMapperTaskID is the task id for the task that maps Airflow DAG processor manager logs to timeline events.
 var AirflowDagProcessorManagerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GoogleCloudComposerTaskIDPrefix + "mapper-dag-processor-manager")
@@ -93,7 +93,7 @@ var AirflowDagProcessorManagerLogToTimelineMapperTaskID = taskid.NewDefaultImple
 var AirflowWorkerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GoogleCloudComposerTaskIDPrefix + "grouper-worker")
 
 // AirflowWorkerLogIngesterTaskID is the task id for the task that ingests Airflow worker logs.
-var AirflowWorkerLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "ingester-worker")
+var AirflowWorkerLogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudComposerTaskIDPrefix + "ingester-worker")
 
 // AirflowWorkerLogToTimelineMapperTaskID is the task id for the task that maps Airflow worker logs to timeline events.
 var AirflowWorkerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GoogleCloudComposerTaskIDPrefix + "mapper-worker")
@@ -102,7 +102,7 @@ var AirflowWorkerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[i
 var AirflowOtherLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GoogleCloudComposerTaskIDPrefix + "grouper-other")
 
 // AirflowOtherLogIngesterTaskID is the task id for the task that ingests other Airflow logs.
-var AirflowOtherLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GoogleCloudComposerTaskIDPrefix + "ingester-other")
+var AirflowOtherLogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](GoogleCloudComposerTaskIDPrefix + "ingester-other")
 
 // AirflowOtherLogToTimelineMapperTaskID is the task id for the task that maps other Airflow logs to timeline events.
 var AirflowOtherLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](GoogleCloudComposerTaskIDPrefix + "mapper-other")

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper.go
@@ -155,7 +155,7 @@ type dagProcessorManagerTimelineMapper struct {
 }
 
 // LogIngesterTask returns a reference to the ingester task.
-func (m *dagProcessorManagerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *dagProcessorManagerTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudclustercomposer_contract.AirflowDagProcessorManagerLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/other.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/other.go
@@ -80,7 +80,7 @@ type otherLogToTimelineMapper struct {
 }
 
 // LogIngesterTask returns a reference to the ingester task.
-func (m *otherLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *otherLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudclustercomposer_contract.AirflowOtherLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler.go
@@ -81,7 +81,7 @@ type schedulerLogToTimelineMapper struct {
 }
 
 // LogIngesterTask returns a reference to the ingester task.
-func (m *schedulerLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *schedulerLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudclustercomposer_contract.AirflowSchedulerLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/worker.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/worker.go
@@ -81,7 +81,7 @@ type workerLogToTimelineMapper struct {
 }
 
 // LogIngesterTask returns a reference to the ingester task.
-func (m *workerLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *workerLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudclustercomposer_contract.AirflowWorkerLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudcommon/contract/log_ingester.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/log_ingester.go
@@ -95,6 +95,6 @@ func (i *GCPOperationLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*
 var _ inspectiontaskbase.LogIngester = (*GCPOperationLogIngester)(nil)
 
 // NewGCPOperationLogIngesterTask returns a new log ingester task for GCP Operation audit logs.
-func NewGCPOperationLogIngesterTask(taskID taskid.TaskImplementationID[[]*log.Log], rawLogTask taskid.TaskReference[[]*log.Log], logType *pb.LogType) coretask.Task[[]*log.Log] {
+func NewGCPOperationLogIngesterTask(taskID taskid.TaskImplementationID[struct{}], rawLogTask taskid.TaskReference[[]*log.Log], logType *pb.LogType) coretask.Task[struct{}] {
 	return inspectiontaskbase.NewLogIngesterTask(taskID, NewGCPOperationLogIngester(rawLogTask, logType))
 }

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/contract/taskid.go
@@ -31,7 +31,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](ComposerAPIAuditLogTaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task ID to finalize Composer audit logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](ComposerAPIAuditLogTaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](ComposerAPIAuditLogTaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task ID to group Composer audit logs by environment name.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](ComposerAPIAuditLogTaskIDPrefix + "grouper")

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/parser_tasks.go
@@ -79,7 +79,7 @@ func (s *composerAuditLogLogToTimelineMapperSetting) GroupedLogTask() taskid.Tas
 }
 
 // LogIngesterTask returns a reference to the log ingester task.
-func (s *composerAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (s *composerAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogcomposerapiaudit_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/contract/taskid.go
@@ -32,7 +32,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](ComputeAPIAuditLogTaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](ComputeAPIAuditLogTaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](ComputeAPIAuditLogTaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task id to group logs by target instance to process logs in LogToTimelineMapper in parallel.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](ComputeAPIAuditLogTaskIDPrefix + "grouper")

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks.go
@@ -60,7 +60,7 @@ type gcpComputeAuditLogLogToTimelineMapperSetting struct {
 }
 
 // LogIngesterTask returns a reference to the log ingester task.
-func (g *gcpComputeAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (g *gcpComputeAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogcomputeapiaudit_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogcsm/contract/taskid.go
@@ -34,7 +34,7 @@ var InputCSMResponseFlagsTaskID = taskid.NewDefaultImplementationID[*gcpqueryuti
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "list-log-entries")
 
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task ID to group CSM traffic logs by their reporter pod for parallel processing.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "grouper")
@@ -52,7 +52,7 @@ var CSMClusterIdentifierTaskID = taskid.NewDefaultImplementationID[[]string](Tas
 var ListCSMTrafficDirectorLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "list-traffic-director-log-entries")
 
 // CSMTrafficDirectorLogIngesterTaskID is the task ID to finalize the CSM Traffic Director logs.
-var CSMTrafficDirectorLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "traffic-director/log-ingester")
+var CSMTrafficDirectorLogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "traffic-director/log-ingester")
 
 // CSMTrafficDirectorLogGrouperTaskID is the task ID to group CSM Traffic Director logs.
 var CSMTrafficDirectorLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "traffic-director/grouper")

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task.go
@@ -95,7 +95,7 @@ type CSMTrafficLogLogToTimelineMapper struct {
 }
 
 // LogIngesterTask returns a reference to the task that provides ingested logs.
-func (m *CSMTrafficLogLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *CSMTrafficLogLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogcsm_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
@@ -56,7 +56,7 @@ type CSMTrafficDirectorLogToTimelineMapper struct {
 }
 
 // LogIngesterTask returns a reference to the task that provides ingested logs.
-func (m *CSMTrafficDirectorLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *CSMTrafficDirectorLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogcsm_contract.CSMTrafficDirectorLogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/contract/taskid.go
@@ -30,7 +30,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GKEAPIAuditLogTaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GKEAPIAuditLogTaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](GKEAPIAuditLogTaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task id to group logs by target instance to process logs in LogToTimelineMapper in parallel.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GKEAPIAuditLogTaskIDPrefix + "grouper")

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks.go
@@ -73,7 +73,7 @@ func (g *gkeAuditLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskRefe
 }
 
 // LogIngesterTask returns a reference to the log ingester task.
-func (g *gkeAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (g *gkeAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudloggkeapiaudit_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/contract/taskid.go
@@ -30,7 +30,7 @@ var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](gkeAuto
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](gkeAutoscalerTaskIDPrefix + "log-grouper")
 
 // LogIngesterTaskID is the task id for the task that serializes GKE autoscaler logs.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](gkeAutoscalerTaskIDPrefix + "log-serializer")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](gkeAutoscalerTaskIDPrefix + "log-serializer")
 
 // LogToTimelineMapperTaskID is the task id for the task that modifies the history based on GKE autoscaler logs.
 var LogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](gkeAutoscalerTaskIDPrefix + "timeline-mapper")

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser.go
@@ -94,7 +94,7 @@ type autoscalerTimelineMapper struct {
 }
 
 // LogIngesterTask returns the prerequisite log serializer task.
-func (m *autoscalerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *autoscalerTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudloggkeautoscaler_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8scontainer/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/contract/taskid.go
@@ -37,7 +37,7 @@ var InputContainerQueryPodNamesTaskID = taskid.NewDefaultImplementationID[*gcpqu
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task id to group logs by target instance to process logs in LogToTimelineMapper in parallel.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "grouper")

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task.go
@@ -100,7 +100,7 @@ type containerLogLogToTimelineMapper struct {
 }
 
 // LogIngesterTask returns the task reference of LogIngester.
-func (m *containerLogLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *containerLogLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8scontainer_contract.LogIngesterTaskID.Ref()
 }
 
@@ -158,7 +158,7 @@ type containerLogPodPhaseTimelineMapper struct {
 	inspectiontaskbase.SinglePassMapperBase[*containerLogPodPhaseMapperState]
 }
 
-func (m *containerLogPodPhaseTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *containerLogPodPhaseTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8scontainer_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/taskid.go
@@ -36,7 +36,7 @@ var InputControlPlaneComponentNameFilterTaskID = taskid.NewDefaultImplementation
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](K8sControlPlaneLogTaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task ID to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](K8sControlPlaneLogTaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](K8sControlPlaneLogTaskIDPrefix + "log-ingester")
 
 // SchedulerLogFilterTaskID is the task ID for filtering scheduler logs.
 var SchedulerLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](K8sControlPlaneLogTaskIDPrefix + "scheduler-log-filter")

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task.go
@@ -103,7 +103,7 @@ func (o *ControllerManagerTimelineMapper) GroupedLogTask() taskid.TaskReference[
 }
 
 // LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *ControllerManagerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (o *ControllerManagerTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8scontrolplane_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task.go
@@ -65,7 +65,7 @@ func (o *OtherTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectionta
 }
 
 // LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *OtherTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (o *OtherTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8scontrolplane_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task.go
@@ -62,7 +62,7 @@ func (m *SchedulerTimelineMapper) GroupedLogTask() taskid.TaskReference[inspecti
 }
 
 // LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (m *SchedulerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *SchedulerTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8scontrolplane_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8sevent/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/contract/taskid.go
@@ -31,7 +31,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GKEK8sEventLogTaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](GKEK8sEventLogTaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](GKEK8sEventLogTaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task id to group logs by target instance to process logs in LogToTimelineMapper in parallel.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](GKEK8sEventLogTaskIDPrefix + "grouper")

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task.go
@@ -91,7 +91,7 @@ type KubernetesEventTimelineMapper struct {
 }
 
 // LogIngesterTask returns the prerequisite log ingester task.
-func (m *KubernetesEventTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *KubernetesEventTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8sevent_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/taskid.go
@@ -36,7 +36,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task ID to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "log-ingester")
 
 // ContainerdLogFilterTaskID is the ID for a task to filter only the logs for containerd.
 var ContainerdLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "containerd-log-filter")

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task.go
@@ -277,7 +277,7 @@ func (c *containerdNodeLogLogToTimelineMapperSetting) GroupedLogTask() taskid.Ta
 }
 
 // LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (c *containerdNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (c *containerdNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8snode_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/kubelet_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/kubelet_task.go
@@ -56,7 +56,7 @@ func (k *kubeletNodeLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskR
 }
 
 // LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (k *kubeletNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (k *kubeletNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8snode_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/other_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/other_task.go
@@ -51,7 +51,7 @@ func (o *otherNodeLogLogToTimelineMapperSetting) GroupedLogTask() taskid.TaskRef
 }
 
 // LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (o *otherNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (o *otherNodeLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8snode_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/contract/taskid.go
@@ -30,7 +30,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](MultiCloudAPIAuditLogTaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](MultiCloudAPIAuditLogTaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](MultiCloudAPIAuditLogTaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task id to group logs by target instance to process logs in LogToTimelineMapper in parallel.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](MultiCloudAPIAuditLogTaskIDPrefix + "grouper")

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks.go
@@ -67,7 +67,7 @@ func (m *multicloudAuditLogLogToTimelineMapperSetting) GroupedLogTask() taskid.T
 }
 
 // LogIngesterTask implements LogToTimelineMapper.
-func (m *multicloudAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *multicloudAuditLogLogToTimelineMapperSetting) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogmulticloudapiaudit_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/contract/taskid.go
@@ -32,7 +32,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](NetworkAPILogTaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](NetworkAPILogTaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](NetworkAPILogTaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task id to group logs by target instance to process logs in LogToTimelineMapper in parallel.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](NetworkAPILogTaskIDPrefix + "grouper")

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
@@ -72,7 +72,7 @@ type networkAPITimelineMapper struct {
 }
 
 // LogIngesterTask is the task reference that provides the ingested logs.
-func (m *networkAPITimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *networkAPITimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlognetworkapiaudit_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/contract/taskid.go
@@ -31,7 +31,7 @@ var ClusterIdentityTaskID = taskid.NewDefaultImplementationID[googlecloudk8scomm
 var ListLogEntriesTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OnPremCloudAPITaskIDPrefix + "query")
 
 // LogIngesterTaskID is the task id to finalize the logs to be included in the final output.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OnPremCloudAPITaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](OnPremCloudAPITaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task id to group logs by target instance to process logs in LogToTimelineMapper in parallel.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](OnPremCloudAPITaskIDPrefix + "grouper")

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/parser_tasks.go
@@ -55,7 +55,7 @@ type OnPremAPIAuditTimelineMapper struct {
 }
 
 // LogIngesterTask returns the task reference providing the ingested logs.
-func (m *OnPremAPIAuditTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *OnPremAPIAuditTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogonpremapiaudit_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogserialport/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/taskid.go
@@ -33,7 +33,7 @@ var LogQueryTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix 
 var LogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "filter")
 
 // LogIngesterTaskID is the task id to serialize logs to history.
-var LogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](TaskIDPrefix + "log-ingester")
+var LogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](TaskIDPrefix + "log-ingester")
 
 // LogGrouperTaskID is the task id to group logs by node name and serial port number.
 var LogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](TaskIDPrefix + "log-grouper")

--- a/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks.go
@@ -105,7 +105,7 @@ type serialportLogToTimelineMapper struct {
 }
 
 // LogIngesterTask implements the LogToTimelineMapper interface.
-func (s *serialportLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (s *serialportLogToTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogserialport_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/ossclusterk8s/contract/taskid.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/taskid.go
@@ -29,7 +29,7 @@ var InputAuditLogFilesFormTaskID = taskid.NewDefaultImplementationID[upload.Uplo
 var AuditLogFileReaderTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "audit-log-reader")
 var NonEventAuditLogFilterTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogProviderRef, "oss")
 var EventAuditLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "audit-log-filter-event-audit")
-var OSSK8sEventLogIngesterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](OSSTaskPrefix + "event-log-ingester")
+var OSSK8sEventLogIngesterTaskID = taskid.NewDefaultImplementationID[struct{}](OSSTaskPrefix + "event-log-ingester")
 var OSSK8sEventLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](OSSTaskPrefix + "event-log-grouper")
 var OSSK8sEventLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](OSSTaskPrefix + "event-timeline-mapper")
 

--- a/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task.go
@@ -86,7 +86,7 @@ type OSSK8sEventTimelineMapper struct {
 }
 
 // LogIngesterTask returns the prerequisite log ingester task.
-func (m *OSSK8sEventTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *OSSK8sEventTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return ossclusterk8s_contract.OSSK8sEventLogIngesterTaskID.Ref()
 }
 


### PR DESCRIPTION
## Summary

This PR addresses memory consumption during log ingestion in KHI by optimizing two key areas:
1. **Unwrap `orderedMapNode`**: `orderedMapNode` was previously converting map entries to a full array on every call to `Children()`, causing massive allocation overhead (~4.49 GB) during structured path traversal. An `Unwrap() Node` method was introduced, allowing `NodeReader` to directly traverse the underlying map node.
2. **Release raw logs after ingestion**: Log ingester tasks retained full slices of `[]*log.Log` in the task DAG for downstream timeline mapper tasks. By updating log ingester tasks to return `taskid.TaskReference[struct{}]` and releasing raw logs immediately upon ingestion, we allow the Go GC to reclaim memory during DAG execution.

## Profiling & Benchmark Comparison

Benchmark on 5 hours of GKE cluster logs (approx. 100k log entries):

| Metric | Before (Baseline) | After (This PR) | Reduction |
| :--- | :--- | :--- | :--- |
| **Total Cumulative Allocations (`alloc_space`)** | **8,567.15 MB** (~8.57 GB) | **4,945.85 MB** (~4.95 GB) | **-3,621.30 MB (-42.3%)** |
| **`orderedMapNode.Children` Allocations** | **4,493.59 MB** | **0 MB** | **-100% (Eliminated)** |
| **Final Retained Memory (`inuse_space`)** | **430.58 MB** | **421.47 MB** | **-9.11 MB** |

## Verification
- `make test-go` passed cleanly
- `make lint-go` passed with 0 issues
- `make pre-commit` passed