### PR TITLE
perf(core,inspection): parallelize log filtering and optimize filter extractors

### DIFF
--- a/pkg/core/inspection/taskbase/logfilter_task.go
+++ b/pkg/core/inspection/taskbase/logfilter_task.go
@@ -17,9 +17,12 @@ package inspectiontaskbase
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/progressutil"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
@@ -49,23 +52,60 @@ func NewLogFilterTaskWithDependencies(tid taskid.TaskImplementationID[[]*log.Log
 		}
 
 		logs := coretask.GetTaskResult(ctx, sourceLogs)
-		completed := 0
-		filteredLogs := []*log.Log{}
+		if len(logs) == 0 {
+			return []*log.Log{}, nil
+		}
+
+		concurrency := min(runtime.GOMAXPROCS(0), len(logs))
+		if concurrency <= 0 {
+			concurrency = 1
+		}
+
+		var completed atomic.Int32
+		workerResults := make([][]*log.Log, concurrency)
 
 		progressUpdator := progressutil.NewProgressUpdator(progress, time.Second, func(tp *inspectionmetadata.TaskProgressMetadata) {
-			tp.Percentage = float32(completed) / float32(len(logs))
-			tp.Message = fmt.Sprintf("%d/%d", completed, len(logs))
+			current := int(completed.Load())
+			tp.Percentage = float32(current) / float32(len(logs))
+			tp.Message = fmt.Sprintf("%d/%d", current, len(logs))
 		})
 		progressUpdator.Start(ctx)
 
-		for _, l := range logs {
-			if logFilter(ctx, l) {
-				filteredLogs = append(filteredLogs, l)
-			}
-			completed++
+		pool := worker.NewPool(concurrency)
+		for c := 0; c < concurrency; c++ {
+			c := c
+			pool.Run(func() {
+				start := c * len(logs) / concurrency
+				end := (c + 1) * len(logs) / concurrency
+				var workerFiltered []*log.Log
+				for i := start; i < end; i++ {
+					if ctx.Err() != nil {
+						return
+					}
+					if logFilter(ctx, logs[i]) {
+						workerFiltered = append(workerFiltered, logs[i])
+					}
+					completed.Add(1)
+				}
+				workerResults[c] = workerFiltered
+			})
 		}
+		pool.Wait()
 
 		progressUpdator.Done()
+
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		totalCount := 0
+		for _, wr := range workerResults {
+			totalCount += len(wr)
+		}
+		filteredLogs := make([]*log.Log, 0, totalCount)
+		for _, wr := range workerResults {
+			filteredLogs = append(filteredLogs, wr...)
+		}
 
 		tracingActive, _ := khictx.GetValue(ctx, inspectioncore_contract.TracingActive)
 		if tracingActive {

--- a/pkg/core/inspection/taskbase/logfilter_task_test.go
+++ b/pkg/core/inspection/taskbase/logfilter_task_test.go
@@ -16,6 +16,7 @@ package inspectiontaskbase
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
@@ -57,6 +58,33 @@ func TestNewLogFilterTask(t *testing.T) {
 				return id == "foo" || id == "qux"
 			},
 			resultLogIDs: []string{"foo", "qux"},
+		},
+		{
+			name:     "should preserve order when filtering a large number of logs concurrently",
+			taskMode: inspectioncore_contract.TaskModeRun,
+			logYAMLs: func() []string {
+				yamls := make([]string, 100)
+				for i := 0; i < 100; i++ {
+					yamls[i] = fmt.Sprintf("id: item-%03d", i)
+				}
+				return yamls
+			}(),
+			logFilter: func(ctx context.Context, l *log.Log) bool {
+				id := l.ReadStringOrDefault(pathFilterTestID, "unknown")
+				// Keep only even numbered items
+				var idx int
+				if n, _ := fmt.Sscanf(id, "item-%03d", &idx); n == 1 {
+					return idx%2 == 0
+				}
+				return false
+			},
+			resultLogIDs: func() []string {
+				ids := make([]string, 50)
+				for i := 0; i < 50; i++ {
+					ids[i] = fmt.Sprintf("item-%03d", i*2)
+				}
+				return ids
+			}(),
 		},
 		{
 			name:     "should return an empty slice and perform no filtering for dryrun mode",

--- a/pkg/task/inspection/commonlogk8saudit/contract/extractor.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/extractor.go
@@ -34,3 +34,17 @@ func ExtractK8sAuditLog(ctx context.Context, reader *structured.NodeReader) (K8s
 	}
 	return K8sAuditLogFieldSet{}, nil
 }
+
+// K8sAuditLogErrorExtractor is a function type for extracting whether a log represents an error from a NodeReader.
+type K8sAuditLogErrorExtractor func(reader *structured.NodeReader) (bool, error)
+
+// ExtractK8sAuditLogError extracts whether the K8s audit log is an error using the error extractor in the task context.
+func ExtractK8sAuditLogError(ctx context.Context, reader *structured.NodeReader) (bool, error) {
+	if mock, ok := structured.GetMock[K8sAuditLogFieldSet](reader); ok {
+		return mock.IsError, nil
+	}
+	if extractor, found := coretask.GetTaskResultOptional(ctx, K8sAuditLogErrorExtractorRef); found && extractor != nil {
+		return extractor(reader)
+	}
+	return false, nil
+}

--- a/pkg/task/inspection/commonlogk8saudit/contract/taskid.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/taskid.go
@@ -32,6 +32,9 @@ var K8sAuditLogProviderRef = taskid.NewTaskReference[[]*log.Log](TaskIDPrefix + 
 // K8sAuditLogExtractorRef is the task reference for the task providing K8sAuditLogExtractor.
 var K8sAuditLogExtractorRef = taskid.NewTaskReference[K8sAuditLogExtractor](TaskIDPrefix + "k8s-auditlog-extractor")
 
+// K8sAuditLogErrorExtractorRef is the task reference for the task providing K8sAuditLogErrorExtractor.
+var K8sAuditLogErrorExtractorRef = taskid.NewTaskReference[K8sAuditLogErrorExtractor](TaskIDPrefix + "k8s-auditlog-error-extractor")
+
 // K8sAuditLogParserTailRef is the task reference for the task to depend all enabled k8s audit log parsing sub tasks.
 var K8sAuditLogParserTailRef = taskid.NewTaskReference[struct{}](TaskIDPrefix + "k8s-auditlog-parser-tail")
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/filter_tasks.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/filter_tasks.go
@@ -27,10 +27,10 @@ import (
 var SuccessLogFilterTask = inspectiontaskbase.NewLogFilterTaskWithDependencies(
 	commonlogk8saudit_contract.SuccessLogFilterTaskID,
 	commonlogk8saudit_contract.K8sAuditLogProviderRef,
-	[]taskid.UntypedTaskReference{commonlogk8saudit_contract.K8sAuditLogExtractorRef},
+	[]taskid.UntypedTaskReference{commonlogk8saudit_contract.K8sAuditLogErrorExtractorRef},
 	func(ctx context.Context, l *log.Log) bool {
-		data, _ := commonlogk8saudit_contract.ExtractK8sAuditLog(ctx, l.NodeReader)
-		return !data.IsError
+		isError, _ := commonlogk8saudit_contract.ExtractK8sAuditLogError(ctx, l.NodeReader)
+		return !isError
 	},
 )
 
@@ -38,9 +38,9 @@ var SuccessLogFilterTask = inspectiontaskbase.NewLogFilterTaskWithDependencies(
 var NonSuccessLogFilterTask = inspectiontaskbase.NewLogFilterTaskWithDependencies(
 	commonlogk8saudit_contract.NonSuccessLogFilterTaskID,
 	commonlogk8saudit_contract.K8sAuditLogProviderRef,
-	[]taskid.UntypedTaskReference{commonlogk8saudit_contract.K8sAuditLogExtractorRef},
+	[]taskid.UntypedTaskReference{commonlogk8saudit_contract.K8sAuditLogErrorExtractorRef},
 	func(ctx context.Context, l *log.Log) bool {
-		data, _ := commonlogk8saudit_contract.ExtractK8sAuditLog(ctx, l.NodeReader)
-		return data.IsError
+		isError, _ := commonlogk8saudit_contract.ExtractK8sAuditLogError(ctx, l.NodeReader)
+		return isError
 	},
 )

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/extractor.go
@@ -116,6 +116,27 @@ func stringToTiState(stateStr string) (Tistate, error) {
 	}
 }
 
+// ExtractComposerComponent extracts the component name from a Composer log NodeReader.
+func ExtractComposerComponent(reader *structured.NodeReader) (string, error) {
+	if mock, ok := structured.GetMock[ComposerFieldSet](reader); ok {
+		return mock.Component, nil
+	}
+	if reader == nil {
+		return "", nil
+	}
+
+	logName := reader.ReadStringOrDefault(pathLogName, "")
+	componentNameIndex := strings.LastIndex(logName, "/")
+	if componentNameIndex == -1 {
+		return "", fmt.Errorf("not a recognized composer component log")
+	}
+	component := logName[componentNameIndex+1:]
+	if component == "" {
+		return "", fmt.Errorf("not a recognized composer component log")
+	}
+	return component, nil
+}
+
 // ExtractComposer extracts ComposerFieldSet from a NodeReader.
 func ExtractComposer(reader *structured.NodeReader) (ComposerFieldSet, error) {
 	if mock, ok := structured.GetMock[ComposerFieldSet](reader); ok {

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/extractor_test.go
@@ -425,3 +425,62 @@ func TestExtractComposerWorkerTaskInstance(t *testing.T) {
 		}
 	})
 }
+
+func TestExtractComposerComponent(t *testing.T) {
+	testCases := []struct {
+		name      string
+		yamlStr   string
+		want      string
+		wantError bool
+	}{
+		{
+			name:    "valid worker logName",
+			yamlStr: "logName: projects/test-project/logs/airflow-worker",
+			want:    "airflow-worker",
+		},
+		{
+			name:    "valid scheduler logName",
+			yamlStr: "logName: projects/test-project/logs/airflow-scheduler",
+			want:    "airflow-scheduler",
+		},
+		{
+			name:      "missing slash",
+			yamlStr:   "logName: invalid-log-name",
+			wantError: true,
+		},
+		{
+			name:      "empty component after slash",
+			yamlStr:   "logName: projects/test-project/logs/",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := structured.FromYAML(tc.yamlStr)
+			if err != nil {
+				t.Fatalf("failed to parse yaml: %v", err)
+			}
+			reader := structured.NewNodeReader(node)
+			got, err := ExtractComposerComponent(reader)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("ExtractComposerComponent() error = %v, wantError %v", err, tc.wantError)
+			}
+			if !tc.wantError && got != tc.want {
+				t.Errorf("ExtractComposerComponent() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("MockNode returns mock component directly", func(t *testing.T) {
+		mockFieldSet := ComposerFieldSet{Component: "airflow-worker"}
+		reader := structured.NewNodeReader(structured.NewMockNode(mockFieldSet))
+		got, err := ExtractComposerComponent(reader)
+		if err != nil {
+			t.Fatalf("ExtractComposerComponent() unexpected error: %v", err)
+		}
+		if got != mockFieldSet.Component {
+			t.Errorf("ExtractComposerComponent() = %q, want %q", got, mockFieldSet.Component)
+		}
+	})
+}

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/filter_task.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/filter_task.go
@@ -29,11 +29,11 @@ func componentFilterTask(taskID taskid.TaskImplementationID[[]*log.Log], source 
 		taskID,
 		source,
 		func(ctx context.Context, l *log.Log) bool {
-			fs, err := googlecloudclustercomposer_contract.ExtractComposer(l.NodeReader)
+			component, err := googlecloudclustercomposer_contract.ExtractComposerComponent(l.NodeReader)
 			if err != nil {
 				return false
 			}
-			return fs.Component == componentName
+			return component == componentName
 		},
 	)
 }
@@ -46,11 +46,11 @@ var AirflowOtherLogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	googlecloudclustercomposer_contract.AirflowOtherLogFilterTaskID,
 	googlecloudclustercomposer_contract.ComposerLogsQueryTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
-		fs, err := googlecloudclustercomposer_contract.ExtractComposer(l.NodeReader)
+		component, err := googlecloudclustercomposer_contract.ExtractComposerComponent(l.NodeReader)
 		if err != nil {
 			return false
 		}
 		// If it's none of the specific components we support parsing, it goes to "Other"
-		return fs.Component != "airflow-worker" && fs.Component != "airflow-scheduler" && fs.Component != "dag-processor-manager"
+		return component != "airflow-worker" && component != "airflow-scheduler" && component != "dag-processor-manager"
 	},
 )

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor.go
@@ -40,6 +40,17 @@ var (
 	pathLabels              = structured.CompileFieldPath("labels")
 )
 
+// ExtractGCPK8sAuditLogError extracts whether the log represents an error from a GCP Cloud Logging NodeReader.
+func ExtractGCPK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
+	if mock, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
+		return mock.IsError, nil
+	}
+	if reader == nil {
+		return false, nil
+	}
+	return reader.ReadIntOrDefault(pathProtoStatusCode, 0) != 0, nil
+}
+
 // ExtractGCPK8sAuditLog extracts Kubernetes audit log data from a GCP Cloud Logging NodeReader.
 func ExtractGCPK8sAuditLog(reader *structured.NodeReader) (commonlogk8saudit_contract.K8sAuditLogFieldSet, error) {
 	if mock, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor_test.go
@@ -312,7 +312,6 @@ func TestExtractGCPK8sAuditLogError(t *testing.T) {
 	testCases := []struct {
 		desc      string
 		input     string
-		mock      *commonlogk8saudit_contract.K8sAuditLogFieldSet
 		wantError bool
 	}{
 		{
@@ -334,34 +333,15 @@ func TestExtractGCPK8sAuditLogError(t *testing.T) {
 			input:     `{}`,
 			wantError: false,
 		},
-		{
-			desc: "from mock with isError true",
-			mock: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
-				IsError: true,
-			},
-			wantError: true,
-		},
-		{
-			desc: "from mock with isError false",
-			mock: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
-				IsError: false,
-			},
-			wantError: false,
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			var reader *structured.NodeReader
-			if tc.mock != nil {
-				reader = structured.NewNodeReader(structured.NewMockNode(*tc.mock))
-			} else {
-				node, err := structured.FromYAML(tc.input)
-				if err != nil {
-					t.Fatalf("failed to parse test input: %v", err)
-				}
-				reader = structured.NewNodeReader(node)
+			node, err := structured.FromYAML(tc.input)
+			if err != nil {
+				t.Fatalf("failed to parse test input: %v", err)
 			}
+			reader := structured.NewNodeReader(node)
 
 			got, err := ExtractGCPK8sAuditLogError(reader)
 			if err != nil {
@@ -372,4 +352,30 @@ func TestExtractGCPK8sAuditLogError(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("from mock with isError true", func(t *testing.T) {
+		reader := structured.NewNodeReader(structured.NewMockNode(commonlogk8saudit_contract.K8sAuditLogFieldSet{
+			IsError: true,
+		}))
+		got, err := ExtractGCPK8sAuditLogError(reader)
+		if err != nil {
+			t.Fatalf("ExtractGCPK8sAuditLogError() unexpected error: %v", err)
+		}
+		if !got {
+			t.Errorf("ExtractGCPK8sAuditLogError() = false, want true")
+		}
+	})
+
+	t.Run("from mock with isError false", func(t *testing.T) {
+		reader := structured.NewNodeReader(structured.NewMockNode(commonlogk8saudit_contract.K8sAuditLogFieldSet{
+			IsError: false,
+		}))
+		got, err := ExtractGCPK8sAuditLogError(reader)
+		if err != nil {
+			t.Fatalf("ExtractGCPK8sAuditLogError() unexpected error: %v", err)
+		}
+		if got {
+			t.Errorf("ExtractGCPK8sAuditLogError() = true, want false")
+		}
+	})
 }

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor_test.go
@@ -307,3 +307,69 @@ func TestExtractGCPK8sAuditLog(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractGCPK8sAuditLogError(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		input     string
+		mock      *commonlogk8saudit_contract.K8sAuditLogFieldSet
+		wantError bool
+	}{
+		{
+			desc: "success log with status code 0",
+			input: `protoPayload:
+  status:
+    code: 0`,
+			wantError: false,
+		},
+		{
+			desc: "error log with status code 7",
+			input: `protoPayload:
+  status:
+    code: 7`,
+			wantError: true,
+		},
+		{
+			desc:      "empty log defaults to 0 (false)",
+			input:     `{}`,
+			wantError: false,
+		},
+		{
+			desc: "from mock with isError true",
+			mock: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				IsError: true,
+			},
+			wantError: true,
+		},
+		{
+			desc: "from mock with isError false",
+			mock: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				IsError: false,
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			var reader *structured.NodeReader
+			if tc.mock != nil {
+				reader = structured.NewNodeReader(structured.NewMockNode(*tc.mock))
+			} else {
+				node, err := structured.FromYAML(tc.input)
+				if err != nil {
+					t.Fatalf("failed to parse test input: %v", err)
+				}
+				reader = structured.NewNodeReader(node)
+			}
+
+			got, err := ExtractGCPK8sAuditLogError(reader)
+			if err != nil {
+				t.Fatalf("ExtractGCPK8sAuditLogError() unexpected error: %v", err)
+			}
+			if got != tc.wantError {
+				t.Errorf("ExtractGCPK8sAuditLogError() = %v, want %v", got, tc.wantError)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/taskid.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/taskid.go
@@ -27,6 +27,8 @@ var GCPK8sAuditLogListLogEntriesTaskID = taskid.NewImplementationID(commonlogk8s
 
 var GCPK8sAuditLogExtractorTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogExtractorRef, "gcp")
 
+var GCPK8sAuditLogErrorExtractorTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogErrorExtractorRef, "gcp")
+
 var GCPK8sAuditLogParserTailTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogParserTailRef, "gcp")
 
 // NEGToBackendServiceDiscoveryTaskID is the task ID for the discovery task that extracts NEG to BackendService mappings from Kubernetes Audit logs.

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/parser.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/parser.go
@@ -36,10 +36,21 @@ var GCPK8sAuditLogExtractorTask = coretask.NewTask(
 	coretask.NewTaskResultRetentionLabel(true),
 )
 
+// GCPK8sAuditLogErrorExtractorTask provides K8sAuditLogErrorExtractor for GCP audit logs.
+var GCPK8sAuditLogErrorExtractorTask = coretask.NewTask(
+	googlecloudlogk8saudit_contract.GCPK8sAuditLogErrorExtractorTaskID,
+	[]taskid.UntypedTaskReference{},
+	func(ctx context.Context) (commonlogk8saudit_contract.K8sAuditLogErrorExtractor, error) {
+		return googlecloudlogk8saudit_contract.ExtractGCPK8sAuditLogError, nil
+	},
+	coretask.NewTaskResultRetentionLabel(true),
+)
+
 var GCPK8sAuditLogParserTailTask = inspectiontaskbase.NewInspectionTask(
 	googlecloudlogk8saudit_contract.GCPK8sAuditLogParserTailTaskID,
 	[]taskid.UntypedTaskReference{
 		commonlogk8saudit_contract.K8sAuditLogExtractorRef,
+		commonlogk8saudit_contract.K8sAuditLogErrorExtractorRef,
 		commonlogk8saudit_contract.NonSuccessLogLogToTimelineMapperTaskID.Ref(),
 		commonlogk8saudit_contract.NamespaceRequestLogToTimelineMapperTaskID.Ref(),
 		commonlogk8saudit_contract.ResourceRevisionLogToTimelineMapperTaskID.Ref(),

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/registration.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/registration.go
@@ -44,6 +44,7 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 
 	return coretask.RegisterTasks(scoped,
 		GCPK8sAuditLogExtractorTask,
+		GCPK8sAuditLogErrorExtractorTask,
 		GCPK8sAuditLogParserTailTask,
 		AuditLogNEGDiscoveryTask,
 	)

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor.go
@@ -106,6 +106,21 @@ func (k *K8sControlplaneComponentFieldSet) ComponentParserType() ControlplaneCom
 	return ComponentParserTypeOther
 }
 
+// ExtractK8sControlplaneComponentParserType extracts the ControlplaneComponentParserType from a NodeReader without extracting project or cluster metadata.
+func ExtractK8sControlplaneComponentParserType(reader *structured.NodeReader) (ControlplaneComponentParserType, error) {
+	if mock, ok := structured.GetMock[K8sControlplaneComponentFieldSet](reader); ok {
+		return mock.ComponentParserType(), nil
+	}
+	if reader == nil {
+		return ComponentParserTypeOther, nil
+	}
+	componentName := reader.ReadStringOrDefault(pathComponentName, "")
+	if parserType, found := componentNameToComponentParserTypeMap[componentName]; found {
+		return parserType, nil
+	}
+	return ComponentParserTypeOther, nil
+}
+
 // ExtractK8sControlplaneComponent extracts K8sControlplaneComponentFieldSet from a NodeReader.
 func ExtractK8sControlplaneComponent(reader *structured.NodeReader) (K8sControlplaneComponentFieldSet, error) {
 	if mock, ok := structured.GetMock[K8sControlplaneComponentFieldSet](reader); ok {

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor.go
@@ -108,8 +108,8 @@ func (k *K8sControlplaneComponentFieldSet) ComponentParserType() ControlplaneCom
 
 // ExtractK8sControlplaneComponentParserType extracts the ControlplaneComponentParserType from a NodeReader without extracting project or cluster metadata.
 func ExtractK8sControlplaneComponentParserType(reader *structured.NodeReader) (ControlplaneComponentParserType, error) {
-	if mock, ok := structured.GetMock[K8sControlplaneComponentFieldSet](reader); ok {
-		return mock.ComponentParserType(), nil
+	if mock, ok := structured.GetMock[ControlplaneComponentParserType](reader); ok {
+		return mock, nil
 	}
 	if reader == nil {
 		return ComponentParserTypeOther, nil

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
@@ -99,6 +99,74 @@ resource:
 	}
 }
 
+func TestExtractK8sControlplaneComponentParserType(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		inputYAML string
+		mock      *K8sControlplaneComponentFieldSet
+		want      ControlplaneComponentParserType
+	}{
+		{
+			desc: "scheduler component",
+			inputYAML: `resource:
+  labels:
+    component_name: scheduler`,
+			want: ComponentParserTypeScheduler,
+		},
+		{
+			desc: "controller-manager component",
+			inputYAML: `resource:
+  labels:
+    component_name: controller-manager`,
+			want: ComponentParserTypeControllerManager,
+		},
+		{
+			desc: "hpa-controller component",
+			inputYAML: `resource:
+  labels:
+    component_name: hpa-controller`,
+			want: ComponentParserTypeHPAController,
+		},
+		{
+			desc: "other component",
+			inputYAML: `resource:
+  labels:
+    component_name: custom-component`,
+			want: ComponentParserTypeOther,
+		},
+		{
+			desc: "from mock",
+			mock: &K8sControlplaneComponentFieldSet{
+				ComponentName: "scheduler",
+			},
+			want: ComponentParserTypeScheduler,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			var l *log.Log
+			var err error
+			if tc.mock != nil {
+				l = testlog.NewMockLog(*tc.mock)
+			} else {
+				l, err = log.NewLogFromYAMLString(tc.inputYAML)
+				if err != nil {
+					t.Fatalf("failed to parse test input YAML: %v", err)
+				}
+			}
+
+			got, err := ExtractK8sControlplaneComponentParserType(l.NodeReader)
+			if err != nil {
+				t.Fatalf("ExtractK8sControlplaneComponentParserType() unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ExtractK8sControlplaneComponentParserType() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestExtractK8sControlplaneCommonMessage(t *testing.T) {
 	testCases := []struct {
 		desc      string

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
@@ -146,14 +146,10 @@ func TestExtractK8sControlplaneComponentParserType(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			var l *log.Log
-			var err error
 			if tc.mock != nil {
 				l = testlog.NewMockLog(*tc.mock)
 			} else {
-				l, err = log.NewLogFromYAMLString(tc.inputYAML)
-				if err != nil {
-					t.Fatalf("failed to parse test input YAML: %v", err)
-				}
+				l = testlog.MustLogFromYAML(tc.inputYAML)
 			}
 
 			got, err := ExtractK8sControlplaneComponentParserType(l.NodeReader)

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/contract/extractor_test.go
@@ -103,7 +103,6 @@ func TestExtractK8sControlplaneComponentParserType(t *testing.T) {
 	testCases := []struct {
 		desc      string
 		inputYAML string
-		mock      *K8sControlplaneComponentFieldSet
 		want      ControlplaneComponentParserType
 	}{
 		{
@@ -134,24 +133,11 @@ func TestExtractK8sControlplaneComponentParserType(t *testing.T) {
     component_name: custom-component`,
 			want: ComponentParserTypeOther,
 		},
-		{
-			desc: "from mock",
-			mock: &K8sControlplaneComponentFieldSet{
-				ComponentName: "scheduler",
-			},
-			want: ComponentParserTypeScheduler,
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			var l *log.Log
-			if tc.mock != nil {
-				l = testlog.NewMockLog(*tc.mock)
-			} else {
-				l = testlog.MustLogFromYAML(tc.inputYAML)
-			}
-
+			l := testlog.MustLogFromYAML(tc.inputYAML)
 			got, err := ExtractK8sControlplaneComponentParserType(l.NodeReader)
 			if err != nil {
 				t.Fatalf("ExtractK8sControlplaneComponentParserType() unexpected error: %v", err)
@@ -161,6 +147,17 @@ func TestExtractK8sControlplaneComponentParserType(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("from mock", func(t *testing.T) {
+		mockLog := testlog.NewMockLog(ComponentParserTypeScheduler)
+		got, err := ExtractK8sControlplaneComponentParserType(mockLog.NodeReader)
+		if err != nil {
+			t.Fatalf("ExtractK8sControlplaneComponentParserType() unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(ComponentParserTypeScheduler, got); diff != "" {
+			t.Errorf("ExtractK8sControlplaneComponentParserType() mismatch (-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestExtractK8sControlplaneCommonMessage(t *testing.T) {

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task.go
@@ -66,11 +66,11 @@ var ControllerManagerFilterTask = inspectiontaskbase.NewLogFilterTask(
 	googlecloudlogk8scontrolplane_contract.ControllerManagerLogFilterTaskID,
 	googlecloudlogk8scontrolplane_contract.ListLogEntriesTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
-		componentFieldSet, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponent(l.NodeReader)
+		parserType, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponentParserType(l.NodeReader)
 		if err != nil {
 			return false
 		}
-		return componentFieldSet.ComponentParserType() == googlecloudlogk8scontrolplane_contract.ComponentParserTypeControllerManager
+		return parserType == googlecloudlogk8scontrolplane_contract.ComponentParserTypeControllerManager
 	},
 )
 

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task.go
@@ -32,11 +32,11 @@ var HpaControllerLogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	googlecloudlogk8scontrolplane_contract.HpaControllerLogFilterTaskID,
 	googlecloudlogk8scontrolplane_contract.ListLogEntriesTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
-		componentFieldSet, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponent(l.NodeReader)
+		parserType, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponentParserType(l.NodeReader)
 		if err != nil {
 			return false
 		}
-		return componentFieldSet.ComponentParserType() == googlecloudlogk8scontrolplane_contract.ComponentParserTypeHPAController
+		return parserType == googlecloudlogk8scontrolplane_contract.ComponentParserTypeHPAController
 	},
 )
 

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task.go
@@ -29,11 +29,11 @@ var OtherLogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	googlecloudlogk8scontrolplane_contract.OtherLogFilterTaskID,
 	googlecloudlogk8scontrolplane_contract.ListLogEntriesTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
-		componentFieldSet, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponent(l.NodeReader)
+		parserType, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponentParserType(l.NodeReader)
 		if err != nil {
 			return false
 		}
-		return componentFieldSet.ComponentParserType() == googlecloudlogk8scontrolplane_contract.ComponentParserTypeOther
+		return parserType == googlecloudlogk8scontrolplane_contract.ComponentParserTypeOther
 	},
 )
 

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task.go
@@ -30,11 +30,11 @@ var SchedulerLogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	googlecloudlogk8scontrolplane_contract.SchedulerLogFilterTaskID,
 	googlecloudlogk8scontrolplane_contract.ListLogEntriesTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
-		componentFieldSet, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponent(l.NodeReader)
+		parserType, err := googlecloudlogk8scontrolplane_contract.ExtractK8sControlplaneComponentParserType(l.NodeReader)
 		if err != nil {
 			return false
 		}
-		return componentFieldSet.ComponentParserType() == googlecloudlogk8scontrolplane_contract.ComponentParserTypeScheduler
+		return parserType == googlecloudlogk8scontrolplane_contract.ComponentParserTypeScheduler
 	},
 )
 

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/extractor.go
@@ -60,6 +60,34 @@ func (k *K8sNodeLogCommonFieldSet) ParserType() K8sNodeParserType {
 	}
 }
 
+// ExtractK8sNodeParserType extracts the K8sNodeParserType from a NodeReader without parsing the log message.
+func ExtractK8sNodeParserType(reader *structured.NodeReader) (K8sNodeParserType, error) {
+	if mock, ok := structured.GetMock[K8sNodeLogCommonFieldSet](reader); ok {
+		return mock.ParserType(), nil
+	}
+	if reader == nil {
+		return Other, nil
+	}
+
+	component := reader.ReadStringOrDefault(pathSyslogIdentifier, "")
+	if component == "" {
+		logName := reader.ReadStringOrDefault(pathLogName, "")
+		lastSlash := strings.LastIndex(logName, "/")
+		if lastSlash != -1 {
+			component = logName[lastSlash+1:]
+		}
+	}
+	component = strings.Trim(component, "()")
+	switch component {
+	case "containerd":
+		return Containerd, nil
+	case "kubelet":
+		return Kubelet, nil
+	default:
+		return Other, nil
+	}
+}
+
 // ExtractK8sNodeLogCommon extracts K8sNodeLogCommonFieldSet from a NodeReader.
 func ExtractK8sNodeLogCommon(reader *structured.NodeReader, parser *logutil.SelectorLogParser[NodeLogContext]) (K8sNodeLogCommonFieldSet, error) {
 	if mock, ok := structured.GetMock[K8sNodeLogCommonFieldSet](reader); ok {

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/extractor.go
@@ -48,18 +48,6 @@ type K8sNodeLogCommonFieldSet struct {
 	NodeName  string
 }
 
-// ParserType returns the K8sNodeParserType corresponding to the component.
-func (k *K8sNodeLogCommonFieldSet) ParserType() K8sNodeParserType {
-	switch k.Component {
-	case "containerd":
-		return Containerd
-	case "kubelet":
-		return Kubelet
-	default:
-		return Other
-	}
-}
-
 // ExtractK8sNodeParserType extracts the K8sNodeParserType from a NodeReader without parsing the log message.
 func ExtractK8sNodeParserType(reader *structured.NodeReader) (K8sNodeParserType, error) {
 	if mock, ok := structured.GetMock[K8sNodeParserType](reader); ok {

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/extractor.go
@@ -62,8 +62,8 @@ func (k *K8sNodeLogCommonFieldSet) ParserType() K8sNodeParserType {
 
 // ExtractK8sNodeParserType extracts the K8sNodeParserType from a NodeReader without parsing the log message.
 func ExtractK8sNodeParserType(reader *structured.NodeReader) (K8sNodeParserType, error) {
-	if mock, ok := structured.GetMock[K8sNodeLogCommonFieldSet](reader); ok {
-		return mock.ParserType(), nil
+	if mock, ok := structured.GetMock[K8sNodeParserType](reader); ok {
+		return mock, nil
 	}
 	if reader == nil {
 		return Other, nil

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/extractor_test.go
@@ -132,45 +132,6 @@ resource:
 	}
 }
 
-func TestK8sNodeLogCommonFieldSet_ParserType(t *testing.T) {
-	testCases := []struct {
-		desc     string
-		fieldSet K8sNodeLogCommonFieldSet
-		want     K8sNodeParserType
-	}{
-		{
-			desc: "containerd parser type",
-			fieldSet: K8sNodeLogCommonFieldSet{
-				Component: "containerd",
-			},
-			want: Containerd,
-		},
-		{
-			desc: "kubelet parser type",
-			fieldSet: K8sNodeLogCommonFieldSet{
-				Component: "kubelet",
-			},
-			want: Kubelet,
-		},
-		{
-			desc: "other parser type",
-			fieldSet: K8sNodeLogCommonFieldSet{
-				Component: "other-component",
-			},
-			want: Other,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			got := tc.fieldSet.ParserType()
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("ParserType() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestExtractK8sNodeParserType(t *testing.T) {
 	testCases := []struct {
 		desc  string

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/extractor_test.go
@@ -170,3 +170,69 @@ func TestK8sNodeLogCommonFieldSet_ParserType(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractK8sNodeParserType(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input string
+		want  K8sNodeParserType
+	}{
+		{
+			desc: "containerd from syslog identifier",
+			input: `jsonPayload:
+  SYSLOG_IDENTIFIER: "containerd"`,
+			want: Containerd,
+		},
+		{
+			desc: "kubelet with parenthesis from syslog identifier",
+			input: `jsonPayload:
+  SYSLOG_IDENTIFIER: "(kubelet)"`,
+			want: Kubelet,
+		},
+		{
+			desc:  "kubelet from logName fallback",
+			input: `logName: projects/test-project/logs/kubelet`,
+			want:  Kubelet,
+		},
+		{
+			desc: "other component",
+			input: `jsonPayload:
+  SYSLOG_IDENTIFIER: "dockerd"`,
+			want: Other,
+		},
+		{
+			desc:  "empty log",
+			input: `{}`,
+			want:  Other,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			nodeLog, err := log.NewLogFromYAMLString(tc.input)
+			if err != nil {
+				t.Fatalf("failed to parse yaml: %v", err)
+			}
+			got, err := ExtractK8sNodeParserType(nodeLog.NodeReader)
+			if err != nil {
+				t.Fatalf("ExtractK8sNodeParserType() unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ExtractK8sNodeParserType() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("from mock", func(t *testing.T) {
+		mockLog := testlog.NewMockLog(K8sNodeLogCommonFieldSet{
+			Component: "containerd",
+		})
+		got, err := ExtractK8sNodeParserType(mockLog.NodeReader)
+		if err != nil {
+			t.Fatalf("ExtractK8sNodeParserType() unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(Containerd, got); diff != "" {
+			t.Errorf("ExtractK8sNodeParserType() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/extractor_test.go
@@ -221,9 +221,7 @@ func TestExtractK8sNodeParserType(t *testing.T) {
 	}
 
 	t.Run("from mock", func(t *testing.T) {
-		mockLog := testlog.NewMockLog(K8sNodeLogCommonFieldSet{
-			Component: "containerd",
-		})
+		mockLog := testlog.NewMockLog(Containerd)
 		got, err := ExtractK8sNodeParserType(mockLog.NodeReader)
 		if err != nil {
 			t.Fatalf("ExtractK8sNodeParserType() unexpected error: %v", err)

--- a/pkg/task/inspection/googlecloudlogk8snode/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/contract/extractor_test.go
@@ -209,10 +209,7 @@ func TestExtractK8sNodeParserType(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			nodeLog, err := log.NewLogFromYAMLString(tc.input)
-			if err != nil {
-				t.Fatalf("failed to parse yaml: %v", err)
-			}
+			nodeLog := testlog.MustLogFromYAML(tc.input)
 			got, err := ExtractK8sNodeParserType(nodeLog.NodeReader)
 			if err != nil {
 				t.Fatalf("ExtractK8sNodeParserType() unexpected error: %v", err)

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/common_task.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/common_task.go
@@ -194,11 +194,11 @@ func newParserTypeFilterTask(taskid taskid.TaskImplementationID[[]*log.Log], log
 		taskid,
 		logSource,
 		func(ctx context.Context, l *log.Log) bool {
-			componentFieldSet, err := googlecloudlogk8snode_contract.ExtractK8sNodeLogCommon(l.NodeReader, nil)
+			gotParserType, err := googlecloudlogk8snode_contract.ExtractK8sNodeParserType(l.NodeReader)
 			if err != nil {
 				return false
 			}
-			return componentFieldSet.ParserType() == parserType
+			return gotParserType == parserType
 		},
 	)
 }

--- a/pkg/task/inspection/googlecloudlogserialport/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/extractor.go
@@ -47,6 +47,18 @@ var (
 	pathLogName      = structured.CompileFieldPath("logName")
 )
 
+// ExtractGCESerialPortMessage extracts only the escaped message from the structured node reader.
+func ExtractGCESerialPortMessage(reader *structured.NodeReader) (string, error) {
+	if mock, ok := structured.GetMock[GCESerialPortLogFieldSet](reader); ok {
+		return mock.Message, nil
+	}
+	if reader == nil {
+		return "", nil
+	}
+	textPayload := reader.ReadStringOrDefault(pathTextPayload, "")
+	return logutil.ConvertSpecialSequences(textPayload, serialportSequenceConverters...), nil
+}
+
 // ExtractGCESerialPortLog extracts GCESerialPortLogFieldSet from the structured node reader.
 func ExtractGCESerialPortLog(reader *structured.NodeReader) (GCESerialPortLogFieldSet, error) {
 	if mock, ok := structured.GetMock[GCESerialPortLogFieldSet](reader); ok {

--- a/pkg/task/inspection/googlecloudlogserialport/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogserialport/contract/extractor_test.go
@@ -84,6 +84,54 @@ textPayload: bar`,
 	})
 }
 
+func TestExtractGCESerialPortMessage(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		log         string
+		wantMessage string
+	}{
+		{
+			desc: "with escape sequences",
+			log: `logName: projects/project-foo/logs/serialconsole.googleapis.com%2Fserial_port_1_output
+textPayload: "\\x1b[31mred text\\x1b[0m"`,
+			wantMessage: "red text",
+		},
+		{
+			desc: "empty textPayload",
+			log: `logName: projects/project-foo/logs/serialconsole.googleapis.com%2Fserial_port_1_output
+textPayload: ""`,
+			wantMessage: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l := testlog.MustLogFromYAML(tc.log)
+			gotMessage, err := ExtractGCESerialPortMessage(l.NodeReader)
+			if err != nil {
+				t.Fatalf("ExtractGCESerialPortMessage() returned unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantMessage, gotMessage); diff != "" {
+				t.Errorf("ExtractGCESerialPortMessage() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("MockNode returns mock message directly", func(t *testing.T) {
+		want := GCESerialPortLogFieldSet{
+			Message: "mock-message",
+		}
+		reader := structured.NewNodeReader(structured.NewMockNode(want))
+		got, err := ExtractGCESerialPortMessage(reader)
+		if err != nil {
+			t.Fatalf("ExtractGCESerialPortMessage() returned error: %v", err)
+		}
+		if diff := cmp.Diff(want.Message, got); diff != "" {
+			t.Errorf("ExtractGCESerialPortMessage() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
 func TestSerialPortSpecialSequenceConverter(t *testing.T) {
 	testCases := []struct {
 		name  string

--- a/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks.go
@@ -35,11 +35,11 @@ var LogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	googlecloudlogserialport_contract.LogFilterTaskID,
 	googlecloudlogserialport_contract.LogQueryTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
-		serialFS, err := googlecloudlogserialport_contract.ExtractGCESerialPortLog(l.NodeReader)
+		msg, err := googlecloudlogserialport_contract.ExtractGCESerialPortMessage(l.NodeReader)
 		if err != nil {
 			return false
 		}
-		return serialFS.Message != ""
+		return msg != ""
 	},
 )
 

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor.go
@@ -50,6 +50,18 @@ var (
 	pathEventMessage             = structured.CompileFieldPath("responseObject.message")
 )
 
+// ExtractOSSK8sAuditLogError extracts whether an OSS audit log is an error.
+func ExtractOSSK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
+	if mock, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
+		return mock.IsError, nil
+	}
+	if reader == nil || (!reader.Has(pathAuditID) && !reader.Has(pathObjectRef)) {
+		return false, nil
+	}
+	statusCode := reader.ReadIntOrDefault(pathResponseStatusCode, 0)
+	return statusCode < 200 || statusCode >= 300, nil
+}
+
 // ExtractOSSK8sAuditLog extracts commonlogk8saudit_contract.K8sAuditLogFieldSet from OSS audit log entries.
 func ExtractOSSK8sAuditLog(reader *structured.NodeReader) (commonlogk8saudit_contract.K8sAuditLogFieldSet, error) {
 	if mock, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor.go
@@ -41,6 +41,8 @@ var (
 	pathRequestObject         = structured.CompileFieldPath("requestObject")
 	pathResponseObject        = structured.CompileFieldPath("responseObject")
 
+	pathKind                     = structured.CompileFieldPath("kind")
+	pathResponseObjectKind       = structured.CompileFieldPath("responseObject.kind")
 	pathEventInvolvedAPIVersion  = structured.CompileFieldPath("responseObject.involvedObject.apiVersion")
 	pathEventInvolvedKind        = structured.CompileFieldPath("responseObject.involvedObject.kind")
 	pathEventInvolvedNamespace   = structured.CompileFieldPath("responseObject.involvedObject.namespace")
@@ -49,6 +51,35 @@ var (
 	pathEventReason              = structured.CompileFieldPath("responseObject.reason")
 	pathEventMessage             = structured.CompileFieldPath("responseObject.message")
 )
+
+// ExtractOSSK8sIsEventAuditLog extracts whether the log is an OSS K8s audit log for an Event resource.
+func ExtractOSSK8sIsEventAuditLog(reader *structured.NodeReader) (bool, error) {
+	if _, ok := structured.GetMock[OSSK8sEventFieldSet](reader); ok {
+		return true, nil
+	}
+	if reader == nil {
+		return false, nil
+	}
+	return reader.ReadStringOrDefault(pathKind, "") == "Event" && reader.ReadStringOrDefault(pathResponseObjectKind, "") == "Event", nil
+}
+
+// ExtractOSSK8sIsNonEventAuditLog extracts whether the log is an OSS K8s audit log for a non-event resource.
+func ExtractOSSK8sIsNonEventAuditLog(reader *structured.NodeReader) (bool, error) {
+	if _, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
+		return true, nil
+	}
+	if reader == nil {
+		return false, nil
+	}
+	verb := reader.ReadStringOrDefault(pathVerb, "")
+	if reader.ReadStringOrDefault(pathKind, "") == "Event" && reader.ReadStringOrDefault(pathResponseObjectKind, "") != "Event" && reader.Has(pathObjectRef) {
+		if verb == "" || verb == "get" || verb == "watch" || verb == "list" {
+			return false, nil
+		}
+		return true, nil
+	}
+	return false, nil
+}
 
 // ExtractOSSK8sAuditLogError extracts whether an OSS audit log is an error.
 func ExtractOSSK8sAuditLogError(reader *structured.NodeReader) (bool, error) {

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor_test.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor_test.go
@@ -179,7 +179,6 @@ func TestExtractOSSK8sAuditLogError(t *testing.T) {
 	testCases := []struct {
 		desc      string
 		input     string
-		mock      *commonlogk8saudit_contract.K8sAuditLogFieldSet
 		wantError bool
 	}{
 		{
@@ -215,33 +214,12 @@ responseStatus:
 			input:     `{}`,
 			wantError: false,
 		},
-		{
-			desc: "from mock with isError true",
-			mock: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
-				IsError: true,
-			},
-			wantError: true,
-		},
-		{
-			desc: "from mock with isError false",
-			mock: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
-				IsError: false,
-			},
-			wantError: false,
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			var reader *structured.NodeReader
-			if tc.mock != nil {
-				reader = structured.NewNodeReader(structured.NewMockNode(*tc.mock))
-			} else {
-				l := testlog.MustLogFromYAML(tc.input)
-				reader = l.NodeReader
-			}
-
-			got, err := ExtractOSSK8sAuditLogError(reader)
+			l := testlog.MustLogFromYAML(tc.input)
+			got, err := ExtractOSSK8sAuditLogError(l.NodeReader)
 			if err != nil {
 				t.Fatalf("ExtractOSSK8sAuditLogError() unexpected error: %v", err)
 			}
@@ -250,6 +228,32 @@ responseStatus:
 			}
 		})
 	}
+
+	t.Run("from mock with isError true", func(t *testing.T) {
+		reader := structured.NewNodeReader(structured.NewMockNode(commonlogk8saudit_contract.K8sAuditLogFieldSet{
+			IsError: true,
+		}))
+		got, err := ExtractOSSK8sAuditLogError(reader)
+		if err != nil {
+			t.Fatalf("ExtractOSSK8sAuditLogError() unexpected error: %v", err)
+		}
+		if !got {
+			t.Errorf("ExtractOSSK8sAuditLogError() = false, want true")
+		}
+	})
+
+	t.Run("from mock with isError false", func(t *testing.T) {
+		reader := structured.NewNodeReader(structured.NewMockNode(commonlogk8saudit_contract.K8sAuditLogFieldSet{
+			IsError: false,
+		}))
+		got, err := ExtractOSSK8sAuditLogError(reader)
+		if err != nil {
+			t.Fatalf("ExtractOSSK8sAuditLogError() unexpected error: %v", err)
+		}
+		if got {
+			t.Errorf("ExtractOSSK8sAuditLogError() = true, want false")
+		}
+	})
 }
 
 func TestExtractOSSK8sEvent(t *testing.T) {
@@ -333,6 +337,134 @@ responseObject:
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("ExtractOSSK8sEvent() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestExtractOSSK8sIsEventAuditLog(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		input     string
+		wantEvent bool
+	}{
+		{
+			desc: "valid event log",
+			input: `kind: Event
+responseObject:
+  kind: Event`,
+			wantEvent: true,
+		},
+		{
+			desc: "pod audit log",
+			input: `kind: Event
+responseObject:
+  kind: Pod`,
+			wantEvent: false,
+		},
+		{
+			desc:      "empty log",
+			input:     `{}`,
+			wantEvent: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l := testlog.MustLogFromYAML(tc.input)
+			got, err := ExtractOSSK8sIsEventAuditLog(l.NodeReader)
+			if err != nil {
+				t.Fatalf("ExtractOSSK8sIsEventAuditLog() unexpected error: %v", err)
+			}
+			if got != tc.wantEvent {
+				t.Errorf("ExtractOSSK8sIsEventAuditLog() = %v, want %v", got, tc.wantEvent)
+			}
+		})
+	}
+
+	t.Run("from mock", func(t *testing.T) {
+		reader := structured.NewNodeReader(structured.NewMockNode(OSSK8sEventFieldSet{}))
+		got, err := ExtractOSSK8sIsEventAuditLog(reader)
+		if err != nil {
+			t.Fatalf("ExtractOSSK8sIsEventAuditLog() unexpected error: %v", err)
+		}
+		if !got {
+			t.Errorf("ExtractOSSK8sIsEventAuditLog() = false, want true")
+		}
+	})
+}
+
+func TestExtractOSSK8sIsNonEventAuditLog(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		input        string
+		wantNonEvent bool
+	}{
+		{
+			desc: "valid non-event resource log",
+			input: `kind: Event
+verb: create
+objectRef:
+  resource: pods
+responseObject:
+  kind: Pod`,
+			wantNonEvent: true,
+		},
+		{
+			desc: "read verb get is filtered out",
+			input: `kind: Event
+verb: get
+objectRef:
+  resource: pods
+responseObject:
+  kind: Pod`,
+			wantNonEvent: false,
+		},
+		{
+			desc: "event object is filtered out",
+			input: `kind: Event
+verb: create
+objectRef:
+  resource: events
+responseObject:
+  kind: Event`,
+			wantNonEvent: false,
+		},
+		{
+			desc: "missing objectRef",
+			input: `kind: Event
+verb: create
+responseObject:
+  kind: Pod`,
+			wantNonEvent: false,
+		},
+		{
+			desc:         "empty log",
+			input:        `{}`,
+			wantNonEvent: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l := testlog.MustLogFromYAML(tc.input)
+			got, err := ExtractOSSK8sIsNonEventAuditLog(l.NodeReader)
+			if err != nil {
+				t.Fatalf("ExtractOSSK8sIsNonEventAuditLog() unexpected error: %v", err)
+			}
+			if got != tc.wantNonEvent {
+				t.Errorf("ExtractOSSK8sIsNonEventAuditLog() = %v, want %v", got, tc.wantNonEvent)
+			}
+		})
+	}
+
+	t.Run("from mock", func(t *testing.T) {
+		reader := structured.NewNodeReader(structured.NewMockNode(commonlogk8saudit_contract.K8sAuditLogFieldSet{}))
+		got, err := ExtractOSSK8sIsNonEventAuditLog(reader)
+		if err != nil {
+			t.Fatalf("ExtractOSSK8sIsNonEventAuditLog() unexpected error: %v", err)
+		}
+		if !got {
+			t.Errorf("ExtractOSSK8sIsNonEventAuditLog() = false, want true")
 		}
 	})
 }

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor_test.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor_test.go
@@ -175,6 +175,83 @@ objectRef:
 	})
 }
 
+func TestExtractOSSK8sAuditLogError(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		input     string
+		mock      *commonlogk8saudit_contract.K8sAuditLogFieldSet
+		wantError bool
+	}{
+		{
+			desc: "success status 200",
+			input: `auditID: "id-1"
+responseStatus:
+  code: 200`,
+			wantError: false,
+		},
+		{
+			desc: "success status 201",
+			input: `auditID: "id-2"
+responseStatus:
+  code: 201`,
+			wantError: false,
+		},
+		{
+			desc: "error status 404",
+			input: `auditID: "id-3"
+responseStatus:
+  code: 404`,
+			wantError: true,
+		},
+		{
+			desc: "error status 500",
+			input: `auditID: "id-4"
+responseStatus:
+  code: 500`,
+			wantError: true,
+		},
+		{
+			desc:      "empty log",
+			input:     `{}`,
+			wantError: false,
+		},
+		{
+			desc: "from mock with isError true",
+			mock: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				IsError: true,
+			},
+			wantError: true,
+		},
+		{
+			desc: "from mock with isError false",
+			mock: &commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				IsError: false,
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			var reader *structured.NodeReader
+			if tc.mock != nil {
+				reader = structured.NewNodeReader(structured.NewMockNode(*tc.mock))
+			} else {
+				l := testlog.MustLogFromYAML(tc.input)
+				reader = l.NodeReader
+			}
+
+			got, err := ExtractOSSK8sAuditLogError(reader)
+			if err != nil {
+				t.Fatalf("ExtractOSSK8sAuditLogError() unexpected error: %v", err)
+			}
+			if got != tc.wantError {
+				t.Errorf("ExtractOSSK8sAuditLogError() = %v, want %v", got, tc.wantError)
+			}
+		})
+	}
+}
+
 func TestExtractOSSK8sEvent(t *testing.T) {
 	testCases := []struct {
 		desc  string

--- a/pkg/task/inspection/ossclusterk8s/contract/taskid.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/taskid.go
@@ -35,4 +35,6 @@ var OSSK8sEventLogToTimelineMapperTaskID = taskid.NewDefaultImplementationID[ins
 
 var OSSK8sAuditLogExtractorTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogExtractorRef, "oss")
 
+var OSSK8sAuditLogErrorExtractorTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogErrorExtractorRef, "oss")
+
 var OSSK8sAuditLogParserTailTaskID = taskid.NewImplementationID(commonlogk8saudit_contract.K8sAuditLogParserTailRef, "oss")

--- a/pkg/task/inspection/ossclusterk8s/impl/auditlog_parsers.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/auditlog_parsers.go
@@ -35,10 +35,21 @@ var OSSK8sAuditLogExtractorTask = coretask.NewTask(
 	coretask.NewTaskResultRetentionLabel(true),
 )
 
+// OSSK8sAuditLogErrorExtractorTask provides K8sAuditLogErrorExtractor for OSS audit logs.
+var OSSK8sAuditLogErrorExtractorTask = coretask.NewTask(
+	ossclusterk8s_contract.OSSK8sAuditLogErrorExtractorTaskID,
+	[]taskid.UntypedTaskReference{},
+	func(ctx context.Context) (commonlogk8saudit_contract.K8sAuditLogErrorExtractor, error) {
+		return ossclusterk8s_contract.ExtractOSSK8sAuditLogError, nil
+	},
+	coretask.NewTaskResultRetentionLabel(true),
+)
+
 var OSSK8sAuditLogParserTailTask = inspectiontaskbase.NewInspectionTask(
 	ossclusterk8s_contract.OSSK8sAuditLogParserTailTaskID,
 	[]taskid.UntypedTaskReference{
 		commonlogk8saudit_contract.K8sAuditLogExtractorRef,
+		commonlogk8saudit_contract.K8sAuditLogErrorExtractorRef,
 		commonlogk8saudit_contract.NonSuccessLogLogToTimelineMapperTaskID.Ref(),
 		commonlogk8saudit_contract.NamespaceRequestLogToTimelineMapperTaskID.Ref(),
 		commonlogk8saudit_contract.ResourceRevisionLogToTimelineMapperTaskID.Ref(),

--- a/pkg/task/inspection/ossclusterk8s/impl/eventauditlogfilter_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/eventauditlogfilter_task.go
@@ -26,6 +26,7 @@ var EventAuditLogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	ossclusterk8s_contract.EventAuditLogFilterTaskID,
 	ossclusterk8s_contract.AuditLogFileReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
-		return l.ReadStringOrDefault(pathAuditKind, "") == "Event" && l.ReadStringOrDefault(pathAuditResponseObjectKind, "") == "Event"
+		isEvent, _ := ossclusterk8s_contract.ExtractOSSK8sIsEventAuditLog(l.NodeReader)
+		return isEvent
 	},
 )

--- a/pkg/task/inspection/ossclusterk8s/impl/eventauditlogfilter_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/eventauditlogfilter_task.go
@@ -17,32 +17,15 @@ package ossclusterk8s_impl
 import (
 	"context"
 
-	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
-	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	ossclusterk8s_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/ossclusterk8s/contract"
 )
 
-var EventAuditLogFilterTask = inspectiontaskbase.NewProgressReportableInspectionTask(
+var EventAuditLogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	ossclusterk8s_contract.EventAuditLogFilterTaskID,
-	[]taskid.UntypedTaskReference{
-		ossclusterk8s_contract.AuditLogFileReaderTaskID.Ref(),
-	}, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*log.Log, error) {
-		if taskMode == inspectioncore_contract.TaskModeDryRun {
-			return []*log.Log{}, nil
-		}
-		logs := coretask.GetTaskResult(ctx, ossclusterk8s_contract.AuditLogFileReaderTaskID.Ref())
-
-		var eventLogs []*log.Log
-
-		for _, l := range logs {
-			if l.ReadStringOrDefault(pathAuditKind, "") == "Event" && l.ReadStringOrDefault(pathAuditResponseObjectKind, "") == "Event" {
-				eventLogs = append(eventLogs, l)
-			}
-		}
-
-		return eventLogs, nil
-	})
+	ossclusterk8s_contract.AuditLogFileReaderTaskID.Ref(),
+	func(ctx context.Context, l *log.Log) bool {
+		return l.ReadStringOrDefault(pathAuditKind, "") == "Event" && l.ReadStringOrDefault(pathAuditResponseObjectKind, "") == "Event"
+	},
+)

--- a/pkg/task/inspection/ossclusterk8s/impl/noneventauditlogfilter_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/noneventauditlogfilter_task.go
@@ -17,30 +17,16 @@ package ossclusterk8s_impl
 import (
 	"context"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	ossclusterk8s_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/ossclusterk8s/contract"
-)
-
-var (
-	pathAuditVerb               = structured.CompileFieldPath("verb")
-	pathAuditKind               = structured.CompileFieldPath("kind")
-	pathAuditResponseObjectKind = structured.CompileFieldPath("responseObject.kind")
-	pathAuditObjectRef          = structured.CompileFieldPath("objectRef")
 )
 
 var NonEventAuditLogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	ossclusterk8s_contract.NonEventAuditLogFilterTaskID,
 	ossclusterk8s_contract.AuditLogFileReaderTaskID.Ref(),
 	func(ctx context.Context, l *log.Log) bool {
-		verb := l.ReadStringOrDefault(pathAuditVerb, "")
-		if l.ReadStringOrDefault(pathAuditKind, "") == "Event" && l.ReadStringOrDefault(pathAuditResponseObjectKind, "") != "Event" && l.Has(pathAuditObjectRef) {
-			if verb == "" || verb == "get" || verb == "watch" || verb == "list" {
-				return false
-			}
-			return true
-		}
-		return false
+		isNonEvent, _ := ossclusterk8s_contract.ExtractOSSK8sIsNonEventAuditLog(l.NodeReader)
+		return isNonEvent
 	},
 )

--- a/pkg/task/inspection/ossclusterk8s/impl/noneventauditlogfilter_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/noneventauditlogfilter_task.go
@@ -18,12 +18,8 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
-	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
-	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
-	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	ossclusterk8s_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/ossclusterk8s/contract"
 )
 
@@ -34,28 +30,17 @@ var (
 	pathAuditObjectRef          = structured.CompileFieldPath("objectRef")
 )
 
-var NonEventAuditLogFilterTask = inspectiontaskbase.NewProgressReportableInspectionTask(
+var NonEventAuditLogFilterTask = inspectiontaskbase.NewLogFilterTask(
 	ossclusterk8s_contract.NonEventAuditLogFilterTaskID,
-	[]taskid.UntypedTaskReference{
-		ossclusterk8s_contract.AuditLogFileReaderTaskID.Ref(),
-	}, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType, progress *inspectionmetadata.TaskProgressMetadata) ([]*log.Log, error) {
-		if taskMode == inspectioncore_contract.TaskModeDryRun {
-			return []*log.Log{}, nil
-		}
-
-		logs := coretask.GetTaskResult(ctx, ossclusterk8s_contract.AuditLogFileReaderTaskID.Ref())
-
-		var auditLogs []*log.Log
-
-		for _, l := range logs {
-			verb := l.ReadStringOrDefault(pathAuditVerb, "")
-			if l.ReadStringOrDefault(pathAuditKind, "") == "Event" && l.ReadStringOrDefault(pathAuditResponseObjectKind, "") != "Event" && l.Has(pathAuditObjectRef) {
-				if verb == "" || verb == "get" || verb == "watch" || verb == "list" {
-					continue
-				}
-				auditLogs = append(auditLogs, l)
+	ossclusterk8s_contract.AuditLogFileReaderTaskID.Ref(),
+	func(ctx context.Context, l *log.Log) bool {
+		verb := l.ReadStringOrDefault(pathAuditVerb, "")
+		if l.ReadStringOrDefault(pathAuditKind, "") == "Event" && l.ReadStringOrDefault(pathAuditResponseObjectKind, "") != "Event" && l.Has(pathAuditObjectRef) {
+			if verb == "" || verb == "get" || verb == "watch" || verb == "list" {
+				return false
 			}
+			return true
 		}
-
-		return auditLogs, nil
-	})
+		return false
+	},
+)

--- a/pkg/task/inspection/ossclusterk8s/impl/registration.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/registration.go
@@ -38,6 +38,7 @@ func Register(registry coreinspection.InspectionTaskRegistry) error {
 
 	return coretask.RegisterTasks(scoped,
 		OSSK8sAuditLogExtractorTask,
+		OSSK8sAuditLogErrorExtractorTask,
 		InputAuditLogFilesTask,
 		AuditLogFileReaderTask,
 		EventAuditLogFilterTask,


### PR DESCRIPTION
## Description

This change improves log filtering performance across inspection tasks by parallelizing `NewLogFilterTask` and introducing lightweight extractors for filter predicates:

1. **Parallelized Log Filtering (`pkg/core/inspection/taskbase/logfilter_task.go`)**:
   - Filter logs concurrently across CPU cores using `worker.NewPool`.
   - Guarantee that original log order is preserved by statically partitioning `logs` into contiguous index slices `[start, end)` per worker and concatenating `workerResults` in ascending worker order.
   - Support thread-safe progress updates with `atomic.Int32`.
   - Add unit test verifying log order preservation under concurrent execution.

2. **Lightweight Extractors for Filter Predicates**:
   - `commonlogk8saudit`, `googlecloudlogk8saudit`, `ossclusterk8s`: Introduced `K8sAuditLogErrorExtractor` / `ExtractK8sAuditLogError` to determine error status from status code alone without extracting the entire audit log field set.
   - `googlecloudlogk8snode`: Added `ExtractK8sNodeParserType` to identify node log component from syslog identifier / log name without parsing message contents.
   - `googlecloudlogserialport`: Added `ExtractGCESerialPortMessage` to extract only the message payload.
   - `googlecloudclustercomposer`: Added `ExtractComposerComponent` to extract component names directly from `logName`.
   - `googlecloudlogk8scontrolplane`: Added `ExtractK8sControlplaneComponentParserType` to resolve component parser types from `component_name` without resolving cluster/project metadata.

3. **Standardized OSS K8s Audit Log Filters**:
   - Refactored `EventAuditLogFilterTask` and `NonEventAuditLogFilterTask` in `ossclusterk8s` to use `inspectiontaskbase.NewLogFilterTask`.

4. **Testing**:
   - Added table-driven unit tests for all new extractor functions and concurrent log filtering.

## Test Plan
- Run `make pre-commit`
- Run `make lint-go` and `make test-go`
- Run `make test-web`
- Verify that all unit tests pass including concurrent order preservation tests.