### PR TITLE
ci: cache dependencies and share frontend build artifacts across workflows

### DIFF
--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -49,7 +49,13 @@ jobs:
         id: cache-frontend-build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: pkg/server/dist
+          path: |
+            pkg/server/dist
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            web/angular.json
+            web/src/environments/version*
+            scripts/make/*.done
           key: frontend-build-${{ runner.os }}-${{ hashFiles('web/src/**', 'web/package-lock.json', 'web/angular-template.json', 'web/tsconfig*.json', 'web/.browserslistrc', 'proto/**', 'buf.gen.yaml', 'pkg/model/enum/**', 'pkg/task/inspection/**', 'scripts/generate-angular-json.sh', 'scripts/generate-version.sh', 'scripts/frontend-codegen/**', 'scripts/fontlist-gen/**', 'scripts/msdf-generator/**', '.node-version', 'VERSION') }}
 
       - name: Set up Go
@@ -85,12 +91,16 @@ jobs:
             pkg/model/khifile/v6/style/assets
             scripts/msdf-generator/zzz_generated_used_icons.json
             scripts/make/generate-font-atlas.done
-            scripts/make/msdf-setup.done
           key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
 
       - name: Touch font atlas dummy
         if: steps.cache-frontend-build.outputs.cache-hit != 'true' && steps.cache-font-atlas.outputs.cache-hit == 'true'
-        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+        run: |
+          touch scripts/make/build-proto.done
+          touch scripts/make/generate-backend.done
+          touch scripts/msdf-generator/zzz_generated_used_icons.json
+          touch scripts/make/generate-font-atlas.done
+          touch scripts/make/generate-frontend.done
 
       - name: npm install
         if: steps.cache-frontend-build.outputs.cache-hit != 'true'
@@ -105,7 +115,13 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-dist
-          path: pkg/server/dist
+          path: |
+            pkg/server/dist
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            web/angular.json
+            web/src/environments/version*
+            scripts/make/*.done
           retention-days: 1
 
   backend-tests:
@@ -130,10 +146,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: frontend-dist
-          path: pkg/server/dist
 
       - name: Touch frontend build artifact dummy
-        run: touch pkg/server/dist/browser/build-web.done
+        run: |
+          touch scripts/make/build-proto.done
+          touch pkg/server/dist/browser/build-web.done
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -201,12 +218,16 @@ jobs:
             pkg/model/khifile/v6/style/assets
             scripts/msdf-generator/zzz_generated_used_icons.json
             scripts/make/generate-font-atlas.done
-            scripts/make/msdf-setup.done
           key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
 
       - name: Touch font atlas dummy
         if: steps.cache-font-atlas.outputs.cache-hit == 'true'
-        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+        run: |
+          touch scripts/make/build-proto.done
+          touch scripts/make/generate-backend.done
+          touch scripts/msdf-generator/zzz_generated_used_icons.json
+          touch scripts/make/generate-font-atlas.done
+          touch scripts/make/generate-frontend.done
 
       - name: Generate frontend codes
         run: make generate-frontend
@@ -268,12 +289,16 @@ jobs:
             pkg/model/khifile/v6/style/assets
             scripts/msdf-generator/zzz_generated_used_icons.json
             scripts/make/generate-font-atlas.done
-            scripts/make/msdf-setup.done
           key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
 
       - name: Touch font atlas dummy
         if: steps.cache-font-atlas.outputs.cache-hit == 'true'
-        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+        run: |
+          touch scripts/make/build-proto.done
+          touch scripts/make/generate-backend.done
+          touch scripts/msdf-generator/zzz_generated_used_icons.json
+          touch scripts/make/generate-font-atlas.done
+          touch scripts/make/generate-frontend.done
 
       - name: Generate frontend codes
         run: make generate-frontend
@@ -305,10 +330,19 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: frontend-dist
-          path: pkg/server/dist
+
+      - name: Generate backend code
+        run: |
+          touch scripts/make/build-proto.done
+          make generate-backend
 
       - name: Touch frontend build artifact dummy
-        run: touch pkg/server/dist/browser/build-web.done
+        run: |
+          touch web/angular.json web/src/environments/version*
+          touch scripts/msdf-generator/zzz_generated_used_icons.json
+          touch scripts/make/generate-font-atlas.done
+          touch scripts/make/generate-frontend.done
+          touch pkg/server/dist/browser/build-web.done
 
       - name: Build binary
         run: make build-go-binaries

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -37,8 +37,80 @@ jobs:
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
 
+  build-web:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Cache frontend build
+        id: cache-frontend-build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: pkg/server/dist
+          key: frontend-build-${{ runner.os }}-${{ hashFiles('web/src/**', 'web/package-lock.json', 'web/angular-template.json', 'web/tsconfig*.json', 'web/.browserslistrc', 'proto/**', 'buf.gen.yaml', 'pkg/model/enum/**', 'pkg/task/inspection/**', 'scripts/generate-angular-json.sh', 'scripts/generate-version.sh', 'scripts/frontend-codegen/**', 'scripts/fontlist-gen/**', 'scripts/msdf-generator/**', '.node-version', 'VERSION') }}
+
+      - name: Set up Go
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "./go.mod"
+          cache: true
+          cache-dependency-path: "go.sum"
+
+      - name: Set up Node.js
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: "./.node-version"
+          cache: "npm"
+          cache-dependency-path: "web/package-lock.json"
+
+      - name: Cache woff2_decompress binary
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: scripts/msdf-generator/vendor/woff2/woff2_decompress
+          key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
+
+      - name: Cache font atlas
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
+        id: cache-font-atlas
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            web/src/assets/zzz-*
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            scripts/make/generate-font-atlas.done
+            scripts/make/msdf-setup.done
+          key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
+
+      - name: Touch font atlas dummy
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true' && steps.cache-font-atlas.outputs.cache-hit == 'true'
+        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+
+      - name: npm install
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
+        working-directory: ./web
+        run: npm ci
+
+      - name: Build web
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
+        run: make build-web
+
+      - name: Upload frontend build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: frontend-dist
+          path: pkg/server/dist
+          retention-days: 1
+
   backend-tests:
     runs-on: ubuntu-latest
+    needs: [build-web]
     permissions:
       contents: "read"
       id-token: "write"
@@ -53,42 +125,25 @@ jobs:
           go-version-file: "./go.mod"
           cache: true
           cache-dependency-path: "go.sum"
+
+      - name: Download frontend artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: frontend-dist
+          path: pkg/server/dist
+
+      - name: Touch frontend build artifact dummy
+        run: touch pkg/server/dist/browser/build-web.done
+
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "./.node-version"
           cache: "npm"
           cache-dependency-path: "web/package-lock.json"
+
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
-      # Building frontend artifacts because that is used in embed.fs in Go.
-      - name: npm install
-        working-directory: ./web
-        run: npm ci
-      - name: Cache woff2_decompress binary
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: scripts/msdf-generator/vendor/woff2/woff2_decompress
-          key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
-
-      - name: Cache font atlas
-        id: cache-font-atlas
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            web/src/assets/zzz-*
-            pkg/model/khifile/v6/style/assets
-            scripts/msdf-generator/zzz_generated_used_icons.json
-            scripts/make/generate-font-atlas.done
-            scripts/make/msdf-setup.done
-          key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
-
-      - name: Touch font atlas dummy
-        if: steps.cache-font-atlas.outputs.cache-hit == 'true'
-        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
-
-      - name: Build web
-        run: make build-web
 
       - name: Backend Test
         run: |
@@ -232,6 +287,7 @@ jobs:
         run: npm run build-storybook
   build-binaries:
     runs-on: ubuntu-latest
+    needs: [build-web]
     permissions:
       contents: "read"
     steps:
@@ -244,36 +300,15 @@ jobs:
           go-version-file: "./go.mod"
           cache: true
           cache-dependency-path: "go.sum"
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: "./.node-version"
-          cache: "npm"
-          cache-dependency-path: "web/package-lock.json"
-      - name: npm install
-        working-directory: ./web
-        run: npm ci
-      - name: Cache woff2_decompress binary
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: scripts/msdf-generator/vendor/woff2/woff2_decompress
-          key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
 
-      - name: Cache font atlas
-        id: cache-font-atlas
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download frontend artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: |
-            web/src/assets/zzz-*
-            pkg/model/khifile/v6/style/assets
-            scripts/msdf-generator/zzz_generated_used_icons.json
-            scripts/make/generate-font-atlas.done
-            scripts/make/msdf-setup.done
-          key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
+          name: frontend-dist
+          path: pkg/server/dist
 
-      - name: Touch font atlas dummy
-        if: steps.cache-font-atlas.outputs.cache-hit == 'true'
-        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+      - name: Touch frontend build artifact dummy
+        run: touch pkg/server/dist/browser/build-web.done
 
       - name: Build binary
         run: make build-go-binaries

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -65,6 +65,28 @@ jobs:
       - name: npm install
         working-directory: ./web
         run: npm ci
+      - name: Cache woff2_decompress binary
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: scripts/msdf-generator/vendor/woff2/woff2_decompress
+          key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
+
+      - name: Cache font atlas
+        id: cache-font-atlas
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            web/src/assets/zzz-*
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            scripts/make/generate-font-atlas.done
+            scripts/make/msdf-setup.done
+          key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
+
+      - name: Touch font atlas dummy
+        if: steps.cache-font-atlas.outputs.cache-hit == 'true'
+        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+
       - name: Build web
         run: make build-web
 
@@ -108,6 +130,28 @@ jobs:
       - name: npm install
         working-directory: ./web
         run: npm ci
+
+      - name: Cache woff2_decompress binary
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: scripts/msdf-generator/vendor/woff2/woff2_decompress
+          key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
+
+      - name: Cache font atlas
+        id: cache-font-atlas
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            web/src/assets/zzz-*
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            scripts/make/generate-font-atlas.done
+            scripts/make/msdf-setup.done
+          key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
+
+      - name: Touch font atlas dummy
+        if: steps.cache-font-atlas.outputs.cache-hit == 'true'
+        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
 
       - name: Generate frontend codes
         run: make generate-frontend
@@ -154,6 +198,28 @@ jobs:
         working-directory: ./web
         run: npm ci
 
+      - name: Cache woff2_decompress binary
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: scripts/msdf-generator/vendor/woff2/woff2_decompress
+          key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
+
+      - name: Cache font atlas
+        id: cache-font-atlas
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            web/src/assets/zzz-*
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            scripts/make/generate-font-atlas.done
+            scripts/make/msdf-setup.done
+          key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
+
+      - name: Touch font atlas dummy
+        if: steps.cache-font-atlas.outputs.cache-hit == 'true'
+        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+
       - name: Generate frontend codes
         run: make generate-frontend
 
@@ -187,6 +253,28 @@ jobs:
       - name: npm install
         working-directory: ./web
         run: npm ci
+      - name: Cache woff2_decompress binary
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: scripts/msdf-generator/vendor/woff2/woff2_decompress
+          key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
+
+      - name: Cache font atlas
+        id: cache-font-atlas
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            web/src/assets/zzz-*
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            scripts/make/generate-font-atlas.done
+            scripts/make/msdf-setup.done
+          key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
+
+      - name: Touch font atlas dummy
+        if: steps.cache-font-atlas.outputs.cache-hit == 'true'
+        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+
       - name: Build binary
         run: make build-go-binaries
 

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -51,6 +51,12 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "./go.mod"
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: "./.node-version"
+          cache: "npm"
+          cache-dependency-path: "web/package-lock.json"
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
       # Building frontend artifacts because that is used in embed.fs in Go.
@@ -84,6 +90,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "./.node-version"
+          cache: "npm"
+          cache-dependency-path: "web/package-lock.json"
 
       - name: Set up Go # Go dependency is needed for `make generate-frontend`
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -128,6 +136,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "./.node-version"
+          cache: "npm"
+          cache-dependency-path: "web/package-lock.json"
 
       - name: Set up Go # Go dependency is needed for `make generate-frontend`
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -164,6 +174,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "./.node-version"
+          cache: "npm"
+          cache-dependency-path: "web/package-lock.json"
       - name: npm install
         working-directory: ./web
         run: npm ci
@@ -202,6 +214,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "./.node-version"
+          cache: "npm"
+          cache-dependency-path: "web/package-lock.json"
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -51,6 +51,8 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "./go.mod"
+          cache: true
+          cache-dependency-path: "go.sum"
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -97,6 +99,8 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "./go.mod"
+          cache: true
+          cache-dependency-path: "go.sum"
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -143,6 +147,8 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "./go.mod"
+          cache: true
+          cache-dependency-path: "go.sum"
 
       - name: npm install
         working-directory: ./web
@@ -170,6 +176,8 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "./go.mod"
+          cache: true
+          cache-dependency-path: "go.sum"
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -194,6 +202,8 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "./go.mod"
+          cache: true
+          cache-dependency-path: "go.sum"
 
       - name: Install addlicense package
         run: go mod download
@@ -221,6 +231,8 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "./go.mod"
+          cache: true
+          cache-dependency-path: "go.sum"
 
       - name: npm install (web)
         working-directory: ./web

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,28 +36,37 @@ jobs:
           cache: true
           cache-dependency-path: "go.sum"
 
+      - name: Update VERSION file
+        run: echo "${GITHUB_REF_NAME#v}" > VERSION
+
+      - name: Cache frontend build
+        id: cache-frontend-build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: pkg/server/dist
+          key: frontend-build-${{ runner.os }}-${{ hashFiles('web/src/**', 'web/package-lock.json', 'web/angular-template.json', 'web/tsconfig*.json', 'web/.browserslistrc', 'proto/**', 'buf.gen.yaml', 'pkg/model/enum/**', 'pkg/task/inspection/**', 'scripts/generate-angular-json.sh', 'scripts/generate-version.sh', 'scripts/frontend-codegen/**', 'scripts/fontlist-gen/**', 'scripts/msdf-generator/**', '.node-version', 'VERSION') }}
+
+      - name: Touch frontend build artifact dummy
+        if: steps.cache-frontend-build.outputs.cache-hit == 'true'
+        run: touch pkg/server/dist/browser/build-web.done
+
       - name: Setup Node.js
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "./.node-version"
           cache: "npm"
           cache-dependency-path: "web/package-lock.json"
 
-      - name: Install Frontend Dependencies
-        run: |
-          cd web
-          npm ci
-
-      - name: Update VERSION file
-        run: echo "${GITHUB_REF_NAME#v}" > VERSION
-
       - name: Cache woff2_decompress binary
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: scripts/msdf-generator/vendor/woff2/woff2_decompress
           key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
 
       - name: Cache font atlas
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
         id: cache-font-atlas
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -70,8 +79,14 @@ jobs:
           key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
 
       - name: Touch font atlas dummy
-        if: steps.cache-font-atlas.outputs.cache-hit == 'true'
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true' && steps.cache-font-atlas.outputs.cache-hit == 'true'
         run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+
+      - name: Install Frontend Dependencies
+        if: steps.cache-frontend-build.outputs.cache-hit != 'true'
+        run: |
+          cd web
+          npm ci
 
       - name: Build Binaries
         run: make build-go-binaries

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,28 @@ jobs:
       - name: Update VERSION file
         run: echo "${GITHUB_REF_NAME#v}" > VERSION
 
+      - name: Cache woff2_decompress binary
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: scripts/msdf-generator/vendor/woff2/woff2_decompress
+          key: woff2-bin-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/setup.sh') }}
+
+      - name: Cache font atlas
+        id: cache-font-atlas
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            web/src/assets/zzz-*
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            scripts/make/generate-font-atlas.done
+            scripts/make/msdf-setup.done
+          key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
+
+      - name: Touch font atlas dummy
+        if: steps.cache-font-atlas.outputs.cache-hit == 'true'
+        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+
       - name: Build Binaries
         run: make build-go-binaries
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "./go.mod"
+          cache: true
+          cache-dependency-path: "go.sum"
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "./.node-version"
+          cache: "npm"
+          cache-dependency-path: "web/package-lock.json"
 
       - name: Install Frontend Dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,12 +43,25 @@ jobs:
         id: cache-frontend-build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: pkg/server/dist
+          path: |
+            pkg/server/dist
+            pkg/model/khifile/v6/style/assets
+            scripts/msdf-generator/zzz_generated_used_icons.json
+            web/angular.json
+            web/src/environments/version*
+            scripts/make/*.done
           key: frontend-build-${{ runner.os }}-${{ hashFiles('web/src/**', 'web/package-lock.json', 'web/angular-template.json', 'web/tsconfig*.json', 'web/.browserslistrc', 'proto/**', 'buf.gen.yaml', 'pkg/model/enum/**', 'pkg/task/inspection/**', 'scripts/generate-angular-json.sh', 'scripts/generate-version.sh', 'scripts/frontend-codegen/**', 'scripts/fontlist-gen/**', 'scripts/msdf-generator/**', '.node-version', 'VERSION') }}
 
       - name: Touch frontend build artifact dummy
         if: steps.cache-frontend-build.outputs.cache-hit == 'true'
-        run: touch pkg/server/dist/browser/build-web.done
+        run: |
+          touch scripts/make/build-proto.done
+          make generate-backend
+          touch web/angular.json web/src/environments/version*
+          touch scripts/msdf-generator/zzz_generated_used_icons.json
+          touch scripts/make/generate-font-atlas.done
+          touch scripts/make/generate-frontend.done
+          touch pkg/server/dist/browser/build-web.done
 
       - name: Setup Node.js
         if: steps.cache-frontend-build.outputs.cache-hit != 'true'
@@ -75,12 +88,16 @@ jobs:
             pkg/model/khifile/v6/style/assets
             scripts/msdf-generator/zzz_generated_used_icons.json
             scripts/make/generate-font-atlas.done
-            scripts/make/msdf-setup.done
           key: font-atlas-${{ runner.os }}-${{ hashFiles('scripts/msdf-generator/**', 'scripts/fontlist-gen/**', 'pkg/task/inspection/**') }}
 
       - name: Touch font atlas dummy
         if: steps.cache-frontend-build.outputs.cache-hit != 'true' && steps.cache-font-atlas.outputs.cache-hit == 'true'
-        run: touch scripts/make/generate-font-atlas.done scripts/make/msdf-setup.done
+        run: |
+          touch scripts/make/build-proto.done
+          touch scripts/make/generate-backend.done
+          touch scripts/msdf-generator/zzz_generated_used_icons.json
+          touch scripts/make/generate-font-atlas.done
+          touch scripts/make/generate-frontend.done
 
       - name: Install Frontend Dependencies
         if: steps.cache-frontend-build.outputs.cache-hit != 'true'

--- a/scripts/msdf-generator/setup.sh
+++ b/scripts/msdf-generator/setup.sh
@@ -14,12 +14,23 @@
 # limitations under the License.
 
 
-mkdir -p vendor
-cd vendor
-git clone --recursive https://github.com/google/woff2.git
-cd woff2
-make clean all
-cd ../..
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+WOFF2_COMMIT="1c69169e9e1811dccd6c54c532fedda300233968"
+
+if [ ! -f "./vendor/woff2/woff2_decompress" ]; then
+  mkdir -p vendor
+  cd vendor
+  git clone https://github.com/google/woff2.git
+  cd woff2
+  git checkout "${WOFF2_COMMIT}"
+  git submodule update --init --recursive
+  make clean all
+  cd ../..
+fi
 
 ./vendor/woff2/woff2_decompress ./node_modules/@fontsource/roboto/files/roboto-latin-700-normal.woff2
 ./vendor/woff2/woff2_decompress ./node_modules/material-symbols/material-symbols-outlined.woff2

--- a/scripts/msdf-generator/setup.sh
+++ b/scripts/msdf-generator/setup.sh
@@ -23,13 +23,14 @@ WOFF2_COMMIT="1c69169e9e1811dccd6c54c532fedda300233968"
 
 if [ ! -f "./vendor/woff2/woff2_decompress" ]; then
   mkdir -p vendor
-  cd vendor
-  git clone https://github.com/google/woff2.git
-  cd woff2
-  git checkout "${WOFF2_COMMIT}"
-  git submodule update --init --recursive
-  make clean all
-  cd ../..
+  rm -rf vendor/woff2
+  git clone https://github.com/google/woff2.git vendor/woff2
+  (
+    cd vendor/woff2
+    git checkout "${WOFF2_COMMIT}"
+    git submodule update --init --recursive
+    make clean all
+  )
 fi
 
 ./vendor/woff2/woff2_decompress ./node_modules/@fontsource/roboto/files/roboto-latin-700-normal.woff2


### PR DESCRIPTION
## Summary
This PR optimizes GitHub Actions CI workflow runtimes and reliability by:
1. **Enabling npm dependency caching** across all workflows using `actions/setup-node` with `cache: "npm"` and `cache-dependency-path: "web/package-lock.json"`.
2. **Enabling explicit Go module & build caching** across all workflows with `cache: true` and `cache-dependency-path: "go.sum"`.
3. **Caching font atlas generation & pinning woff2 commit**:
   - Pinned `woff2` git clone to an immutable commit SHA (`1c69169e9e1811dccd6c54c532fedda300233968`).
   - Made `scripts/msdf-generator/setup.sh` CWD-safe.
   - Added two-level caching for the compiled `woff2_decompress` binary and generated font atlas assets to avoid re-cloning and recompiling C++ on every run.
4. **Caching and sharing frontend build artifacts**:
   - Added a dedicated `build-web` job that builds `pkg/server/dist` once, caches it via `actions/cache`, and shares it via `actions/upload-artifact`.
   - Updated `backend-tests` and `build-binaries` to consume the build artifact via `actions/download-artifact`, completely eliminating redundant frontend builds and `npm ci` steps in those jobs.
   - Added frontend build cache support to `release.yaml`.

## Commits
- `ci: enable npm cache across GitHub Actions workflows`
- `ci: configure explicit Go caching with go.sum across GitHub Actions workflows`
- `ci: cache font atlas and woff2 binary across GitHub Actions workflows`
- `ci: cache and share frontend build artifacts across GitHub Actions workflows`