### PR TITLE
docs(skills): add backward-compatibility-policy skill and update coding rules

### DIFF
--- a/.agents/rules/go-coding-rule.md
+++ b/.agents/rules/go-coding-rule.md
@@ -29,6 +29,12 @@ When developing or modifying Go code in the KHI project, you **must** adhere to 
    - Do not capitalize the first character of messages in `fmt.Errorf`, `t.Error`, `t.Errorf`, `t.Fatal`, `t.Fatalf`, etc. (e.g., use lowercase "failed to ..." instead of "Failed to ...").
    - This rule does not apply if the message starts with a capitalized name, such as a method name or proper acronym (e.g. `MyFunction() mismatch (-want +got)`).
 
+3. **Backward Compatibility and Refactoring**:
+   - Internal Go code in KHI requires **no backward compatibility**. When modifying functions, methods, interfaces, or structs, do **NOT** retain deprecated shims, wrappers, or aliases, and do **NOT** introduce unnecessary variadic parameters or defensive nil fallbacks solely to preserve old call sites.
+   - Always update all call sites across the monorepo directly.
+   - Updating test call sites, constructors, and assertions to adapt to refactored signatures is expected and required.
+   - Refer to the `backward-compatibility-policy` skill for concrete anti-patterns and details.
+
 ## Testing Practices
 
 1. **Table-Driven Tests**: Tests must be written using the table-driven testing pattern. Define a slice of anonymous structs representing the test cases, and iterate over them using `t.Run()`.

--- a/.agents/rules/ts-coding-rule.md
+++ b/.agents/rules/ts-coding-rule.md
@@ -18,6 +18,7 @@ globs: **/*.ts
 - Do NOT use `as unknown as X` type assertions in non test code.
 - Do NOT use Object literal type in non test code. Define an interface instead.
 - Do NOT reference types by accessing fields of other types (e.g., `Type['field']`). Use the official type name directly.
+- Internal TypeScript code in KHI requires no backward compatibility. When refactoring functions, classes, interfaces, or Angular component inputs/outputs, update all call sites across the codebase directly without leaving deprecated wrappers, unnecessary optional parameters, or fallback logic. Refer to the `backward-compatibility-policy` skill for anti-patterns and details.
 
 ## Angular coding rules
 

--- a/.agents/skills/backward_compatibility_policy/SKILL.md
+++ b/.agents/skills/backward_compatibility_policy/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: backward-compatibility-policy
+description: Guidelines on backward compatibility in KHI, explaining why internal code requires no backward compatibility, identifying anti-patterns with concrete examples, and detailing the single exception for .khi files.
+---
+
+# Backward Compatibility Policy in KHI
+
+This guide outlines the backward compatibility policy for Kubernetes History Inspector (KHI), explains why internal code requires no backward compatibility, illustrates common anti-patterns with concrete examples, and describes how to handle `.khi` file changes.
+
+---
+
+## 1. Core Principles
+
+### KHI is an Integrated Monorepo Application
+
+KHI is an end-to-end application comprising a Go backend and an Angular frontend. It is not a public library or a distributed microservice system with independent release cycles. All components are versioned, built, and shipped together.
+
+### Zero Backward Compatibility for Internal Code
+
+Internal Go/TypeScript functions, types, interfaces, methods, Connect/gRPC endpoints, and task Directed Acyclic Graph (DAG) nodes have **no external consumers**.
+
+When modifying or refactoring internal code:
+
+- **Never** retain backward-compatibility wrappers, aliases, or shims.
+- **Never** introduce defensive fallbacks for hypothetical legacy callers.
+- **Always** unify directly onto the new implementation. Update all call sites, usages, and tests across the repository in the same change.
+
+### The Single Exception: `.khi` Files
+
+The only data format that persists across KHI versions and user environments is the exported inspection dump file (`.khi` file format, serialized with Protocol Buffers). Backward compatibility is relevant **only** when modifying `.khi` serialization, deserialization, or schema structures.
+
+### Explicit Discussion Required for `.khi` Changes
+
+Even for `.khi` files, never make silent assumptions about backward compatibility. If a change affects `.khi` file persistence, you must explicitly raise and discuss the compatibility strategy with the user during the design and planning phase (`/plan`).
+
+---
+
+## 2. Anti-Patterns and Concrete Examples
+
+### Anti-Pattern 1: Unnecessary Variadic Arguments to Avoid Updating 0-Arg Callers
+
+When a function requires a new argument (e.g., going from 0 arguments to 1 argument), do not make the argument variadic (`...Option` or `...*Config`) merely to keep existing 0-argument callers compiling without modification.
+
+**Bad:**
+
+```go
+// BAD: Variadic parameter added solely to avoid updating existing call sites.
+func ProcessLogEntry(entry *log.Log, options ...ProcessOption) error {
+ var opt ProcessOption
+ if len(options) > 0 {
+  opt = options[0]
+ }
+ // ...
+}
+```
+
+**Good:**
+
+```go
+// GOOD: Required parameter is explicit. Update all callers across the repository.
+func ProcessLogEntry(entry *log.Log, opt ProcessOption) error {
+ // ...
+}
+```
+
+---
+
+### Anti-Pattern 2: Defensive Fallback / Default Injection for Non-Nil Fields
+
+Do not insert nil checks and fallback default assignments for struct fields or parameters that are never nil in the application. Such checks obscure bugs, add dead execution paths, and mislead readers.
+
+**Bad:**
+
+```go
+// BAD: Injects a fallback default even though WorkerPool is always provided by the caller.
+func NewTaskRunner(cfg *TaskRunnerConfig) *TaskRunner {
+ pool := cfg.WorkerPool
+ if pool == nil {
+  pool = workerpool.NewDefaultPool() // Unnecessary fallback for a non-nil internal contract
+ }
+ return &TaskRunner{pool: pool}
+}
+```
+
+**Good:**
+
+```go
+// GOOD: Trust the application contract. If the field is required, expect it directly.
+func NewTaskRunner(cfg *TaskRunnerConfig) *TaskRunner {
+ if cfg.WorkerPool == nil {
+  panic("worker pool must not be nil") // Or fail fast during construction
+ }
+ return &TaskRunner{pool: cfg.WorkerPool}
+}
+```
+
+---
+
+### Anti-Pattern 3: Retaining Deprecated Functions or Wrapper Shims
+
+When renaming or refactoring a function, do not leave behind the old function with a `// Deprecated:` comment delegating to the new function. Delete the old function and update all call sites across the codebase.
+
+**Bad:**
+
+```go
+// BAD: Keeps the old signature as a forwarding shim.
+// Deprecated: Use ExtractResourceNamespace instead.
+func GetResourceNamespace(res *Resource) string {
+ return ExtractResourceNamespace(res)
+}
+
+func ExtractResourceNamespace(res *Resource) string {
+ return res.Metadata.Namespace
+}
+```
+
+**Good:**
+
+```go
+// GOOD: Rename the function cleanly and update all call sites across the monorepo.
+func ExtractResourceNamespace(res *Resource) string {
+ return res.Metadata.Namespace
+}
+```
+
+---
+
+### Anti-Pattern 4: Dual-Field Synchronization & Model Pollution
+
+When replacing a field on a struct or model, do not retain both the old and new fields with runtime fallback or synchronization logic.
+
+**Bad:**
+
+```go
+// BAD: Retains OldName alongside NewName and falls back at runtime.
+type ClusterMetadata struct {
+ ClusterName string // Deprecated
+ Name        string
+}
+
+func (m *ClusterMetadata) GetName() string {
+ if m.Name != "" {
+  return m.Name
+ }
+ return m.ClusterName
+}
+```
+
+**Good:**
+
+```go
+// GOOD: Rename the field directly and update all references across frontend and backend.
+type ClusterMetadata struct {
+ Name string
+}
+
+func (m *ClusterMetadata) GetName() string {
+ return m.Name
+}
+```
+
+---
+
+### Anti-Pattern 5: Defensive Shims for Non-Existent Legacy Data
+
+In internal pipelines, do not add `omitempty`, multi-format parsing, or nil fallbacks for imagined legacy data formats. All internal payloads are generated and consumed by the same version of KHI.
+
+**Bad:**
+
+```go
+// BAD: Accepts both string and array formats for internal intermediate representation.
+type InternalLogPayload struct {
+ Tags any `json:"tags"` // Can be string or []string for "backward compatibility"
+}
+```
+
+**Good:**
+
+```go
+// GOOD: Strictly define the single current format.
+type InternalLogPayload struct {
+ Tags []string `json:"tags"`
+}
+```
+
+---
+
+### Anti-Pattern 6: Task DAG Optional Dependencies & Feature Flags
+
+When modifying the KHI Task DAG, do not use `coretask.GetTaskResultOptional` or add flags like `useLegacyMode` to support older, obsolete task graphs. All task definitions and registration points are maintained in the repository.
+
+**Bad:**
+
+```go
+// BAD: Falls back to legacy logic if an upstream task is missing from the graph.
+func MyTaskFunc(ctx context.Context, mode contract.InspectionTaskModeType) (*MyResult, error) {
+ upstream := coretask.GetTaskResultOptional(ctx, UpstreamTaskID.Ref())
+ if upstream == nil {
+  return runLegacyFallbackLogic(ctx)
+ }
+ return runCurrentLogic(ctx, upstream)
+}
+```
+
+**Good:**
+
+```go
+// GOOD: Declare the dependency as required and update pipeline definitions accordingly.
+var MyTask = coretask.NewTask(
+ MyTaskID,
+ []taskid.UntypedTaskReference{
+  UpstreamTaskID.Ref(),
+ },
+ func(ctx context.Context, mode contract.InspectionTaskModeType) (*MyResult, error) {
+  upstream := coretask.GetTaskResult(ctx, UpstreamTaskID.Ref())
+  return runCurrentLogic(ctx, upstream)
+ },
+)
+```
+
+---
+
+### Anti-Pattern 7: Interface Pollution & Type Assertion Proliferation
+
+When an interface needs a new method, do not create an `InterfaceV2` or use runtime type assertions to conditionally call the new method. Update the interface and update all its implementations in the monorepo.
+
+**Bad:**
+
+```go
+// BAD: Uses runtime type assertion to avoid updating the existing interface.
+type Formatter interface {
+ Format(entry *log.Log) string
+}
+
+type FormatterV2 interface {
+ FormatWithContext(ctx context.Context, entry *log.Log) string
+}
+
+func Render(ctx context.Context, f Formatter, entry *log.Log) string {
+ if f2, ok := f.(FormatterV2); ok {
+  return f2.FormatWithContext(ctx, entry)
+ }
+ return f.Format(entry)
+}
+```
+
+**Good:**
+
+```go
+// GOOD: Update the interface directly and adjust all implementations in the codebase.
+type Formatter interface {
+ Format(ctx context.Context, entry *log.Log) string
+}
+
+func Render(ctx context.Context, f Formatter, entry *log.Log) string {
+ return f.Format(ctx, entry)
+}
+```
+
+---
+
+### Anti-Pattern 8: Preserving Obsolete Behaviors in Test Suites
+
+When refactoring a signature or behavior, update the test call sites to match the new signature. Do not create complex compatibility adapters or duplicate tests to verify obsolete behaviors.
+
+> [!NOTE]
+> Updating test call sites, constructor parameters, and assertions to adapt to refactored code is expected and required.
+> The rule **"Do not remove test cases or weaken test assertions without asking the user"** forbids deleting test cases or weakening assertions without approval; it does not forbid updating test call sites to compile and verify refactored code.
+
+**Bad:**
+
+```go
+// BAD: Retains tests for deprecated signatures alongside new ones.
+func TestHelper_LegacySignature(t *testing.T) {
+ // Preserving test for OldFunc which should have been deleted
+ got := OldFunc("test")
+ // ...
+}
+```
+
+**Good:**
+
+```go
+// GOOD: Update test to invoke the new function directly.
+func TestHelper(t *testing.T) {
+ got := NewFunc("test", true)
+ // ...
+}
+```
+
+---
+
+### Anti-Pattern 9: Dead Code / Commented-Out Implementations "Just in Case"
+
+Never leave unused helper functions or commented-out code blocks in the codebase with notes like "Kept for backward compatibility" or "Old implementation". Source control history (Git / Jujutsu) preserves all historical implementations.
+
+---
+
+## 3. Workflow for `.khi` Format Changes
+
+When you need to modify `.khi` file serialization, deserialization, or Protocol Buffer definitions:
+
+1. **Identify the Scope**: Determine whether the change affects:
+   - Exported file structure (Protocol Buffers under `pkg/generated/khifile/`).
+   - Import/Export validators or serializers (`pkg/server/importinspection/`, `pkg/task/inspection/inspectioncore/impl/serializer.go`).
+2. **Propose the Plan Explicitly**:
+   - In your `/plan` implementation plan, specify what fields or structures are changing.
+   - Explicitly raise an **Open Question** or **User Review Required** item asking whether previously exported `.khi` files must remain loadable.
+3. **Wait for Approval**: Do not implement migration logic, version branches, or fallback decoders until the user confirms the compatibility requirement.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -28,6 +28,7 @@ Language specific rules are written in each language's rule files. Please respec
 
 * All comments must be written in English.
 * License headers are automatically added by commit hook. Do not add license header.
-* Do not modify/remove existing test code without asking the user.
+* Do not remove test cases or weaken test assertions without asking the user. However, updating test call sites, constructor parameters, and argument types to adapt to refactored signatures is required.
+* KHI is an integrated monorepo application. Internal code (Go/TS functions, types, interfaces, internal APIs, and task DAGs) does NOT require backward compatibility. When updating code, unify directly onto the new implementation and update all call sites across the monorepo without retaining legacy shims or wrappers. The only exception is `.khi` file persistence, where compatibility requirements must be discussed during planning. Refer to the `backward-compatibility-policy` skill for anti-patterns and details.
 * Do not perform git commit/push without any approval from the user.
 * Do not assume before reading files. Read the file before changing it.


### PR DESCRIPTION
## Summary

When developing or refactoring code in KHI, AI agents frequently over-engineer backward compatibility (preserving deprecated shims, adding variadic arguments solely to avoid updating 0-arg callers, adding defensive nil fallbacks for non-nil fields, etc.).

This PR adds a dedicated skill and updates coding rules:
1. **New Skill**: `.agents/skills/backward_compatibility_policy/SKILL.md`
   - Explains that KHI is an integrated monorepo where internal code requires zero backward compatibility.
   - Clarifies that `.khi` file serialization is the sole exception where compatibility is relevant, and requires explicit planning/discussion.
   - Documents 9 concrete anti-patterns with Bad vs Good examples.
2. **Global Rules**: Updated `GEMINI.md` to state the monorepo backward compatibility policy and clarify that updating test call sites and constructors to match new signatures is required.
3. **Language Rules**: Updated `go-coding-rule.md` and `ts-coding-rule.md` to explicitly prohibit backward-compatibility wrappers and unnecessary parameter fallbacks in Go and TypeScript.
