### PR TITLE
feat(googlecloudcommon): parallelize Cloud Logging conversion with k-way merge and display fetch ETA

### DIFF
--- a/pkg/common/kwaymerge/kway_merge.go
+++ b/pkg/common/kwaymerge/kway_merge.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kwaymerge
+
+import (
+	"container/heap"
+)
+
+// mergeCursor tracks the current position of an element in a specific slice.
+type mergeCursor[T any] struct {
+	sliceIndex int
+	slice      []T
+	elemIndex  int
+}
+
+// mergeHeap implements heap.Interface to maintain the minimum element across active cursors.
+type mergeHeap[T any] struct {
+	cursors []*mergeCursor[T]
+	cmp     func(a, b T) int
+}
+
+var _ heap.Interface = (*mergeHeap[int])(nil)
+
+// Len returns the number of active cursors in the heap.
+func (h *mergeHeap[T]) Len() int {
+	return len(h.cursors)
+}
+
+// Less reports whether the element at cursor i should sort before the element at cursor j.
+// It breaks ties deterministically using sliceIndex to preserve stable ordering.
+func (h *mergeHeap[T]) Less(i, j int) bool {
+	c := h.cmp(h.cursors[i].slice[h.cursors[i].elemIndex], h.cursors[j].slice[h.cursors[j].elemIndex])
+	if c != 0 {
+		return c < 0
+	}
+	return h.cursors[i].sliceIndex < h.cursors[j].sliceIndex
+}
+
+// Swap swaps the cursors at indexes i and j.
+func (h *mergeHeap[T]) Swap(i, j int) {
+	h.cursors[i], h.cursors[j] = h.cursors[j], h.cursors[i]
+}
+
+// Push adds a cursor to the heap.
+func (h *mergeHeap[T]) Push(x any) {
+	h.cursors = append(h.cursors, x.(*mergeCursor[T]))
+}
+
+// Pop removes and returns the minimum cursor from the heap.
+func (h *mergeHeap[T]) Pop() any {
+	old := h.cursors
+	n := len(old)
+	x := old[n-1]
+	h.cursors = old[0 : n-1]
+	return x
+}
+
+// Merge merges multiple pre-sorted slices into a single sorted slice based on cmp.
+// Each input slice must already be sorted in ascending order according to cmp.
+// The comparison function cmp should return a negative integer if a < b, zero if a == b, and a positive integer if a > b.
+// When elements have equal keys (cmp returns 0), tie-breaking preserves the order of the slice in which they appeared.
+func Merge[T any](slices [][]T, cmp func(a, b T) int) []T {
+	totalCount := 0
+	nonEmptyCount := 0
+	var singleNonEmptySlice []T
+	for _, s := range slices {
+		l := len(s)
+		if l > 0 {
+			totalCount += l
+			nonEmptyCount++
+			singleNonEmptySlice = s
+		}
+	}
+	if nonEmptyCount == 0 {
+		return []T{}
+	}
+	if nonEmptyCount == 1 {
+		result := make([]T, len(singleNonEmptySlice))
+		copy(result, singleNonEmptySlice)
+		return result
+	}
+
+	result := make([]T, 0, totalCount)
+	h := &mergeHeap[T]{
+		cursors: make([]*mergeCursor[T], 0, nonEmptyCount),
+		cmp:     cmp,
+	}
+
+	for i, s := range slices {
+		if len(s) > 0 {
+			h.cursors = append(h.cursors, &mergeCursor[T]{
+				sliceIndex: i,
+				slice:      s,
+				elemIndex:  0,
+			})
+		}
+	}
+	heap.Init(h)
+
+	for len(h.cursors) > 0 {
+		top := h.cursors[0]
+		result = append(result, top.slice[top.elemIndex])
+		top.elemIndex++
+		if top.elemIndex < len(top.slice) {
+			heap.Fix(h, 0)
+		} else {
+			heap.Pop(h)
+		}
+	}
+
+	return result
+}

--- a/pkg/common/kwaymerge/kway_merge.go
+++ b/pkg/common/kwaymerge/kway_merge.go
@@ -63,6 +63,7 @@ func (h *mergeHeap[T]) Pop() any {
 	old := h.cursors
 	n := len(old)
 	x := old[n-1]
+	old[n-1] = nil
 	h.cursors = old[0 : n-1]
 	return x
 }

--- a/pkg/common/kwaymerge/kway_merge_test.go
+++ b/pkg/common/kwaymerge/kway_merge_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kwaymerge
+
+import (
+	"cmp"
+	"strings"
+	"testing"
+	"time"
+
+	gocmp "github.com/google/go-cmp/cmp"
+)
+
+type itemWithSource struct {
+	key    int
+	source string
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	t.Run("integers", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name   string
+			input  [][]int
+			want   []int
+			cmpFun func(a, b int) int
+		}{
+			{
+				name:   "empty input slices",
+				input:  [][]int{},
+				want:   []int{},
+				cmpFun: cmp.Compare[int],
+			},
+			{
+				name:   "all inner slices empty",
+				input:  [][]int{{}, {}, {}},
+				want:   []int{},
+				cmpFun: cmp.Compare[int],
+			},
+			{
+				name:   "single slice",
+				input:  [][]int{{1, 3, 5}},
+				want:   []int{1, 3, 5},
+				cmpFun: cmp.Compare[int],
+			},
+			{
+				name:   "single non-empty with empty slices",
+				input:  [][]int{{}, {2, 4, 6}, {}},
+				want:   []int{2, 4, 6},
+				cmpFun: cmp.Compare[int],
+			},
+			{
+				name:   "disjoint sorted slices",
+				input:  [][]int{{1, 2, 3}, {4, 5, 6}},
+				want:   []int{1, 2, 3, 4, 5, 6},
+				cmpFun: cmp.Compare[int],
+			},
+			{
+				name:   "interleaved sorted slices",
+				input:  [][]int{{1, 4, 7}, {2, 5, 8}, {3, 6, 9}},
+				want:   []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				cmpFun: cmp.Compare[int],
+			},
+			{
+				name:   "different length slices with empty slices",
+				input:  [][]int{{}, {1, 10}, {2, 3, 4, 5, 6}, {}, {7}, {8, 9}},
+				want:   []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				cmpFun: cmp.Compare[int],
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := Merge(tc.input, tc.cmpFun)
+				if diff := gocmp.Diff(tc.want, got); diff != "" {
+					t.Errorf("Merge() mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
+	})
+
+	t.Run("stability with duplicate keys", func(t *testing.T) {
+		t.Parallel()
+		input := [][]itemWithSource{
+			{
+				{key: 1, source: "s0_first"},
+				{key: 2, source: "s0_item"},
+				{key: 3, source: "s0_last"},
+			},
+			{
+				{key: 1, source: "s1_first"},
+				{key: 2, source: "s1_item"},
+			},
+			{
+				{key: 2, source: "s2_item"},
+				{key: 3, source: "s2_last"},
+			},
+		}
+		want := []itemWithSource{
+			{key: 1, source: "s0_first"},
+			{key: 1, source: "s1_first"},
+			{key: 2, source: "s0_item"},
+			{key: 2, source: "s1_item"},
+			{key: 2, source: "s2_item"},
+			{key: 3, source: "s0_last"},
+			{key: 3, source: "s2_last"},
+		}
+
+		got := Merge(input, func(a, b itemWithSource) int {
+			return cmp.Compare(a.key, b.key)
+		})
+
+		if diff := gocmp.Diff(want, got, gocmp.AllowUnexported(itemWithSource{})); diff != "" {
+			t.Errorf("Merge() stability mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+		input := [][]string{
+			{"apple", "cherry"},
+			{"banana", "date"},
+			{"elderberry"},
+		}
+		want := []string{"apple", "banana", "cherry", "date", "elderberry"}
+
+		got := Merge(input, strings.Compare)
+		if diff := gocmp.Diff(want, got); diff != "" {
+			t.Errorf("Merge() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("timestamps", func(t *testing.T) {
+		t.Parallel()
+		base := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+		input := [][]time.Time{
+			{base.Add(1 * time.Minute), base.Add(4 * time.Minute)},
+			{base.Add(2 * time.Minute), base.Add(5 * time.Minute)},
+			{base.Add(3 * time.Minute)},
+		}
+		want := []time.Time{
+			base.Add(1 * time.Minute),
+			base.Add(2 * time.Minute),
+			base.Add(3 * time.Minute),
+			base.Add(4 * time.Minute),
+			base.Add(5 * time.Minute),
+		}
+
+		got := Merge(input, func(a, b time.Time) int {
+			return a.Compare(b)
+		})
+		if diff := gocmp.Diff(want, got); diff != "" {
+			t.Errorf("Merge() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task.go
@@ -78,9 +78,36 @@ type ListLogEntriesTaskSetting interface {
 	Description() *ListLogEntriesTaskDescription
 }
 
-func monitorProgress(ctx context.Context, wg *sync.WaitGroup, source <-chan LogFetchProgress, progressDest *inspectionmetadata.TaskProgressMetadata, listCallIndex int, allListCalls int) {
+// formatETA formats a duration into a human-readable ETA string (e.g. "45s", "1m23s", "1h05m").
+func formatETA(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	d = d.Round(time.Second)
+	s := int(d.Seconds())
+	if s < 60 {
+		return fmt.Sprintf("%ds", s)
+	}
+	if s < 3600 {
+		return fmt.Sprintf("%dm%02ds", s/60, s%60)
+	}
+	return fmt.Sprintf("%dh%02dm", s/3600, (s%3600)/60)
+}
+
+// calculateETA estimates remaining duration based on elapsed time and completion ratio.
+func calculateETA(elapsed time.Duration, completeRatio float32) string {
+	if elapsed < 2*time.Second || completeRatio <= 0.005 {
+		return "--"
+	}
+	if completeRatio >= 1.0 {
+		return "0s"
+	}
+	remainingSeconds := float64(elapsed.Seconds()) * float64(1.0-completeRatio) / float64(completeRatio)
+	return formatETA(time.Duration(remainingSeconds * float64(time.Second)))
+}
+
+func monitorProgress(ctx context.Context, wg *sync.WaitGroup, source <-chan LogFetchProgress, progressDest *inspectionmetadata.TaskProgressMetadata, taskStartTime time.Time, baseLogCount int, listCallIndex int, allListCalls int) {
 	wg.Add(1)
-	startingTime := time.Now()
 	go func() {
 		defer wg.Done()
 		for {
@@ -92,13 +119,15 @@ func monitorProgress(ctx context.Context, wg *sync.WaitGroup, source <-chan LogF
 					return
 				}
 				current := time.Now()
-				elapsed := current.Sub(startingTime).Seconds()
+				elapsed := current.Sub(taskStartTime)
+				totalLogCount := baseLogCount + progress.LogCount
 				var lps float64
-				if elapsed > 0 {
-					lps = float64(progress.LogCount) / elapsed
+				if elapsed.Seconds() > 0 {
+					lps = float64(totalLogCount) / elapsed.Seconds()
 				}
 				completeRatio := (float32(listCallIndex) + progress.Progress) / float32(allListCalls)
-				progressDest.Update(completeRatio, fmt.Sprintf("%d logs fetched(%.2f lps)[%d/%d]", progress.LogCount, lps, listCallIndex, allListCalls))
+				etaStr := calculateETA(elapsed, completeRatio)
+				progressDest.Update(completeRatio, fmt.Sprintf("%d logs fetched(%.2f lps, ETA %s)[%d/%d]", totalLogCount, lps, etaStr, listCallIndex+1, allListCalls))
 			}
 		}
 	}()
@@ -138,6 +167,8 @@ func NewListLogEntriesTask(taskSetting ListLogEntriesTaskSetting) coretask.Task[
 				return nil, fmt.Errorf("TimePartitionCount returned an invalid value %d, it must be bigger than 0", timePartitionCount)
 			}
 
+			taskStartTime := time.Now()
+			totalLogsFetched := 0
 			allLogSlices := make([][]*log.Log, 0, len(filters))
 			for filterIndex, filter := range filters {
 				err := setQueryInfo(ctx, taskID.String(), filter, filterIndex, len(filters), startTime, endTime, description)
@@ -164,7 +195,7 @@ func NewListLogEntriesTask(taskSetting ListLogEntriesTaskSetting) coretask.Task[
 					var progressChan = make(chan LogFetchProgress)
 					listCallIndex := filterIndex*len(groups) + groupIndex
 					allListCalls := len(filters) * len(groups)
-					monitorProgress(ctx, &wg, progressChan, progress, listCallIndex, allListCalls)
+					monitorProgress(ctx, &wg, progressChan, progress, taskStartTime, totalLogsFetched, listCallIndex, allListCalls)
 					logs, err := progressReportableLogFetcher.FetchLogsWithProgress(progressChan, ctx, startTime, endTime, filter, group.container, group.resourceNames)
 					wg.Wait()
 
@@ -172,6 +203,7 @@ func NewListLogEntriesTask(taskSetting ListLogEntriesTaskSetting) coretask.Task[
 						err := setErrorMetadataForFetchLogError(ctx, err)
 						return nil, err
 					}
+					totalLogsFetched += len(logs)
 					allLogSlices = append(allLogSlices, logs)
 				}
 			}

--- a/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task.go
@@ -25,12 +25,10 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
-	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logconvert"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khierrors"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/kwaymerge"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
@@ -106,34 +104,6 @@ func monitorProgress(ctx context.Context, wg *sync.WaitGroup, source <-chan LogF
 	}()
 }
 
-func convertLogsArray(ctx context.Context, wg *sync.WaitGroup, source <-chan *loggingpb.LogEntry, dest *[]*log.Log) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case l, ok := <-source:
-				if !ok {
-					return
-				}
-				node, err := logconvert.LogEntryToNode(l)
-				if err != nil {
-					slog.WarnContext(ctx, fmt.Sprintf("failed to convert loggingpb.LogEntry (insertId: %s, timestamp: %v) to structured.Node %v", l.InsertId, l.Timestamp, err))
-					continue
-				}
-				ts := time.Time{}
-				if l.Timestamp != nil {
-					ts = l.Timestamp.AsTime()
-				}
-				khiLog := log.NewLogWithTimestamp(structured.NewNodeReader(structured.WithKeyOrder(node, logconvert.GCPLogEntryKeyOrder...)), ts)
-				*dest = append(*dest, khiLog)
-			}
-		}
-	}()
-}
-
 // NewListLogEntriesTask creates a new task that lists log entries from Cloud Logging based on the provided settings.
 func NewListLogEntriesTask(taskSetting ListLogEntriesTaskSetting) coretask.Task[[]*log.Log] {
 	taskID := taskSetting.TaskID()
@@ -168,7 +138,7 @@ func NewListLogEntriesTask(taskSetting ListLogEntriesTaskSetting) coretask.Task[
 				return nil, fmt.Errorf("TimePartitionCount returned an invalid value %d, it must be bigger than 0", timePartitionCount)
 			}
 
-			allLogs := make([]*log.Log, 0)
+			allLogSlices := make([][]*log.Log, 0, len(filters))
 			for filterIndex, filter := range filters {
 				err := setQueryInfo(ctx, taskID.String(), filter, filterIndex, len(filters), startTime, endTime, description)
 				if err != nil {
@@ -191,21 +161,24 @@ func NewListLogEntriesTask(taskSetting ListLogEntriesTaskSetting) coretask.Task[
 
 				for groupIndex, group := range groups {
 					var wg sync.WaitGroup
-					var logChan = make(chan *loggingpb.LogEntry)
 					var progressChan = make(chan LogFetchProgress)
 					listCallIndex := filterIndex*len(groups) + groupIndex
 					allListCalls := len(filters) * len(groups)
 					monitorProgress(ctx, &wg, progressChan, progress, listCallIndex, allListCalls)
-					convertLogsArray(ctx, &wg, logChan, &allLogs)
-					err = progressReportableLogFetcher.FetchLogsWithProgress(logChan, progressChan, ctx, startTime, endTime, filter, group.container, group.resourceNames)
+					logs, err := progressReportableLogFetcher.FetchLogsWithProgress(progressChan, ctx, startTime, endTime, filter, group.container, group.resourceNames)
 					wg.Wait()
 
 					if err != nil {
 						err := setErrorMetadataForFetchLogError(ctx, err)
 						return nil, err
 					}
+					allLogSlices = append(allLogSlices, logs)
 				}
 			}
+
+			allLogs := kwaymerge.Merge(allLogSlices, func(a, b *log.Log) int {
+				return a.Timestamp.Compare(b.Timestamp)
+			})
 
 			tracingActive, _ := khictx.GetValue(ctx, inspectioncore_contract.TracingActive)
 			if tracingActive {

--- a/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/listlogentries_task_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -528,5 +530,183 @@ func TestDivideGroupByMaximumResourceName(t *testing.T) {
 				t.Errorf("divideGroupByMaximumResourceName() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestFormatETA(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		input time.Duration
+		want  string
+	}{
+		{
+			name:  "negative duration",
+			input: -5 * time.Second,
+			want:  "0s",
+		},
+		{
+			name:  "zero duration",
+			input: 0,
+			want:  "0s",
+		},
+		{
+			name:  "seconds under one minute",
+			input: 45 * time.Second,
+			want:  "45s",
+		},
+		{
+			name:  "rounding seconds",
+			input: 14*time.Second + 600*time.Millisecond,
+			want:  "15s",
+		},
+		{
+			name:  "exact one minute",
+			input: 60 * time.Second,
+			want:  "1m00s",
+		},
+		{
+			name:  "minutes and single-digit seconds",
+			input: 65 * time.Second,
+			want:  "1m05s",
+		},
+		{
+			name:  "minutes and double-digit seconds",
+			input: 95 * time.Second,
+			want:  "1m35s",
+		},
+		{
+			name:  "exact one hour",
+			input: 3600 * time.Second,
+			want:  "1h00m",
+		},
+		{
+			name:  "hours and single-digit minutes",
+			input: 3600*time.Second + 5*time.Minute,
+			want:  "1h05m",
+		},
+		{
+			name:  "hours and double-digit minutes",
+			input: 2*time.Hour + 30*time.Minute,
+			want:  "2h30m",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatETA(tc.input)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("formatETA() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCalculateETA(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		elapsed       time.Duration
+		completeRatio float32
+		want          string
+	}{
+		{
+			name:          "warmup elapsed under 2 seconds",
+			elapsed:       1500 * time.Millisecond,
+			completeRatio: 0.5,
+			want:          "--",
+		},
+		{
+			name:          "warmup complete ratio too small",
+			elapsed:       10 * time.Second,
+			completeRatio: 0.003,
+			want:          "--",
+		},
+		{
+			name:          "zero complete ratio",
+			elapsed:       10 * time.Second,
+			completeRatio: 0,
+			want:          "--",
+		},
+		{
+			name:          "complete ratio 100%",
+			elapsed:       10 * time.Second,
+			completeRatio: 1.0,
+			want:          "0s",
+		},
+		{
+			name:          "complete ratio over 100%",
+			elapsed:       10 * time.Second,
+			completeRatio: 1.2,
+			want:          "0s",
+		},
+		{
+			name:          "normal remaining seconds",
+			elapsed:       10 * time.Second,
+			completeRatio: 0.2, // 10s * (0.8 / 0.2) = 40s
+			want:          "40s",
+		},
+		{
+			name:          "normal remaining minutes",
+			elapsed:       30 * time.Second,
+			completeRatio: 0.25, // 30s * (0.75 / 0.25) = 90s = 1m30s
+			want:          "1m30s",
+		},
+		{
+			name:          "normal remaining hours",
+			elapsed:       10 * time.Minute,
+			completeRatio: 0.1, // 10m * (0.9 / 0.1) = 90m = 1h30m
+			want:          "1h30m",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := calculateETA(tc.elapsed, tc.completeRatio)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("calculateETA() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMonitorProgress(t *testing.T) {
+	t.Parallel()
+
+	progressDest := inspectionmetadata.NewTaskProgressMetadata("test-task")
+	source := make(chan LogFetchProgress)
+	taskStartTime := time.Now().Add(-10 * time.Second)
+	baseLogCount := 100
+	listCallIndex := 0
+	allListCalls := 2
+
+	var wg sync.WaitGroup
+	monitorProgress(t.Context(), &wg, source, progressDest, taskStartTime, baseLogCount, listCallIndex, allListCalls)
+
+	source <- LogFetchProgress{
+		LogCount: 50,
+		Progress: 0.5,
+	}
+	close(source)
+	wg.Wait()
+
+	wantRatio := float32(0+0.5) / float32(2) // 0.25
+	if diff := cmp.Diff(wantRatio, progressDest.Percentage); diff != "" {
+		t.Errorf("progressDest.Percentage mismatch (-want +got):\n%s", diff)
+	}
+
+	// 100 base + 50 current = 150 logs. Elapsed ~10s -> ~15 lps. Ratio 0.25 -> ETA ~30s.
+	if !strings.HasPrefix(progressDest.Message, "150 logs fetched(") {
+		t.Errorf("expected message to start with '150 logs fetched(', got %q", progressDest.Message)
+	}
+	if !strings.Contains(progressDest.Message, ", ETA ") {
+		t.Errorf("expected message to contain ', ETA ', got %q", progressDest.Message)
+	}
+	if !strings.HasSuffix(progressDest.Message, ")[1/2]") {
+		t.Errorf("expected message to end with ')[1/2]', got %q", progressDest.Message)
 	}
 }

--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
@@ -17,13 +17,18 @@ package googlecloudcommon_contract
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logconvert"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/kwaymerge"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -37,8 +42,8 @@ type LogFetchProgress struct {
 
 type ProgressReportableLogFetcher interface {
 	// FetchLogsWithProgress fetches logs while periodically reporting its progress through a separate channel.
-	// Implementations must close both the dest and progress channels upon completion.
-	FetchLogsWithProgress(dest chan<- *loggingpb.LogEntry, progress chan<- LogFetchProgress, ctx context.Context, beginTime, endTime time.Time, filterWithoutTimeRange string, container googlecloud.ResourceContainer, resourceContainers []string) error
+	// It closes the progress channel upon completion and returns timestamp-sorted logs.
+	FetchLogsWithProgress(progress chan<- LogFetchProgress, ctx context.Context, beginTime, endTime time.Time, filterWithoutTimeRange string, container googlecloud.ResourceContainer, resourceContainers []string) ([]*log.Log, error)
 }
 
 // StandardProgressReportableLogFetcher is a decorator for a LogFetcher that adds the ability
@@ -148,8 +153,6 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 	return nil
 }
 
-var _ ProgressReportableLogFetcher = (*StandardProgressReportableLogFetcher)(nil)
-
 type TimePartitioningProgressReportableLogFetcher struct {
 	client         *StandardProgressReportableLogFetcher
 	partitionCount int
@@ -167,8 +170,7 @@ func NewTimePartitioningProgressReportableLogFetcher(fetcher LogFetcher, interva
 }
 
 // FetchLogsWithProgress implements ProgressReportableLogFetcher.
-func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(logChan chan<- *loggingpb.LogEntry, progressChan chan<- LogFetchProgress, ctx context.Context, beginTime time.Time, endTime time.Time, filterWithoutTimeRange string, container googlecloud.ResourceContainer, resourceContainers []string) error {
-	defer close(logChan)
+func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(progressChan chan<- LogFetchProgress, ctx context.Context, beginTime time.Time, endTime time.Time, filterWithoutTimeRange string, container googlecloud.ResourceContainer, resourceContainers []string) ([]*log.Log, error) {
 	defer close(progressChan)
 
 	ticker := time.NewTicker(t.reportInterval)
@@ -180,10 +182,11 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(log
 		Progress: 0,
 	}:
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 
 	subProgresses := make([]LogFetchProgress, t.partitionCount)
+	partitionLogs := make([][]*log.Log, t.partitionCount)
 	cancellableCtx, cancel := context.WithCancel(ctx)
 	rootGoroutineWaitGroup := sync.WaitGroup{}
 	rootGoroutineWaitGroup.Add(1)
@@ -218,16 +221,17 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(log
 				return groupCtx.Err()
 			default:
 			}
-			partitionBeginTime := times[i]
-			partitionEndTime := times[i+1]
+			partitionBeginTime := times[subProgressIndex]
+			partitionEndTime := times[subProgressIndex+1]
 
 			childWg := sync.WaitGroup{}
 			childWg.Add(2)
 
 			subLogChan := make(chan *loggingpb.LogEntry)
 			subProgressChan := make(chan LogFetchProgress)
+			subLogs := make([]*log.Log, 0)
 
-			// Consume the subLogChan and route the log to the parent channel.
+			// Consume the subLogChan, convert proto to *log.Log in parallel, and append to subLogs.
 			go func() {
 				defer childWg.Done()
 				for {
@@ -238,17 +242,23 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(log
 						if !ok {
 							return
 						}
-						select {
-						case logChan <- logEntry:
-						case <-groupCtx.Done():
-							return
+						node, err := logconvert.LogEntryToNode(logEntry)
+						if err != nil {
+							slog.WarnContext(groupCtx, fmt.Sprintf("failed to convert loggingpb.LogEntry (insertId: %s, timestamp: %v) to structured.Node %v", logEntry.InsertId, logEntry.Timestamp, err))
+							continue
 						}
+						ts := time.Time{}
+						if logEntry.Timestamp != nil {
+							ts = logEntry.Timestamp.AsTime()
+						}
+						khiLog := log.NewLogWithTimestamp(structured.NewNodeReader(structured.WithKeyOrder(node, logconvert.GCPLogEntryKeyOrder...)), ts)
+						subLogs = append(subLogs, khiLog)
 					}
 				}
 			}()
 
 			// Consume the subProgressChan and store it to the progress array.
-			go func(subProgressIndex int) {
+			go func() {
 				defer childWg.Done()
 				for {
 					select {
@@ -261,14 +271,15 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(log
 						subProgresses[subProgressIndex] = progress
 					}
 				}
-			}(subProgressIndex)
+			}()
 
 			err := t.client.FetchLogsWithProgress(subLogChan, subProgressChan, cancellableCtx, partitionBeginTime, partitionEndTime, filterWithoutTimeRange, container, resourceContainers)
+			childWg.Wait()
+			partitionLogs[subProgressIndex] = subLogs
 			if err != nil {
 				cancel()
 				return err
 			}
-			childWg.Wait()
 			return nil
 		})
 	}
@@ -276,8 +287,13 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(log
 	err := wg.Wait()
 	cancel()
 	rootGoroutineWaitGroup.Wait()
+
+	mergedLogs := kwaymerge.Merge(partitionLogs, func(a, b *log.Log) int {
+		return a.Timestamp.Compare(b.Timestamp)
+	})
+
 	if err != nil {
-		return err
+		return mergedLogs, err
 	}
 	sumLog := 0
 	for _, subProgress := range subProgresses {
@@ -289,9 +305,10 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(log
 		Progress: 1,
 	}:
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
-	return nil
+
+	return mergedLogs, nil
 }
 
 func (t *TimePartitioningProgressReportableLogFetcher) getPartitionedTimes(beginTime, endTime time.Time) []time.Time {

--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
@@ -25,7 +25,6 @@ import (
 	"cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logconvert"
-	"github.com/GoogleCloudPlatform/khi/pkg/common/kwaymerge"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -77,7 +76,8 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	logCount := atomic.Int32{}
-	latestLogTime := &beginTime
+	latestLogTime := atomic.Pointer[time.Time]{}
+	latestLogTime.Store(&beginTime)
 	totalDurationInSeconds := endTime.Sub(beginTime).Seconds()
 
 	if totalDurationInSeconds == 0 {
@@ -97,7 +97,7 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 				}
 				logCount.Add(1)
 				t := logEntry.Timestamp.AsTime()
-				latestLogTime = &t
+				latestLogTime.Store(&t)
 				select {
 				case <-subroutineCtx.Done():
 					return
@@ -122,7 +122,8 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 			case <-subroutineCtx.Done():
 				return
 			case <-ticker.C:
-				latestLogTimeFromBeginTimeInSeconds := latestLogTime.Sub(beginTime).Seconds()
+				latest := latestLogTime.Load()
+				latestLogTimeFromBeginTimeInSeconds := latest.Sub(beginTime).Seconds()
 				select {
 				case progress <- LogFetchProgress{
 					LogCount: int(logCount.Load()),
@@ -185,6 +186,7 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(pro
 		return nil, ctx.Err()
 	}
 
+	var subProgressMu sync.Mutex
 	subProgresses := make([]LogFetchProgress, t.partitionCount)
 	partitionLogs := make([][]*log.Log, t.partitionCount)
 	cancellableCtx, cancel := context.WithCancel(ctx)
@@ -199,10 +201,12 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(pro
 				return
 			case <-ticker.C:
 				result := LogFetchProgress{}
+				subProgressMu.Lock()
 				for _, subProgress := range subProgresses {
 					result.LogCount += subProgress.LogCount
 					result.Progress += subProgress.Progress / float32(t.partitionCount)
 				}
+				subProgressMu.Unlock()
 				progressChan <- result
 			}
 		}
@@ -268,7 +272,9 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(pro
 						if !ok {
 							return
 						}
+						subProgressMu.Lock()
 						subProgresses[subProgressIndex] = progress
+						subProgressMu.Unlock()
 					}
 				}
 			}()
@@ -288,17 +294,24 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(pro
 	cancel()
 	rootGoroutineWaitGroup.Wait()
 
-	mergedLogs := kwaymerge.Merge(partitionLogs, func(a, b *log.Log) int {
-		return a.Timestamp.Compare(b.Timestamp)
-	})
+	totalLogs := 0
+	for _, slice := range partitionLogs {
+		totalLogs += len(slice)
+	}
+	mergedLogs := make([]*log.Log, 0, totalLogs)
+	for _, slice := range partitionLogs {
+		mergedLogs = append(mergedLogs, slice...)
+	}
 
 	if err != nil {
 		return mergedLogs, err
 	}
 	sumLog := 0
+	subProgressMu.Lock()
 	for _, subProgress := range subProgresses {
 		sumLog += subProgress.LogCount
 	}
+	subProgressMu.Unlock()
 	select {
 	case progressChan <- LogFetchProgress{
 		LogCount: sumLog,

--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher_test.go
@@ -24,6 +24,9 @@ import (
 
 	"cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
+	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logconvert"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -516,9 +519,7 @@ timestamp < "2025-01-01T00:20:00+0000"`, func(logSource chan<- *loggingpb.LogEnt
 			endTime := beginTime.Add(tc.duration)
 			fetcher := tc.fetcherFactory(t)
 
-			var logs []*loggingpb.LogEntry
 			var progresses []LogFetchProgress
-			logReceiveChan := channelToArrayParallel(t.Context(), &wg, &logs)
 			progressReceiveChan := channelToArrayParallel(t.Context(), &wg, &progresses)
 
 			progressReportableFetcher := NewTimePartitioningProgressReportableLogFetcher(fetcher, tick/2, tc.partitionCount, tc.maxParallelism)
@@ -544,7 +545,7 @@ timestamp < "2025-01-01T00:20:00+0000"`, func(logSource chan<- *loggingpb.LogEnt
 				}()
 			}
 
-			err := progressReportableFetcher.FetchLogsWithProgress(logReceiveChan, progressReceiveChan, cancellableCtx, beginTime, endTime, "test filter", googlecloud.Project("foobar"), []string{})
+			logs, err := progressReportableFetcher.FetchLogsWithProgress(progressReceiveChan, cancellableCtx, beginTime, endTime, "test filter", googlecloud.Project("foobar"), []string{})
 			if tc.wantErr != nil {
 				if err == nil {
 					t.Errorf("FetchLogsWithProgress() expected error, but got nil")
@@ -557,9 +558,34 @@ timestamp < "2025-01-01T00:20:00+0000"`, func(logSource chan<- *loggingpb.LogEnt
 			wg.Wait()
 			close(afterFetchDone)
 
-			slices.SortFunc(logs, func(a, b *loggingpb.LogEntry) int { return a.Timestamp.AsTime().Compare(b.Timestamp.AsTime()) })
+			gotLogsString := []string{}
+			for _, l := range logs {
+				yaml, err := l.Serialize(structured.EmptyFieldPath, &structured.YAMLNodeSerializer{})
+				if err != nil {
+					t.Fatalf("failed to serialize to yaml error=%v", err)
+				}
+				gotLogsString = append(gotLogsString, string(yaml))
+			}
 
-			if diff := cmp.Diff(tc.wantLogs, logs, protocmp.Transform(), cmpopts.IgnoreUnexported()); diff != "" {
+			wantLogsString := []string{}
+			for _, entry := range tc.wantLogs {
+				node, err := logconvert.LogEntryToNode(entry)
+				if err != nil {
+					t.Fatalf("failed to convert entry to node: %v", err)
+				}
+				ts := time.Time{}
+				if entry.Timestamp != nil {
+					ts = entry.Timestamp.AsTime()
+				}
+				khiLog := log.NewLogWithTimestamp(structured.NewNodeReader(structured.WithKeyOrder(node, logconvert.GCPLogEntryKeyOrder...)), ts)
+				yaml, err := khiLog.Serialize(structured.EmptyFieldPath, &structured.YAMLNodeSerializer{})
+				if err != nil {
+					t.Fatalf("failed to serialize to yaml error=%v", err)
+				}
+				wantLogsString = append(wantLogsString, string(yaml))
+			}
+
+			if diff := cmp.Diff(wantLogsString, gotLogsString); diff != "" {
 				t.Errorf("FetchLogsWithProgress() produced non expected result: (-want, +got):\n%v", diff)
 			}
 			if diff := cmp.Diff(tc.wantProgress, progresses); diff != "" {

--- a/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
@@ -271,6 +271,8 @@ func fetchLogsForStructuredQueries(
 	groups = divideGroupByMaximumResourceName(groups, maxResourceNameCountPerRequest)
 	progressReportableLogFetcher := NewTimePartitioningProgressReportableLogFetcher(logFetcher, 500*time.Millisecond, timePartitionCount, runtime.GOMAXPROCS(0))
 
+	taskStartTime := time.Now()
+	totalLogsFetched := 0
 	allLogSlices := make([][]*log.Log, 0, len(queries)*len(groups))
 	for queryIndex, q := range queries {
 		filterString := q.GenerateCloudLoggingQuery()
@@ -283,13 +285,14 @@ func fetchLogsForStructuredQueries(
 			var progressChan = make(chan LogFetchProgress)
 			listCallIndex := queryIndex*len(groups) + groupIndex
 			allListCalls := len(queries) * len(groups)
-			monitorProgress(ctx, &wg, progressChan, progress, listCallIndex, allListCalls)
+			monitorProgress(ctx, &wg, progressChan, progress, taskStartTime, totalLogsFetched, listCallIndex, allListCalls)
 			logs, err := progressReportableLogFetcher.FetchLogsWithProgress(progressChan, ctx, startTime, endTime, filterString, group.container, group.resourceNames)
 			wg.Wait()
 
 			if err != nil {
 				return nil, setErrorMetadataForFetchLogError(ctx, err)
 			}
+			totalLogsFetched += len(logs)
 			allLogSlices = append(allLogSlices, logs)
 		}
 	}

--- a/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/structured_listlogentries_task.go
@@ -22,10 +22,10 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud"
 	"github.com/GoogleCloudPlatform/khi/pkg/api/googlecloud/logestimator"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/kwaymerge"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/gcpqueryutil"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
@@ -271,7 +271,7 @@ func fetchLogsForStructuredQueries(
 	groups = divideGroupByMaximumResourceName(groups, maxResourceNameCountPerRequest)
 	progressReportableLogFetcher := NewTimePartitioningProgressReportableLogFetcher(logFetcher, 500*time.Millisecond, timePartitionCount, runtime.GOMAXPROCS(0))
 
-	allLogs := make([]*log.Log, 0)
+	allLogSlices := make([][]*log.Log, 0, len(queries)*len(groups))
 	for queryIndex, q := range queries {
 		filterString := q.GenerateCloudLoggingQuery()
 		if err := setStructuredQueryInfo(ctx, taskID, filterString, queryIndex, len(queries), startTime, endTime, queryName, nil, false); err != nil {
@@ -280,20 +280,23 @@ func fetchLogsForStructuredQueries(
 
 		for groupIndex, group := range groups {
 			var wg sync.WaitGroup
-			var logChan = make(chan *loggingpb.LogEntry)
 			var progressChan = make(chan LogFetchProgress)
 			listCallIndex := queryIndex*len(groups) + groupIndex
 			allListCalls := len(queries) * len(groups)
 			monitorProgress(ctx, &wg, progressChan, progress, listCallIndex, allListCalls)
-			convertLogsArray(ctx, &wg, logChan, &allLogs)
-			err := progressReportableLogFetcher.FetchLogsWithProgress(logChan, progressChan, ctx, startTime, endTime, filterString, group.container, group.resourceNames)
+			logs, err := progressReportableLogFetcher.FetchLogsWithProgress(progressChan, ctx, startTime, endTime, filterString, group.container, group.resourceNames)
 			wg.Wait()
 
 			if err != nil {
 				return nil, setErrorMetadataForFetchLogError(ctx, err)
 			}
+			allLogSlices = append(allLogSlices, logs)
 		}
 	}
+
+	allLogs := kwaymerge.Merge(allLogSlices, func(a, b *log.Log) int {
+		return a.Timestamp.Compare(b.Timestamp)
+	})
 
 	tracingActive, _ := khictx.GetValue(ctx, inspectioncore_contract.TracingActive)
 	if tracingActive {


### PR DESCRIPTION
## Description

This PR refactors Cloud Logging log retrieval to parallelize proto-to-log conversion, introduces a generic k-way merge sort, and displays estimated time remaining (ETA) in the progress reporter:

1. **Generic K-Way Merge Sort (`pkg/common/kwaymerge`)**:
   - Implemented a generic `kwaymerge.Merge[T any](slices [][]T, cmp func(a, b T) int) []T` utility using a min-heap (`container/heap`).
   - Added unit tests covering integers, strings, timestamps, and stability.

2. **Parallelize Proto-to-Log Conversion (`pkg/task/inspection/googlecloudcommon/contract`)**:
   - Updated `ProgressReportableLogFetcher` interface and `TimePartitioningProgressReportableLogFetcher` to convert `*loggingpb.LogEntry` into `*log.Log` directly in parallel within each partition worker goroutine.
   - Merged partition slices using `kwaymerge.Merge` at the end of `FetchLogsWithProgress`, eliminating the single-goroutine conversion bottleneck.
   - Updated `ListLogEntriesTask` and `StructuredListLogEntriesTask` to merge log slices across multiple queries and resource groups.

3. **Display ETA in Fetch Progress**:
   - Added `formatETA` and `calculateETA` to estimate remaining time based on elapsed time and completion ratio (`completeRatio`), with warm-up threshold.
   - Tracked task start time and accumulated log count across multiple list calls in `monitorProgress` to maintain smooth, continuous LPS and ETA without resets at partition boundaries.
   - Updated progress message format to `"%d logs fetched(%.2f lps, ETA %s)[%d/%d]"`.

## Test Plan
- Run `make pre-commit`
- Run `make lint-go` and `make test-go`
- Unit tests pass including `pkg/common/kwaymerge` and `pkg/task/inspection/googlecloudcommon/contract`