### PR TITLE
feat(inspection/k8saudit): support truncated audit logs and preserve condition continuity

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/contract/fieldset.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/fieldset.go
@@ -100,6 +100,8 @@ type K8sAuditLogFieldSet struct {
 	IsLast bool
 	// IsDryRun is true if the request was a dry run.
 	IsDryRun bool
+	// IsTruncated is true if the audit log entry was truncated by kube-apiserver (audit.k8s.io/truncated: "true").
+	IsTruncated bool
 
 	// APIVersion is the API version of the resource (e.g., "apps/v1").
 	APIVersion string

--- a/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper.go
@@ -93,18 +93,8 @@ func (e *MultiGroupLogEvent) getLastManifestLog(role string) (*ResourceManifestL
 		return group.Logs[i].Log.Timestamp.After(eventTime)
 	})
 
-	// Scan backwards from the match to find the latest log entry with a valid resource body.
-	var lastManifestLog *ResourceManifestLog
-	for i := idx - 1; i >= 0; i-- {
-		logEntry := group.Logs[i]
-		if logEntry.ResourceBodyReader != nil {
-			lastManifestLog = logEntry
-			break
-		}
-	}
-
-	if lastManifestLog != nil {
-		return lastManifestLog, true
+	if idx > 0 {
+		return group.Logs[idx-1], true
 	}
 	return nil, false
 }

--- a/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/revision_state.go
@@ -151,6 +151,15 @@ var (
 		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
 		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
 	)
+	RevisionStateK8sResourceTruncated = style.MustRegisterRevisionState(
+		"Resource exists, but log details were truncated",
+		"deployed_code",
+		`The Kubernetes resource exists, but the audit log payload was truncated by kube-apiserver due to size limits.
+
+**Note**: Full manifest and patch contents are not available for this operation.`,
+		style.Color{R: 0.0, G: 0.0, B: 1.0, A: 1.0},
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
 	RevisionStateK8sResourceDeleting = style.MustRegisterRevisionState(
 		"Resource is being deleted",
 		"auto_delete",

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
@@ -349,16 +349,36 @@ func (c *conditionWalker) checkLastTransitionTimes(condition *model.K8sResourceS
 // It tracks changes in Status, LastTransitionTime, and LastHeartbeatTime (ProbeLikeTime).
 func (c *conditionWalker) CheckAndRecord(ctx context.Context, changedTime time.Time, k8sAuditLog commonlogk8saudit_contract.K8sAuditLogFieldSet, condition *model.K8sResourceStatusCondition, cs *khifilev6.TimelineChangeSet) {
 	if condition == nil {
-		if c.lastStatus != "n/a" {
-			cs.AddRevision(c.conditionPath, &khifilev6.StagingRevision{
-				VerbType:     k8sAuditLog.Verb,
-				ResourceBody: nil,
-				Principal:    k8sAuditLog.Principal,
-				ChangedTime:  changedTime,
-				StateType:    commonlogk8saudit_contract.RevisionStateConditionNotGiven,
-			})
-			c.minChangeTime = &changedTime
-			c.lastStatus = "n/a"
+		refCond := c.getLastCondition(changedTime)
+		if refCond != nil && refCond.Status != "" {
+			if c.lastStatus != refCond.Status {
+				transitionTime, err := time.Parse(time.RFC3339, refCond.LastTransitionTime)
+				if err == nil {
+					state := conditionStateToRevisionState(refCond.Status)
+					body := c.serializeCondition(refCond)
+					cs.AddRevision(c.conditionPath, &khifilev6.StagingRevision{
+						VerbType:     k8sAuditLog.Verb,
+						ResourceBody: body,
+						Principal:    k8sAuditLog.Principal,
+						ChangedTime:  c.clampMinChangeTime(transitionTime),
+						StateType:    state,
+					})
+					c.lastStatus = refCond.Status
+					c.lastTransitionTime = refCond.LastTransitionTime
+				}
+			}
+		} else {
+			if c.lastStatus != "n/a" {
+				cs.AddRevision(c.conditionPath, &khifilev6.StagingRevision{
+					VerbType:     k8sAuditLog.Verb,
+					ResourceBody: nil,
+					Principal:    k8sAuditLog.Principal,
+					ChangedTime:  changedTime,
+					StateType:    commonlogk8saudit_contract.RevisionStateConditionNotGiven,
+				})
+				c.minChangeTime = &changedTime
+				c.lastStatus = "n/a"
+			}
 		}
 	} else {
 		c.lastStatus = condition.Status

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
@@ -341,7 +341,11 @@ func newConditionWalker(conditionPath *khifilev6.TimelinePath, conditionType str
 // checkLastTransitionTimes memorizes the last transition time of the condition. This value is used for complementing values for logs without the full status information.
 func (c *conditionWalker) checkLastTransitionTimes(condition *model.K8sResourceStatusCondition) {
 	if condition != nil && condition.Status != "" && condition.LastTransitionTime != "" {
-		c.lastTransitionStates[condition.LastTransitionTime] = condition
+		t, err := time.Parse(time.RFC3339, condition.LastTransitionTime)
+		if err != nil {
+			return
+		}
+		c.lastTransitionStates[t.UTC().Format(time.RFC3339)] = condition
 	}
 }
 
@@ -463,7 +467,7 @@ func (c *conditionWalker) getLastCondition(beforeThan time.Time) *model.K8sResou
 		return c.lastTransitionTimeSorted[i].After(beforeThan)
 	})
 	if idx > 0 {
-		return c.lastTransitionStates[c.lastTransitionTimeSorted[idx-1].Format(time.RFC3339)]
+		return c.lastTransitionStates[c.lastTransitionTimeSorted[idx-1].UTC().Format(time.RFC3339)]
 	}
 	return nil
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
@@ -700,4 +700,238 @@ status:
 		testchangeset.AssertTimeline(t, cs).
 			HasNoRevision(conditionPath)
 	})
+
+	t.Run("Truncated log maintains unchanged condition status without gap", func(t *testing.T) {
+		builder := khifilev6.NewBuilder()
+		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
+		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
+		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
+		ns := builder.TimelineAccumulator.GetPath(kind, khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace})
+		parentPath := builder.TimelineAccumulator.GetPath(ns, khifilev6.PathSegment{Name: "nginx", Type: inspectioncore_contract.TimelineTypeResource})
+		conditionPath := builder.TimelineAccumulator.GetPath(parentPath, khifilev6.PathSegment{Name: "Ready", Type: commonlogk8saudit_contract.TimelineTypeResourceCondition})
+
+		ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+		// Log 1 (t=10s): Initial update with Ready=True
+		logObj1 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 10, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbUpdate, Principal: "user-1", ClusterName: "k8s"},
+		)
+		bodyReader1 := structured.NewNodeReader(parseYAML(`
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    lastTransitionTime: "2024-01-01T00:00:10Z"
+`))
+
+		// Log 2 (t=20s): Truncated log (ResourceBodyReader == nil)
+		logObj2 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 20, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbPatch, Principal: "user-1", ClusterName: "k8s", IsTruncated: true},
+		)
+
+		// Log 3 (t=30s): Next update with Ready=True (same lastTransitionTime)
+		logObj3 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 30, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbUpdate, Principal: "user-1", ClusterName: "k8s"},
+		)
+		bodyReader3 := structured.NewNodeReader(parseYAML(`
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    lastTransitionTime: "2024-01-01T00:00:10Z"
+`))
+
+		resIdentity := &commonlogk8saudit_contract.ResourceIdentity{
+			APIVersion: "core/v1",
+			Kind:       "pod",
+			Namespace:  "default",
+			Name:       "nginx",
+		}
+
+		groupSet := commonlogk8saudit_contract.RelatedGroupSet{
+			Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
+				"target": {
+					Resource: resIdentity,
+					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
+						{Log: logObj1, ResourceBodyReader: bodyReader1},
+						{Log: logObj2, ResourceBodyReader: nil},
+						{Log: logObj3, ResourceBodyReader: bodyReader3},
+					},
+				},
+			},
+		}
+
+		event1 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj1, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+		event2 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj2, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+		event3 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj3, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+
+		// PreProcessLog
+		var state *conditionLogToTimelineMapperTaskState
+		var err error
+		state, err = taskSetting.PreProcessLog(ctx, 0, event1, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 1 failed: %v", err)
+		}
+		state, err = taskSetting.PreProcessLog(ctx, 1, event2, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 2 failed: %v", err)
+		}
+		state, err = taskSetting.PreProcessLog(ctx, 2, event3, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 3 failed: %v", err)
+		}
+
+		// ProcessLog 1 (t=10s) -> Emits True
+		cs1, state, err := taskSetting.ProcessLog(ctx, event1, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 1 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs1).
+			HasRevision(conditionPath, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbUpdate,
+				ResourceBody: parseYAML("lastTransitionTime: \"2024-01-01T00:00:10Z\"\nstatus: \"True\"\ntype: Ready\n"),
+				Principal:    "user-1",
+				ChangedTime:  time.Date(2024, 1, 1, 0, 0, 10, 0, time.UTC),
+				StateType:    commonlogk8saudit_contract.RevisionStateConditionTrue,
+			}, nodeComparer)
+
+		// ProcessLog 2 (t=20s, truncated) -> Must NOT emit ConditionNotGiven, status continuity is preserved
+		cs2, state, err := taskSetting.ProcessLog(ctx, event2, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 2 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs2).
+			HasNoRevision(conditionPath)
+
+		// ProcessLog 3 (t=30s) -> Same status and transition time, no duplicate revision
+		cs3, _, err := taskSetting.ProcessLog(ctx, event3, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 3 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs3).
+			HasNoRevision(conditionPath)
+	})
+
+	t.Run("Truncated log with condition transition occurred during truncated period", func(t *testing.T) {
+		builder := khifilev6.NewBuilder()
+		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
+		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
+		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
+		ns := builder.TimelineAccumulator.GetPath(kind, khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace})
+		parentPath := builder.TimelineAccumulator.GetPath(ns, khifilev6.PathSegment{Name: "nginx", Type: inspectioncore_contract.TimelineTypeResource})
+		conditionPath := builder.TimelineAccumulator.GetPath(parentPath, khifilev6.PathSegment{Name: "Ready", Type: commonlogk8saudit_contract.TimelineTypeResourceCondition})
+
+		ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+		// Log 1 (t=10s): Ready=True
+		logObj1 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 10, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbUpdate, Principal: "user-1", ClusterName: "k8s"},
+		)
+		bodyReader1 := structured.NewNodeReader(parseYAML(`
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    lastTransitionTime: "2024-01-01T00:00:10Z"
+`))
+
+		// Log 2 (t=20s): Truncated log
+		logObj2 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 20, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbUpdate, Principal: "user-1", ClusterName: "k8s", IsTruncated: true},
+		)
+
+		// Log 3 (t=30s): Ready=False with lastTransitionTime at t=20s
+		logObj3 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 30, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbUpdate, Principal: "user-1", ClusterName: "k8s"},
+		)
+		bodyReader3 := structured.NewNodeReader(parseYAML(`
+status:
+  conditions:
+  - type: Ready
+    status: "False"
+    lastTransitionTime: "2024-01-01T00:00:20Z"
+`))
+
+		resIdentity := &commonlogk8saudit_contract.ResourceIdentity{
+			APIVersion: "core/v1",
+			Kind:       "pod",
+			Namespace:  "default",
+			Name:       "nginx",
+		}
+
+		groupSet := commonlogk8saudit_contract.RelatedGroupSet{
+			Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
+				"target": {
+					Resource: resIdentity,
+					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
+						{Log: logObj1, ResourceBodyReader: bodyReader1},
+						{Log: logObj2, ResourceBodyReader: nil},
+						{Log: logObj3, ResourceBodyReader: bodyReader3},
+					},
+				},
+			},
+		}
+
+		event1 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj1, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+		event2 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj2, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+		event3 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj3, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+
+		// PreProcessLog
+		var state *conditionLogToTimelineMapperTaskState
+		var err error
+		state, err = taskSetting.PreProcessLog(ctx, 0, event1, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 1 failed: %v", err)
+		}
+		state, err = taskSetting.PreProcessLog(ctx, 1, event2, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 2 failed: %v", err)
+		}
+		state, err = taskSetting.PreProcessLog(ctx, 2, event3, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 3 failed: %v", err)
+		}
+
+		// ProcessLog 1 (t=10s) -> Emits True
+		cs1, state, err := taskSetting.ProcessLog(ctx, event1, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 1 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs1).
+			HasRevision(conditionPath, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbUpdate,
+				ResourceBody: parseYAML("lastTransitionTime: \"2024-01-01T00:00:10Z\"\nstatus: \"True\"\ntype: Ready\n"),
+				Principal:    "user-1",
+				ChangedTime:  time.Date(2024, 1, 1, 0, 0, 10, 0, time.UTC),
+				StateType:    commonlogk8saudit_contract.RevisionStateConditionTrue,
+			}, nodeComparer)
+
+		// ProcessLog 2 (t=20s, truncated) -> Emits False at t=20s because lastTransitionTime is 20s
+		cs2, state, err := taskSetting.ProcessLog(ctx, event2, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 2 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs2).
+			HasRevision(conditionPath, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbUpdate,
+				ResourceBody: parseYAML("lastTransitionTime: \"2024-01-01T00:00:20Z\"\nstatus: \"False\"\ntype: Ready\n"),
+				Principal:    "user-1",
+				ChangedTime:  time.Date(2024, 1, 1, 0, 0, 20, 0, time.UTC),
+				StateType:    commonlogk8saudit_contract.RevisionStateConditionFalse,
+			}, nodeComparer)
+
+		// ProcessLog 3 (t=30s) -> Already recorded False at t=20s, no duplicate revision
+		cs3, _, err := taskSetting.ProcessLog(ctx, event3, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 3 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs3).
+			HasNoRevision(conditionPath)
+	})
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
@@ -934,4 +934,124 @@ status:
 		testchangeset.AssertTimeline(t, cs3).
 			HasNoRevision(conditionPath)
 	})
+
+	t.Run("Truncated log with timezone offset in lastTransitionTime correctly normalizes and complements", func(t *testing.T) {
+		builder := khifilev6.NewBuilder()
+		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
+		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
+		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
+		ns := builder.TimelineAccumulator.GetPath(kind, khifilev6.PathSegment{Name: "default", Type: inspectioncore_contract.TimelineTypeNamespace})
+		parentPath := builder.TimelineAccumulator.GetPath(ns, khifilev6.PathSegment{Name: "nginx", Type: inspectioncore_contract.TimelineTypeResource})
+		conditionPath := builder.TimelineAccumulator.GetPath(parentPath, khifilev6.PathSegment{Name: "Ready", Type: commonlogk8saudit_contract.TimelineTypeResourceCondition})
+
+		ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+
+		// Log 1 (t=10s): Ready=True with UTC timezone
+		logObj1 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 10, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbUpdate, Principal: "user-1", ClusterName: "k8s"},
+		)
+		bodyReader1 := structured.NewNodeReader(parseYAML(`
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    lastTransitionTime: "2024-01-01T00:00:10Z"
+`))
+
+		// Log 2 (t=20s): Truncated log
+		logObj2 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 20, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbUpdate, Principal: "user-1", ClusterName: "k8s", IsTruncated: true},
+		)
+
+		// Log 3 (t=30s): Ready=False with non-UTC timezone (+09:00 for 2024-01-01T00:00:20Z -> 2024-01-01T09:00:20+09:00)
+		logObj3 := testlog.NewMockLog(
+			time.Date(2024, 1, 1, 0, 0, 30, 0, time.UTC),
+			commonlogk8saudit_contract.K8sAuditLogFieldSet{Verb: commonlogk8saudit_contract.VerbUpdate, Principal: "user-1", ClusterName: "k8s"},
+		)
+		bodyReader3 := structured.NewNodeReader(parseYAML(`
+status:
+  conditions:
+  - type: Ready
+    status: "False"
+    lastTransitionTime: "2024-01-01T09:00:20+09:00"
+`))
+
+		resIdentity := &commonlogk8saudit_contract.ResourceIdentity{
+			APIVersion: "core/v1",
+			Kind:       "pod",
+			Namespace:  "default",
+			Name:       "nginx",
+		}
+
+		groupSet := commonlogk8saudit_contract.RelatedGroupSet{
+			Roles: map[string]*commonlogk8saudit_contract.ResourceManifestLogGroup{
+				"target": {
+					Resource: resIdentity,
+					Logs: []*commonlogk8saudit_contract.ResourceManifestLog{
+						{Log: logObj1, ResourceBodyReader: bodyReader1},
+						{Log: logObj2, ResourceBodyReader: nil},
+						{Log: logObj3, ResourceBodyReader: bodyReader3},
+					},
+				},
+			},
+		}
+
+		event1 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj1, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+		event2 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj2, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+		event3 := commonlogk8saudit_contract.MultiGroupLogEvent{Log: logObj3, GroupRole: "target", ResourceIdentity: resIdentity, EventType: commonlogk8saudit_contract.ChangeEventTypeModification, GroupSet: groupSet}
+
+		// PreProcessLog
+		var state *conditionLogToTimelineMapperTaskState
+		var err error
+		state, err = taskSetting.PreProcessLog(ctx, 0, event1, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 1 failed: %v", err)
+		}
+		state, err = taskSetting.PreProcessLog(ctx, 1, event2, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 2 failed: %v", err)
+		}
+		state, err = taskSetting.PreProcessLog(ctx, 2, event3, state)
+		if err != nil {
+			t.Fatalf("PreProcessLog 3 failed: %v", err)
+		}
+
+		// ProcessLog 1 (t=10s) -> Emits True
+		cs1, state, err := taskSetting.ProcessLog(ctx, event1, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 1 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs1).
+			HasRevision(conditionPath, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbUpdate,
+				ResourceBody: parseYAML("lastTransitionTime: \"2024-01-01T00:00:10Z\"\nstatus: \"True\"\ntype: Ready\n"),
+				Principal:    "user-1",
+				ChangedTime:  time.Date(2024, 1, 1, 0, 0, 10, 0, time.UTC),
+				StateType:    commonlogk8saudit_contract.RevisionStateConditionTrue,
+			}, nodeComparer)
+
+		// ProcessLog 2 (t=20s, truncated) -> Emits False because parsed timezone offset 09:00 matches 00:00:20Z
+		cs2, state, err := taskSetting.ProcessLog(ctx, event2, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 2 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs2).
+			HasRevision(conditionPath, &khifilev6.StagingRevision{
+				VerbType:     commonlogk8saudit_contract.VerbUpdate,
+				ResourceBody: parseYAML("lastTransitionTime: \"2024-01-01T09:00:20+09:00\"\nstatus: \"False\"\ntype: Ready\n"),
+				Principal:    "user-1",
+				ChangedTime:  time.Date(2024, 1, 1, 0, 0, 20, 0, time.UTC),
+				StateType:    commonlogk8saudit_contract.RevisionStateConditionFalse,
+			}, nodeComparer)
+
+		// ProcessLog 3 (t=30s) -> Already recorded, no duplicate revision
+		cs3, _, err := taskSetting.ProcessLog(ctx, event3, state)
+		if err != nil {
+			t.Fatalf("ProcessLog 3 failed: %v", err)
+		}
+		testchangeset.AssertTimeline(t, cs3).
+			HasNoRevision(conditionPath)
+	})
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
@@ -135,6 +135,13 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 			ResourceBodyReader: g.prevRevisionReader,
 		}, nil
 	}
+	if fieldSet.IsTruncated {
+		g.prevRevisionReader = nil
+		return &commonlogk8saudit_contract.ResourceManifestLog{
+			Log:                l,
+			ResourceBodyReader: nil,
+		}, nil
+	}
 	currentBodyReader := fieldSet.Response
 	partial := false
 	if currentBodyReader == nil {

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
@@ -31,6 +31,7 @@ type testGroupManifestGeneratorInput struct {
 	requestYAML  string
 	responseYAML string
 	isDryRun     bool
+	isTruncated  bool
 }
 
 func TestGroupManifestGenerator(t *testing.T) {
@@ -70,6 +71,42 @@ metadata:
 				`apiVersion: v1
 kind: Pod
 metadata:
+  labels:
+    qux: quux
+`,
+			},
+		},
+		{
+			desc: "truncated log clears previous revision and does not merge old state in subsequent patch",
+			inputs: []*testGroupManifestGeneratorInput{
+				{
+					verb: commonlogk8saudit_contract.VerbCreate,
+					responseYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    foo: bar`,
+				},
+				{
+					verb:        commonlogk8saudit_contract.VerbUpdate,
+					isTruncated: true,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					requestYAML: `metadata:
+  labels:
+    qux: quux`,
+				},
+			},
+			wantBodies: []string{
+				`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    foo: bar
+`,
+				"",
+				`metadata:
   labels:
     qux: quux
 `,
@@ -359,6 +396,7 @@ metadata:
 					Request:     request,
 					Response:    response,
 					IsDryRun:    input.isDryRun,
+					IsTruncated: input.isTruncated,
 				}))
 			}
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper.go
@@ -223,12 +223,20 @@ func (r *ResourceRevisionLogToTimelineMapperTaskSetting) handleTargetChange(ctx 
 	state := commonlogk8saudit_contract.RevisionStateK8sResourceExisting
 	bodyReader, hasBody := event.GetLastBodyReader(event.GroupRole)
 
-	if !hasBody || bodyReader == nil {
+	switch {
+	case k8sFieldSet.IsTruncated:
+		if isDeletiveVerb(k8sFieldSet.Verb) {
+			prevGroupData.DeletionStarted = true
+			state = commonlogk8saudit_contract.RevisionStateK8sResourceDeleted
+		} else {
+			state = commonlogk8saudit_contract.RevisionStateK8sResourceTruncated
+		}
+	case !hasBody || bodyReader == nil:
 		if isDeletiveVerb(k8sFieldSet.Verb) {
 			prevGroupData.DeletionStarted = true
 			state = commonlogk8saudit_contract.RevisionStateK8sResourceDeleted
 		}
-	} else {
+	default:
 		deletionStarted := false
 		underGracefulPeriod := false
 		deletionCompleted := false

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_test.go
@@ -69,15 +69,16 @@ func TestResourceRevisionLogToTimelineMapperTaskSetting_ProcessLog(t *testing.T)
 	}
 
 	testCases := []struct {
-		name       string
-		inputState *resourceRevisionLogToTimelineMapperState
-		verb       *pb.Verb
-		bodyYAML   string
-		role       string
-		eventType  commonlogk8saudit_contract.ChangeEventType
-		isDryRun   bool
-		wantState  *resourceRevisionLogToTimelineMapperState
-		assert     func(t *testing.T, cs *khifilev6.TimelineChangeSet, node structured.Node)
+		name        string
+		inputState  *resourceRevisionLogToTimelineMapperState
+		verb        *pb.Verb
+		bodyYAML    string
+		role        string
+		eventType   commonlogk8saudit_contract.ChangeEventType
+		isDryRun    bool
+		isTruncated bool
+		wantState   *resourceRevisionLogToTimelineMapperState
+		assert      func(t *testing.T, cs *khifilev6.TimelineChangeSet, node structured.Node)
 	}{
 		{
 			name:       "Create event",
@@ -551,6 +552,52 @@ uid: "test-uid"`,
 					HasNoRevision(parentPath)
 			},
 		},
+		{
+			name:        "Truncated log emits RevisionStateK8sResourceTruncated",
+			inputState:  nil,
+			verb:        commonlogk8saudit_contract.VerbUpdate,
+			bodyYAML:    "",
+			role:        "target",
+			eventType:   commonlogk8saudit_contract.ChangeEventTypeModification,
+			isTruncated: true,
+			wantState:   &resourceRevisionLogToTimelineMapperState{},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, node structured.Node) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(parentPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "admin",
+						VerbType:     commonlogk8saudit_contract.VerbUpdate,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceTruncated,
+					}, nodeComparer)
+			},
+		},
+		{
+			name: "Truncated delete log emits RevisionStateK8sResourceDeleted",
+			inputState: &resourceRevisionLogToTimelineMapperState{
+				PrevUID: "test-uid",
+			},
+			verb:        commonlogk8saudit_contract.VerbDelete,
+			bodyYAML:    "",
+			role:        "target",
+			eventType:   commonlogk8saudit_contract.ChangeEventTypeModification,
+			isTruncated: true,
+			wantState: &resourceRevisionLogToTimelineMapperState{
+				WasCompletelyRemoved: false,
+				DeletionStarted:      true,
+				PrevUID:              "test-uid",
+			},
+			assert: func(t *testing.T, cs *khifilev6.TimelineChangeSet, node structured.Node) {
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(parentPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						ResourceBody: nil,
+						Principal:    "admin",
+						VerbType:     commonlogk8saudit_contract.VerbDelete,
+						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceDeleted,
+					}, nodeComparer)
+			},
+		},
 	}
 
 	mapperSetting := &ResourceRevisionLogToTimelineMapperTaskSetting{
@@ -584,6 +631,7 @@ uid: "test-uid"`,
 					ClusterName:  "k8s",
 					Verb:         tc.verb,
 					IsDryRun:     tc.isDryRun,
+					IsTruncated:  tc.isTruncated,
 				},
 			)
 

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor.go
@@ -32,6 +32,7 @@ var (
 	pathProtoMethodName     = structured.CompileFieldPath("protoPayload.methodName")
 	pathResourceClusterName = structured.CompileFieldPath("resource.labels.cluster_name")
 	pathLabelsDryRun        = structured.CompileFieldPath("labels.command\\.gke\\.io/dryRun")
+	pathLabelsTruncated     = structured.CompileFieldPath("labels.audit\\.k8s\\.io/truncated")
 	pathProtoPrincipal      = structured.CompileFieldPath("protoPayload.authenticationInfo.principalEmail")
 	pathProtoStatusCode     = structured.CompileFieldPath("protoPayload.status.code")
 	pathProtoStatusMessage  = structured.CompileFieldPath("protoPayload.status.message")
@@ -58,6 +59,7 @@ func ExtractGCPK8sAuditLog(reader *structured.NodeReader) (commonlogk8saudit_con
 	result.ClusterName = reader.ReadStringOrDefault(pathResourceClusterName, "unknown")
 	result.RequestURI = resourceName
 	result.IsDryRun = reader.ReadStringOrDefault(pathLabelsDryRun, "") != ""
+	result.IsTruncated = reader.ReadStringOrDefault(pathLabelsTruncated, "") == "true" || reader.ReadBoolOrDefault(pathLabelsTruncated, false)
 
 	apiVersion, pluralKind, namespace, name, subResourceName, verb := parseKubernetesOperation(resourceName, methodName)
 	result.APIVersion = apiVersion

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor_test.go
@@ -279,6 +279,32 @@ func TestExtractGCPK8sAuditLog(t *testing.T) {
 				IsDryRun:     true,
 			},
 		},
+		{
+			name: "truncated log",
+			input: `{
+				"operation": {
+					"id": "test-op-5"
+				},
+				"protoPayload": {
+					"resourceName": "core/v1/namespaces/default/pods/nginx",
+					"methodName": "io.k8s.core.v1.pods.update"
+				},
+				"labels": {
+					"audit.k8s.io/truncated": "true"
+				}
+			}`,
+			want: commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				OperationID:  "test-op-5",
+				APIVersion:   "core/v1",
+				PluralKind:   "pods",
+				Namespace:    "default",
+				ResourceName: "nginx",
+				ClusterName:  "unknown",
+				Verb:         commonlogk8saudit_contract.VerbUpdate,
+				RequestURI:   "core/v1/namespaces/default/pods/nginx",
+				IsTruncated:  true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor.go
@@ -25,6 +25,8 @@ import (
 
 var (
 	pathAuditID               = structured.CompileFieldPath("auditID")
+	pathAnnotationsTruncated  = structured.CompileFieldPath("annotations.audit\\.k8s\\.io/truncated")
+	pathLabelsTruncated       = structured.CompileFieldPath("labels.audit\\.k8s\\.io/truncated")
 	pathObjectRef             = structured.CompileFieldPath("objectRef")
 	pathObjectRefAPIGroup     = structured.CompileFieldPath("objectRef.apiGroup")
 	pathObjectRefAPIVersion   = structured.CompileFieldPath("objectRef.apiVersion")
@@ -64,6 +66,10 @@ func ExtractOSSK8sAuditLog(reader *structured.NodeReader) (commonlogk8saudit_con
 	// Currently this won't support the long running operation. TODO: support long running operation
 	result.IsFirst = true
 	result.IsLast = true
+	result.IsTruncated = reader.ReadStringOrDefault(pathAnnotationsTruncated, "") == "true" ||
+		reader.ReadStringOrDefault(pathLabelsTruncated, "") == "true" ||
+		reader.ReadBoolOrDefault(pathAnnotationsTruncated, false) ||
+		reader.ReadBoolOrDefault(pathLabelsTruncated, false)
 	apiGroup := reader.ReadStringOrDefault(pathObjectRefAPIGroup, "core")
 	apiVersion := reader.ReadStringOrDefault(pathObjectRefAPIVersion, "unknown")
 	kind := reader.ReadStringOrDefault(pathObjectRefResource, "unknown")

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor_test.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor_test.go
@@ -131,6 +131,42 @@ objectRef:
 				Verb:            commonlogk8saudit_contract.VerbUpdate,
 			},
 		},
+		{
+			desc: "truncated log",
+			input: `
+auditID: "truncated-audit-id"
+verb: "update"
+annotations:
+  audit.k8s.io/truncated: "true"
+responseStatus:
+  code: 200
+  message: "OK"
+objectRef:
+  apiGroup: "core"
+  apiVersion: "v1"
+  resource: "pods"
+  namespace: "default"
+  name: "truncated-pod"
+`,
+			want: commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				OperationID:     "truncated-audit-id",
+				IsFirst:         true,
+				IsLast:          true,
+				IsTruncated:     true,
+				Principal:       "unknown",
+				StatusCode:      200,
+				StatusMessage:   "OK",
+				IsError:         false,
+				RequestURI:      "",
+				APIVersion:      "core/v1",
+				PluralKind:      "pods",
+				Namespace:       "default",
+				ResourceName:    "truncated-pod",
+				SubresourceName: "",
+				ClusterName:     "cluster",
+				Verb:            commonlogk8saudit_contract.VerbUpdate,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
When Kubernetes audit logs exceed payload limits, kube-apiserver truncates them and marks entries with `audit.k8s.io/truncated: "true"`. This PR adds support for handling truncated audit logs in KHI and ensuring condition timelines remain continuous.

- Extracts `audit.k8s.io/truncated` from GCP and OSS audit logs into `K8sAuditLogFieldSet.IsTruncated`.
- Clears `prevRevisionReader` in `ManifestGeneratorTask` upon encountering truncated logs to prevent merging with unknown/stale states.
- Registers `RevisionStateK8sResourceTruncated` (blue striped pattern: `#0000FF` + `REVISION_STATE_STYLE_PARTIAL_INFO`) to indicate that the resource existed but details were truncated.
- Updates `ConditionLogToTimelineMapperTask` to query `lastTransitionStates` when `condition == nil`. If the active status has not changed, status continuity is maintained without inserting unnecessary `ConditionNotGiven` (blank) gaps.

Fixes #193