### PR TITLE
feat(controlplane): support HPA controller logs parsing and timeline mapping

### DIFF
--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor.go
@@ -496,7 +496,7 @@ func (k *K8sHPAControllerFieldSet) Summary() string {
 
 		currentVal := ""
 		switch {
-		case k.AtomicRecommendation.StatusAvgUtil > 0:
+		case k.AtomicRecommendation.StatusAvgUtil >= 0:
 			currentVal = fmt.Sprintf("%d%%", k.AtomicRecommendation.StatusAvgUtil)
 		case k.AtomicRecommendation.StatusAvgValue != "":
 			currentVal = k.AtomicRecommendation.StatusAvgValue
@@ -506,7 +506,7 @@ func (k *K8sHPAControllerFieldSet) Summary() string {
 
 		targetVal := ""
 		switch {
-		case k.AtomicRecommendation.SpecTargetAvgUtil > 0:
+		case k.AtomicRecommendation.SpecTargetAvgUtil >= 0:
 			targetVal = fmt.Sprintf("%d%%", k.AtomicRecommendation.SpecTargetAvgUtil)
 		case k.AtomicRecommendation.SpecTargetAvgValue != "":
 			targetVal = k.AtomicRecommendation.SpecTargetAvgValue
@@ -592,10 +592,10 @@ func ExtractK8sHPAControllerComponent(reader *structured.NodeReader) (K8sHPACont
 			MetricType:             reader.ReadStringOrDefault(pathAtomicMetricType, ""),
 			MetricName:             reader.ReadStringOrDefault(pathAtomicMetricSpecName, ""),
 			SpecTargetAvgValue:     reader.ReadStringOrDefault(pathAtomicMetricSpecTargetAvgValue, ""),
-			SpecTargetAvgUtil:      reader.ReadIntOrDefault(pathAtomicMetricSpecTargetAvgUtil, 0),
+			SpecTargetAvgUtil:      reader.ReadIntOrDefault(pathAtomicMetricSpecTargetAvgUtil, -1),
 			SpecTargetValue:        reader.ReadStringOrDefault(pathAtomicMetricSpecTargetValue, ""),
 			StatusAvgValue:         reader.ReadStringOrDefault(pathAtomicMetricStatusAvgValue, ""),
-			StatusAvgUtil:          reader.ReadIntOrDefault(pathAtomicMetricStatusAvgUtil, 0),
+			StatusAvgUtil:          reader.ReadIntOrDefault(pathAtomicMetricStatusAvgUtil, -1),
 			StatusValue:            reader.ReadStringOrDefault(pathAtomicMetricStatusValue, ""),
 			NewestSampleAgeSeconds: reader.ReadFloatOrDefault(pathAtomicMetricNewestSampleAge, 0),
 			NewestSampleTime:       reader.ReadStringOrDefault(pathAtomicMetricNewestSampleTime, ""),

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor.go
@@ -16,6 +16,7 @@ package googlecloudlogk8scontrolplane_contract
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -31,6 +32,41 @@ var (
 	pathComponentName = structured.CompileFieldPath("resource.labels.component_name")
 	pathMessage       = structured.CompileFieldPath("jsonPayload.message")
 	pathSourceFile    = structured.CompileFieldPath("sourceLocation.file")
+
+	pathAtomicRecommendation           = structured.CompileFieldPath("jsonPayload.atomicRecommendation")
+	pathAtomicHPA                      = structured.CompileFieldPath("jsonPayload.atomicRecommendation.hpa")
+	pathAtomicStartTime                = structured.CompileFieldPath("jsonPayload.atomicRecommendation.startTime")
+	pathAtomicMetricType               = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.type")
+	pathAtomicMetricSpecName           = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.spec.name")
+	pathAtomicMetricSpecTargetAvgValue = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.spec.target.averageValue")
+	pathAtomicMetricSpecTargetAvgUtil  = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.spec.target.averageUtilization")
+	pathAtomicMetricSpecTargetValue    = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.spec.target.value")
+	pathAtomicMetricStatusAvgValue     = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.status.averageValue")
+	pathAtomicMetricStatusAvgUtil      = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.status.averageUtilization")
+	pathAtomicMetricStatusValue        = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.status.value")
+	pathAtomicMetricNewestSampleAge    = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.newestSampleAgeSeconds")
+	pathAtomicMetricNewestSampleTime   = structured.CompileFieldPath("jsonPayload.atomicRecommendation.metric.newestSampleTime")
+	pathAtomicPodCountReady            = structured.CompileFieldPath("jsonPayload.atomicRecommendation.podCount.ready")
+	pathAtomicPodCountTotal            = structured.CompileFieldPath("jsonPayload.atomicRecommendation.podCount.total")
+	pathAtomicPodCountUnready          = structured.CompileFieldPath("jsonPayload.atomicRecommendation.podCount.unready")
+	pathAtomicPodCountIgnored          = structured.CompileFieldPath("jsonPayload.atomicRecommendation.podCount.ignored")
+	pathAtomicSummaryDampening         = structured.CompileFieldPath("jsonPayload.atomicRecommendation.summary.dampening")
+	pathAtomicSummaryOverride          = structured.CompileFieldPath("jsonPayload.atomicRecommendation.summary.override")
+	pathAtomicSummaryReplicas          = structured.CompileFieldPath("jsonPayload.atomicRecommendation.summary.replicas")
+
+	pathFinalRecommendation      = structured.CompileFieldPath("jsonPayload.finalRecommendation")
+	pathFinalHPA                 = structured.CompileFieldPath("jsonPayload.finalRecommendation.hpa")
+	pathFinalStartTime           = structured.CompileFieldPath("jsonPayload.finalRecommendation.startTime")
+	pathFinalActuationTime       = structured.CompileFieldPath("jsonPayload.finalRecommendation.actuationTime")
+	pathFinalActuationLatency    = structured.CompileFieldPath("jsonPayload.finalRecommendation.actuationLatencySeconds")
+	pathFinalConfiguredSize      = structured.CompileFieldPath("jsonPayload.finalRecommendation.configuredSize")
+	pathFinalReplicas            = structured.CompileFieldPath("jsonPayload.finalRecommendation.replicas")
+	pathFinalLeadingMetricIndex  = structured.CompileFieldPath("jsonPayload.finalRecommendation.leadingMetricIndex")
+	pathFinalTargetRefAPIVersion = structured.CompileFieldPath("jsonPayload.finalRecommendation.targetRef.apiVersion")
+	pathFinalTargetRefKind       = structured.CompileFieldPath("jsonPayload.finalRecommendation.targetRef.kind")
+	pathFinalTargetRefName       = structured.CompileFieldPath("jsonPayload.finalRecommendation.targetRef.name")
+	pathFinalTopLevelLimit       = structured.CompileFieldPath("jsonPayload.finalRecommendation.topLevelLimit")
+	pathFinalTopLevelOverride    = structured.CompileFieldPath("jsonPayload.finalRecommendation.topLevelOverride")
 )
 
 // ControlplaneComponentParserType defines the parser type for control plane components.
@@ -41,6 +77,8 @@ var (
 	ComponentParserTypeScheduler ControlplaneComponentParserType = "scheduler"
 	// ComponentParserTypeControllerManager identifies controller-manager logs.
 	ComponentParserTypeControllerManager ControlplaneComponentParserType = "controller-manager"
+	// ComponentParserTypeHPAController identifies hpa-controller logs.
+	ComponentParserTypeHPAController ControlplaneComponentParserType = "hpa-controller"
 	// ComponentParserTypeOther identifies other control plane component logs.
 	ComponentParserTypeOther ControlplaneComponentParserType = "other"
 )
@@ -48,6 +86,7 @@ var (
 var componentNameToComponentParserTypeMap = map[string]ControlplaneComponentParserType{
 	"scheduler":          ComponentParserTypeScheduler,
 	"controller-manager": ComponentParserTypeControllerManager,
+	"hpa-controller":     ComponentParserTypeHPAController,
 }
 
 var itemsCaptureRegex = regexp.MustCompile(`\[(?P<apiVersionKind>[^,]+), namespace: (?P<namespace>[^,]*), name: (?P<name>[^,]+)`)
@@ -338,4 +377,242 @@ func (k *K8sControllerManagerComponentExtractor) ReadResourceAssociationFromItem
 		}
 	}
 	return result
+}
+
+// HPATargetRef contains reference information for the scaling target workload.
+type HPATargetRef struct {
+	APIVersion string
+	Kind       string
+	Name       string
+}
+
+// HasTarget returns whether TargetRef has valid kind and name.
+func (t HPATargetRef) HasTarget() bool {
+	return t.Kind != "" && t.Name != ""
+}
+
+// HasValidResourceIdentity returns whether TargetRef has valid apiVersion, kind, and name for resource timeline mapping.
+func (t HPATargetRef) HasValidResourceIdentity() bool {
+	return t.APIVersion != "" && t.Kind != "" && t.Name != ""
+}
+
+// String returns the formatted resource representation "<Kind>/<Name>".
+func (t HPATargetRef) String() string {
+	return fmt.Sprintf("%s/%s", t.Kind, t.Name)
+}
+
+// HPAPodCount contains pod counts associated with an HPA recommendation.
+type HPAPodCount struct {
+	Ready   int
+	Total   int
+	Unready int
+	Ignored int
+}
+
+// HPAAtomicRecommendation contains atomic recommendation details for a single metric.
+type HPAAtomicRecommendation struct {
+	HPA                    string
+	HPANamespace           string
+	HPAName                string
+	StartTime              string
+	MetricType             string
+	MetricName             string
+	SpecTargetAvgValue     string
+	SpecTargetAvgUtil      int
+	SpecTargetValue        string
+	StatusAvgValue         string
+	StatusAvgUtil          int
+	StatusValue            string
+	NewestSampleAgeSeconds float64
+	NewestSampleTime       string
+	PodCount               HPAPodCount
+	Dampening              string
+	Override               string
+	Replicas               int
+}
+
+// HPAFinalRecommendation contains merged final recommendation details for an HPA.
+type HPAFinalRecommendation struct {
+	HPA                     string
+	HPANamespace            string
+	HPAName                 string
+	StartTime               string
+	ActuationTime           string
+	ActuationLatencySeconds float64
+	ConfiguredSize          int
+	Replicas                int
+	LeadingMetricIndex      int
+	TargetRef               HPATargetRef
+	TopLevelLimit           string
+	TopLevelOverride        string
+}
+
+// K8sHPAControllerFieldSet contains extracted fields from an HPA controller log entry.
+type K8sHPAControllerFieldSet struct {
+	AtomicRecommendation *HPAAtomicRecommendation
+	FinalRecommendation  *HPAFinalRecommendation
+	Message              string
+}
+
+// Summary returns a human-readable summary of the HPA controller log entry.
+func (k *K8sHPAControllerFieldSet) Summary() string {
+	if k.FinalRecommendation != nil {
+		hpa := k.FinalRecommendation.HPA
+		replicas := k.FinalRecommendation.Replicas
+		configuredSize := k.FinalRecommendation.ConfiguredSize
+		targetRef := k.FinalRecommendation.TargetRef
+
+		var extra []string
+		if k.FinalRecommendation.TopLevelLimit != "" && k.FinalRecommendation.TopLevelLimit != "none" {
+			extra = append(extra, fmt.Sprintf("limit: %s", k.FinalRecommendation.TopLevelLimit))
+		}
+		if k.FinalRecommendation.TopLevelOverride != "" && k.FinalRecommendation.TopLevelOverride != "none" {
+			extra = append(extra, fmt.Sprintf("override: %s", k.FinalRecommendation.TopLevelOverride))
+		}
+		extraStr := ""
+		if len(extra) > 0 {
+			extraStr = fmt.Sprintf(" (%s)", strings.Join(extra, ", "))
+		}
+
+		if targetRef.HasTarget() {
+			if configuredSize != replicas {
+				return fmt.Sprintf("[HPA Final] %s: %s %d -> %d replicas%s", hpa, targetRef.String(), configuredSize, replicas, extraStr)
+			}
+			return fmt.Sprintf("[HPA Final] %s: %s = %d replicas%s", hpa, targetRef.String(), replicas, extraStr)
+		}
+		if configuredSize != replicas {
+			return fmt.Sprintf("[HPA Final] %s: %d -> %d replicas%s", hpa, configuredSize, replicas, extraStr)
+		}
+		return fmt.Sprintf("[HPA Final] %s = %d replicas%s", hpa, replicas, extraStr)
+	}
+
+	if k.AtomicRecommendation != nil {
+		hpa := k.AtomicRecommendation.HPA
+		replicas := k.AtomicRecommendation.Replicas
+		metricName := k.AtomicRecommendation.MetricName
+		if metricName == "" {
+			metricName = k.AtomicRecommendation.MetricType
+		}
+
+		currentVal := ""
+		switch {
+		case k.AtomicRecommendation.StatusAvgUtil > 0:
+			currentVal = fmt.Sprintf("%d%%", k.AtomicRecommendation.StatusAvgUtil)
+		case k.AtomicRecommendation.StatusAvgValue != "":
+			currentVal = k.AtomicRecommendation.StatusAvgValue
+		case k.AtomicRecommendation.StatusValue != "":
+			currentVal = k.AtomicRecommendation.StatusValue
+		}
+
+		targetVal := ""
+		switch {
+		case k.AtomicRecommendation.SpecTargetAvgUtil > 0:
+			targetVal = fmt.Sprintf("%d%%", k.AtomicRecommendation.SpecTargetAvgUtil)
+		case k.AtomicRecommendation.SpecTargetAvgValue != "":
+			targetVal = k.AtomicRecommendation.SpecTargetAvgValue
+		case k.AtomicRecommendation.SpecTargetValue != "":
+			targetVal = k.AtomicRecommendation.SpecTargetValue
+		}
+
+		var extra []string
+		if k.AtomicRecommendation.Dampening != "" && k.AtomicRecommendation.Dampening != "none" {
+			extra = append(extra, fmt.Sprintf("dampened: %s", k.AtomicRecommendation.Dampening))
+		}
+		if k.AtomicRecommendation.Override != "" && k.AtomicRecommendation.Override != "none" {
+			extra = append(extra, fmt.Sprintf("override: %s", k.AtomicRecommendation.Override))
+		}
+		extraStr := ""
+		if len(extra) > 0 {
+			extraStr = fmt.Sprintf(" (%s)", strings.Join(extra, ", "))
+		}
+
+		if metricName != "" && currentVal != "" && targetVal != "" {
+			return fmt.Sprintf("[HPA Metric] %s: %s (%s / target %s) -> %d replicas%s", hpa, metricName, currentVal, targetVal, replicas, extraStr)
+		}
+		if metricName != "" && currentVal != "" {
+			return fmt.Sprintf("[HPA Metric] %s: %s (%s) -> %d replicas%s", hpa, metricName, currentVal, replicas, extraStr)
+		}
+		if metricName != "" {
+			return fmt.Sprintf("[HPA Metric] %s: %s -> %d replicas%s", hpa, metricName, replicas, extraStr)
+		}
+		return fmt.Sprintf("[HPA Metric] %s -> %d replicas%s", hpa, replicas, extraStr)
+	}
+
+	return k.Message
+}
+
+func splitNamespaceAndName(fqdn string) (string, string) {
+	parts := strings.Split(fqdn, "/")
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", fqdn
+}
+
+// ExtractK8sHPAControllerComponent extracts K8sHPAControllerFieldSet from a NodeReader.
+func ExtractK8sHPAControllerComponent(reader *structured.NodeReader) (K8sHPAControllerFieldSet, error) {
+	if mock, ok := structured.GetMock[K8sHPAControllerFieldSet](reader); ok {
+		return mock, nil
+	}
+	var result K8sHPAControllerFieldSet
+
+	if reader.Has(pathFinalRecommendation) {
+		hpa := reader.ReadStringOrDefault(pathFinalHPA, "")
+		ns, name := splitNamespaceAndName(hpa)
+		finalRec := &HPAFinalRecommendation{
+			HPA:                     hpa,
+			HPANamespace:            ns,
+			HPAName:                 name,
+			StartTime:               reader.ReadStringOrDefault(pathFinalStartTime, ""),
+			ActuationTime:           reader.ReadStringOrDefault(pathFinalActuationTime, ""),
+			ActuationLatencySeconds: reader.ReadFloatOrDefault(pathFinalActuationLatency, 0),
+			ConfiguredSize:          reader.ReadIntOrDefault(pathFinalConfiguredSize, 0),
+			Replicas:                reader.ReadIntOrDefault(pathFinalReplicas, 0),
+			LeadingMetricIndex:      reader.ReadIntOrDefault(pathFinalLeadingMetricIndex, 0),
+			TargetRef: HPATargetRef{
+				APIVersion: reader.ReadStringOrDefault(pathFinalTargetRefAPIVersion, ""),
+				Kind:       reader.ReadStringOrDefault(pathFinalTargetRefKind, ""),
+				Name:       reader.ReadStringOrDefault(pathFinalTargetRefName, ""),
+			},
+			TopLevelLimit:    reader.ReadStringOrDefault(pathFinalTopLevelLimit, ""),
+			TopLevelOverride: reader.ReadStringOrDefault(pathFinalTopLevelOverride, ""),
+		}
+		result.FinalRecommendation = finalRec
+		return result, nil
+	}
+
+	if reader.Has(pathAtomicRecommendation) {
+		hpa := reader.ReadStringOrDefault(pathAtomicHPA, "")
+		ns, name := splitNamespaceAndName(hpa)
+		atomicRec := &HPAAtomicRecommendation{
+			HPA:                    hpa,
+			HPANamespace:           ns,
+			HPAName:                name,
+			StartTime:              reader.ReadStringOrDefault(pathAtomicStartTime, ""),
+			MetricType:             reader.ReadStringOrDefault(pathAtomicMetricType, ""),
+			MetricName:             reader.ReadStringOrDefault(pathAtomicMetricSpecName, ""),
+			SpecTargetAvgValue:     reader.ReadStringOrDefault(pathAtomicMetricSpecTargetAvgValue, ""),
+			SpecTargetAvgUtil:      reader.ReadIntOrDefault(pathAtomicMetricSpecTargetAvgUtil, 0),
+			SpecTargetValue:        reader.ReadStringOrDefault(pathAtomicMetricSpecTargetValue, ""),
+			StatusAvgValue:         reader.ReadStringOrDefault(pathAtomicMetricStatusAvgValue, ""),
+			StatusAvgUtil:          reader.ReadIntOrDefault(pathAtomicMetricStatusAvgUtil, 0),
+			StatusValue:            reader.ReadStringOrDefault(pathAtomicMetricStatusValue, ""),
+			NewestSampleAgeSeconds: reader.ReadFloatOrDefault(pathAtomicMetricNewestSampleAge, 0),
+			NewestSampleTime:       reader.ReadStringOrDefault(pathAtomicMetricNewestSampleTime, ""),
+			PodCount: HPAPodCount{
+				Ready:   reader.ReadIntOrDefault(pathAtomicPodCountReady, 0),
+				Total:   reader.ReadIntOrDefault(pathAtomicPodCountTotal, 0),
+				Unready: reader.ReadIntOrDefault(pathAtomicPodCountUnready, 0),
+				Ignored: reader.ReadIntOrDefault(pathAtomicPodCountIgnored, 0),
+			},
+			Dampening: reader.ReadStringOrDefault(pathAtomicSummaryDampening, ""),
+			Override:  reader.ReadStringOrDefault(pathAtomicSummaryOverride, ""),
+			Replicas:  reader.ReadIntOrDefault(pathAtomicSummaryReplicas, 0),
+		}
+		result.AtomicRecommendation = atomicRec
+		return result, nil
+	}
+
+	result.Message = reader.ReadStringOrDefault(pathMessage, "")
+	return result, nil
 }

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
@@ -523,3 +523,268 @@ func TestExtractK8sControllerManagerComponent_FromMock(t *testing.T) {
 		t.Errorf("Extract() mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestExtractK8sHPAControllerComponent(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		inputYAML string
+		mock      *K8sHPAControllerFieldSet
+		want      K8sHPAControllerFieldSet
+	}{
+		{
+			desc: "atomic recommendation log entry",
+			inputYAML: `
+jsonPayload:
+  atomicRecommendation:
+    hpa: gke-managed-cim/kube-state-metrics
+    metric:
+      newestSampleAgeSeconds: -34.480346499
+      newestSampleTime: "2026-08-26T01:07:26.771Z"
+      spec:
+        name: memory
+        target:
+          averageValue: "400Mi"
+      status:
+        averageUtilization: 27
+        averageValue: "36745216"
+        value: "36745216"
+      type: Resource
+    podCount:
+      ready: 1
+      total: 1
+    startTime: "2026-08-26T01:08:01.251346499Z"
+    summary:
+      dampening: none
+      override: none
+      replicas: 1
+`,
+			want: K8sHPAControllerFieldSet{
+				AtomicRecommendation: &HPAAtomicRecommendation{
+					HPA:                    "gke-managed-cim/kube-state-metrics",
+					HPANamespace:           "gke-managed-cim",
+					HPAName:                "kube-state-metrics",
+					StartTime:              "2026-08-26T01:08:01.251346499Z",
+					MetricType:             "Resource",
+					MetricName:             "memory",
+					SpecTargetAvgValue:     "400Mi",
+					StatusAvgValue:         "36745216",
+					StatusAvgUtil:          27,
+					StatusValue:            "36745216",
+					NewestSampleAgeSeconds: -34.480346499,
+					NewestSampleTime:       "2026-08-26T01:07:26.771Z",
+					PodCount: HPAPodCount{
+						Ready: 1,
+						Total: 1,
+					},
+					Dampening: "none",
+					Override:  "none",
+					Replicas:  1,
+				},
+			},
+		},
+		{
+			desc: "final recommendation log entry",
+			inputYAML: `
+jsonPayload:
+  finalRecommendation:
+    actuationLatencySeconds: 0.000970647
+    actuationTime: "2026-08-25T00:24:25.753642670Z"
+    configuredSize: 1
+    hpa: gke-managed-cim/kube-state-metrics
+    leadingMetricIndex: 0
+    replicas: 1
+    startTime: "2026-08-25T00:24:25.752672023Z"
+    targetRef:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      name: kube-state-metrics
+    topLevelLimit: none
+    topLevelOverride: none
+`,
+			want: K8sHPAControllerFieldSet{
+				FinalRecommendation: &HPAFinalRecommendation{
+					HPA:                     "gke-managed-cim/kube-state-metrics",
+					HPANamespace:            "gke-managed-cim",
+					HPAName:                 "kube-state-metrics",
+					StartTime:               "2026-08-25T00:24:25.752672023Z",
+					ActuationTime:           "2026-08-25T00:24:25.753642670Z",
+					ActuationLatencySeconds: 0.000970647,
+					ConfiguredSize:          1,
+					Replicas:                1,
+					LeadingMetricIndex:      0,
+					TargetRef: HPATargetRef{
+						APIVersion: "apps/v1",
+						Kind:       "StatefulSet",
+						Name:       "kube-state-metrics",
+					},
+					TopLevelLimit:    "none",
+					TopLevelOverride: "none",
+				},
+			},
+		},
+		{
+			desc: "fallback message entry",
+			inputYAML: `
+jsonPayload:
+  message: "hpa controller leader elected"
+`,
+			want: K8sHPAControllerFieldSet{
+				Message: "hpa controller leader elected",
+			},
+		},
+		{
+			desc: "from mock",
+			mock: &K8sHPAControllerFieldSet{
+				Message: "mock-message",
+			},
+			want: K8sHPAControllerFieldSet{
+				Message: "mock-message",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			var l *log.Log
+			var err error
+			if tc.mock != nil {
+				l = testlog.NewMockLog(*tc.mock)
+			} else {
+				l, err = log.NewLogFromYAMLString(tc.inputYAML)
+				if err != nil {
+					t.Fatalf("failed to parse test input YAML: %v", err)
+				}
+			}
+
+			got, err := ExtractK8sHPAControllerComponent(l.NodeReader)
+			if err != nil {
+				t.Fatalf("ExtractK8sHPAControllerComponent() unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ExtractK8sHPAControllerComponent() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestK8sHPAControllerFieldSet_Summary(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		field K8sHPAControllerFieldSet
+		want  string
+	}{
+		{
+			desc: "final recommendation scaling workload",
+			field: K8sHPAControllerFieldSet{
+				FinalRecommendation: &HPAFinalRecommendation{
+					HPA:            "default/web",
+					ConfiguredSize: 1,
+					Replicas:       3,
+					TargetRef: HPATargetRef{
+						Kind: "Deployment",
+						Name: "web",
+					},
+				},
+			},
+			want: "[HPA Final] default/web: Deployment/web 1 -> 3 replicas",
+		},
+		{
+			desc: "final recommendation maintaining workload",
+			field: K8sHPAControllerFieldSet{
+				FinalRecommendation: &HPAFinalRecommendation{
+					HPA:            "gke-managed-cim/kube-state-metrics",
+					ConfiguredSize: 1,
+					Replicas:       1,
+					TargetRef: HPATargetRef{
+						Kind: "StatefulSet",
+						Name: "kube-state-metrics",
+					},
+				},
+			},
+			want: "[HPA Final] gke-managed-cim/kube-state-metrics: StatefulSet/kube-state-metrics = 1 replicas",
+		},
+		{
+			desc: "final recommendation with limit and override",
+			field: K8sHPAControllerFieldSet{
+				FinalRecommendation: &HPAFinalRecommendation{
+					HPA:              "default/web",
+					ConfiguredSize:   2,
+					Replicas:         5,
+					TopLevelLimit:    "maxReplicas",
+					TopLevelOverride: "scaleUpStabilization",
+					TargetRef: HPATargetRef{
+						Kind: "Deployment",
+						Name: "web",
+					},
+				},
+			},
+			want: "[HPA Final] default/web: Deployment/web 2 -> 5 replicas (limit: maxReplicas, override: scaleUpStabilization)",
+		},
+		{
+			desc: "final recommendation without targetRef",
+			field: K8sHPAControllerFieldSet{
+				FinalRecommendation: &HPAFinalRecommendation{
+					HPA:            "default/web",
+					ConfiguredSize: 2,
+					Replicas:       4,
+				},
+			},
+			want: "[HPA Final] default/web: 2 -> 4 replicas",
+		},
+		{
+			desc: "atomic recommendation with metric name, status util, and target value",
+			field: K8sHPAControllerFieldSet{
+				AtomicRecommendation: &HPAAtomicRecommendation{
+					HPA:                "gke-managed-cim/kube-state-metrics",
+					MetricName:         "memory",
+					StatusAvgUtil:      27,
+					SpecTargetAvgValue: "400Mi",
+					Replicas:           1,
+				},
+			},
+			want: "[HPA Metric] gke-managed-cim/kube-state-metrics: memory (27% / target 400Mi) -> 1 replicas",
+		},
+		{
+			desc: "atomic recommendation with dampening and override",
+			field: K8sHPAControllerFieldSet{
+				AtomicRecommendation: &HPAAtomicRecommendation{
+					HPA:               "default/web",
+					MetricName:        "cpu",
+					StatusAvgUtil:     85,
+					SpecTargetAvgUtil: 80,
+					Dampening:         "up",
+					Override:          "tolerance",
+					Replicas:          3,
+				},
+			},
+			want: "[HPA Metric] default/web: cpu (85% / target 80%) -> 3 replicas (dampened: up, override: tolerance)",
+		},
+		{
+			desc: "atomic recommendation minimal",
+			field: K8sHPAControllerFieldSet{
+				AtomicRecommendation: &HPAAtomicRecommendation{
+					HPA:        "default/web",
+					MetricType: "Resource",
+					Replicas:   2,
+				},
+			},
+			want: "[HPA Metric] default/web: Resource -> 2 replicas",
+		},
+		{
+			desc: "fallback message",
+			field: K8sHPAControllerFieldSet{
+				Message: "custom message",
+			},
+			want: "custom message",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := tc.field.Summary()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Summary() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
@@ -567,6 +567,7 @@ jsonPayload:
 					MetricType:             "Resource",
 					MetricName:             "memory",
 					SpecTargetAvgValue:     "400Mi",
+					SpecTargetAvgUtil:      -1,
 					StatusAvgValue:         "36745216",
 					StatusAvgUtil:          27,
 					StatusValue:            "36745216",
@@ -738,11 +739,25 @@ func TestK8sHPAControllerFieldSet_Summary(t *testing.T) {
 					HPA:                "gke-managed-cim/kube-state-metrics",
 					MetricName:         "memory",
 					StatusAvgUtil:      27,
+					SpecTargetAvgUtil:  -1,
 					SpecTargetAvgValue: "400Mi",
 					Replicas:           1,
 				},
 			},
 			want: "[HPA Metric] gke-managed-cim/kube-state-metrics: memory (27% / target 400Mi) -> 1 replicas",
+		},
+		{
+			desc: "atomic recommendation with 0% utilization",
+			field: K8sHPAControllerFieldSet{
+				AtomicRecommendation: &HPAAtomicRecommendation{
+					HPA:               "default/web",
+					MetricName:        "cpu",
+					StatusAvgUtil:     0,
+					SpecTargetAvgUtil: 50,
+					Replicas:          1,
+				},
+			},
+			want: "[HPA Metric] default/web: cpu (0% / target 50%) -> 1 replicas",
 		},
 		{
 			desc: "atomic recommendation with dampening and override",
@@ -763,9 +778,11 @@ func TestK8sHPAControllerFieldSet_Summary(t *testing.T) {
 			desc: "atomic recommendation minimal",
 			field: K8sHPAControllerFieldSet{
 				AtomicRecommendation: &HPAAtomicRecommendation{
-					HPA:        "default/web",
-					MetricType: "Resource",
-					Replicas:   2,
+					HPA:               "default/web",
+					MetricType:        "Resource",
+					SpecTargetAvgUtil: -1,
+					StatusAvgUtil:     -1,
+					Replicas:          2,
 				},
 			},
 			want: "[HPA Metric] default/web: Resource -> 2 replicas",

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/taskid.go
@@ -65,5 +65,14 @@ var OtherLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase
 // OtherLogToTimelineMapperTaskID is the task ID for adding events on history based on the other control plane components.
 var OtherLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](K8sControlPlaneLogTaskIDPrefix + "timeline-mapper-other")
 
+// HpaControllerLogFilterTaskID is the task ID for filtering HPA controller logs.
+var HpaControllerLogFilterTaskID = taskid.NewDefaultImplementationID[[]*log.Log](K8sControlPlaneLogTaskIDPrefix + "hpa-controller-log-filter")
+
+// HpaControllerLogGrouperTaskID is the task ID for grouping HPA controller logs.
+var HpaControllerLogGrouperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.LogGroupMap](K8sControlPlaneLogTaskIDPrefix + "grouper-hpa-controller")
+
+// HpaControllerLogToTimelineMapperTaskID is the task ID for adding events on history based on HPA controller logs.
+var HpaControllerLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[inspectiontaskbase.TimelineMapperResult](K8sControlPlaneLogTaskIDPrefix + "timeline-mapper-hpa-controller")
+
 // TailTaskID is the task ID for the final task in the control plane log processing pipeline.
 var TailTaskID = taskid.NewDefaultImplementationID[struct{}](K8sControlPlaneLogTaskIDPrefix + "tail")

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task.go
@@ -30,6 +30,7 @@ var TailTask = inspectiontaskbase.NewInspectionTask(googlecloudlogk8scontrolplan
 	[]taskid.UntypedTaskReference{
 		googlecloudlogk8scontrolplane_contract.SchedulerLogToTimelineMapperTaskID.Ref(),
 		googlecloudlogk8scontrolplane_contract.ControllerManagerLogToTimelineMapperTaskID.Ref(),
+		googlecloudlogk8scontrolplane_contract.HpaControllerLogToTimelineMapperTaskID.Ref(),
 		googlecloudlogk8scontrolplane_contract.OtherLogToTimelineMapperTaskID.Ref(),
 	},
 	func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) (struct{}, error) {
@@ -71,6 +72,10 @@ func (i *K8sControlPlaneLogIngester) ProcessLog(ctx context.Context, l *log.Log)
 
 	if msg, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneCommonMessage(l.NodeReader); err == nil && msg != "" {
 		cs.SetSummary(msg)
+	} else if hpaFS, err := googlecloudlogk8scontrolplane_contract.ExtractK8sHPAControllerComponent(l.NodeReader); err == nil {
+		if summary := hpaFS.Summary(); summary != "" {
+			cs.SetSummary(summary)
+		}
 	}
 
 	return cs, nil

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task.go
@@ -70,11 +70,16 @@ func (i *K8sControlPlaneLogIngester) ProcessLog(ctx context.Context, l *log.Log)
 		cs.SetSeverity(severity)
 	}
 
-	if msg, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneCommonMessage(l.NodeReader); err == nil && msg != "" {
-		cs.SetSummary(msg)
-	} else if hpaFS, err := googlecloudlogk8scontrolplane_contract.ExtractK8sHPAControllerComponent(l.NodeReader); err == nil {
-		if summary := hpaFS.Summary(); summary != "" {
-			cs.SetSummary(summary)
+	componentFieldSet, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponent(l.NodeReader)
+	if err == nil && componentFieldSet.ComponentParserType() == googlecloudlogk8scontrolplane_contract.ComponentParserTypeHPAController {
+		if hpaFS, err := googlecloudlogk8scontrolplane_contract.ExtractK8sHPAControllerComponent(l.NodeReader); err == nil {
+			if summary := hpaFS.Summary(); summary != "" {
+				cs.SetSummary(summary)
+			}
+		}
+	} else {
+		if msg, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneCommonMessage(l.NodeReader); err == nil && msg != "" {
+			cs.SetSummary(msg)
 		}
 	}
 

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task_test.go
@@ -65,6 +65,50 @@ func TestK8sControlPlaneLogIngester_ProcessLog(t *testing.T) {
 					HasSummary("")
 			},
 		},
+		{
+			name: "successful HPA final recommendation log ingestion",
+			input: testlog.NewMockLog(
+				testTime,
+				googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet{
+					FinalRecommendation: &googlecloudlogk8scontrolplane_contract.HPAFinalRecommendation{
+						HPA:            "gke-managed-cim/kube-state-metrics",
+						ConfiguredSize: 1,
+						Replicas:       1,
+						TargetRef: googlecloudlogk8scontrolplane_contract.HPATargetRef{
+							Kind: "StatefulSet",
+							Name: "kube-state-metrics",
+						},
+					},
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(testTime).
+					HasLogType(googlecloudlogk8scontrolplane_contract.LogTypeControlPlaneComponent).
+					HasSummary("[HPA Final] gke-managed-cim/kube-state-metrics: StatefulSet/kube-state-metrics = 1 replicas")
+			},
+		},
+		{
+			name: "successful HPA atomic recommendation log ingestion",
+			input: testlog.NewMockLog(
+				testTime,
+				googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet{
+					AtomicRecommendation: &googlecloudlogk8scontrolplane_contract.HPAAtomicRecommendation{
+						HPA:                "gke-managed-cim/kube-state-metrics",
+						MetricName:         "memory",
+						StatusAvgUtil:      27,
+						SpecTargetAvgValue: "400Mi",
+						Replicas:           1,
+					},
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(testTime).
+					HasLogType(googlecloudlogk8scontrolplane_contract.LogTypeControlPlaneComponent).
+					HasSummary("[HPA Metric] gke-managed-cim/kube-state-metrics: memory (27% / target 400Mi) -> 1 replicas")
+			},
+		},
 	}
 
 	ingester := &K8sControlPlaneLogIngester{}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/common_task_test.go
@@ -69,6 +69,9 @@ func TestK8sControlPlaneLogIngester_ProcessLog(t *testing.T) {
 			name: "successful HPA final recommendation log ingestion",
 			input: testlog.NewMockLog(
 				testTime,
+				googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{
+					ComponentName: "hpa-controller",
+				},
 				googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet{
 					FinalRecommendation: &googlecloudlogk8scontrolplane_contract.HPAFinalRecommendation{
 						HPA:            "gke-managed-cim/kube-state-metrics",
@@ -92,11 +95,15 @@ func TestK8sControlPlaneLogIngester_ProcessLog(t *testing.T) {
 			name: "successful HPA atomic recommendation log ingestion",
 			input: testlog.NewMockLog(
 				testTime,
+				googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{
+					ComponentName: "hpa-controller",
+				},
 				googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet{
 					AtomicRecommendation: &googlecloudlogk8scontrolplane_contract.HPAAtomicRecommendation{
 						HPA:                "gke-managed-cim/kube-state-metrics",
 						MetricName:         "memory",
 						StatusAvgUtil:      27,
+						SpecTargetAvgUtil:  -1,
 						SpecTargetAvgValue: "400Mi",
 						Replicas:           1,
 					},

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8scontrolplane_impl
+
+import (
+	"context"
+	"strings"
+
+	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
+)
+
+// HpaControllerLogFilterTask filters logs for HPA controller.
+var HpaControllerLogFilterTask = inspectiontaskbase.NewLogFilterTask(
+	googlecloudlogk8scontrolplane_contract.HpaControllerLogFilterTaskID,
+	googlecloudlogk8scontrolplane_contract.ListLogEntriesTaskID.Ref(),
+	func(ctx context.Context, l *log.Log) bool {
+		componentFieldSet, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponent(l.NodeReader)
+		if err != nil {
+			return false
+		}
+		return componentFieldSet.ComponentParserType() == googlecloudlogk8scontrolplane_contract.ComponentParserTypeHPAController
+	},
+)
+
+// HpaControllerGrouperTask groups HPA controller logs.
+var HpaControllerGrouperTask = inspectiontaskbase.NewLogGrouperTask(
+	googlecloudlogk8scontrolplane_contract.HpaControllerLogGrouperTaskID,
+	googlecloudlogk8scontrolplane_contract.HpaControllerLogFilterTaskID.Ref(),
+	func(ctx context.Context, log *log.Log) string {
+		return "" // No grouping needed
+	},
+)
+
+// HpaControllerTimelineMapper maps HPA controller logs to timeline paths.
+type HpaControllerTimelineMapper struct {
+	inspectiontaskbase.StatelessMapperBase
+}
+
+// Dependencies implements inspectiontaskbase.LogToTimelineMapper.
+func (m *HpaControllerTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
+	return []taskid.UntypedTaskReference{}
+}
+
+// GroupedLogTask implements inspectiontaskbase.LogToTimelineMapper.
+func (m *HpaControllerTimelineMapper) GroupedLogTask() taskid.TaskReference[inspectiontaskbase.LogGroupMap] {
+	return googlecloudlogk8scontrolplane_contract.HpaControllerLogGrouperTaskID.Ref()
+}
+
+// LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
+func (m *HpaControllerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+	return googlecloudlogk8scontrolplane_contract.LogIngesterTaskID.Ref()
+}
+
+// ProcessLogByGroup implements inspectiontaskbase.LogToTimelineMapper.
+func (m *HpaControllerTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
+	componentFieldSet, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponent(l.NodeReader)
+	if err != nil {
+		return nil, struct{}{}, err
+	}
+	hpaFieldSet, err := googlecloudlogk8scontrolplane_contract.ExtractK8sHPAControllerComponent(l.NodeReader)
+	if err != nil {
+		return nil, struct{}{}, err
+	}
+
+	cs := khifilev6.NewTimelineChangeSet(l)
+
+	projectTimeline := googlecloudcommon_contract.MustGCPProjectTimeline(ctx, componentFieldSet.ProjectID)
+	gkeTimeline := googlecloudcommon_contract.MustGKEClusterTimeline(ctx, projectTimeline, componentFieldSet.ClusterName)
+	compTimeline := googlecloudlogk8scontrolplane_contract.MustControlPlaneComponentTimeline(ctx, gkeTimeline, componentFieldSet.ComponentName)
+	cs.AddEvent(compTimeline)
+
+	hpaNamespace := ""
+	hpaName := ""
+	if hpaFieldSet.FinalRecommendation != nil {
+		hpaNamespace = hpaFieldSet.FinalRecommendation.HPANamespace
+		hpaName = hpaFieldSet.FinalRecommendation.HPAName
+	} else if hpaFieldSet.AtomicRecommendation != nil {
+		hpaNamespace = hpaFieldSet.AtomicRecommendation.HPANamespace
+		hpaName = hpaFieldSet.AtomicRecommendation.HPAName
+	}
+
+	if hpaNamespace != "" && hpaName != "" {
+		clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, componentFieldSet.ClusterName)
+		apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "autoscaling/v2")
+		kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "horizontalpodautoscaler")
+		namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, hpaNamespace)
+		hpaTimeline := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, hpaName)
+		cs.AddEvent(hpaTimeline)
+	}
+
+	if hpaFieldSet.FinalRecommendation != nil && hpaFieldSet.FinalRecommendation.TargetRef.HasValidResourceIdentity() {
+		targetRef := hpaFieldSet.FinalRecommendation.TargetRef
+		targetAPIVersion := targetRef.APIVersion
+		if targetAPIVersion == "v1" {
+			targetAPIVersion = "core/v1"
+		}
+		targetResource := &commonlogk8saudit_contract.ResourceIdentity{
+			APIVersion: targetAPIVersion,
+			Kind:       strings.ToLower(targetRef.Kind),
+			Namespace:  hpaNamespace,
+			Name:       targetRef.Name,
+		}
+		targetTimeline := commonlogk8saudit_contract.MustResourceTimeline(ctx, componentFieldSet.ClusterName, targetResource)
+		cs.AddEvent(targetTimeline)
+	}
+
+	return cs, struct{}{}, nil
+}
+
+var _ inspectiontaskbase.LogToTimelineMapper[struct{}] = (*HpaControllerTimelineMapper)(nil)
+
+// HpaControllerLogToTimelineMapperTask creates timeline events for HPA controller logs.
+var HpaControllerLogToTimelineMapperTask = inspectiontaskbase.NewLogToTimelineMapperTask(googlecloudlogk8scontrolplane_contract.HpaControllerLogToTimelineMapperTaskID, &HpaControllerTimelineMapper{})

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task.go
@@ -65,7 +65,7 @@ func (m *HpaControllerTimelineMapper) GroupedLogTask() taskid.TaskReference[insp
 }
 
 // LogIngesterTask implements inspectiontaskbase.LogToTimelineMapper.
-func (m *HpaControllerTimelineMapper) LogIngesterTask() taskid.TaskReference[[]*log.Log] {
+func (m *HpaControllerTimelineMapper) LogIngesterTask() taskid.TaskReference[struct{}] {
 	return googlecloudlogk8scontrolplane_contract.LogIngesterTaskID.Ref()
 }
 

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlogk8scontrolplane_impl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
+	googlecloudlogk8scontrolplane_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8scontrolplane/contract"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testchangeset"
+	"github.com/GoogleCloudPlatform/khi/pkg/testutil/testlog"
+)
+
+func TestHpaControllerTimelineMapper_ProcessLogByGroup(t *testing.T) {
+	builder := khifilev6.NewBuilder()
+
+	projectTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-project",
+		Type: googlecloudcommon_contract.TimelineTypeGCPProject,
+	})
+	gkeClusterTimeline := builder.TimelineAccumulator.GetPath(projectTimeline, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: googlecloudcommon_contract.TimelineTypeGKE,
+	})
+	controlPlanesTimeline := builder.TimelineAccumulator.GetPath(gkeClusterTimeline, khifilev6.PathSegment{
+		Name: "controlplanes",
+		Type: googlecloudcommon_contract.TimelineTypeGKEControlPlanes,
+	})
+	wantCompTimeline := builder.TimelineAccumulator.GetPath(controlPlanesTimeline, khifilev6.PathSegment{
+		Name: "hpa-controller",
+		Type: googlecloudlogk8scontrolplane_contract.TimelineTypeControlPlaneComponent,
+	})
+
+	k8sClusterTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
+		Name: "test-cluster",
+		Type: inspectioncore_contract.TimelineTypeK8sCluster,
+	})
+
+	autoscalingApiTimeline := builder.TimelineAccumulator.GetPath(k8sClusterTimeline, khifilev6.PathSegment{
+		Name: "autoscaling/v2",
+		Type: inspectioncore_contract.TimelineTypeAPIVersion,
+	})
+	hpaKindTimeline := builder.TimelineAccumulator.GetPath(autoscalingApiTimeline, khifilev6.PathSegment{
+		Name: "horizontalpodautoscaler",
+		Type: inspectioncore_contract.TimelineTypeKind,
+	})
+	hpaNamespaceTimeline := builder.TimelineAccumulator.GetPath(hpaKindTimeline, khifilev6.PathSegment{
+		Name: "gke-managed-cim",
+		Type: inspectioncore_contract.TimelineTypeNamespace,
+	})
+	wantHpaTimeline := builder.TimelineAccumulator.GetPath(hpaNamespaceTimeline, khifilev6.PathSegment{
+		Name: "kube-state-metrics",
+		Type: inspectioncore_contract.TimelineTypeResource,
+	})
+
+	appsApiTimeline := builder.TimelineAccumulator.GetPath(k8sClusterTimeline, khifilev6.PathSegment{
+		Name: "apps/v1",
+		Type: inspectioncore_contract.TimelineTypeAPIVersion,
+	})
+	statefulSetKindTimeline := builder.TimelineAccumulator.GetPath(appsApiTimeline, khifilev6.PathSegment{
+		Name: "statefulset",
+		Type: inspectioncore_contract.TimelineTypeKind,
+	})
+	statefulSetNamespaceTimeline := builder.TimelineAccumulator.GetPath(statefulSetKindTimeline, khifilev6.PathSegment{
+		Name: "gke-managed-cim",
+		Type: inspectioncore_contract.TimelineTypeNamespace,
+	})
+	wantTargetTimeline := builder.TimelineAccumulator.GetPath(statefulSetNamespaceTimeline, khifilev6.PathSegment{
+		Name: "kube-state-metrics",
+		Type: inspectioncore_contract.TimelineTypeResource,
+	})
+
+	testCases := []struct {
+		desc                string
+		inputComponentField googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet
+		inputHPAField       googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet
+		assert              func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+	}{
+		{
+			desc: "final recommendation with targetRef maps to controlplane, HPA, and target workload",
+			inputComponentField: googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{
+				ProjectID:     "test-project",
+				ClusterName:   "test-cluster",
+				ComponentName: "hpa-controller",
+			},
+			inputHPAField: googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet{
+				FinalRecommendation: &googlecloudlogk8scontrolplane_contract.HPAFinalRecommendation{
+					HPA:            "gke-managed-cim/kube-state-metrics",
+					HPANamespace:   "gke-managed-cim",
+					HPAName:        "kube-state-metrics",
+					ConfiguredSize: 1,
+					Replicas:       1,
+					TargetRef: googlecloudlogk8scontrolplane_contract.HPATargetRef{
+						APIVersion: "apps/v1",
+						Kind:       "StatefulSet",
+						Name:       "kube-state-metrics",
+					},
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantCompTimeline).
+					HasEvent(wantHpaTimeline).
+					HasEvent(wantTargetTimeline)
+			},
+		},
+		{
+			desc: "atomic recommendation maps to controlplane and HPA",
+			inputComponentField: googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{
+				ProjectID:     "test-project",
+				ClusterName:   "test-cluster",
+				ComponentName: "hpa-controller",
+			},
+			inputHPAField: googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet{
+				AtomicRecommendation: &googlecloudlogk8scontrolplane_contract.HPAAtomicRecommendation{
+					HPA:          "gke-managed-cim/kube-state-metrics",
+					HPANamespace: "gke-managed-cim",
+					HPAName:      "kube-state-metrics",
+					MetricName:   "memory",
+					Replicas:     1,
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantCompTimeline).
+					HasEvent(wantHpaTimeline).
+					HasNoEvent(wantTargetTimeline)
+			},
+		},
+		{
+			desc: "fallback message maps only to controlplane",
+			inputComponentField: googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{
+				ProjectID:     "test-project",
+				ClusterName:   "test-cluster",
+				ComponentName: "hpa-controller",
+			},
+			inputHPAField: googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet{
+				Message: "starting hpa controller",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantCompTimeline).
+					HasNoEvent(wantHpaTimeline).
+					HasNoEvent(wantTargetTimeline)
+			},
+		},
+		{
+			desc: "final recommendation with missing targetRef apiVersion does not map target workload timeline",
+			inputComponentField: googlecloudlogk8scontrolplane_contract.K8sControlplaneComponentFieldSet{
+				ProjectID:     "test-project",
+				ClusterName:   "test-cluster",
+				ComponentName: "hpa-controller",
+			},
+			inputHPAField: googlecloudlogk8scontrolplane_contract.K8sHPAControllerFieldSet{
+				FinalRecommendation: &googlecloudlogk8scontrolplane_contract.HPAFinalRecommendation{
+					HPA:            "gke-managed-cim/kube-state-metrics",
+					HPANamespace:   "gke-managed-cim",
+					HPAName:        "kube-state-metrics",
+					ConfiguredSize: 1,
+					Replicas:       1,
+					TargetRef: googlecloudlogk8scontrolplane_contract.HPATargetRef{
+						Kind: "StatefulSet",
+						Name: "kube-state-metrics",
+					},
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(wantCompTimeline).
+					HasEvent(wantHpaTimeline).
+					HasNoEvent(wantTargetTimeline)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			l := testlog.NewMockLog(tc.inputComponentField, tc.inputHPAField)
+			mapper := &HpaControllerTimelineMapper{}
+			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
+			if err != nil {
+				t.Fatalf("ProcessLogByGroup() returned an unexpected error, err=%v", err)
+			}
+			tc.assert(t, ctx, cs)
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/registration.go
@@ -27,9 +27,11 @@ flowchart TD
     ListLogEntriesTask --> LogIngesterTask
     ListLogEntriesTask --> SchedulerLogFilterTask --> SchedulerGrouperTask --> SchedulerLogToTimelineMapperTask --> TailTask
     ListLogEntriesTask --> ControllerManagerLogFilterTask --> ControllerManagerGrouperTask --> ControllerManagerLogToTimelineMapperTask --> TailTask
+    ListLogEntriesTask --> HpaControllerLogFilterTask --> HpaControllerGrouperTask --> HpaControllerLogToTimelineMapperTask --> TailTask
     ListLogEntriesTask --> OtherLogFilterTask --> OtherGrouperTask --> OtherLogToTimelineMapperTask --> TailTask
     LogIngesterTask --> SchedulerLogToTimelineMapperTask
     LogIngesterTask --> ControllerManagerLogToTimelineMapperTask
+    LogIngesterTask --> HpaControllerLogToTimelineMapperTask
     LogIngesterTask --> OtherLogToTimelineMapperTask
 */
 func Register(registry coreinspection.InspectionTaskRegistry) error {
@@ -65,6 +67,9 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 		ControllerManagerFilterTask,
 		ControllerManagerGrouperTask,
 		ControllerManagerLogToTimelineMapperTask,
+		HpaControllerLogFilterTask,
+		HpaControllerGrouperTask,
+		HpaControllerLogToTimelineMapperTask,
 		OtherLogFilterTask,
 		OtherGrouperTask,
 		OtherLogToTimelineMapperTask,


### PR DESCRIPTION
## Summary

Add support for parsing GKE HPA controller logs (`atomicRecommendation` and `finalRecommendation`), generating readable tag-style summaries (`[HPA Final]`, `[HPA Metric]`), and mapping logs to the appropriate timelines.

### Changes
- **Log Field Extraction**: Added extraction of `atomicRecommendation` and `finalRecommendation` structures from `jsonPayload`.
- **Summary Generation**:
  - `[HPA Final] <namespace>/<hpa>: <targetRef> <from> -> <to> replicas` (or `= <replicas> replicas` when maintained).
  - `[HPA Metric] <namespace>/<hpa>: <metricName> (<current> / target <target>) -> <replicas> replicas`.
- **Timeline Mapping**:
  - Control plane component timeline: `controlplanes/hpa-controller`
  - HPA resource timeline: `autoscaling/v2/horizontalpodautoscaler/<namespace>/<name>`
  - Target workload timeline (when `targetRef` has valid `apiVersion`): `<targetAPIVersion>/<kind>/<namespace>/<name>`
- **Tests**: Added comprehensive unit tests in `contract` and `impl` packages covering field extraction, summary formatting, log ingestion, and timeline mapping.