### PR TITLE
fix(timeline): unify dashed border stripe coordinates to screen pixels

### DIFF
--- a/web/src/assets/revision.color-fragment.glsl
+++ b/web/src/assets/revision.color-fragment.glsl
@@ -10,7 +10,7 @@ precision highp int;
 flat in RevisionModel revisionModel;
 in vec2 uv;
 in vec2 revisionScreenSize;
-flat in float leftEdgeTimeMS;
+flat in float revisionClippedOffsetPx;
 
 layout(location = 0) out vec4 fragColor;
 
@@ -65,10 +65,9 @@ float borderStripePattern(float pitch){
 
   float isVerticalEdge = step(distFromEdge.x, distFromEdge.y);
 
-  float posAlongBorder = mix(revisionRelativeUV.x, revisionRelativeUV.y, isVerticalEdge);
+  float posAlongBorder = mix(revisionClippedOffsetPx + revisionRelativeUV.x, revisionRelativeUV.y, isVerticalEdge);
 
-  float patternVal = leftEdgeTimeMS + posAlongBorder;
-  float stripeVal = mod(patternVal, pitch);
+  float stripeVal = mod(posAlongBorder, pitch);
   return step(stripeVal, pitch / 2.0);
 }
 

--- a/web/src/assets/revision.hittest-fragment.glsl
+++ b/web/src/assets/revision.hittest-fragment.glsl
@@ -10,7 +10,7 @@ precision highp int;
 flat in RevisionModel revisionModel;
 in vec2 uv;
 in vec2 revisionScreenSize;
-flat in float leftEdgeTimeMS;
+flat in float revisionClippedOffsetPx;
 
 
 // Output for picking / hit testing.

--- a/web/src/assets/revision.vertex.glsl
+++ b/web/src/assets/revision.vertex.glsl
@@ -19,7 +19,7 @@ uniform highp usampler2D u_highlightBitset;
 out vec2 uv;                // UV coordinates for the quad (0.0 to 1.0).
 out vec2 revisionScreenSize; // The dimensions of the revision box in pixels.
 flat out RevisionModel revisionModel; // The revision data model passed to fragment shader.
-flat out float leftEdgeTimeMS; // The timestamp at the left edge of the revision in ms (used for stripe patterns).
+flat out float revisionClippedOffsetPx; // The clipped left edge offset of the revision in screen pixels.
 
 // Generates the position of the vertex based on gl_VertexID.
 vec4 genQuadPosition(){
@@ -81,9 +81,10 @@ void main(){
   // 4. Transform the vertex position.
   pos.x = leftEdgeClip + durationClip * (pos.x * 0.5 + 0.5);
   
-  // 5. Pass screen size and time information to fragment shader.
+  // 5. Pass screen size and clipped pixel offset to fragment shader.
   revisionScreenSize = vec2(durationXScreen, targetHeight);
-  leftEdgeTimeMS = float(leftEdgeRelativeTime.x)* 1e+3 + float(leftEdgeRelativeTime.y) * 1e-6;
+  ivec2 clippedDiffTime = ivec2(cappedTime.xy - time.xy);
+  revisionClippedOffsetPx = (float(clippedDiffTime.x) * 1e+3 + float(clippedDiffTime.y) * 1e-6) * vs.pixelsPerMs;
   
   // Z=0.0 is the default depth for revisions.
   gl_Position = pos;

--- a/web/src/assets/revision.vertex.glsl
+++ b/web/src/assets/revision.vertex.glsl
@@ -84,7 +84,8 @@ void main(){
   // 5. Pass screen size and clipped pixel offset to fragment shader.
   revisionScreenSize = vec2(durationXScreen, targetHeight);
   ivec2 clippedDiffTime = ivec2(cappedTime.xy - time.xy);
-  revisionClippedOffsetPx = (float(clippedDiffTime.x) * 1e+3 + float(clippedDiffTime.y) * 1e-6) * vs.pixelsPerMs;
+  float rawOffset = (float(clippedDiffTime.x) * 1e+3 + float(clippedDiffTime.y) * 1e-6) * vs.pixelsPerMs;
+  revisionClippedOffsetPx = mod(rawOffset, rls.borderStripePitch);
   
   // Z=0.0 is the default depth for revisions.
   gl_Position = pos;


### PR DESCRIPTION
## Summary

Fixes a unit inconsistency in revision dashed border rendering where milliseconds (time) were directly added to screen pixels (space).

### Root Cause
In `revision.color-fragment.glsl`, `borderStripePattern` previously computed:
```glsl
float patternVal = leftEdgeTimeMS + posAlongBorder;
float stripeVal = mod(patternVal, pitch);
```
- `leftEdgeTimeMS` was passed from the vertex shader in **milliseconds** (time difference from `vs.leftEdgeTime`).
- `posAlongBorder` was computed in **screen pixels** (`uv * revisionScreenSize`).
- When zooming, `vs.pixelsPerMs` changes, causing the phase offset `leftEdgeTimeMS mod pitch` to spin violently relative to zoom level. This produced severe stroboscopic flickering and moire artifacts across rows.
- Furthermore, on vertical edges, adding horizontal milliseconds to the vertical pixel coordinate caused box corners to misalign or clip.

### Solution
1. **`revision.vertex.glsl`**: Replaced `leftEdgeTimeMS` with `revisionClippedOffsetPx` (screen pixel offset for revisions that start outside the viewport and are clamped by `minTime`). For unclipped revisions, this is `0.0`.
2. **`revision.color-fragment.glsl`**: Replaced `leftEdgeTimeMS + posAlongBorder` with `mix(revisionClippedOffsetPx + revisionRelativeUV.x, revisionRelativeUV.y, isVerticalEdge)`. Dashes now run along pure screen pixel units for both horizontal and vertical edges.
3. **`revision.hittest-fragment.glsl`**: Updated the unused input variable declaration to match the vertex shader output.

## Test Plan
- `npx ng test --include src/app/timeline/components/canvas/glsl-function-tester.spec.ts --browsers ChromeHeadlessNoSandbox --watch=false` (10/10 passed)
- `make test-web` (1088/1088 passed)
- `make pre-commit` (all linters and formatters passed cleanly)