### PR TITLE
fix(inspection/googlecloudcommon): avoid race condition dropping partition boundary logs in log fetcher

### DIFF
--- a/pkg/core/inspection/formtask/setform.go
+++ b/pkg/core/inspection/formtask/setform.go
@@ -220,7 +220,7 @@ func (b *SetFormTaskBuilder[T]) Build(labelOpts ...common_task.LabelOpt) common_
 		field.Default = defaultValue
 		currentValue = defaultValue
 
-		if valueRaw, exist := req[b.id.ReferenceIDString()]; exist {
+		if valueRaw, exist := req[b.id.ReferenceIDString()]; exist && valueRaw != nil {
 			valueSlice, isSlice := valueRaw.([]interface{})
 			if !isSlice {
 				// Also try to handle string[] (though json unmarshal usually gives []interface{})

--- a/pkg/task/inspection/commonlogk8saudit/impl/nodenameinventory_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/nodenameinventory_task.go
@@ -16,6 +16,7 @@ package commonlogk8saudit_impl
 
 import (
 	"context"
+	"slices"
 
 	inspectionmetadata "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/metadata"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
@@ -43,6 +44,7 @@ func (n *nodeNameMergeStrategy) Merge(results [][]string) ([]string, error) {
 	for k := range result {
 		ret = append(ret, k)
 	}
+	slices.Sort(ret)
 	return ret, nil
 }
 

--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
@@ -157,11 +157,15 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 	consumerWg.Wait()
 	cancelProgress()
 	progressWg.Wait()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	// Send final progress report.
 	select {
 	case progress <- LogFetchProgress{LogCount: int(logCount.Load()), Progress: 1.0}:
 	case <-ctx.Done():
+		return ctx.Err()
 	}
 	return nil
 }

--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
@@ -72,12 +72,15 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 	defer ticker.Stop() // ticker must be closed before closing progress
 
 	stubChan := make(chan *loggingpb.LogEntry)
-	subroutineCtx, cancelSubroutine := context.WithCancel(ctx)
+	consumerCtx, cancelConsumer := context.WithCancel(ctx)
+	defer cancelConsumer()
+	progressCtx, cancelProgress := context.WithCancel(ctx)
+	defer cancelProgress()
 
 	filter := fmt.Sprintf("%s\n%s", filterWithoutTimeRange, gcpqueryutil.TimeRangeQuerySection(beginTime, endTime, false))
 
-	wg := sync.WaitGroup{}
-	wg.Add(2)
+	var consumerWg sync.WaitGroup
+	var progressWg sync.WaitGroup
 	logCount := atomic.Int32{}
 	latestLogTime := atomic.Pointer[time.Time]{}
 	latestLogTime.Store(&beginTime)
@@ -88,11 +91,12 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 	}
 
 	// Consume logs from log fetcher and record count and the latest time for reporting progress
+	consumerWg.Add(1)
 	go func() {
-		defer wg.Done() // fetcher.FetchLogs is expected to run in sync. But make sure all the logs are consumed in this go routine.
+		defer consumerWg.Done()
 		for {
 			select {
-			case <-subroutineCtx.Done():
+			case <-consumerCtx.Done():
 				return
 			case logEntry, ok := <-stubChan:
 				if !ok {
@@ -102,7 +106,7 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 				t := logEntry.Timestamp.AsTime()
 				latestLogTime.Store(&t)
 				select {
-				case <-subroutineCtx.Done():
+				case <-consumerCtx.Done():
 					return
 				case dest <- logEntry:
 				}
@@ -111,18 +115,19 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 	}()
 
 	// Report progress for every reportInterval
+	progressWg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer progressWg.Done()
 		// Send initial progress
 		select {
 		case progress <- LogFetchProgress{}:
-		case <-subroutineCtx.Done():
+		case <-progressCtx.Done():
 			return
 		}
 
 		for {
 			select {
-			case <-subroutineCtx.Done():
+			case <-progressCtx.Done():
 				return
 			case <-ticker.C:
 				latest := latestLogTime.Load()
@@ -132,7 +137,7 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 					LogCount: int(logCount.Load()),
 					Progress: float32(latestLogTimeFromBeginTimeInSeconds) / float32(totalDurationInSeconds),
 				}:
-				case <-subroutineCtx.Done():
+				case <-progressCtx.Done():
 					return
 				}
 			}
@@ -141,13 +146,17 @@ func (s *StandardProgressReportableLogFetcher) FetchLogsWithProgress(dest chan<-
 
 	err := s.fetcher.FetchLogs(stubChan, ctx, filter, container, resourceContainers)
 	if err != nil {
-		cancelSubroutine()
-		wg.Wait()
+		cancelConsumer()
+		cancelProgress()
+		consumerWg.Wait()
+		progressWg.Wait()
 		return err
 	}
 
-	cancelSubroutine()
-	wg.Wait()
+	// Wait for consumer to consume all logs from stubChan and forward them to dest.
+	consumerWg.Wait()
+	cancelProgress()
+	progressWg.Wait()
 
 	// Send final progress report.
 	select {


### PR DESCRIPTION
## Summary

This PR resolves an intermittent issue where logs at time partition boundaries were randomly dropped during log fetching, causing non-deterministic log counts across inspection runs.

### Root Cause
In `StandardProgressReportableLogFetcher.FetchLogsWithProgress`, a consumer goroutine forwards log entries from `stubChan` to `dest`. When `FetchLogs` returned synchronously, `cancelSubroutine()` immediately cancelled `subroutineCtx`.
Because the consumer goroutine used:
```go
select {
case <-subroutineCtx.Done():
    return
case dest <- logEntry:
}
```
If `cancelSubroutine()` executed while forwarding a log entry, Go's `select` statement would randomly pick between the cancelled context and `dest <- logEntry`. When `<-subroutineCtx.Done()` won the race (~50% chance), the final log entry of that time partition was discarded.

### Fix Details
1. **Draining `stubChan` before stopping progress reporting** (`progressreportablelogfetcher.go`):
   - Separated the consumer and progress synchronization contexts and WaitGroups (`consumerCtx`, `progressCtx`, `consumerWg`, `progressWg`).
   - After `FetchLogs` completes, `consumerWg.Wait()` waits for the consumer goroutine to fully drain `stubChan` until closed (`!ok`) without cancelling `consumerCtx`.
   - Only after all logs are drained does it cancel progress reporting and send the final 100% progress report.
2. **Deterministic Node Ordering** (`nodenameinventory_task.go`):
   - Added `slices.Sort(ret)` to `nodeNameMergeStrategy.Merge` to ensure node query split orders are strictly deterministic across runs.
3. **Graceful `null` Parameter Handling** (`setform.go`):
   - Handled `valueRaw == nil` in `SetFormTask` so passing `null` in job inspection values falls back to the default empty array instead of failing with `request parameter ... was not given in array`.

### Verification
- Ran 3 consecutive full-stack E2E inspection jobs with all log features enabled (`autoscaler`, `compute-api`, `gke-api`, `k8s-container`, `k8s-control-plane`, `k8s-event`, `k8s-node`, `network-api`, `serialport`, `k8s-auditlog`).
- Verified that all 10 log ingesters produced **exact, identical log counts across all 3 runs** (total: 241,819 entries, 0 differences).
- `make lint-go` and `make test-go` passed with 0 issues.