### PR TITLE
fix(csm): return structured.Node from TrackAndGetManifest to fix ResourceBody intern error

### DIFF
--- a/pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go
@@ -202,21 +202,28 @@ func ProcessGCPClusterNodepoolOperationLog(
 }
 
 // TrackAndGetManifest tracks the latest resource manifest from an audit log and returns it if updated.
-func (t *GCPOperationTracker) TrackAndGetManifest(audit *GCPAuditLogFieldSet) (string, bool) {
+func (t *GCPOperationTracker) TrackAndGetManifest(audit *GCPAuditLogFieldSet) (structured.Node, bool) {
+	var manifestNode structured.Node
 	manifest := ""
 	if resp, err := audit.ResponseString(); err == nil && resp != "" {
 		manifest = resp
+		if audit.Response != nil {
+			manifestNode = audit.Response.Node
+		}
 	} else if req, err := audit.RequestString(); err == nil && req != "" {
 		manifest = req
+		if audit.Request != nil {
+			manifestNode = audit.Request.Node
+		}
 	}
-	if manifest == "" {
-		return "", false
+	if manifest == "" || manifestNode == nil {
+		return nil, false
 	}
 	if t.lastManifest == manifest {
-		return manifest, false
+		return manifestNode, false
 	}
 	t.lastManifest = manifest
-	return manifest, true
+	return manifestNode, true
 }
 
 // ProcessOperationLog adds necessary operation revisions or events to the TimelineChangeSet.

--- a/pkg/task/inspection/googlecloudcommon/contract/operation_tracker_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/operation_tracker_test.go
@@ -17,6 +17,7 @@ package googlecloudcommon_contract
 import (
 	"testing"
 	"time"
+	"unique"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 
@@ -313,4 +314,131 @@ func TestProcessGCPClusterNodepoolOperationLog(t *testing.T) {
 				ChangedTime: testTime,
 			})
 	})
+}
+
+func TestGCPOperationTracker_TrackAndGetManifest(t *testing.T) {
+	createReader := func(t *testing.T, data map[string]any) *structured.NodeReader {
+		t.Helper()
+		if data == nil {
+			return nil
+		}
+		node, err := structured.FromGoValue(data, &structured.AlphabeticalGoMapKeyOrderProvider{})
+		if err != nil {
+			t.Fatalf("failed to create node: %v", err)
+		}
+		return structured.NewNodeReader(node)
+	}
+
+	testCases := []struct {
+		name       string
+		operations []struct {
+			audit       *GCPAuditLogFieldSet
+			wantNode    structured.Node
+			wantUpdated bool
+		}
+	}{
+		{
+			name: "no request or response returns nil and false",
+			operations: []struct {
+				audit       *GCPAuditLogFieldSet
+				wantNode    structured.Node
+				wantUpdated bool
+			}{
+				{
+					audit:       &GCPAuditLogFieldSet{},
+					wantNode:    nil,
+					wantUpdated: false,
+				},
+			},
+		},
+		{
+			name: "response manifest tracked and deduplicated",
+			operations: func() []struct {
+				audit       *GCPAuditLogFieldSet
+				wantNode    structured.Node
+				wantUpdated bool
+			} {
+				node1 := createReader(t, map[string]any{"name": "res-1"}).Node
+				node2 := createReader(t, map[string]any{"name": "res-2"}).Node
+				return []struct {
+					audit       *GCPAuditLogFieldSet
+					wantNode    structured.Node
+					wantUpdated bool
+				}{
+					{
+						audit: &GCPAuditLogFieldSet{
+							Response: structured.NewNodeReader(node1),
+						},
+						wantNode:    node1,
+						wantUpdated: true,
+					},
+					{
+						audit: &GCPAuditLogFieldSet{
+							Response: structured.NewNodeReader(node1),
+						},
+						wantNode:    node1,
+						wantUpdated: false,
+					},
+					{
+						audit: &GCPAuditLogFieldSet{
+							Response: structured.NewNodeReader(node2),
+						},
+						wantNode:    node2,
+						wantUpdated: true,
+					},
+				}
+			}(),
+		},
+		{
+			name: "request manifest tracked when response absent",
+			operations: func() []struct {
+				audit       *GCPAuditLogFieldSet
+				wantNode    structured.Node
+				wantUpdated bool
+			} {
+				node1 := createReader(t, map[string]any{"name": "req-1"}).Node
+				return []struct {
+					audit       *GCPAuditLogFieldSet
+					wantNode    structured.Node
+					wantUpdated bool
+				}{
+					{
+						audit: &GCPAuditLogFieldSet{
+							Request: structured.NewNodeReader(node1),
+						},
+						wantNode:    node1,
+						wantUpdated: true,
+					},
+					{
+						audit: &GCPAuditLogFieldSet{
+							Request: structured.NewNodeReader(node1),
+						},
+						wantNode:    node1,
+						wantUpdated: false,
+					},
+				}
+			}(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := NewGCPOperationTracker()
+			for i, op := range tc.operations {
+				gotNode, gotUpdated := tracker.TrackAndGetManifest(op.audit)
+				if gotUpdated != op.wantUpdated {
+					t.Errorf("op %d: TrackAndGetManifest() gotUpdated = %v, want %v", i, gotUpdated, op.wantUpdated)
+				}
+				if diff := cmp.Diff(op.wantNode, gotNode, cmp.AllowUnexported(
+					structured.StandardMapNode{},
+					structured.StandardScalarNode[string]{},
+					structured.StandardScalarNode[any]{},
+					structured.StandardSequenceNode{},
+					unique.Handle[string]{},
+				)); diff != "" {
+					t.Errorf("op %d: TrackAndGetManifest() node mismatch (-want +got):\n%s", i, diff)
+				}
+			}
+		})
+	}
 }

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
@@ -98,7 +97,7 @@ func (m *CSMTrafficDirectorLogToTimelineMapper) ProcessLogByGroup(ctx context.Co
 		tracker.ProcessOperationLog(ctx, cs, operationTimelinePath, &audit, l.Timestamp)
 	}
 
-	manifest, shouldUpdate := tracker.TrackAndGetManifest(&audit)
+	manifestNode, shouldUpdate := tracker.TrackAndGetManifest(&audit)
 	if shouldUpdate {
 		switch {
 		case verb == commonlogk8saudit_contract.VerbDelete:
@@ -112,7 +111,7 @@ func (m *CSMTrafficDirectorLogToTimelineMapper) ProcessLogByGroup(ctx context.Co
 			cs.AddEvent(resourceTimelinePath)
 		default:
 			cs.AddRevision(resourceTimelinePath, &khifilev6.StagingRevision{
-				ResourceBody: structured.NewStandardScalarNode(manifest),
+				ResourceBody: manifestNode,
 				VerbType:     verb,
 				StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
 				Principal:    audit.PrincipalEmail,

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
@@ -175,9 +176,15 @@ func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 						VerbType:     commonlogk8saudit_contract.VerbCreate,
 						StateType:    commonlogk8saudit_contract.RevisionStateK8sResourceExisting,
 						Principal:    "u@e.c",
-						ResourceBody: structured.NewStandardScalarNode("description: init\n"),
+						ResourceBody: reqNode,
 						ChangedTime:  now,
-					}, cmp.AllowUnexported(structured.StandardScalarNode[string]{})).
+					}, cmp.AllowUnexported(
+						structured.StandardMapNode{},
+						structured.StandardScalarNode[string]{},
+						structured.StandardScalarNode[any]{},
+						structured.StandardSequenceNode{},
+						unique.Handle[string]{},
+					)).
 					HasRevision(wantOpPath, &khifilev6.StagingRevision{
 						VerbType:     googlecloudcommon_contract.VerbOperationStart,
 						StateType:    googlecloudcommon_contract.RevisionStateOperationStarted,
@@ -230,6 +237,20 @@ func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					t.Fatalf("log %d: unexpected error: %v", i, err)
 				}
 				results = append(results, cs)
+
+				// Register the mock log so that cs.Flush can resolve the log ID.
+				dummyID := uint32(1)
+				if err := builder.LogAccumulator.AddLog(&khifilev6.StagingLog{
+					Log:      l,
+					Severity: &pb.Severity{Id: &dummyID},
+					LogType:  &pb.LogType{Id: &dummyID},
+				}); err != nil {
+					t.Fatalf("log %d: AddLog() failed: %v", i, err)
+				}
+				// Flush verifies that all revisions and their ResourceBody can be interned without error.
+				if err := cs.Flush(builder.TimelineAccumulator); err != nil {
+					t.Fatalf("log %d: Flush() failed: %v", i, err)
+				}
 			}
 
 			tc.assert(t, builder, results)


### PR DESCRIPTION
## Description

When parsing CSM (Cloud Service Mesh) Traffic Director audit logs into timelines, an inspection failure occurred with the following error:
```text
error: failed to intern resource body for revision: expected map node, got 1
```

### Root Cause
1. In KHI v6, `StagingRevision.ResourceBody` stores resource tree structures as interned dictionary-compressed protobuf structures (`InternedStruct`) via `khifilev6.ToInternedStruct(node, pool)`. `ToInternedStruct` strictly requires `node.Type() == structured.MapNodeType` (value `3`).
2. `GCPOperationTracker.TrackAndGetManifest` returned the resource manifest as a YAML string (`string`).
3. In `CSMTrafficDirectorLogToTimelineMapper.ProcessLogByGroup`, this YAML string was wrapped into `structured.NewStandardScalarNode(manifest)` (`ScalarNodeType` = `1`) before being assigned to `StagingRevision.ResourceBody`. When `TimelineChangeSet.Flush()` called `ToInternedStruct`, it threw a validation error expecting a MapNode instead of a ScalarNode.
4. Existing unit tests asserted against `structured.NewStandardScalarNode(...)` without calling `Flush()` or `ToInternedStruct()`, which allowed this discrepancy to slip through.

### Changes
1. **`pkg/task/inspection/googlecloudcommon/contract/operation_tracker.go`**:
   - Updated `TrackAndGetManifest(audit *GCPAuditLogFieldSet)` signature to return `(structured.Node, bool)`.
   - Extracted `structured.Node` from `audit.Response.Node` or `audit.Request.Node`, while preserving deduplication comparison using YAML string representations.
2. **`pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task.go`**:
   - Assigned the returned `manifestNode` directly to `StagingRevision.ResourceBody` without wrapping it in a scalar node.
   - Removed unused `structured` package import.
3. **Unit Tests**:
   - Added `TestGCPOperationTracker_TrackAndGetManifest` in `operation_tracker_test.go` covering node extraction and deduplication.
   - Updated `traffic_director_parser_task_test.go` to expect the map node `reqNode` in `wantMeshPath` and added `cs.Flush(builder.TimelineAccumulator)` verification to ensure serialization into `InternedStruct` succeeds without errors.

## Test Plan
- Ran `make build-go`
- Ran `make test-go`
- Ran `make lint-go`
- Ran `make format-go`
- Ran `make pre-commit`