### PR TITLE
perf(khifile): optimize InternPool memory retention, ID resolutions, and ToInternedStruct allocations

### DIFF
--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -352,6 +352,10 @@ func (p *InternPool) resolveFieldSetFromID(id uint32) []uint32 {
 // It checks if an identical struct is already interned, and if not, assigns a new ID and stores it.
 func (p *InternPool) InternStruct(fieldPathSetID uint32, values []*pb.InternedValue) *InternStructRef {
 	key := structKey(fieldPathSetID, values)
+	return p.internStructWithKey(fieldPathSetID, values, key)
+}
+
+func (p *InternPool) internStructWithKey(fieldPathSetID uint32, values []*pb.InternedValue, key string) *InternStructRef {
 	if id, ok := p.structToID.Load(key); ok {
 		return &InternStructRef{pool: p, id: id.(uint32)}
 	}

--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -198,9 +198,11 @@ func (p *InternPool) InternString(value string) *InternStringRef {
 	}
 
 	id := p.idGen.New(p.idNs)
-	p.idToStr.Store(id, value)
+	// Clone string before storing in the pool to prevent pinning large underlying byte buffers (such as protojson buffers).
+	cloned := strings.Clone(value)
+	p.idToStr.Store(id, cloned)
 
-	actual, loaded := p.strToID.LoadOrStore(value, id)
+	actual, loaded := p.strToID.LoadOrStore(cloned, id)
 	if loaded {
 		p.idToStr.Store(id, "")
 		return &InternStringRef{pool: p, id: actual.(uint32)}

--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"iter"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -199,8 +200,8 @@ func (p *InternPool) storeString(id uint32, value string) {
 	}
 	p.idToStrMu.Lock()
 	defer p.idToStrMu.Unlock()
-	if needed := idx + 1 - len(p.idToStr); needed > 0 {
-		p.idToStr = append(p.idToStr, make([]string, needed)...)
+	if idx >= len(p.idToStr) {
+		p.idToStr = slices.Grow(p.idToStr, idx+1-len(p.idToStr))[:idx+1]
 	}
 	p.idToStr[idx] = value
 }
@@ -212,8 +213,8 @@ func (p *InternPool) storeFieldSet(id uint32, fieldSet []uint32) {
 	idx := int(id - 1)
 	p.idToFieldSetMu.Lock()
 	defer p.idToFieldSetMu.Unlock()
-	if needed := idx + 1 - len(p.idToFieldSet); needed > 0 {
-		p.idToFieldSet = append(p.idToFieldSet, make([][]uint32, needed)...)
+	if idx >= len(p.idToFieldSet) {
+		p.idToFieldSet = slices.Grow(p.idToFieldSet, idx+1-len(p.idToFieldSet))[:idx+1]
 	}
 	p.idToFieldSet[idx] = fieldSet
 }
@@ -225,8 +226,8 @@ func (p *InternPool) storeStruct(id uint32, s *pb.InternedStruct) {
 	idx := int(id - 1)
 	p.idToStructMu.Lock()
 	defer p.idToStructMu.Unlock()
-	if needed := idx + 1 - len(p.idToStruct); needed > 0 {
-		p.idToStruct = append(p.idToStruct, make([]*pb.InternedStruct, needed)...)
+	if idx >= len(p.idToStruct) {
+		p.idToStruct = slices.Grow(p.idToStruct, idx+1-len(p.idToStruct))[:idx+1]
 	}
 	p.idToStruct[idx] = s
 }
@@ -280,14 +281,13 @@ func (p *InternPool) resolveStringFromID(id uint32) string {
 	idx := p.strIndex(id)
 	if idx >= 0 {
 		p.idToStrMu.RLock()
+		var val string
 		if idx < len(p.idToStr) {
-			val := p.idToStr[idx]
-			p.idToStrMu.RUnlock()
-			if val != "" {
-				return val
-			}
-		} else {
-			p.idToStrMu.RUnlock()
+			val = p.idToStr[idx]
+		}
+		p.idToStrMu.RUnlock()
+		if val != "" {
+			return val
 		}
 	}
 	if p.parentPool != nil {

--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -106,19 +106,24 @@ func (r *InternStructRef) ToProto() *pb.InternedStruct {
 }
 
 // InternPool manages interning of strings, field path sets, and structs to reduce memory usage.
-// It uses sync.Map for concurrent access and relies on IDGenerator for generating IDs.
+// It uses sync.Map for forward key deduplication and slice-based index resolution for ID lookup.
 type InternPool struct {
 	parentPool *InternPool
 	idGen      *IDGenerator
 	idNs       IDNamespace
-	strToID    sync.Map // map[string]uint32
-	idToStr    sync.Map // map[uint32]string
 
+	strToID      sync.Map // map[string]uint32
 	fieldSetToID sync.Map // map[string]uint32 (key is byte representation of []uint32)
-	idToFieldSet sync.Map // map[uint32][]uint32
+	structToID   sync.Map // map[string]uint32
 
-	structToID sync.Map // map[string]uint32
-	idToStruct sync.Map // map[uint32]*pb.InternedStruct
+	idToStrMu sync.RWMutex
+	idToStr   []string
+
+	idToFieldSetMu sync.RWMutex
+	idToFieldSet   [][]uint32
+
+	idToStructMu sync.RWMutex
+	idToStruct   []*pb.InternedStruct
 }
 
 var _ ReadonlyPool = (*InternPool)(nil)
@@ -154,24 +159,76 @@ func (p *InternPool) IngestChunk(chunk *pbv6.InterningPoolChunk) {
 	}
 	for _, str := range chunk.Strings {
 		if str.Id != nil && str.Value != nil {
-			p.idToStr.Store(*str.Id, *str.Value)
+			p.storeString(*str.Id, *str.Value)
 			p.strToID.Store(*str.Value, *str.Id)
 		}
 	}
 	for _, fs := range chunk.FieldPathSets {
 		if fs.Id != nil {
-			p.idToFieldSet.Store(*fs.Id, fs.FieldPathStringIds)
+			p.storeFieldSet(*fs.Id, fs.FieldPathStringIds)
 			p.fieldSetToID.Store(fieldSetKey(fs.FieldPathStringIds), *fs.Id)
 		}
 	}
 	for _, s := range chunk.Structs {
 		if s.Id != nil {
-			p.idToStruct.Store(*s.Id, s)
+			p.storeStruct(*s.Id, s)
 			if s.FieldPathSetId != nil {
 				p.structToID.Store(structKey(*s.FieldPathSetId, s.Values), *s.Id)
 			}
 		}
 	}
+}
+
+func (p *InternPool) strIndex(id uint32) int {
+	if p.idNs == IDServerString {
+		if id <= ServerStringIDBase {
+			return -1
+		}
+		return int(id - ServerStringIDBase - 1)
+	}
+	if id == 0 {
+		return -1
+	}
+	return int(id - 1)
+}
+
+func (p *InternPool) storeString(id uint32, value string) {
+	idx := p.strIndex(id)
+	if idx < 0 {
+		return
+	}
+	p.idToStrMu.Lock()
+	defer p.idToStrMu.Unlock()
+	if needed := idx + 1 - len(p.idToStr); needed > 0 {
+		p.idToStr = append(p.idToStr, make([]string, needed)...)
+	}
+	p.idToStr[idx] = value
+}
+
+func (p *InternPool) storeFieldSet(id uint32, fieldSet []uint32) {
+	if id == 0 {
+		return
+	}
+	idx := int(id - 1)
+	p.idToFieldSetMu.Lock()
+	defer p.idToFieldSetMu.Unlock()
+	if needed := idx + 1 - len(p.idToFieldSet); needed > 0 {
+		p.idToFieldSet = append(p.idToFieldSet, make([][]uint32, needed)...)
+	}
+	p.idToFieldSet[idx] = fieldSet
+}
+
+func (p *InternPool) storeStruct(id uint32, s *pb.InternedStruct) {
+	if id == 0 {
+		return
+	}
+	idx := int(id - 1)
+	p.idToStructMu.Lock()
+	defer p.idToStructMu.Unlock()
+	if needed := idx + 1 - len(p.idToStruct); needed > 0 {
+		p.idToStruct = append(p.idToStruct, make([]*pb.InternedStruct, needed)...)
+	}
+	p.idToStruct[idx] = s
 }
 
 // InternString returns a InternStringRef for the given string.
@@ -200,11 +257,11 @@ func (p *InternPool) InternString(value string) *InternStringRef {
 	id := p.idGen.New(p.idNs)
 	// Clone string before storing in the pool to prevent pinning large underlying byte buffers (such as protojson buffers).
 	cloned := strings.Clone(value)
-	p.idToStr.Store(id, cloned)
+	p.storeString(id, cloned)
 
 	actual, loaded := p.strToID.LoadOrStore(cloned, id)
 	if loaded {
-		p.idToStr.Store(id, "")
+		p.storeString(id, "")
 		return &InternStringRef{pool: p, id: actual.(uint32)}
 	}
 
@@ -220,13 +277,21 @@ func (p *InternPool) ResolveStringFromID(id uint32) string {
 // resolveStringFromID returns the string corresponding to the given ID.
 // It returns an empty string if the ID is not found.
 func (p *InternPool) resolveStringFromID(id uint32) string {
-	if value, ok := p.idToStr.Load(id); ok {
-		return value.(string)
+	idx := p.strIndex(id)
+	if idx >= 0 {
+		p.idToStrMu.RLock()
+		if idx < len(p.idToStr) {
+			val := p.idToStr[idx]
+			p.idToStrMu.RUnlock()
+			if val != "" {
+				return val
+			}
+		} else {
+			p.idToStrMu.RUnlock()
+		}
 	}
 	if p.parentPool != nil {
-		if value, ok := p.parentPool.idToStr.Load(id); ok {
-			return value.(string)
-		}
+		return p.parentPool.resolveStringFromID(id)
 	}
 	return ""
 }
@@ -250,12 +315,12 @@ func (p *InternPool) InternFieldSet(fieldNames []string) *FieldPathSetRef {
 
 	namesCopy := make([]uint32, len(ids))
 	copy(namesCopy, ids)
-	p.idToFieldSet.Store(id, namesCopy)
+	p.storeFieldSet(id, namesCopy)
 	keyStore := fieldSetKey(namesCopy)
 
 	actual, loaded := p.fieldSetToID.LoadOrStore(keyStore, id)
 	if loaded {
-		p.idToFieldSet.Store(id, []uint32{})
+		p.storeFieldSet(id, nil)
 		return &FieldPathSetRef{pool: p, id: actual.(uint32)}
 	}
 
@@ -271,8 +336,14 @@ func (p *InternPool) ResolveFieldSetFromID(id uint32) []uint32 {
 // resolveFieldSetFromID returns the field path set corresponding to the given ID.
 // It returns nil if the ID is not found.
 func (p *InternPool) resolveFieldSetFromID(id uint32) []uint32 {
-	if value, ok := p.idToFieldSet.Load(id); ok {
-		return value.([]uint32)
+	if id == 0 {
+		return nil
+	}
+	idx := int(id - 1)
+	p.idToFieldSetMu.RLock()
+	defer p.idToFieldSetMu.RUnlock()
+	if idx < len(p.idToFieldSet) {
+		return p.idToFieldSet[idx]
 	}
 	return nil
 }
@@ -291,11 +362,11 @@ func (p *InternPool) InternStruct(fieldPathSetID uint32, values []*pb.InternedVa
 		FieldPathSetId: &fieldPathSetID,
 		Values:         values,
 	}
-	p.idToStruct.Store(id, s)
+	p.storeStruct(id, s)
 
 	actual, loaded := p.structToID.LoadOrStore(key, id)
 	if loaded {
-		p.idToStruct.Store(id, (*pb.InternedStruct)(nil))
+		p.storeStruct(id, nil)
 		return &InternStructRef{pool: p, id: actual.(uint32)}
 	}
 
@@ -311,8 +382,14 @@ func (p *InternPool) ResolveStructFromID(id uint32) *pb.InternedStruct {
 // resolveStructFromID returns the InternedStruct corresponding to the given ID.
 // It returns nil if the ID is not found.
 func (p *InternPool) resolveStructFromID(id uint32) *pb.InternedStruct {
-	if val, ok := p.idToStruct.Load(id); ok {
-		return val.(*pb.InternedStruct)
+	if id == 0 {
+		return nil
+	}
+	idx := int(id - 1)
+	p.idToStructMu.RLock()
+	defer p.idToStructMu.RUnlock()
+	if idx < len(p.idToStruct) {
+		return p.idToStruct[idx]
 	}
 	return nil
 }

--- a/pkg/model/khifile/v6/intern_test.go
+++ b/pkg/model/khifile/v6/intern_test.go
@@ -444,7 +444,7 @@ func TestInternPool_StructRefs(t *testing.T) {
 
 	// Simulate an orphaned struct ID in idToStruct (e.g. from concurrent InternStruct collision).
 	orphanedID := idGen.New(IDStruct)
-	pool.idToStruct.Store(orphanedID, (*khifile.InternedStruct)(nil))
+	pool.storeStruct(orphanedID, (*khifile.InternedStruct)(nil))
 
 	var refs []*InternStructRef
 	for ref := range pool.StructRefs() {

--- a/pkg/model/khifile/v6/struct.go
+++ b/pkg/model/khifile/v6/struct.go
@@ -16,14 +16,35 @@
 package khifilev6
 
 import (
+	"encoding/binary"
 	"fmt"
+	"math"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	nullInternedValue = &pb.InternedValue{
+		Kind: &pb.InternedValue_NullValue{
+			NullValue: structpb.NullValue_NULL_VALUE,
+		},
+	}
+	boolTrueInternedValue = &pb.InternedValue{
+		Kind: &pb.InternedValue_BoolValue{
+			BoolValue: true,
+		},
+	}
+	boolFalseInternedValue = &pb.InternedValue{
+		Kind: &pb.InternedValue_BoolValue{
+			BoolValue: false,
+		},
+	}
 )
 
 // FieldPathSeparator is the separator used for field paths in InternedStruct.
@@ -47,6 +68,19 @@ func ToInternedStruct(node structured.Node, pool *InternPool) (*InternStructRef,
 
 	fieldSetRef := pool.InternFieldSet(flattenedKeys)
 
+	// Fast-path: compute deterministic structKey directly from node values.
+	// If the struct is already interned, we can return its reference immediately
+	// without allocating []*pb.InternedValue and individual *pb.InternedValue proto messages.
+	key, err := structKeyFromNodes(fieldSetRef.id, flattenedValues, pool, keyBuf)
+	if err != nil {
+		return nil, err
+	}
+
+	if id, ok := pool.structToID.Load(key); ok {
+		return &InternStructRef{pool: pool, id: id.(uint32)}, nil
+	}
+
+	// Slow-path: construct protobuf values only for new unique structs.
 	values := make([]*pb.InternedValue, 0, len(flattenedValues))
 	for _, valNode := range flattenedValues {
 		val, err := ToInternedValue(valNode, pool)
@@ -56,7 +90,7 @@ func ToInternedStruct(node structured.Node, pool *InternPool) (*InternStructRef,
 		values = append(values, val)
 	}
 
-	return pool.InternStruct(fieldSetRef.id, values), nil
+	return pool.internStructWithKey(fieldSetRef.id, values, key), nil
 }
 
 // flattenNode is a helper function to recursively flatten map nodes.
@@ -122,19 +156,14 @@ func scalarToInternedValue(node structured.Node, pool *InternPool) (*pb.Interned
 		return nil, err
 	}
 	if val == nil {
-		return &pb.InternedValue{
-			Kind: &pb.InternedValue_NullValue{
-				NullValue: structpb.NullValue_NULL_VALUE,
-			},
-		}, nil
+		return nullInternedValue, nil
 	}
 	switch v := val.(type) {
 	case bool:
-		return &pb.InternedValue{
-			Kind: &pb.InternedValue_BoolValue{
-				BoolValue: v,
-			},
-		}, nil
+		if v {
+			return boolTrueInternedValue, nil
+		}
+		return boolFalseInternedValue, nil
 	case string:
 		strRef := pool.InternString(v)
 		return &pb.InternedValue{
@@ -162,6 +191,78 @@ func scalarToInternedValue(node structured.Node, pool *InternPool) (*pb.Interned
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported scalar type: %T", v)
+	}
+}
+
+func structKeyFromNodes(fieldPathSetID uint32, nodes []structured.Node, pool *InternPool, buf []byte) (string, error) {
+	buf = buf[:0]
+	buf = binary.LittleEndian.AppendUint32(buf, fieldPathSetID)
+	for _, n := range nodes {
+		var err error
+		buf, err = appendNodeKey(buf, n, pool)
+		if err != nil {
+			return "", err
+		}
+	}
+	return unsafe.String(unsafe.SliceData(buf), len(buf)), nil
+}
+
+func appendNodeKey(buf []byte, node structured.Node, pool *InternPool) ([]byte, error) {
+	if node == nil {
+		return append(buf, 0x00), nil
+	}
+	switch node.Type() {
+	case structured.ScalarNodeType:
+		val, err := node.NodeScalarValue()
+		if err != nil {
+			return nil, err
+		}
+		if val == nil {
+			return append(buf, 0x01), nil
+		}
+		switch v := val.(type) {
+		case bool:
+			if v {
+				return append(buf, 0x02, 0x01), nil
+			}
+			return append(buf, 0x02, 0x00), nil
+		case int:
+			buf = append(buf, 0x03)
+			return binary.LittleEndian.AppendUint64(buf, uint64(v)), nil
+		case float64:
+			buf = append(buf, 0x04)
+			return binary.LittleEndian.AppendUint64(buf, math.Float64bits(v)), nil
+		case string:
+			strRef := pool.InternString(v)
+			buf = append(buf, 0x05)
+			return binary.LittleEndian.AppendUint32(buf, strRef.id), nil
+		case time.Time:
+			buf = append(buf, 0x07)
+			buf = binary.LittleEndian.AppendUint64(buf, uint64(v.Unix()))
+			return binary.LittleEndian.AppendUint32(buf, uint32(v.Nanosecond())), nil
+		default:
+			return nil, fmt.Errorf("unsupported scalar type: %T", v)
+		}
+	case structured.SequenceNodeType:
+		buf = append(buf, 0x08)
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(node.Len()))
+		for _, child := range node.Children() {
+			var err error
+			buf, err = appendNodeKey(buf, child, pool)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return buf, nil
+	case structured.MapNodeType:
+		s, err := ToInternedStruct(node, pool)
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, 0x06)
+		return binary.LittleEndian.AppendUint32(buf, s.id), nil
+	default:
+		return append(buf, 0xFF), nil
 	}
 }
 


### PR DESCRIPTION
## Description

This PR introduces memory and allocation optimizations to `khifilev6` interning and struct conversion:

1. **Prevent pinning underlying byte buffers in `InternString`**:
   - Strings passed to `InternPool.InternString` (e.g., extracted from large `protojson` byte buffers) could keep entire input buffers alive in memory.
   - Cloned interned strings via `strings.Clone` before storing in the pool to allow transient buffers to be garbage-collected.

2. **Replace `sync.Map` with mutex-protected slices for ID resolutions in `InternPool`**:
   - Replaced `sync.Map` for `idToStr`, `idToFieldSet`, and `idToStruct` with dense slices (`[]string`, `[][]uint32`, `[]*pb.InternedStruct`) guarded by `sync.RWMutex`.
   - Monotonically increasing sequential IDs allow direct O(1) index lookups without map hashing overhead or interface boxing allocations.

3. **Fast-path binary key computation in `ToInternedStruct`**:
   - Avoid allocating `[]*pb.InternedValue` and proto messages when a struct is already interned in `InternPool`.
   - Implemented `structKeyFromNodes` to compute the cache key directly from `structured.Node` values using a reusable byte buffer.
   - Pre-allocated singleton proto messages for `bool` (`true`/`false`) and `null` interned values.

## Test Plan
- Run `make pre-commit`
- Run `make lint-go` and `make test-go`
- Unit tests pass including `pkg/model/khifile/v6`
