### PR TITLE
refactor(model): refactor TimelineBuilder revisions and events to lightweight types

### DIFF
--- a/pkg/model/khifile/v6/builder_test.go
+++ b/pkg/model/khifile/v6/builder_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // TestBuilder_Build verifies that the Builder successfully generates a KHI file.
@@ -90,9 +89,9 @@ func TestBuilder_Build(t *testing.T) {
 				})
 				tb := b.TimelineAccumulator.GetBuilder(path)
 				logID := uint32(1)
-				tb.AddRevision(&pb.Revision{
-					LogId:       &logID,
-					ChangedTime: timestamppb.New(time.Date(2026, 4, 29, 8, 0, 0, 0, time.UTC)),
+				tb.AddRevision(pendingRevision{
+					LogID:       logID,
+					ChangedTime: time.Date(2026, 4, 29, 8, 0, 0, 0, time.UTC),
 				})
 			},
 			verify: func(t *testing.T, reader *Reader) {

--- a/pkg/model/khifile/v6/changeset.go
+++ b/pkg/model/khifile/v6/changeset.go
@@ -168,15 +168,9 @@ func (cs *TimelineChangeSet) Flush(accumulator *TimelineAccumulator) error {
 
 	for path := range cs.Events {
 		builder := registry.GetBuilder(path)
-		timestamp := cs.Log.Timestamp
-		if timestamp.IsZero() {
-			if pbLog := logAcc.GetLog(resolvedLogID); pbLog != nil && pbLog.Ts != nil {
-				timestamp = pbLog.Ts.AsTime()
-			}
-		}
 		builder.AddEvent(pendingEvent{
 			LogID:     resolvedLogID,
-			Timestamp: timestamp,
+			Timestamp: cs.Log.Timestamp,
 		})
 	}
 

--- a/pkg/model/khifile/v6/changeset.go
+++ b/pkg/model/khifile/v6/changeset.go
@@ -21,7 +21,6 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // StagingRevision represents a resource revision in parser-side domain model before serialization.
@@ -169,75 +168,73 @@ func (cs *TimelineChangeSet) Flush(accumulator *TimelineAccumulator) error {
 
 	for path := range cs.Events {
 		builder := registry.GetBuilder(path)
-		builder.AddEvent(&pb.Event{
-			LogId: &resolvedLogID,
+		timestamp := cs.Log.Timestamp
+		if timestamp.IsZero() {
+			if pbLog := logAcc.GetLog(resolvedLogID); pbLog != nil && pbLog.Ts != nil {
+				timestamp = pbLog.Ts.AsTime()
+			}
+		}
+		builder.AddEvent(pendingEvent{
+			LogID:     resolvedLogID,
+			Timestamp: timestamp,
 		})
 	}
 
 	for path, revisions := range cs.Revisions {
 		builder := registry.GetBuilder(path)
 		for _, r := range revisions {
-			var bodyStructID *uint32
+			var bodyStructID uint32
 			if r.ResourceBody != nil {
 				structRef, err := ToInternedStruct(r.ResourceBody, serverPool)
 				if err != nil {
 					return fmt.Errorf("failed to intern resource body for revision: %w", err)
 				}
-				bodyStructID = &structRef.id
+				bodyStructID = structRef.id
 			}
 
-			var principalID *uint32
+			var principalID uint32
 			if r.Principal != "" {
 				ref := clientPool.InternString(r.Principal)
-				principalID = &ref.id
+				principalID = ref.id
 			}
 
-			var verbID *uint32
-			if r.VerbType != nil {
-				verbID = r.VerbType.Id
+			var verbID uint32
+			if r.VerbType != nil && r.VerbType.Id != nil {
+				verbID = *r.VerbType.Id
 			}
 
-			var stateID *uint32
-			if r.StateType != nil {
-				stateID = r.StateType.Id
+			var stateID uint32
+			if r.StateType != nil && r.StateType.Id != nil {
+				stateID = *r.StateType.Id
 			}
 
-			var changedTime *timestamppb.Timestamp
-			if !r.ChangedTime.IsZero() {
-				changedTime = timestamppb.New(r.ChangedTime)
-			}
-
-			var pbAnnotations []*pb.FieldAnnotation
+			var annotations []pendingFieldAnnotation
 			for _, fa := range r.FieldAnnotations {
 				fieldPathRef := clientPool.InternString(fa.FieldPath)
-				pbAnn := &pb.FieldAnnotation{
-					FieldPathStringId: &fieldPathRef.id,
+				ann := pendingFieldAnnotation{
+					FieldPathStringID: fieldPathRef.id,
 				}
 				if fa.MutatingWebhook != nil {
 					configRef := clientPool.InternString(fa.MutatingWebhook.Configuration)
 					webhookRef := clientPool.InternString(fa.MutatingWebhook.Webhook)
-					var round int32 = int32(fa.MutatingWebhook.Round)
-					var index int32 = int32(fa.MutatingWebhook.Index)
-					pbAnn.Payload = &pb.FieldAnnotation_MutatingWebhook{
-						MutatingWebhook: &pb.MutatingWebhookInfo{
-							ConfigurationStringId: &configRef.id,
-							WebhookStringId:       &webhookRef.id,
-							Round:                 &round,
-							Index:                 &index,
-						},
+					ann.MutatingWebhook = &pendingMutatingWebhookInfo{
+						ConfigurationStringID: configRef.id,
+						WebhookStringID:       webhookRef.id,
+						Round:                 fa.MutatingWebhook.Round,
+						Index:                 fa.MutatingWebhook.Index,
 					}
 				}
-				pbAnnotations = append(pbAnnotations, pbAnn)
+				annotations = append(annotations, ann)
 			}
 
-			builder.AddRevision(&pb.Revision{
-				LogId:                &resolvedLogID,
-				ChangedTime:          changedTime,
-				ResourceBodyStructId: bodyStructID,
-				PrincipalStringId:    principalID,
+			builder.AddRevision(pendingRevision{
+				LogID:                resolvedLogID,
+				ChangedTime:          r.ChangedTime,
+				ResourceBodyStructID: bodyStructID,
+				PrincipalStringID:    principalID,
 				VerbType:             verbID,
 				StateType:            stateID,
-				FieldAnnotations:     pbAnnotations,
+				FieldAnnotations:     annotations,
 			})
 		}
 	}

--- a/pkg/model/khifile/v6/changeset.go
+++ b/pkg/model/khifile/v6/changeset.go
@@ -192,17 +192,10 @@ func (cs *TimelineChangeSet) Flush(accumulator *TimelineAccumulator) error {
 				principalID = ref.id
 			}
 
-			var verbID uint32
-			if r.VerbType != nil && r.VerbType.Id != nil {
-				verbID = *r.VerbType.Id
-			}
+			verbID := r.VerbType.GetId()
+			stateID := r.StateType.GetId()
 
-			var stateID uint32
-			if r.StateType != nil && r.StateType.Id != nil {
-				stateID = *r.StateType.Id
-			}
-
-			var annotations []pendingFieldAnnotation
+			annotations := make([]pendingFieldAnnotation, 0, len(r.FieldAnnotations))
 			for _, fa := range r.FieldAnnotations {
 				fieldPathRef := clientPool.InternString(fa.FieldPath)
 				ann := pendingFieldAnnotation{

--- a/pkg/model/khifile/v6/timeline_builder.go
+++ b/pkg/model/khifile/v6/timeline_builder.go
@@ -18,9 +18,59 @@ import (
 	"cmp"
 	"slices"
 	"sync"
+	"time"
 
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// pendingEvent represents a lightweight, value-type event accumulated in TimelineBuilder pending serialization.
+// It stores primitive values rather than protobuf heap pointers to reduce memory footprint and GC overhead.
+type pendingEvent struct {
+	// Timestamp is the time of the event copied from the associated log.
+	Timestamp time.Time
+	// LogID is the unique identifier of the log associated with this event.
+	LogID uint32
+}
+
+// pendingFieldAnnotation represents staged field annotation IDs before serialization to protobuf.
+type pendingFieldAnnotation struct {
+	// FieldPathStringID is the interned string ID for the field path.
+	FieldPathStringID uint32
+	// MutatingWebhook contains metadata for mutating webhook annotations, or nil if none.
+	MutatingWebhook *pendingMutatingWebhookInfo
+}
+
+// pendingMutatingWebhookInfo represents staged mutating webhook annotation metadata.
+type pendingMutatingWebhookInfo struct {
+	// ConfigurationStringID is the interned string ID of the webhook configuration name.
+	ConfigurationStringID uint32
+	// WebhookStringID is the interned string ID of the webhook name.
+	WebhookStringID uint32
+	// Round indicates the mutation round index.
+	Round int32
+	// Index indicates the mutation index within the round.
+	Index int32
+}
+
+// pendingRevision represents a lightweight, value-type resource revision accumulated in TimelineBuilder pending serialization.
+// It stores primitive IDs and values rather than protobuf heap pointers to reduce memory footprint and GC overhead.
+type pendingRevision struct {
+	// ChangedTime is the timestamp of the resource modification.
+	ChangedTime time.Time
+	// FieldAnnotations stores the list of staged field annotations.
+	FieldAnnotations []pendingFieldAnnotation
+	// LogID is the unique identifier of the log associated with this revision.
+	LogID uint32
+	// ResourceBodyStructID is the interned ID of the resource body struct (0 if none).
+	ResourceBodyStructID uint32
+	// PrincipalStringID is the interned string ID of the principal (0 if none).
+	PrincipalStringID uint32
+	// VerbType is the style ID of the revision verb (0 if none).
+	VerbType uint32
+	// StateType is the style ID of the revision state (0 if none).
+	StateType uint32
+}
 
 // TimelineBuilder accumulates parsed data (like logs, revisions, and events) for a specific TimelinePath.
 // This struct will be shared across multiple goroutines processing different chunks, so all modifications
@@ -31,25 +81,23 @@ type TimelineBuilder struct {
 	Path *TimelinePath
 	// TimelineItemsID is the unique identifier for the accumulated timeline items.
 	TimelineItemsID uint32
-	// internPool is the pool used to intern strings when accumulating data.
-	internPool *InternPool
 	// mu protects the revisions and events slices from concurrent modification.
 	mu sync.Mutex
 	// revisions accumulates the history of resource changes.
-	revisions []*pb.Revision
+	revisions []pendingRevision
 	// events accumulates the logs or events associated with the timeline.
-	events []*pb.Event
+	events []pendingEvent
 }
 
 // AddEvent adds a parsed event to the builder in a thread-safe manner.
-func (b *TimelineBuilder) AddEvent(e *pb.Event) {
+func (b *TimelineBuilder) AddEvent(e pendingEvent) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.events = append(b.events, e)
 }
 
 // AddRevision adds a parsed revision to the builder in a thread-safe manner.
-func (b *TimelineBuilder) AddRevision(r *pb.Revision) {
+func (b *TimelineBuilder) AddRevision(r pendingRevision) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.revisions = append(b.revisions, r)
@@ -62,6 +110,35 @@ func (b *TimelineBuilder) HasItems() bool {
 	return len(b.events) > 0 || len(b.revisions) > 0
 }
 
+// FindOldestTime returns the oldest timestamp among all accumulated events and revisions in this builder.
+func (b *TimelineBuilder) FindOldestTime() (time.Time, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var oldest time.Time
+	found := false
+
+	for _, rev := range b.revisions {
+		if rev.ChangedTime.IsZero() {
+			continue
+		}
+		if !found || rev.ChangedTime.Before(oldest) {
+			oldest = rev.ChangedTime
+			found = true
+		}
+	}
+	for _, ev := range b.events {
+		if ev.Timestamp.IsZero() {
+			continue
+		}
+		if !found || ev.Timestamp.Before(oldest) {
+			oldest = ev.Timestamp
+			found = true
+		}
+	}
+	return oldest, found
+}
+
 // ToProto converts the accumulated data into a TimelineItems protobuf message.
 // It returns nil if there are no events and no revisions.
 func (b *TimelineBuilder) ToProto() *pb.TimelineItems {
@@ -72,27 +149,112 @@ func (b *TimelineBuilder) ToProto() *pb.TimelineItems {
 		return nil
 	}
 
-	var events []*pb.Event
-	if len(b.events) > 0 {
-		events = slices.Clone(b.events)
-		slices.SortStableFunc(events, func(a, b *pb.Event) int {
-			// TODO: Sort events by time of their associated log after implementing the log registry.
-			return cmp.Compare(a.GetLogId(), b.GetLogId())
-		})
-	}
-
-	var revisions []*pb.Revision
-	if len(b.revisions) > 0 {
-		revisions = slices.Clone(b.revisions)
-		slices.SortStableFunc(revisions, func(a, b *pb.Revision) int {
-			return a.GetChangedTime().AsTime().Compare(b.GetChangedTime().AsTime())
-		})
-	}
-
 	itemsID := b.TimelineItemsID
 	return &pb.TimelineItems{
 		Id:        &itemsID,
-		Events:    events,
-		Revisions: revisions,
+		Events:    b.convertEventsToProtoLocked(),
+		Revisions: b.convertRevisionsToProtoLocked(),
 	}
+}
+
+func (b *TimelineBuilder) convertEventsToProtoLocked() []*pb.Event {
+	if len(b.events) == 0 {
+		return nil
+	}
+	sortedEvents := slices.Clone(b.events)
+	slices.SortStableFunc(sortedEvents, func(a, b pendingEvent) int {
+		if cmpResult := a.Timestamp.Compare(b.Timestamp); cmpResult != 0 {
+			return cmpResult
+		}
+		return cmp.Compare(a.LogID, b.LogID)
+	})
+	events := make([]*pb.Event, len(sortedEvents))
+	for i, ev := range sortedEvents {
+		id := ev.LogID
+		events[i] = &pb.Event{
+			LogId: &id,
+		}
+	}
+	return events
+}
+
+func (b *TimelineBuilder) convertRevisionsToProtoLocked() []*pb.Revision {
+	if len(b.revisions) == 0 {
+		return nil
+	}
+	sortedRevs := slices.Clone(b.revisions)
+	slices.SortStableFunc(sortedRevs, func(a, b pendingRevision) int {
+		return a.ChangedTime.Compare(b.ChangedTime)
+	})
+	revisions := make([]*pb.Revision, len(sortedRevs))
+	for i, r := range sortedRevs {
+		revisions[i] = convertRevisionToProto(r)
+	}
+	return revisions
+}
+
+func convertRevisionToProto(r pendingRevision) *pb.Revision {
+	var bodyStructID *uint32
+	if r.ResourceBodyStructID != 0 {
+		id := r.ResourceBodyStructID
+		bodyStructID = &id
+	}
+	var principalID *uint32
+	if r.PrincipalStringID != 0 {
+		id := r.PrincipalStringID
+		principalID = &id
+	}
+	var verbID *uint32
+	if r.VerbType != 0 {
+		id := r.VerbType
+		verbID = &id
+	}
+	var stateID *uint32
+	if r.StateType != 0 {
+		id := r.StateType
+		stateID = &id
+	}
+	var changedTime *timestamppb.Timestamp
+	if !r.ChangedTime.IsZero() {
+		changedTime = timestamppb.New(r.ChangedTime)
+	}
+	logID := r.LogID
+	return &pb.Revision{
+		LogId:                &logID,
+		ChangedTime:          changedTime,
+		ResourceBodyStructId: bodyStructID,
+		PrincipalStringId:    principalID,
+		VerbType:             verbID,
+		StateType:            stateID,
+		FieldAnnotations:     convertFieldAnnotationsToProto(r.FieldAnnotations),
+	}
+}
+
+func convertFieldAnnotationsToProto(annotations []pendingFieldAnnotation) []*pb.FieldAnnotation {
+	if len(annotations) == 0 {
+		return nil
+	}
+	pbAnnotations := make([]*pb.FieldAnnotation, len(annotations))
+	for i, fa := range annotations {
+		fieldPathID := fa.FieldPathStringID
+		pbAnn := &pb.FieldAnnotation{
+			FieldPathStringId: &fieldPathID,
+		}
+		if fa.MutatingWebhook != nil {
+			configID := fa.MutatingWebhook.ConfigurationStringID
+			webhookID := fa.MutatingWebhook.WebhookStringID
+			round := fa.MutatingWebhook.Round
+			index := fa.MutatingWebhook.Index
+			pbAnn.Payload = &pb.FieldAnnotation_MutatingWebhook{
+				MutatingWebhook: &pb.MutatingWebhookInfo{
+					ConfigurationStringId: &configID,
+					WebhookStringId:       &webhookID,
+					Round:                 &round,
+					Index:                 &index,
+				},
+			}
+		}
+		pbAnnotations[i] = pbAnn
+	}
+	return pbAnnotations
 }

--- a/pkg/model/khifile/v6/timeline_builder_test.go
+++ b/pkg/model/khifile/v6/timeline_builder_test.go
@@ -28,28 +28,140 @@ func TestTimelineBuilder_ToProto_SortsRevisionsByTime(t *testing.T) {
 	builder := &TimelineBuilder{}
 
 	now := time.Now()
-	t1 := timestamppb.New(now.Add(-2 * time.Hour))
-	t2 := timestamppb.New(now.Add(-1 * time.Hour))
-	t3 := timestamppb.New(now)
+	t1 := now.Add(-2 * time.Hour)
+	t2 := now.Add(-1 * time.Hour)
+	t3 := now
 
 	id1 := uint32(1)
 	id2 := uint32(2)
 	id3 := uint32(3)
 
 	// Add out of chronological order
-	builder.AddRevision(&pb.Revision{LogId: &id2, ChangedTime: t2})
-	builder.AddRevision(&pb.Revision{LogId: &id3, ChangedTime: t3})
-	builder.AddRevision(&pb.Revision{LogId: &id1, ChangedTime: t1})
+	builder.AddRevision(pendingRevision{LogID: id2, ChangedTime: t2})
+	builder.AddRevision(pendingRevision{LogID: id3, ChangedTime: t3})
+	builder.AddRevision(pendingRevision{LogID: id1, ChangedTime: t1})
 
 	got := builder.ToProto()
 
 	wantRevisions := []*pb.Revision{
-		{LogId: &id1, ChangedTime: t1},
-		{LogId: &id2, ChangedTime: t2},
-		{LogId: &id3, ChangedTime: t3},
+		{LogId: &id1, ChangedTime: timestamppb.New(t1)},
+		{LogId: &id2, ChangedTime: timestamppb.New(t2)},
+		{LogId: &id3, ChangedTime: timestamppb.New(t3)},
 	}
 
 	if diff := cmp.Diff(wantRevisions, got.Revisions, protocmp.Transform()); diff != "" {
 		t.Errorf("Revisions not sorted chronologically (-want +got):\n%s", diff)
+	}
+}
+
+func TestTimelineBuilder_ToProto_SortsEventsByTime(t *testing.T) {
+	builder := &TimelineBuilder{}
+
+	now := time.Now()
+	t1 := now.Add(-2 * time.Hour)
+	t2 := now.Add(-1 * time.Hour)
+	t3 := now
+
+	id1 := uint32(1)
+	id2 := uint32(2)
+	id3 := uint32(3)
+
+	// Add out of chronological order
+	builder.AddEvent(pendingEvent{LogID: id2, Timestamp: t2})
+	builder.AddEvent(pendingEvent{LogID: id3, Timestamp: t3})
+	builder.AddEvent(pendingEvent{LogID: id1, Timestamp: t1})
+
+	got := builder.ToProto()
+
+	wantEvents := []*pb.Event{
+		{LogId: &id1},
+		{LogId: &id2},
+		{LogId: &id3},
+	}
+
+	if diff := cmp.Diff(wantEvents, got.Events, protocmp.Transform()); diff != "" {
+		t.Errorf("Events not sorted chronologically (-want +got):\n%s", diff)
+	}
+}
+
+func TestTimelineBuilder_FindOldestTime(t *testing.T) {
+	now := time.Now()
+	t1 := now.Add(-2 * time.Hour)
+	t2 := now.Add(-1 * time.Hour)
+	t3 := now
+
+	testCases := []struct {
+		name      string
+		revisions []pendingRevision
+		events    []pendingEvent
+		wantTime  time.Time
+		wantFound bool
+	}{
+		{
+			name:      "empty builder returns not found",
+			wantFound: false,
+		},
+		{
+			name: "finds oldest from revisions only",
+			revisions: []pendingRevision{
+				{ChangedTime: t2},
+				{ChangedTime: t1},
+				{ChangedTime: t3},
+			},
+			wantTime:  t1,
+			wantFound: true,
+		},
+		{
+			name: "finds oldest from events only",
+			events: []pendingEvent{
+				{Timestamp: t3},
+				{Timestamp: t1},
+				{Timestamp: t2},
+			},
+			wantTime:  t1,
+			wantFound: true,
+		},
+		{
+			name: "event is older than revision",
+			revisions: []pendingRevision{
+				{ChangedTime: t2},
+			},
+			events: []pendingEvent{
+				{Timestamp: t1},
+			},
+			wantTime:  t1,
+			wantFound: true,
+		},
+		{
+			name: "revision is older than event",
+			revisions: []pendingRevision{
+				{ChangedTime: t1},
+			},
+			events: []pendingEvent{
+				{Timestamp: t2},
+			},
+			wantTime:  t1,
+			wantFound: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &TimelineBuilder{}
+			for _, r := range tc.revisions {
+				b.AddRevision(r)
+			}
+			for _, e := range tc.events {
+				b.AddEvent(e)
+			}
+
+			gotTime, gotFound := b.FindOldestTime()
+			if gotFound != tc.wantFound {
+				t.Fatalf("FindOldestTime() found mismatch: want %v, got %v", tc.wantFound, gotFound)
+			}
+			if tc.wantFound && !gotTime.Equal(tc.wantTime) {
+				t.Errorf("FindOldestTime() time mismatch: want %v, got %v", tc.wantTime, gotTime)
+			}
+		})
 	}
 }

--- a/pkg/model/khifile/v6/timeline_registry.go
+++ b/pkg/model/khifile/v6/timeline_registry.go
@@ -66,7 +66,6 @@ func (r *TimelineRegistry) GetBuilder(path *TimelinePath) *TimelineBuilder {
 	newBuilder := &TimelineBuilder{
 		Path:            path,
 		TimelineItemsID: newID,
-		internPool:      r.clientPool,
 	}
 	r.idToBuilder.Store(newID, newBuilder)
 

--- a/pkg/model/khifile/v6/timeline_serializer_test.go
+++ b/pkg/model/khifile/v6/timeline_serializer_test.go
@@ -39,8 +39,8 @@ func TestExtractTimelinesAndItemsChunkSource(t *testing.T) {
 		name      string
 		ttype     *pb.TimelineType
 		aliasOf   string
-		events    []*pb.Event
-		revisions []*pb.Revision
+		events    []pendingEvent
+		revisions []pendingRevision
 	}
 
 	testCases := []struct {
@@ -55,14 +55,14 @@ func TestExtractTimelinesAndItemsChunkSource(t *testing.T) {
 					id:     "root",
 					name:   "root",
 					ttype:  typeA,
-					events: []*pb.Event{{LogId: &id1}},
+					events: []pendingEvent{{LogID: id1}},
 				},
 				{
 					id:        "child",
 					parent:    "root",
 					name:      "child",
 					ttype:     typeB,
-					revisions: []*pb.Revision{{LogId: &id2}},
+					revisions: []pendingRevision{{LogID: id2}},
 				},
 				{
 					id:      "alias",
@@ -127,7 +127,7 @@ func TestExtractTimelinesAndItemsChunkSource(t *testing.T) {
 					parent:    "timelineB",
 					name:      "C",
 					ttype:     typeA,
-					revisions: []*pb.Revision{{LogId: &id1}},
+					revisions: []pendingRevision{{LogID: id1}},
 				},
 			},
 			want: func(paths map[string]*TimelinePath, reg *TimelineRegistry) ([]*pb.Timeline, []*pb.TimelineItems) {

--- a/pkg/model/khifile/v6/timeline_sorter.go
+++ b/pkg/model/khifile/v6/timeline_sorter.go
@@ -181,23 +181,8 @@ func FindOldestTime(path *TimelinePath, registry *TimelineRegistry, parentToChil
 	}
 
 	if builder, exists := registry.GetBuilderIfExists(path); exists {
-		builder.mu.Lock()
-		revisions := slices.Clone(builder.revisions)
-		events := slices.Clone(builder.events)
-		builder.mu.Unlock()
-
-		for _, rev := range revisions {
-			if t := rev.GetChangedTime(); t != nil {
-				updateOldest(t.AsTime())
-			}
-		}
-
-		for _, ev := range events {
-			if logEntry := registry.GetLog(ev.GetLogId()); logEntry != nil {
-				if t := logEntry.GetTs(); t != nil {
-					updateOldest(t.AsTime())
-				}
-			}
+		if t, ok := builder.FindOldestTime(); ok {
+			updateOldest(t)
 		}
 	}
 

--- a/pkg/model/khifile/v6/timeline_sorter_test.go
+++ b/pkg/model/khifile/v6/timeline_sorter_test.go
@@ -21,7 +21,6 @@ import (
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestCompareAlphabetical(t *testing.T) {
@@ -114,10 +113,22 @@ func TestCompareChronological(t *testing.T) {
 			name: "both have direct revisions, A is older",
 			setupFunc: func(registry *TimelineRegistry) {
 				bA := registry.GetBuilder(pathA)
-				bA.AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t1)})
+				bA.AddRevision(pendingRevision{ChangedTime: t1})
 
 				bB := registry.GetBuilder(pathB)
-				bB.AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t2)})
+				bB.AddRevision(pendingRevision{ChangedTime: t2})
+			},
+			maxDepth: 0,
+			want:     -1,
+		},
+		{
+			name: "both have direct events, A is older",
+			setupFunc: func(registry *TimelineRegistry) {
+				bA := registry.GetBuilder(pathA)
+				bA.AddEvent(pendingEvent{Timestamp: t1})
+
+				bB := registry.GetBuilder(pathB)
+				bB.AddEvent(pendingEvent{Timestamp: t2})
 			},
 			maxDepth: 0,
 			want:     -1,
@@ -126,10 +137,10 @@ func TestCompareChronological(t *testing.T) {
 			name: "A's grandchild is older, A comes first when depth allows search",
 			setupFunc: func(registry *TimelineRegistry) {
 				bGrandChild := registry.GetBuilder(pathAGrandChild)
-				bGrandChild.AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t1)})
+				bGrandChild.AddRevision(pendingRevision{ChangedTime: t1})
 
 				bB := registry.GetBuilder(pathB)
-				bB.AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t2)})
+				bB.AddRevision(pendingRevision{ChangedTime: t2})
 			},
 			maxDepth: 2, // depth 2 allows reaching grandchild
 			want:     -1,
@@ -138,10 +149,10 @@ func TestCompareChronological(t *testing.T) {
 			name: "A's grandchild is older, but A loses when search depth is 1",
 			setupFunc: func(registry *TimelineRegistry) {
 				bGrandChild := registry.GetBuilder(pathAGrandChild)
-				bGrandChild.AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t1)})
+				bGrandChild.AddRevision(pendingRevision{ChangedTime: t1})
 
 				bB := registry.GetBuilder(pathB)
-				bB.AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t2)})
+				bB.AddRevision(pendingRevision{ChangedTime: t2})
 			},
 			maxDepth: 1, // depth 1 only reaches ChildA, not GrandChildA
 			want:     1, // B comes first since B has t2, A has no times within depth 1
@@ -203,8 +214,8 @@ func TestCompareGroupedChronological(t *testing.T) {
 			a:    path1,
 			b:    path2,
 			setupFunc: func(registry *TimelineRegistry) {
-				registry.GetBuilder(path1).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t1)}) // 10:00
-				registry.GetBuilder(path2).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t2)}) // 09:30
+				registry.GetBuilder(path1).AddRevision(pendingRevision{ChangedTime: t1}) // 10:00
+				registry.GetBuilder(path2).AddRevision(pendingRevision{ChangedTime: t2}) // 09:30
 			},
 			want: 1, // path1 (10:00) > path2 (09:30), so path2 comes first
 		},
@@ -213,9 +224,9 @@ func TestCompareGroupedChronological(t *testing.T) {
 			a:    path1, // cccc group (min time t2 = 09:30)
 			b:    path3, // dddd group (min time t3 = 09:45)
 			setupFunc: func(registry *TimelineRegistry) {
-				registry.GetBuilder(path1).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t1)}) // 10:00
-				registry.GetBuilder(path2).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t2)}) // 09:30
-				registry.GetBuilder(path3).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t3)}) // 09:45
+				registry.GetBuilder(path1).AddRevision(pendingRevision{ChangedTime: t1}) // 10:00
+				registry.GetBuilder(path2).AddRevision(pendingRevision{ChangedTime: t2}) // 09:30
+				registry.GetBuilder(path3).AddRevision(pendingRevision{ChangedTime: t3}) // 09:45
 			},
 			want: -1, // cccc group (09:30) < dddd group (09:45)
 		},
@@ -224,8 +235,8 @@ func TestCompareGroupedChronological(t *testing.T) {
 			a:    pathParent,
 			b:    pathChild,
 			setupFunc: func(registry *TimelineRegistry) {
-				registry.GetBuilder(pathParent).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t1)})
-				registry.GetBuilder(pathChild).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t2)})
+				registry.GetBuilder(pathParent).AddRevision(pendingRevision{ChangedTime: t1})
+				registry.GetBuilder(pathChild).AddRevision(pendingRevision{ChangedTime: t2})
 			},
 			want: -1, // pathParent ("aaaa-bbbb") comes before pathChild ("aaaa-bbbb-cccc-dddd") regardless of times
 		},
@@ -234,9 +245,9 @@ func TestCompareGroupedChronological(t *testing.T) {
 			a:    pathGroupA, // "aaaa-bb-01" (time = 09:00)
 			b:    pathGroupB, // "aaaa-bbbb-01" (time = 10:00, but sibling "aaaa-bbbb-02" has 08:00)
 			setupFunc: func(registry *TimelineRegistry) {
-				registry.GetBuilder(pathGroupA).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t0900)})  // 09:00
-				registry.GetBuilder(pathGroupB).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t1000)})  // 10:00
-				registry.GetBuilder(pathGroupB2).AddRevision(&pb.Revision{ChangedTime: timestamppb.New(t0800)}) // 08:00
+				registry.GetBuilder(pathGroupA).AddRevision(pendingRevision{ChangedTime: t0900})  // 09:00
+				registry.GetBuilder(pathGroupB).AddRevision(pendingRevision{ChangedTime: t1000})  // 10:00
+				registry.GetBuilder(pathGroupB2).AddRevision(pendingRevision{ChangedTime: t0800}) // 08:00
 			},
 			want: 1, // pathGroupB's group ("aaaa-bbbb") has representative time 08:00 < 09:00 ("aaaa-bb"). If "aaaa-bbbb" leaked into "aaaa-bb", it would tie at 08:00 and return -1.
 		},


### PR DESCRIPTION
## Description

In `khifilev6`, `TimelineBuilder` previously accumulated events as `[]*pb.Event` and revisions as `[]*pb.Revision`. Each mutation converted data into heap-allocated Protobuf message structs and pointers (`*uint32`, `*timestamppb.Timestamp`, etc.), leading to excessive memory allocations, GC pressure, and coupling with `LogAccumulator` during timeline sorting (`timeline_sorter.go`).

This change refactors `TimelineBuilder` to accumulate lightweight value-type structs:

1. **Lightweight Value Types (`pkg/model/khifile/v6/timeline_builder.go`)**:
   - `pendingEvent`: Holds `Timestamp time.Time` (copied from the associated log) and `LogID uint32` in a contiguous slice `[]pendingEvent`.
   - `pendingRevision`: Holds primitive IDs (`uint32`), `time.Time`, and unexported `pendingFieldAnnotation` structs in a contiguous slice `[]pendingRevision`.
   - Removed unused `internPool` field from `TimelineBuilder`.

2. **Decoupled Sorting via `TimelineBuilder.FindOldestTime()`**:
   - Finds the oldest timestamp among accumulated events and revisions directly under mutex lock.
   - Eliminates `slices.Clone` and queries to `registry.GetLog` in `timeline_sorter.go`.

3. **Deferred Protobuf Serialization**:
   - `TimelineBuilder.ToProto()` delegates to modular helper functions (`convertEventsToProtoLocked`, `convertRevisionsToProtoLocked`, etc.).
   - Events are sorted chronologically by timestamp during Protobuf conversion.

4. **Updated Accumulation and Tests**:
   - `TimelineChangeSet.Flush`: Converts staging events and revisions to lightweight pending types.
   - Updated unit tests in `timeline_builder_test.go`, `timeline_serializer_test.go`, `timeline_sorter_test.go`, and `builder_test.go` to match the new internal signatures and verified event sorting and oldest time detection.

## Test Plan
- Run `make pre-commit`
- Run `make lint-go` and `make test-go`
- Verified all unit and integration tests pass.