### PR TITLE
perf(khifile): optimize in-memory model via flat structure-of-arrays representation

### DIFF
--- a/pkg/core/inspection/runner.go
+++ b/pkg/core/inspection/runner.go
@@ -19,8 +19,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -130,7 +132,26 @@ func (i *InspectionTaskRunner) addDefaultRunContextOptions() {
 			return id.NewGenerator(), nil
 		}),
 		RunContextOptionFromFunc(inspectioncore_contract.Builder, func(ctx context.Context, mode inspectioncore_contract.InspectionTaskModeType) (*khifilev6.Builder, error) {
-			return khifilev6.NewBuilder(khictx.MustGetValue(ctx, inspectioncore_contract.IDGenerator)), nil
+			var writer *khifilev6.Writer
+			if mode == inspectioncore_contract.TaskModeDryRun {
+				var err error
+				writer, err = khifilev6.NewWriter(io.Discard)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				store := inspectioncore_contract.NewFileSystemInspectionResultRepository(filepath.Join(i.ioconfig.DataDestination, i.ID+".khi"))
+				fileWriter, err := store.GetWriter()
+				if err != nil {
+					return nil, err
+				}
+				writer, err = khifilev6.NewWriter(fileWriter)
+				if err != nil {
+					_ = fileWriter.Close()
+					return nil, err
+				}
+			}
+			return khifilev6.NewBuilder(khictx.MustGetValue(ctx, inspectioncore_contract.IDGenerator), writer), nil
 		}),
 	}
 

--- a/pkg/core/inspection/taskbase/mapper_task.go
+++ b/pkg/core/inspection/taskbase/mapper_task.go
@@ -218,7 +218,7 @@ func NewLogToTimelineMapperTask[T any](tid taskid.TaskImplementationID[TimelineM
 					groupData = nextGroupData
 
 					if cs != nil {
-						err := cs.Flush(builder.TimelineAccumulator)
+						err := cs.Flush(builder.TimelineAccumulator, builder.LogAccumulator)
 						if err != nil {
 							logTaskError(ctx, "failed to flush the changeset to timeline registry", err, l)
 							setErr(err)

--- a/pkg/core/inspection/taskbase/mapper_task_test.go
+++ b/pkg/core/inspection/taskbase/mapper_task_test.go
@@ -245,7 +245,7 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				}
 			}
 
-			pool := khifilev6.NewInternPool(idGen)
+			pool := khifilev6.NewTestInternPool(idGen)
 			pathPool := khifilev6.NewTimelinePathPool(idGen, pool)
 			timelineTypeID := uint32(3)
 			timelineType := &pb.TimelineType{Id: &timelineTypeID}

--- a/pkg/core/inspection/test/testutil.go
+++ b/pkg/core/inspection/test/testutil.go
@@ -61,7 +61,7 @@ func WithDefaultTestInspectionTaskContext(baseContext context.Context) context.C
 	idGen := id.NewGenerator()
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.IDGenerator, idGen)
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.CurrentIOConfig, ioConfig)
-	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.Builder, khifilev6.NewBuilder(idGen))
+	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.Builder, khifilev6.NewTestBuilder(idGen))
 	taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.InspectionRunMetadata, generateTestMetadata())
 	return taskCtx
 }

--- a/pkg/model/khifile/v6/builder.go
+++ b/pkg/model/khifile/v6/builder.go
@@ -16,12 +16,8 @@ package khifilev6
 
 import (
 	"fmt"
-	"io"
-	"iter"
 	"slices"
 
-	khifile "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
-	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
 )
@@ -35,6 +31,7 @@ type BuilderProgressReporter interface {
 // Builder orchestrates the accumulators, pools, and final file generation for KHI v6 format.
 type Builder struct {
 	idGenerator         *id.Generator
+	writer              *Writer
 	internPool          *InternPool
 	serverInternPool    *InternPool
 	TimelineAccumulator *TimelineAccumulator
@@ -43,39 +40,39 @@ type Builder struct {
 }
 
 // NewBuilder initializes a new v6 Builder with all necessary accumulators and pools.
-func NewBuilder(gen *id.Generator) *Builder {
-	internPool := NewInternPool(gen)
-	serverPool := NewServerInternPool(internPool, gen)
-	logAcc := NewLogAccumulator(internPool, serverPool, gen)
+func NewBuilder(gen *id.Generator, writer *Writer) *Builder {
+	internPool := NewInternPool(gen, writer)
+	serverPool := NewServerInternPool(internPool, gen, writer)
+	logAcc := NewLogAccumulator(internPool, serverPool, gen, writer)
 
 	return &Builder{
 		idGenerator:         gen,
+		writer:              writer,
 		internPool:          internPool,
 		serverInternPool:    serverPool,
-		TimelineAccumulator: NewTimelineAccumulator(gen, internPool, serverPool, logAcc),
+		TimelineAccumulator: NewTimelineAccumulator(gen, internPool, serverPool),
 		LogAccumulator:      logAcc,
 		MetadataAccumulator: NewMetadataAccumulator(),
 	}
 }
 
-// Build writes the accumulated data to the provided io.Writer in KHI v6 format.
-func (b *Builder) Build(w io.Writer, reporter BuilderProgressReporter) error {
+// NewTestBuilder creates a Builder for testing purposes with an in-memory test writer.
+func NewTestBuilder(gen *id.Generator) *Builder {
+	return NewBuilder(gen, MustNewTestWriter())
+}
+
+// Build writes the accumulated metadata, timeline chunks, and flushes remaining log and intern pool chunks.
+func (b *Builder) Build(reporter BuilderProgressReporter) error {
 	report := func(progress float32, status string) {
 		if reporter != nil {
 			reporter.ReportProgress(progress, status)
 		}
 	}
 
-	report(0.0, "Initializing KHI writer")
-	writer, err := NewWriter(w)
-	if err != nil {
-		return fmt.Errorf("failed to create writer: %w", err)
-	}
-
 	report(0.1, "Writing timeline style chunk")
 	// 1. Write TimelineStyleChunk directly (no generator needed since it's a single chunk)
 	styleChunk := style.GenerateChunk()
-	if err := writer.WriteChunk(ChunkTypeTimelineStyle, styleChunk); err != nil {
+	if err := b.writer.WriteChunk(ChunkTypeTimelineStyle, styleChunk); err != nil {
 		return fmt.Errorf("failed to write timeline style chunk: %w", err)
 	}
 
@@ -85,20 +82,15 @@ func (b *Builder) Build(w io.Writer, reporter BuilderProgressReporter) error {
 	if len(metadataList) > 0 {
 		metadataGen := NewMetadataGenerator(slices.Values(metadataList))
 		defer metadataGen.Close()
-		if err := writer.WriteGenerator(metadataGen); err != nil {
+		if err := b.writer.WriteGenerator(metadataGen); err != nil {
 			return fmt.Errorf("failed to write metadata chunk: %w", err)
 		}
 	}
 
-	report(0.4, "Writing log chunks")
-	// 3. Write LogChunks
-	logs := b.LogAccumulator.Accumulate()
-	if len(logs) > 0 {
-		logGen := NewLogGenerator(slices.Values(logs))
-		defer logGen.Close()
-		if err := writer.WriteGenerator(logGen); err != nil {
-			return fmt.Errorf("failed to write log chunks: %w", err)
-		}
+	report(0.4, "Flushing log chunks")
+	// 3. Flush remaining LogChunks
+	if err := b.LogAccumulator.Flush(); err != nil {
+		return fmt.Errorf("failed to flush log accumulator: %w", err)
 	}
 
 	report(0.6, "Writing timeline chunks")
@@ -108,7 +100,7 @@ func (b *Builder) Build(w io.Writer, reporter BuilderProgressReporter) error {
 	if len(timelines) > 0 {
 		timelineGen := NewTimelineGenerator(slices.Values(timelines))
 		defer timelineGen.Close()
-		if err := writer.WriteGenerator(timelineGen); err != nil {
+		if err := b.writer.WriteGenerator(timelineGen); err != nil {
 			return fmt.Errorf("failed to write timeline chunks: %w", err)
 		}
 	}
@@ -116,56 +108,25 @@ func (b *Builder) Build(w io.Writer, reporter BuilderProgressReporter) error {
 	if len(timelineItems) > 0 {
 		timelineItemsGen := NewTimelineItemsGenerator(slices.Values(timelineItems))
 		defer timelineItemsGen.Close()
-		if err := writer.WriteGenerator(timelineItemsGen); err != nil {
+		if err := b.writer.WriteGenerator(timelineItemsGen); err != nil {
 			return fmt.Errorf("failed to write timeline items chunks: %w", err)
 		}
 	}
 
-	report(0.8, "Writing intern pool chunks")
-	// 5. Write Client InternPoolChunk (ChunkTypeInternPool = 2)
-	clientStringSeq := mapSeq(b.internPool.SortedStringRefs(), func(ref *InternStringRef) *pb.InternString {
-		return ref.ToProto()
-	})
-	clientStringGen := NewInternPoolGenerator(ChunkTypeInternPool, clientStringSeq)
-	if err := writer.WriteGenerator(clientStringGen); err != nil {
-		return fmt.Errorf("failed to write client intern string chunks: %w", err)
+	report(0.8, "Flushing intern pool chunks")
+	// 5. Flush client and server intern pool chunks
+	if err := b.internPool.Flush(); err != nil {
+		return fmt.Errorf("failed to flush client intern pool: %w", err)
+	}
+	if err := b.serverInternPool.Flush(); err != nil {
+		return fmt.Errorf("failed to flush server intern pool: %w", err)
 	}
 
-	// 6. Write Server InternPoolChunk (ChunkTypeServerInternPool = 6)
-	serverStringSeq := mapSeq(b.serverInternPool.SortedStringRefs(), func(ref *InternStringRef) *pb.InternString {
-		return ref.ToProto()
-	})
-	serverStringGen := NewInternPoolGenerator(ChunkTypeServerInternPool, serverStringSeq)
-	if err := writer.WriteGenerator(serverStringGen); err != nil {
-		return fmt.Errorf("failed to write server intern string chunks: %w", err)
-	}
-
-	fieldSetSeq := mapSeq(b.serverInternPool.FieldSetRefs(), func(ref *FieldPathSetRef) *pb.InternFieldPathSet {
-		return ref.ToProto()
-	})
-	fieldPathSetGen := NewInternFieldPathSetGenerator(ChunkTypeServerInternPool, fieldSetSeq)
-	if err := writer.WriteGenerator(fieldPathSetGen); err != nil {
-		return fmt.Errorf("failed to write server intern field path set chunks: %w", err)
-	}
-
-	structSeq := mapSeq(b.serverInternPool.StructRefs(), func(ref *InternStructRef) *khifile.InternedStruct {
-		return ref.ToProto()
-	})
-	structGen := NewInternStructGenerator(ChunkTypeServerInternPool, structSeq)
-	if err := writer.WriteGenerator(structGen); err != nil {
-		return fmt.Errorf("failed to write server intern struct chunks: %w", err)
+	report(0.95, "Closing writer")
+	if err := b.writer.Close(); err != nil {
+		return fmt.Errorf("failed to close writer: %w", err)
 	}
 
 	report(1.0, "Done")
 	return nil
-}
-
-func mapSeq[T any, U any](seq iter.Seq[T], f func(T) U) iter.Seq[U] {
-	return func(yield func(U) bool) {
-		for v := range seq {
-			if !yield(f(v)) {
-				return
-			}
-		}
-	}
 }

--- a/pkg/model/khifile/v6/builder.go
+++ b/pkg/model/khifile/v6/builder.go
@@ -62,7 +62,13 @@ func NewTestBuilder(gen *id.Generator) *Builder {
 }
 
 // Build writes the accumulated metadata, timeline chunks, and flushes remaining log and intern pool chunks.
-func (b *Builder) Build(reporter BuilderProgressReporter) error {
+func (b *Builder) Build(reporter BuilderProgressReporter) (err error) {
+	defer func() {
+		if closeErr := b.writer.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("failed to close writer: %w", closeErr)
+		}
+	}()
+
 	report := func(progress float32, status string) {
 		if reporter != nil {
 			reporter.ReportProgress(progress, status)
@@ -120,11 +126,6 @@ func (b *Builder) Build(reporter BuilderProgressReporter) error {
 	}
 	if err := b.serverInternPool.Flush(); err != nil {
 		return fmt.Errorf("failed to flush server intern pool: %w", err)
-	}
-
-	report(0.95, "Closing writer")
-	if err := b.writer.Close(); err != nil {
-		return fmt.Errorf("failed to close writer: %w", err)
 	}
 
 	report(1.0, "Done")

--- a/pkg/model/khifile/v6/builder_test.go
+++ b/pkg/model/khifile/v6/builder_test.go
@@ -115,8 +115,6 @@ func TestBuilder_Build(t *testing.T) {
 					ChunkTypeTimeline,
 					ChunkTypeInternPool,
 					ChunkTypeServerInternPool,
-					ChunkTypeServerInternPool,
-					ChunkTypeServerInternPool,
 				}
 
 				var gotTypes []ChunkType
@@ -227,8 +225,29 @@ func TestBuilder_Build(t *testing.T) {
 								}
 							}
 							if !foundSummary {
-								t.Error("Expected 'hello summary' to be interned in InternPool.")
+								t.Error("Expected 'hello summary' to be interned in client InternPool.")
 							}
+						}
+
+					case ChunkTypeServerInternPool:
+						var internPool pb.InterningPoolChunk
+						if err := proto.Unmarshal(c.Data, &internPool); err != nil {
+							t.Fatalf("Failed to unmarshal server intern pool chunk: %v.", err)
+						}
+						if len(internPool.Strings) > 0 {
+							foundLogMsg := false
+							for _, s := range internPool.Strings {
+								if s.GetValue() == "hello log" {
+									foundLogMsg = true
+									break
+								}
+							}
+							if !foundLogMsg {
+								t.Error("Expected 'hello log' to be interned in server InternPool.")
+							}
+						}
+						if len(internPool.Structs) == 0 {
+							t.Error("Expected interned structs in server InternPool.")
 						}
 					}
 				}
@@ -239,11 +258,15 @@ func TestBuilder_Build(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			gen := id.NewGenerator()
-			b := NewBuilder(gen)
+			var buf bytes.Buffer
+			writer, err := NewWriter(&buf)
+			if err != nil {
+				t.Fatalf("NewWriter() failed: %v.", err)
+			}
+			b := NewBuilder(gen, writer)
 			tc.setup(gen, b)
 
-			var buf bytes.Buffer
-			if err := b.Build(&buf, nil); err != nil {
+			if err := b.Build(nil); err != nil {
 				t.Fatalf("Build() failed: %v.", err)
 			}
 

--- a/pkg/model/khifile/v6/changeset.go
+++ b/pkg/model/khifile/v6/changeset.go
@@ -149,11 +149,10 @@ func (cs *TimelineChangeSet) AddAlias(aliasPath, targetPath *TimelinePath) {
 }
 
 // Flush converts staging events, revisions, and aliases to serialized types and writes them to the TimelineAccumulator.
-func (cs *TimelineChangeSet) Flush(accumulator *TimelineAccumulator) error {
+func (cs *TimelineChangeSet) Flush(accumulator *TimelineAccumulator, logAcc *LogAccumulator) error {
 	registry := accumulator.registry
 	clientPool := registry.clientPool
 	serverPool := registry.serverPool
-	logAcc := registry.logAcc
 
 	resolvedLogID, ok := logAcc.ResolveLogID(cs.Log.ID)
 	if !ok {

--- a/pkg/model/khifile/v6/changeset_test.go
+++ b/pkg/model/khifile/v6/changeset_test.go
@@ -28,9 +28,9 @@ import (
 
 func TestLogChangeSet_Flush(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := khifilev6.NewInternPool(idGen)
-	serverPool := khifilev6.NewServerInternPool(pool, idGen)
-	logAcc := khifilev6.NewLogAccumulator(pool, serverPool, idGen)
+	pool := khifilev6.NewTestInternPool(idGen)
+	serverPool := khifilev6.NewTestServerInternPool(pool, idGen)
+	logAcc := khifilev6.NewTestLogAccumulator(pool, serverPool, idGen)
 
 	node := structured.NewStandardMap(nil, nil)
 	l := log.NewLog(idGen, structured.NewNodeReader(node))
@@ -73,10 +73,10 @@ func TestLogChangeSet_Flush(t *testing.T) {
 
 func TestTimelineChangeSet_Flush(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := khifilev6.NewInternPool(idGen)
-	serverPool := khifilev6.NewServerInternPool(pool, idGen)
-	logAcc := khifilev6.NewLogAccumulator(pool, serverPool, idGen)
-	accumulator := khifilev6.NewTimelineAccumulator(idGen, pool, serverPool, logAcc)
+	pool := khifilev6.NewTestInternPool(idGen)
+	serverPool := khifilev6.NewTestServerInternPool(pool, idGen)
+	logAcc := khifilev6.NewTestLogAccumulator(pool, serverPool, idGen)
+	accumulator := khifilev6.NewTimelineAccumulator(idGen, pool, serverPool)
 
 	node := structured.NewStandardMap(nil, nil)
 	l := log.NewLog(idGen, structured.NewNodeReader(node))
@@ -122,7 +122,7 @@ func TestTimelineChangeSet_Flush(t *testing.T) {
 		HasRevision(path, stagingRev)
 
 	// Flush to accumulator.
-	if err := cs.Flush(accumulator); err != nil {
+	if err := cs.Flush(accumulator, logAcc); err != nil {
 		t.Fatalf("Flush() returned unexpected error: %v", err)
 	}
 

--- a/pkg/model/khifile/v6/container.go
+++ b/pkg/model/khifile/v6/container.go
@@ -49,8 +49,10 @@ const (
 )
 
 // Writer writes chunks to a KHI v6 file.
+// It is safe for concurrent use by multiple goroutines.
 type Writer struct {
-	w io.Writer
+	w  io.Writer
+	mu sync.Mutex
 }
 
 // NewWriter creates a new Writer and writes the magic bytes and version.
@@ -62,46 +64,82 @@ func NewWriter(w io.Writer) (*Writer, error) {
 	return &Writer{w: w}, nil
 }
 
-// WriteChunk serializes the given protobuf message, gzips it, and writes the chunk header and payload.
-func (w *Writer) WriteChunk(chunkType ChunkType, message proto.Message) error {
-	// 1. Serialize proto message
+// MustNewTestWriter creates a new Writer writing to an in-memory bytes.Buffer for testing purposes.
+func MustNewTestWriter() *Writer {
+	var buf bytes.Buffer
+	w, err := NewWriter(&buf)
+	if err != nil {
+		panic(err)
+	}
+	return w
+}
+
+// Close closes the underlying writer if it implements io.Closer.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if closer, ok := w.w.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+// CompressChunk serializes and gzip-compresses the given protobuf message into a RawChunk.
+func CompressChunk(chunkType ChunkType, message proto.Message) (*RawChunk, error) {
 	b, err := proto.Marshal(message)
 	if err != nil {
-		return fmt.Errorf("failed to marshal proto message: %w", err)
+		return nil, fmt.Errorf("failed to marshal proto message: %w", err)
 	}
 
-	// 2. Compress payload with gzip
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	if _, err := gw.Write(b); err != nil {
-		return fmt.Errorf("failed to compress payload: %w", err)
+		return nil, fmt.Errorf("failed to compress payload: %w", err)
 	}
 	if err := gw.Close(); err != nil {
-		return fmt.Errorf("failed to close gzip writer: %w", err)
+		return nil, fmt.Errorf("failed to close gzip writer: %w", err)
 	}
 
 	payload := buf.Bytes()
 	const maxChunkSize = 64 * 1024 * 1024 // 64MB hard limit based on Protobuf constraints
 	if len(payload) > maxChunkSize {
-		return fmt.Errorf("payload size %d exceeds maximum allowed chunk size (64MB)", len(payload))
+		return nil, fmt.Errorf("payload size %d exceeds maximum allowed chunk size (64MB)", len(payload))
 	}
-	size := uint32(len(payload))
 
-	// 3. Write chunk header (Size, Type)
+	return &RawChunk{
+		Type: chunkType,
+		Data: payload,
+	}, nil
+}
+
+// WriteRawChunk writes a pre-compressed chunk header and payload directly to the underlying writer.
+func (w *Writer) WriteRawChunk(chunk *RawChunk) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	size := uint32(len(chunk.Data))
 	var header [8]byte
 	binary.LittleEndian.PutUint32(header[0:4], size)
-	binary.LittleEndian.PutUint32(header[4:8], uint32(chunkType))
+	binary.LittleEndian.PutUint32(header[4:8], uint32(chunk.Type))
 
 	if _, err := w.w.Write(header[:]); err != nil {
 		return fmt.Errorf("failed to write chunk header: %w", err)
 	}
 
-	// 4. Write payload
-	if _, err := w.w.Write(payload); err != nil {
+	if _, err := w.w.Write(chunk.Data); err != nil {
 		return fmt.Errorf("failed to write chunk payload: %w", err)
 	}
 
 	return nil
+}
+
+// WriteChunk serializes the given protobuf message, gzips it, and writes the chunk header and payload.
+func (w *Writer) WriteChunk(chunkType ChunkType, message proto.Message) error {
+	rawChunk, err := CompressChunk(chunkType, message)
+	if err != nil {
+		return err
+	}
+	return w.WriteRawChunk(rawChunk)
 }
 
 // WriteGenerator consumes the ChunkGenerator and writes all generated chunks sequentially.

--- a/pkg/model/khifile/v6/direct_yaml_test.go
+++ b/pkg/model/khifile/v6/direct_yaml_test.go
@@ -232,7 +232,7 @@ protoPayload:
 			}
 
 			idGen := id.NewGenerator()
-			pool := NewInternPool(idGen)
+			pool := NewTestInternPool(idGen)
 
 			internedRef, err := ToInternedStruct(node, pool)
 			if err != nil {
@@ -370,7 +370,7 @@ spec:
 	}
 
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 	internedRef, err := ToInternedStruct(node, pool)
 	if err != nil {
 		b.Fatalf("ToInternedStruct() error = %v", err)

--- a/pkg/model/khifile/v6/flat_struct.go
+++ b/pkg/model/khifile/v6/flat_struct.go
@@ -15,9 +15,12 @@
 package khifilev6
 
 import (
+	"fmt"
 	"math"
 	"sync"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -132,6 +135,157 @@ func (s *FlatStructStore) Store(id uint32, fieldPathSetID uint32, values []*pb.I
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.storeLocked(id, fieldPathSetID, values)
+}
+
+// StoreFromNodes encodes and saves an interned struct directly from a slice of structured nodes.
+// It bypasses intermediate Protobuf value allocations to minimize heap churn during ingestion.
+func (s *FlatStructStore) StoreFromNodes(id uint32, fieldPathSetID uint32, nodes []structured.Node, pool *InternPool) error {
+	// Pre-intern any nested maps before acquiring the store lock to prevent self-deadlock on s.mu.
+	for _, n := range nodes {
+		if err := ensureNestedMapsInterned(n, pool); err != nil {
+			return err
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ensureStructCapacity(id)
+	if !s.structPresent[id] {
+		s.structPresent[id] = true
+		s.count++
+	}
+
+	s.structFieldPathSetIDs[id] = fieldPathSetID
+	valCount := uint32(len(nodes))
+	s.structValueCounts[id] = valCount
+
+	if valCount == 0 {
+		s.structValueOffsets[id] = 0
+		return nil
+	}
+
+	startOffset := s.reserveSlots(valCount)
+	s.structValueOffsets[id] = startOffset
+
+	for i, n := range nodes {
+		slot := startOffset + uint32(i)
+		if err := s.encodeNodeAt(slot, n, pool); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureNestedMapsInterned eagerly interns child map nodes before acquiring the store lock.
+// This prevents self-deadlock on s.mu when recursively interning nested structures.
+func ensureNestedMapsInterned(node structured.Node, pool *InternPool) error {
+	if node == nil {
+		return nil
+	}
+	switch node.Type() {
+	case structured.MapNodeType:
+		_, err := ToInternedStruct(node, pool)
+		return err
+	case structured.SequenceNodeType:
+		for _, child := range node.Children() {
+			if err := ensureNestedMapsInterned(child, pool); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// encodeNodeAt packs a single structured.Node into the target slot within the SoA arrays.
+// It translates leaf values directly to primitive representations without allocating heap wrappers.
+func (s *FlatStructStore) encodeNodeAt(slot uint32, node structured.Node, pool *InternPool) error {
+	if node == nil {
+		s.valueKinds[slot] = uint8(FlatValueKindNull)
+		s.valueData[slot] = 0
+		s.valueAux[slot] = 0
+		return nil
+	}
+
+	switch node.Type() {
+	case structured.ScalarNodeType:
+		val, err := node.NodeScalarValue()
+		if err != nil {
+			return err
+		}
+		if val == nil {
+			s.valueKinds[slot] = uint8(FlatValueKindNull)
+			s.valueData[slot] = 0
+			s.valueAux[slot] = 0
+			return nil
+		}
+		switch v := val.(type) {
+		case bool:
+			s.valueKinds[slot] = uint8(FlatValueKindBool)
+			if v {
+				s.valueData[slot] = 1
+			} else {
+				s.valueData[slot] = 0
+			}
+			s.valueAux[slot] = 0
+		case int:
+			s.valueKinds[slot] = uint8(FlatValueKindInt64)
+			s.valueData[slot] = uint64(int64(v))
+			s.valueAux[slot] = 0
+		case float64:
+			s.valueKinds[slot] = uint8(FlatValueKindDouble)
+			s.valueData[slot] = math.Float64bits(v)
+			s.valueAux[slot] = 0
+		case string:
+			strRef := pool.InternString(v)
+			s.valueKinds[slot] = uint8(FlatValueKindStringID)
+			s.valueData[slot] = uint64(strRef.id)
+			s.valueAux[slot] = 0
+		case time.Time:
+			s.valueKinds[slot] = uint8(FlatValueKindTimestamp)
+			s.valueData[slot] = uint64(v.Unix())
+			s.valueAux[slot] = uint32(v.Nanosecond())
+		default:
+			return fmt.Errorf("unsupported scalar type: %T", v)
+		}
+		return nil
+
+	case structured.SequenceNodeType:
+		listCount := uint32(node.Len())
+		s.valueKinds[slot] = uint8(FlatValueKindList)
+		s.valueAux[slot] = listCount
+
+		if listCount == 0 {
+			s.valueData[slot] = 0
+			return nil
+		}
+
+		listOffset := s.reserveSlots(listCount)
+		s.valueData[slot] = uint64(listOffset)
+
+		idx := uint32(0)
+		for _, child := range node.Children() {
+			itemSlot := listOffset + idx
+			idx++
+			if err := s.encodeNodeAt(itemSlot, child, pool); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case structured.MapNodeType:
+		sRef, err := ToInternedStruct(node, pool)
+		if err != nil {
+			return err
+		}
+		s.valueKinds[slot] = uint8(FlatValueKindStructID)
+		s.valueData[slot] = uint64(sRef.id)
+		s.valueAux[slot] = 0
+		return nil
+
+	default:
+		return fmt.Errorf("unknown node type: %v", node.Type())
+	}
 }
 
 func (s *FlatStructStore) storeLocked(id uint32, fieldPathSetID uint32, values []*pb.InternedValue) {

--- a/pkg/model/khifile/v6/flat_struct_test.go
+++ b/pkg/model/khifile/v6/flat_struct_test.go
@@ -16,8 +16,11 @@ package khifilev6
 
 import (
 	"testing"
+	"time"
 
+	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -336,6 +339,188 @@ func TestFlatStructStore_NestedStructWithID(t *testing.T) {
 			gotChild := store.ResolveStruct(*tc.wantChild.Id)
 			if diff := cmp.Diff(tc.wantChild, gotChild, protocmp.Transform()); diff != "" {
 				t.Errorf("ResolveStruct(%d) child mismatch (-want +got):\n%s", *tc.wantChild.Id, diff)
+			}
+		})
+	}
+}
+
+func TestFlatStructStore_StoreFromNodes(t *testing.T) {
+	testTime := time.Date(2026, 4, 20, 3, 0, 0, 500000, time.UTC)
+
+	testCases := []struct {
+		name       string
+		id         uint32
+		fsID       uint32
+		nodes      func(pool *InternPool) []structured.Node
+		wantStruct func(pool *InternPool) *pb.InternedStruct
+	}{
+		{
+			name: "all scalar node types",
+			id:   1,
+			fsID: 10,
+			nodes: func(pool *InternPool) []structured.Node {
+				return []structured.Node{
+					structured.NewStandardScalarNode[any](nil),
+					structured.NewStandardScalarNode(true),
+					structured.NewStandardScalarNode(false),
+					structured.NewStandardScalarNode(12345),
+					structured.NewStandardScalarNode(3.14159),
+					structured.NewStandardScalarNode("hello world"),
+					structured.NewStandardScalarNode(testTime),
+				}
+			},
+			wantStruct: func(pool *InternPool) *pb.InternedStruct {
+				return &pb.InternedStruct{
+					Id:             proto.Uint32(1),
+					FieldPathSetId: proto.Uint32(10),
+					Values: []*pb.InternedValue{
+						{Kind: &pb.InternedValue_NullValue{NullValue: structpb.NullValue_NULL_VALUE}},
+						{Kind: &pb.InternedValue_BoolValue{BoolValue: true}},
+						{Kind: &pb.InternedValue_BoolValue{BoolValue: false}},
+						{Kind: &pb.InternedValue_Int64Value{Int64Value: 12345}},
+						{Kind: &pb.InternedValue_DoubleValue{DoubleValue: 3.14159}},
+						{Kind: &pb.InternedValue_StringValue{StringValue: pool.InternString("hello world").id}},
+						{
+							Kind: &pb.InternedValue_TimestampValue{
+								TimestampValue: &timestamppb.Timestamp{
+									Seconds: testTime.Unix(),
+									Nanos:   int32(testTime.Nanosecond()),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "nested sequence node with mixed values",
+			id:   2,
+			fsID: 20,
+			nodes: func(pool *InternPool) []structured.Node {
+				return []structured.Node{
+					structured.NewStandardSequenceNode([]structured.Node{
+						structured.NewStandardScalarNode(100),
+						structured.NewStandardScalarNode("item"),
+						structured.NewStandardScalarNode[any](nil),
+					}),
+				}
+			},
+			wantStruct: func(pool *InternPool) *pb.InternedStruct {
+				return &pb.InternedStruct{
+					Id:             proto.Uint32(2),
+					FieldPathSetId: proto.Uint32(20),
+					Values: []*pb.InternedValue{
+						{
+							Kind: &pb.InternedValue_ListValue{
+								ListValue: &pb.InternedListValue{
+									Values: []*pb.InternedValue{
+										{Kind: &pb.InternedValue_Int64Value{Int64Value: 100}},
+										{Kind: &pb.InternedValue_StringValue{StringValue: pool.InternString("item").id}},
+										{Kind: &pb.InternedValue_NullValue{NullValue: structpb.NullValue_NULL_VALUE}},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "sequence containing nested map without deadlock",
+			id:   3,
+			fsID: 30,
+			nodes: func(pool *InternPool) []structured.Node {
+				childMap := structured.NewStandardMap(
+					[]string{"val"},
+					[]structured.Node{structured.NewStandardScalarNode(999)},
+				)
+				return []structured.Node{
+					structured.NewStandardSequenceNode([]structured.Node{
+						childMap,
+					}),
+				}
+			},
+			wantStruct: func(pool *InternPool) *pb.InternedStruct {
+				childMap := structured.NewStandardMap(
+					[]string{"val"},
+					[]structured.Node{structured.NewStandardScalarNode(999)},
+				)
+				childRef, _ := ToInternedStruct(childMap, pool)
+				return &pb.InternedStruct{
+					Id:             proto.Uint32(3),
+					FieldPathSetId: proto.Uint32(30),
+					Values: []*pb.InternedValue{
+						{
+							Kind: &pb.InternedValue_ListValue{
+								ListValue: &pb.InternedListValue{
+									Values: []*pb.InternedValue{
+										{Kind: &pb.InternedValue_StructId{StructId: childRef.id}},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "empty map node",
+			id:   4,
+			fsID: 40,
+			nodes: func(pool *InternPool) []structured.Node {
+				emptyMap := structured.NewStandardMap(nil, nil)
+				return []structured.Node{
+					emptyMap,
+				}
+			},
+			wantStruct: func(pool *InternPool) *pb.InternedStruct {
+				emptyMap := structured.NewStandardMap(nil, nil)
+				childRef, _ := ToInternedStruct(emptyMap, pool)
+				return &pb.InternedStruct{
+					Id:             proto.Uint32(4),
+					FieldPathSetId: proto.Uint32(40),
+					Values: []*pb.InternedValue{
+						{Kind: &pb.InternedValue_StructId{StructId: childRef.id}},
+					},
+				}
+			},
+		},
+		{
+			name: "empty struct without nodes",
+			id:   5,
+			fsID: 50,
+			nodes: func(pool *InternPool) []structured.Node {
+				return nil
+			},
+			wantStruct: func(pool *InternPool) *pb.InternedStruct {
+				return &pb.InternedStruct{
+					Id:             proto.Uint32(5),
+					FieldPathSetId: proto.Uint32(50),
+					Values:         []*pb.InternedValue{},
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			idGen := id.NewGenerator()
+			pool := NewTestInternPool(idGen)
+			store := NewFlatStructStore()
+
+			nodes := tc.nodes(pool)
+			if err := store.StoreFromNodes(tc.id, tc.fsID, nodes, pool); err != nil {
+				t.Fatalf("StoreFromNodes() unexpected error: %v", err)
+			}
+
+			if !store.Has(tc.id) {
+				t.Fatalf("store.Has(%d) = false, want true", tc.id)
+			}
+
+			got := store.ResolveStruct(tc.id)
+			want := tc.wantStruct(pool)
+			if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("ResolveStruct(%d) mismatch (-want +got):\n%s", tc.id, diff)
 			}
 		})
 	}

--- a/pkg/model/khifile/v6/generator.go
+++ b/pkg/model/khifile/v6/generator.go
@@ -20,7 +20,6 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	khifile "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 )
 
@@ -131,42 +130,6 @@ func (g *splittingGenerator[T, C]) Close() error {
 
 // splittingGenerator implements ChunkGenerator
 var _ ChunkGenerator = (*splittingGenerator[proto.Message, proto.Message])(nil)
-
-// NewInternPoolGenerator creates a SplittingGenerator for InternPool chunks.
-// It groups pb.InternString messages into pb.InterningPoolChunk respecting the size limit.
-func NewInternPoolGenerator(chunkType ChunkType, seq iter.Seq[*pb.InternString]) ChunkGenerator {
-	wrapper := func(batch []*pb.InternString) *pb.InterningPoolChunk {
-		return &pb.InterningPoolChunk{Strings: batch}
-	}
-	return NewSplittingGenerator(chunkType, seq, DefaultChunkSizeLimit, wrapper)
-}
-
-// NewInternFieldPathSetGenerator creates a SplittingGenerator for InternPool chunks containing field path sets.
-// It groups pb.InternFieldPathSet messages into pb.InterningPoolChunk respecting the size limit.
-func NewInternFieldPathSetGenerator(chunkType ChunkType, seq iter.Seq[*pb.InternFieldPathSet]) ChunkGenerator {
-	wrapper := func(batch []*pb.InternFieldPathSet) *pb.InterningPoolChunk {
-		return &pb.InterningPoolChunk{FieldPathSets: batch}
-	}
-	return NewSplittingGenerator(chunkType, seq, DefaultChunkSizeLimit, wrapper)
-}
-
-// NewInternStructGenerator creates a SplittingGenerator for InternPool chunks containing structs.
-// It groups khifile.InternedStruct messages into pb.InterningPoolChunk respecting the size limit.
-func NewInternStructGenerator(chunkType ChunkType, seq iter.Seq[*khifile.InternedStruct]) ChunkGenerator {
-	wrapper := func(batch []*khifile.InternedStruct) *pb.InterningPoolChunk {
-		return &pb.InterningPoolChunk{Structs: batch}
-	}
-	return NewSplittingGenerator(chunkType, seq, DefaultChunkSizeLimit, wrapper)
-}
-
-// NewLogGenerator creates a SplittingGenerator for Log chunks.
-// It groups pb.Log messages into pb.LogChunk respecting the size limit.
-func NewLogGenerator(seq iter.Seq[*pb.Log]) ChunkGenerator {
-	wrapper := func(batch []*pb.Log) *pb.LogChunk {
-		return &pb.LogChunk{Logs: batch}
-	}
-	return NewSplittingGenerator(ChunkTypeLog, seq, DefaultChunkSizeLimit, wrapper)
-}
 
 // NewTimelineGenerator creates a SplittingGenerator for Timeline chunks.
 // It groups pb.Timeline messages into pb.TimelineChunk respecting the size limit.

--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -15,6 +15,7 @@
 package khifilev6
 
 import (
+	"cmp"
 	"encoding/binary"
 	"fmt"
 	"iter"
@@ -481,6 +482,20 @@ func (p *InternPool) flushLocked() error {
 	if len(p.unflushedStrings) == 0 && len(p.unflushedFieldSets) == 0 && len(p.unflushedStructs) == 0 {
 		return nil
 	}
+
+	// Sort items inside the chunk before flushing to optimize gzip compression.
+	slices.SortFunc(p.unflushedStrings, func(a, b *pbv6.InternString) int {
+		return strings.Compare(a.GetValue(), b.GetValue())
+	})
+	slices.SortFunc(p.unflushedFieldSets, func(a, b *pbv6.InternFieldPathSet) int {
+		return cmp.Compare(a.GetId(), b.GetId())
+	})
+	slices.SortFunc(p.unflushedStructs, func(a, b *pb.InternedStruct) int {
+		if diff := cmp.Compare(a.GetFieldPathSetId(), b.GetFieldPathSetId()); diff != 0 {
+			return diff
+		}
+		return cmp.Compare(a.GetId(), b.GetId())
+	})
 
 	chunk := &pbv6.InterningPoolChunk{
 		Strings:       p.unflushedStrings,

--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -26,8 +26,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"google.golang.org/protobuf/proto"
-
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
 	pbv6 "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
@@ -112,6 +110,19 @@ func (r *InternStructRef) ToProto() *pb.InternedStruct {
 }
 
 // InternPool manages interning of strings, field path sets, and structs to reduce memory usage.
+// stagedString holds an unflushed interned string as a flat value to avoid protobuf pointer allocations.
+type stagedString struct {
+	id    uint32
+	value string
+}
+
+// stagedFieldSet holds an unflushed interned field path set as a flat value to avoid protobuf pointer allocations.
+type stagedFieldSet struct {
+	id                 uint32
+	fieldPathStringIDs []uint32
+}
+
+// InternPool manages interning for strings, field paths, and structs in KHI v6.
 // It uses sync.Map for forward key deduplication and slice-based index resolution for ID lookup.
 // Newly interned elements are staged and flushed to the writer in chunks when reaching chunkSizeLimit.
 type InternPool struct {
@@ -120,6 +131,7 @@ type InternPool struct {
 	idNs       id.Namespace
 	writer     *Writer
 	chunkType  ChunkType
+	err        error
 
 	strToID      sync.Map // map[string]uint32
 	fieldSetToID sync.Map // map[string]uint32 (key is byte representation of []uint32)
@@ -136,8 +148,8 @@ type InternPool struct {
 	flushMu            sync.Mutex
 	chunkSizeLimit     int
 	currentBatchSize   int
-	unflushedStrings   []*pbv6.InternString
-	unflushedFieldSets []*pbv6.InternFieldPathSet
+	unflushedStrings   []stagedString
+	unflushedFieldSets []stagedFieldSet
 	unflushedStructIDs []uint32
 }
 
@@ -176,38 +188,6 @@ func NewServerInternPool(parent *InternPool, idGen *id.Generator, writer *Writer
 // NewTestServerInternPool creates a server InternPool with MustNewTestWriter for testing purposes.
 func NewTestServerInternPool(parent *InternPool, idGen *id.Generator) *InternPool {
 	return NewServerInternPool(parent, idGen, MustNewTestWriter())
-}
-
-// NewInternPoolFromChunk creates an InternPool pre-populated with entries from an InterningPoolChunk.
-func NewInternPoolFromChunk(chunk *pbv6.InterningPoolChunk) *InternPool {
-	pool := NewInternPool(nil, MustNewTestWriter())
-	pool.IngestChunk(chunk)
-	return pool
-}
-
-// IngestChunk adds all strings, field path sets, and structs from an InterningPoolChunk into the pool.
-func (p *InternPool) IngestChunk(chunk *pbv6.InterningPoolChunk) {
-	if chunk == nil {
-		return
-	}
-	for _, str := range chunk.Strings {
-		if str.Id != nil && str.Value != nil {
-			p.storeString(*str.Id, *str.Value)
-			p.strToID.Store(*str.Value, *str.Id)
-		}
-	}
-	for _, fs := range chunk.FieldPathSets {
-		if fs.Id != nil {
-			p.storeFieldSet(*fs.Id, fs.FieldPathStringIds)
-			p.fieldSetToID.Store(fieldSetKey(fs.FieldPathStringIds), *fs.Id)
-		}
-	}
-	p.flatStructs.StoreProtoBatch(chunk.Structs)
-	for _, s := range chunk.Structs {
-		if s.Id != nil && s.FieldPathSetId != nil {
-			p.structToID.Store(structKey(*s.FieldPathSetId, s.Values), *s.Id)
-		}
-	}
 }
 
 func (p *InternPool) strIndex(idVal uint32) int {
@@ -400,16 +380,16 @@ func (p *InternPool) internStructWithKey(fieldPathSetID uint32, values []*pb.Int
 }
 
 func (p *InternPool) stageString(idVal uint32, val string) {
-	item := &pbv6.InternString{
-		Id:    &idVal,
-		Value: &val,
-	}
-	itemSize := proto.Size(item) + 8
+	// Approximate Protobuf encoded size: tag + varint(id) + tag + varint(len) + len(val) + chunk framing.
+	itemSize := len(val) + 16
 
 	p.flushMu.Lock()
 	defer p.flushMu.Unlock()
 
-	p.unflushedStrings = append(p.unflushedStrings, item)
+	p.unflushedStrings = append(p.unflushedStrings, stagedString{
+		id:    idVal,
+		value: val,
+	})
 	p.currentBatchSize += itemSize
 
 	if p.currentBatchSize >= p.chunkSizeLimit {
@@ -418,16 +398,16 @@ func (p *InternPool) stageString(idVal uint32, val string) {
 }
 
 func (p *InternPool) stageFieldSet(idVal uint32, ids []uint32) {
-	item := &pbv6.InternFieldPathSet{
-		Id:                 &idVal,
-		FieldPathStringIds: ids,
-	}
-	itemSize := proto.Size(item) + 8
+	// Approximate Protobuf encoded size: tag + varint(id) + tag + varint(len) + repeated varints + chunk framing.
+	itemSize := 16 + len(ids)*4
 
 	p.flushMu.Lock()
 	defer p.flushMu.Unlock()
 
-	p.unflushedFieldSets = append(p.unflushedFieldSets, item)
+	p.unflushedFieldSets = append(p.unflushedFieldSets, stagedFieldSet{
+		id:                 idVal,
+		fieldPathStringIDs: ids,
+	})
 	p.currentBatchSize += itemSize
 
 	if p.currentBatchSize >= p.chunkSizeLimit {
@@ -461,21 +441,46 @@ func (p *InternPool) SetChunkSizeLimit(limit int) {
 func (p *InternPool) Flush() error {
 	p.flushMu.Lock()
 	defer p.flushMu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
 	return p.flushLocked()
 }
 
 func (p *InternPool) flushLocked() error {
+	if p.err != nil {
+		return p.err
+	}
 	if len(p.unflushedStrings) == 0 && len(p.unflushedFieldSets) == 0 && len(p.unflushedStructIDs) == 0 {
 		return nil
 	}
 
 	// Sort items inside the chunk before flushing to optimize gzip compression.
-	slices.SortFunc(p.unflushedStrings, func(a, b *pbv6.InternString) int {
-		return strings.Compare(a.GetValue(), b.GetValue())
+	slices.SortFunc(p.unflushedStrings, func(a, b stagedString) int {
+		return strings.Compare(a.value, b.value)
 	})
-	slices.SortFunc(p.unflushedFieldSets, func(a, b *pbv6.InternFieldPathSet) int {
-		return cmp.Compare(a.GetId(), b.GetId())
+	slices.SortFunc(p.unflushedFieldSets, func(a, b stagedFieldSet) int {
+		return cmp.Compare(a.id, b.id)
 	})
+
+	pbStrings := make([]*pbv6.InternString, len(p.unflushedStrings))
+	for i := range p.unflushedStrings {
+		id := p.unflushedStrings[i].id
+		val := p.unflushedStrings[i].value
+		pbStrings[i] = &pbv6.InternString{
+			Id:    &id,
+			Value: &val,
+		}
+	}
+
+	pbFieldSets := make([]*pbv6.InternFieldPathSet, len(p.unflushedFieldSets))
+	for i := range p.unflushedFieldSets {
+		id := p.unflushedFieldSets[i].id
+		pbFieldSets[i] = &pbv6.InternFieldPathSet{
+			Id:                 &id,
+			FieldPathStringIds: p.unflushedFieldSets[i].fieldPathStringIDs,
+		}
+	}
 
 	structs := make([]*pb.InternedStruct, 0, len(p.unflushedStructIDs))
 	for _, sID := range p.unflushedStructIDs {
@@ -491,23 +496,25 @@ func (p *InternPool) flushLocked() error {
 	})
 
 	chunk := &pbv6.InterningPoolChunk{
-		Strings:       p.unflushedStrings,
-		FieldPathSets: p.unflushedFieldSets,
+		Strings:       pbStrings,
+		FieldPathSets: pbFieldSets,
 		Structs:       structs,
 	}
 
-	p.unflushedStrings = nil
-	p.unflushedFieldSets = nil
-	p.unflushedStructIDs = nil
+	p.unflushedStrings = p.unflushedStrings[:0]
+	p.unflushedFieldSets = p.unflushedFieldSets[:0]
+	p.unflushedStructIDs = p.unflushedStructIDs[:0]
 	p.currentBatchSize = 0
 
 	rawChunk, err := CompressChunk(p.chunkType, chunk)
 	if err != nil {
-		return fmt.Errorf("failed to compress intern pool chunk: %w", err)
+		p.err = fmt.Errorf("failed to compress intern pool chunk: %w", err)
+		return p.err
 	}
 
 	if err := p.writer.WriteRawChunk(rawChunk); err != nil {
-		return fmt.Errorf("failed to write intern pool raw chunk: %w", err)
+		p.err = fmt.Errorf("failed to write intern pool raw chunk: %w", err)
+		return p.err
 	}
 
 	return nil

--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -16,6 +16,7 @@ package khifilev6
 
 import (
 	"encoding/binary"
+	"fmt"
 	"iter"
 	"math"
 	"slices"
@@ -23,6 +24,8 @@ import (
 	"strings"
 	"sync"
 	"unsafe"
+
+	"google.golang.org/protobuf/proto"
 
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
 	pbv6 "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
@@ -109,10 +112,13 @@ func (r *InternStructRef) ToProto() *pb.InternedStruct {
 
 // InternPool manages interning of strings, field path sets, and structs to reduce memory usage.
 // It uses sync.Map for forward key deduplication and slice-based index resolution for ID lookup.
+// Newly interned elements are staged and flushed to the writer in chunks when reaching chunkSizeLimit.
 type InternPool struct {
 	parentPool *InternPool
 	idGen      *id.Generator
 	idNs       id.Namespace
+	writer     *Writer
+	chunkType  ChunkType
 
 	strToID      sync.Map // map[string]uint32
 	fieldSetToID sync.Map // map[string]uint32 (key is byte representation of []uint32)
@@ -126,30 +132,53 @@ type InternPool struct {
 
 	idToStructMu sync.RWMutex
 	idToStruct   []*pb.InternedStruct
+
+	flushMu            sync.Mutex
+	chunkSizeLimit     int
+	currentBatchSize   int
+	unflushedStrings   []*pbv6.InternString
+	unflushedFieldSets []*pbv6.InternFieldPathSet
+	unflushedStructs   []*pb.InternedStruct
 }
 
 var _ ReadonlyPool = (*InternPool)(nil)
 
-// NewInternPool creates a new InternPool with the given IDGenerator.
-func NewInternPool(idGen *id.Generator) *InternPool {
+// NewInternPool creates a new client InternPool with the given IDGenerator and Writer.
+func NewInternPool(idGen *id.Generator, writer *Writer) *InternPool {
 	return &InternPool{
-		idGen: idGen,
-		idNs:  id.String,
+		idGen:          idGen,
+		idNs:           id.String,
+		writer:         writer,
+		chunkType:      ChunkTypeInternPool,
+		chunkSizeLimit: DefaultChunkSizeLimit,
 	}
 }
 
+// NewTestInternPool creates a client InternPool with MustNewTestWriter for testing purposes.
+func NewTestInternPool(idGen *id.Generator) *InternPool {
+	return NewInternPool(idGen, MustNewTestWriter())
+}
+
 // NewServerInternPool creates a new server-only InternPool delegating string lookup to parent when available.
-func NewServerInternPool(parent *InternPool, idGen *id.Generator) *InternPool {
+func NewServerInternPool(parent *InternPool, idGen *id.Generator, writer *Writer) *InternPool {
 	return &InternPool{
-		parentPool: parent,
-		idGen:      idGen,
-		idNs:       id.ServerString,
+		parentPool:     parent,
+		idGen:          idGen,
+		idNs:           id.ServerString,
+		writer:         writer,
+		chunkType:      ChunkTypeServerInternPool,
+		chunkSizeLimit: DefaultChunkSizeLimit,
 	}
+}
+
+// NewTestServerInternPool creates a server InternPool with MustNewTestWriter for testing purposes.
+func NewTestServerInternPool(parent *InternPool, idGen *id.Generator) *InternPool {
+	return NewServerInternPool(parent, idGen, MustNewTestWriter())
 }
 
 // NewInternPoolFromChunk creates an InternPool pre-populated with entries from an InterningPoolChunk.
 func NewInternPoolFromChunk(chunk *pbv6.InterningPoolChunk) *InternPool {
-	pool := NewInternPool(nil)
+	pool := NewInternPool(nil, MustNewTestWriter())
 	pool.IngestChunk(chunk)
 	return pool
 }
@@ -267,6 +296,8 @@ func (p *InternPool) InternString(value string) *InternStringRef {
 		return &InternStringRef{pool: p, id: actual.(uint32)}
 	}
 
+	p.stageString(id, cloned)
+
 	return &InternStringRef{pool: p, id: id}
 }
 
@@ -325,6 +356,8 @@ func (p *InternPool) InternFieldSet(fieldNames []string) *FieldPathSetRef {
 		return &FieldPathSetRef{pool: p, id: actual.(uint32)}
 	}
 
+	p.stageFieldSet(newID, namesCopy)
+
 	return &FieldPathSetRef{pool: p, id: newID}
 }
 
@@ -375,7 +408,101 @@ func (p *InternPool) internStructWithKey(fieldPathSetID uint32, values []*pb.Int
 		return &InternStructRef{pool: p, id: actual.(uint32)}
 	}
 
+	p.stageStruct(s)
+
 	return &InternStructRef{pool: p, id: newID}
+}
+
+func (p *InternPool) stageString(idVal uint32, val string) {
+	item := &pbv6.InternString{
+		Id:    &idVal,
+		Value: &val,
+	}
+	itemSize := proto.Size(item) + 8
+
+	p.flushMu.Lock()
+	defer p.flushMu.Unlock()
+
+	p.unflushedStrings = append(p.unflushedStrings, item)
+	p.currentBatchSize += itemSize
+
+	if p.currentBatchSize >= p.chunkSizeLimit {
+		_ = p.flushLocked()
+	}
+}
+
+func (p *InternPool) stageFieldSet(idVal uint32, ids []uint32) {
+	item := &pbv6.InternFieldPathSet{
+		Id:                 &idVal,
+		FieldPathStringIds: ids,
+	}
+	itemSize := proto.Size(item) + 8
+
+	p.flushMu.Lock()
+	defer p.flushMu.Unlock()
+
+	p.unflushedFieldSets = append(p.unflushedFieldSets, item)
+	p.currentBatchSize += itemSize
+
+	if p.currentBatchSize >= p.chunkSizeLimit {
+		_ = p.flushLocked()
+	}
+}
+
+func (p *InternPool) stageStruct(s *pb.InternedStruct) {
+	itemSize := proto.Size(s) + 8
+
+	p.flushMu.Lock()
+	defer p.flushMu.Unlock()
+
+	p.unflushedStructs = append(p.unflushedStructs, s)
+	p.currentBatchSize += itemSize
+
+	if p.currentBatchSize >= p.chunkSizeLimit {
+		_ = p.flushLocked()
+	}
+}
+
+// SetChunkSizeLimit overrides the default chunk size limit for testing or performance tuning.
+func (p *InternPool) SetChunkSizeLimit(limit int) {
+	p.flushMu.Lock()
+	defer p.flushMu.Unlock()
+	p.chunkSizeLimit = limit
+}
+
+// Flush writes any pending unflushed intern pool items directly to the writer.
+func (p *InternPool) Flush() error {
+	p.flushMu.Lock()
+	defer p.flushMu.Unlock()
+	return p.flushLocked()
+}
+
+func (p *InternPool) flushLocked() error {
+	if len(p.unflushedStrings) == 0 && len(p.unflushedFieldSets) == 0 && len(p.unflushedStructs) == 0 {
+		return nil
+	}
+
+	chunk := &pbv6.InterningPoolChunk{
+		Strings:       p.unflushedStrings,
+		FieldPathSets: p.unflushedFieldSets,
+		Structs:       p.unflushedStructs,
+	}
+
+	p.unflushedStrings = nil
+	p.unflushedFieldSets = nil
+	p.unflushedStructs = nil
+	p.currentBatchSize = 0
+
+	rawChunk, err := CompressChunk(p.chunkType, chunk)
+	if err != nil {
+		return fmt.Errorf("failed to compress intern pool chunk: %w", err)
+	}
+
+	if err := p.writer.WriteRawChunk(rawChunk); err != nil {
+		return fmt.Errorf("failed to write intern pool raw chunk: %w", err)
+	}
+
+	return nil
 }
 
 // ResolveStructFromID returns the InternedStruct corresponding to the given ID.

--- a/pkg/model/khifile/v6/intern.go
+++ b/pkg/model/khifile/v6/intern.go
@@ -131,15 +131,14 @@ type InternPool struct {
 	idToFieldSetMu sync.RWMutex
 	idToFieldSet   [][]uint32
 
-	idToStructMu sync.RWMutex
-	idToStruct   []*pb.InternedStruct
+	flatStructs *FlatStructStore
 
 	flushMu            sync.Mutex
 	chunkSizeLimit     int
 	currentBatchSize   int
 	unflushedStrings   []*pbv6.InternString
 	unflushedFieldSets []*pbv6.InternFieldPathSet
-	unflushedStructs   []*pb.InternedStruct
+	unflushedStructIDs []uint32
 }
 
 var _ ReadonlyPool = (*InternPool)(nil)
@@ -152,6 +151,7 @@ func NewInternPool(idGen *id.Generator, writer *Writer) *InternPool {
 		writer:         writer,
 		chunkType:      ChunkTypeInternPool,
 		chunkSizeLimit: DefaultChunkSizeLimit,
+		flatStructs:    NewFlatStructStore(),
 	}
 }
 
@@ -169,6 +169,7 @@ func NewServerInternPool(parent *InternPool, idGen *id.Generator, writer *Writer
 		writer:         writer,
 		chunkType:      ChunkTypeServerInternPool,
 		chunkSizeLimit: DefaultChunkSizeLimit,
+		flatStructs:    NewFlatStructStore(),
 	}
 }
 
@@ -201,12 +202,10 @@ func (p *InternPool) IngestChunk(chunk *pbv6.InterningPoolChunk) {
 			p.fieldSetToID.Store(fieldSetKey(fs.FieldPathStringIds), *fs.Id)
 		}
 	}
+	p.flatStructs.StoreProtoBatch(chunk.Structs)
 	for _, s := range chunk.Structs {
-		if s.Id != nil {
-			p.storeStruct(*s.Id, s)
-			if s.FieldPathSetId != nil {
-				p.structToID.Store(structKey(*s.FieldPathSetId, s.Values), *s.Id)
-			}
+		if s.Id != nil && s.FieldPathSetId != nil {
+			p.structToID.Store(structKey(*s.FieldPathSetId, s.Values), *s.Id)
 		}
 	}
 }
@@ -250,17 +249,9 @@ func (p *InternPool) storeFieldSet(idVal uint32, fieldSet []uint32) {
 	p.idToFieldSet[idx] = fieldSet
 }
 
-func (p *InternPool) storeStruct(idVal uint32, s *pb.InternedStruct) {
-	if idVal == 0 {
-		return
-	}
-	idx := int(idVal - 1)
-	p.idToStructMu.Lock()
-	defer p.idToStructMu.Unlock()
-	if idx >= len(p.idToStruct) {
-		p.idToStruct = slices.Grow(p.idToStruct, idx+1-len(p.idToStruct))[:idx+1]
-	}
-	p.idToStruct[idx] = s
+// FlatStructStore returns the underlying FlatStructStore.
+func (p *InternPool) FlatStructStore() *FlatStructStore {
+	return p.flatStructs
 }
 
 // InternString returns a InternStringRef for the given string.
@@ -396,20 +387,14 @@ func (p *InternPool) internStructWithKey(fieldPathSetID uint32, values []*pb.Int
 	}
 
 	newID := p.idGen.New(id.Struct)
-	s := &pb.InternedStruct{
-		Id:             &newID,
-		FieldPathSetId: &fieldPathSetID,
-		Values:         values,
-	}
-	p.storeStruct(newID, s)
+	p.flatStructs.Store(newID, fieldPathSetID, values)
 
 	actual, loaded := p.structToID.LoadOrStore(key, newID)
 	if loaded {
-		p.storeStruct(newID, nil)
 		return &InternStructRef{pool: p, id: actual.(uint32)}
 	}
 
-	p.stageStruct(s)
+	p.stageStruct(newID)
 
 	return &InternStructRef{pool: p, id: newID}
 }
@@ -450,13 +435,14 @@ func (p *InternPool) stageFieldSet(idVal uint32, ids []uint32) {
 	}
 }
 
-func (p *InternPool) stageStruct(s *pb.InternedStruct) {
-	itemSize := proto.Size(s) + 8
+func (p *InternPool) stageStruct(idVal uint32) {
+	_, _, count, _ := p.flatStructs.GetValueSpan(idVal)
+	itemSize := int(16 + count*12 + 8)
 
 	p.flushMu.Lock()
 	defer p.flushMu.Unlock()
 
-	p.unflushedStructs = append(p.unflushedStructs, s)
+	p.unflushedStructIDs = append(p.unflushedStructIDs, idVal)
 	p.currentBatchSize += itemSize
 
 	if p.currentBatchSize >= p.chunkSizeLimit {
@@ -479,7 +465,7 @@ func (p *InternPool) Flush() error {
 }
 
 func (p *InternPool) flushLocked() error {
-	if len(p.unflushedStrings) == 0 && len(p.unflushedFieldSets) == 0 && len(p.unflushedStructs) == 0 {
+	if len(p.unflushedStrings) == 0 && len(p.unflushedFieldSets) == 0 && len(p.unflushedStructIDs) == 0 {
 		return nil
 	}
 
@@ -490,7 +476,14 @@ func (p *InternPool) flushLocked() error {
 	slices.SortFunc(p.unflushedFieldSets, func(a, b *pbv6.InternFieldPathSet) int {
 		return cmp.Compare(a.GetId(), b.GetId())
 	})
-	slices.SortFunc(p.unflushedStructs, func(a, b *pb.InternedStruct) int {
+
+	structs := make([]*pb.InternedStruct, 0, len(p.unflushedStructIDs))
+	for _, sID := range p.unflushedStructIDs {
+		if s := p.flatStructs.ResolveStruct(sID); s != nil {
+			structs = append(structs, s)
+		}
+	}
+	slices.SortFunc(structs, func(a, b *pb.InternedStruct) int {
 		if diff := cmp.Compare(a.GetFieldPathSetId(), b.GetFieldPathSetId()); diff != 0 {
 			return diff
 		}
@@ -500,12 +493,12 @@ func (p *InternPool) flushLocked() error {
 	chunk := &pbv6.InterningPoolChunk{
 		Strings:       p.unflushedStrings,
 		FieldPathSets: p.unflushedFieldSets,
-		Structs:       p.unflushedStructs,
+		Structs:       structs,
 	}
 
 	p.unflushedStrings = nil
 	p.unflushedFieldSets = nil
-	p.unflushedStructs = nil
+	p.unflushedStructIDs = nil
 	p.currentBatchSize = 0
 
 	rawChunk, err := CompressChunk(p.chunkType, chunk)
@@ -532,11 +525,11 @@ func (p *InternPool) resolveStructFromID(id uint32) *pb.InternedStruct {
 	if id == 0 {
 		return nil
 	}
-	idx := int(id - 1)
-	p.idToStructMu.RLock()
-	defer p.idToStructMu.RUnlock()
-	if idx < len(p.idToStruct) {
-		return p.idToStruct[idx]
+	if s := p.flatStructs.ResolveStruct(id); s != nil {
+		return s
+	}
+	if p.parentPool != nil {
+		return p.parentPool.resolveStructFromID(id)
 	}
 	return nil
 }

--- a/pkg/model/khifile/v6/intern_test.go
+++ b/pkg/model/khifile/v6/intern_test.go
@@ -22,6 +22,7 @@ import (
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -734,5 +735,53 @@ func TestInternPool_StreamingFlush(t *testing.T) {
 
 	if chunkCount < 2 {
 		t.Errorf("expected at least 2 intern pool chunks due to streaming split, got %d", chunkCount)
+	}
+}
+
+func TestInternPool_ChunkSorting(t *testing.T) {
+	var buf bytes.Buffer
+	writer, err := NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("NewWriter() error = %v", err)
+	}
+
+	idGen := id.NewGenerator()
+	pool := NewServerInternPool(nil, idGen, writer)
+
+	// Add strings in non-alphabetical order.
+	pool.InternString("zebra")
+	pool.InternString("apple")
+	pool.InternString("mango")
+
+	// Flush to writer.
+	if err := pool.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reader, err := NewReader(&buf)
+	if err != nil {
+		t.Fatalf("NewReader() error = %v", err)
+	}
+
+	chunk, err := reader.NextChunk()
+	if err != nil {
+		t.Fatalf("NextChunk() error = %v", err)
+	}
+
+	var poolChunk pb.InterningPoolChunk
+	if err := proto.Unmarshal(chunk.Data, &poolChunk); err != nil {
+		t.Fatalf("proto.Unmarshal() error = %v", err)
+	}
+
+	var gotValues []string
+	for _, s := range poolChunk.Strings {
+		gotValues = append(gotValues, s.GetValue())
+	}
+	wantValues := []string{"apple", "mango", "zebra"}
+	if diff := cmp.Diff(wantValues, gotValues); diff != "" {
+		t.Errorf("chunk strings mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/model/khifile/v6/intern_test.go
+++ b/pkg/model/khifile/v6/intern_test.go
@@ -16,6 +16,7 @@ package khifilev6
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	khifile "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
@@ -488,157 +489,6 @@ func TestInternPool_StructRefs(t *testing.T) {
 	}
 }
 
-func TestNewInternPoolFromChunk(t *testing.T) {
-	str1ID := uint32(1)
-	str1Val := "key"
-	fs1ID := uint32(1)
-	struct1ID := uint32(1)
-
-	chunk := &pb.InterningPoolChunk{
-		Strings: []*pb.InternString{
-			{Id: &str1ID, Value: &str1Val},
-		},
-		FieldPathSets: []*pb.InternFieldPathSet{
-			{Id: &fs1ID, FieldPathStringIds: []uint32{str1ID}},
-		},
-		Structs: []*khifile.InternedStruct{
-			{
-				Id:             &struct1ID,
-				FieldPathSetId: &fs1ID,
-				Values: []*khifile.InternedValue{
-					{Kind: &khifile.InternedValue_StringValue{StringValue: str1ID}},
-				},
-			},
-		},
-	}
-
-	testCases := []struct {
-		name       string
-		poolChunk  *pb.InterningPoolChunk
-		queryID    uint32
-		wantFound  bool
-		wantString string
-	}{
-		{
-			name:       "resolves struct from populated chunk",
-			poolChunk:  chunk,
-			queryID:    struct1ID,
-			wantFound:  true,
-			wantString: "key",
-		},
-		{
-			name:       "returns nil for non-existent struct ID",
-			poolChunk:  chunk,
-			queryID:    999,
-			wantFound:  false,
-			wantString: "",
-		},
-		{
-			name:       "handles nil chunk gracefully",
-			poolChunk:  nil,
-			queryID:    struct1ID,
-			wantFound:  false,
-			wantString: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			pool := NewInternPoolFromChunk(tc.poolChunk)
-			gotStruct := pool.ResolveStructFromID(tc.queryID)
-			if (gotStruct != nil) != tc.wantFound {
-				t.Fatalf("ResolveStructFromID(%d) = %v, wantFound = %v", tc.queryID, gotStruct, tc.wantFound)
-			}
-			if tc.wantFound {
-				if diff := cmp.Diff(tc.poolChunk.Structs[0], gotStruct, protocmp.Transform()); diff != "" {
-					t.Errorf("ResolveStructFromID() struct mismatch (-want +got):\n%s", diff)
-				}
-				resolvedStr := pool.resolveStringFromID(gotStruct.Values[0].GetStringValue())
-				if resolvedStr != tc.wantString {
-					t.Errorf("resolveStringFromID() = %q, want %q", resolvedStr, tc.wantString)
-				}
-			}
-		})
-	}
-}
-
-func TestInternPool_IngestChunk(t *testing.T) {
-	str1ID := uint32(1)
-	str1Val := "status"
-	str2ID := uint32(2)
-	str2Val := "Running"
-	fs1ID := uint32(1)
-	struct1ID := uint32(10)
-
-	stringChunk := &pb.InterningPoolChunk{
-		Strings: []*pb.InternString{
-			{Id: &str1ID, Value: &str1Val},
-			{Id: &str2ID, Value: &str2Val},
-		},
-	}
-
-	fieldPathChunk := &pb.InterningPoolChunk{
-		FieldPathSets: []*pb.InternFieldPathSet{
-			{Id: &fs1ID, FieldPathStringIds: []uint32{str1ID}},
-		},
-	}
-
-	structChunk := &pb.InterningPoolChunk{
-		Structs: []*khifile.InternedStruct{
-			{
-				Id:             &struct1ID,
-				FieldPathSetId: &fs1ID,
-				Values: []*khifile.InternedValue{
-					{Kind: &khifile.InternedValue_StringValue{StringValue: str2ID}},
-				},
-			},
-		},
-	}
-
-	testCases := []struct {
-		name       string
-		chunks     []*pb.InterningPoolChunk
-		queryID    uint32
-		wantFound  bool
-		wantString string
-	}{
-		{
-			name:       "sequentially ingests multiple chunks for strings, field paths, and structs",
-			chunks:     []*pb.InterningPoolChunk{stringChunk, fieldPathChunk, structChunk},
-			queryID:    struct1ID,
-			wantFound:  true,
-			wantString: "Running",
-		},
-		{
-			name:       "handles nil chunk during multi-chunk ingestion",
-			chunks:     []*pb.InterningPoolChunk{stringChunk, nil, fieldPathChunk, structChunk},
-			queryID:    struct1ID,
-			wantFound:  true,
-			wantString: "Running",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			pool := NewTestInternPool(nil)
-			for _, c := range tc.chunks {
-				pool.IngestChunk(c)
-			}
-
-			gotStruct := pool.ResolveStructFromID(tc.queryID)
-			if (gotStruct != nil) != tc.wantFound {
-				t.Fatalf("ResolveStructFromID(%d) = %v, wantFound = %v", tc.queryID, gotStruct, tc.wantFound)
-			}
-			if tc.wantFound {
-				resolvedStr := pool.resolveStringFromID(gotStruct.Values[0].GetStringValue())
-				if resolvedStr != tc.wantString {
-					t.Errorf("resolveStringFromID() = %q, want %q", resolvedStr, tc.wantString)
-				}
-			}
-		})
-	}
-}
-
 func TestServerInternPool(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -783,5 +633,57 @@ func TestInternPool_ChunkSorting(t *testing.T) {
 	wantValues := []string{"apple", "mango", "zebra"}
 	if diff := cmp.Diff(wantValues, gotValues); diff != "" {
 		t.Errorf("chunk strings mismatch (-want +got):\n%s", diff)
+	}
+}
+
+type failingWriter struct {
+	failAfter int
+	written   int
+}
+
+func (f *failingWriter) Write(p []byte) (n int, err error) {
+	if f.written >= f.failAfter {
+		return 0, errors.New("simulated write error")
+	}
+	f.written += len(p)
+	return len(p), nil
+}
+
+func TestInternPool_ErrorPropagation(t *testing.T) {
+	testCases := []struct {
+		name    string
+		mutate  func(pool *InternPool)
+		wantErr bool
+	}{
+		{
+			name: "propagates writer error on Flush",
+			mutate: func(pool *InternPool) {
+				pool.InternString("some_string")
+			},
+			wantErr: true,
+		},
+		{
+			name: "propagates error encountered during streaming flush",
+			mutate: func(pool *InternPool) {
+				pool.SetChunkSizeLimit(10)
+				pool.InternString("string_exceeding_limit")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			writer, err := NewWriter(&failingWriter{failAfter: 4})
+			if err != nil {
+				t.Fatalf("NewWriter() error = %v", err)
+			}
+			pool := NewInternPool(id.NewGenerator(), writer)
+			tc.mutate(pool)
+
+			if err := pool.Flush(); (err != nil) != tc.wantErr {
+				t.Errorf("Flush() error = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/model/khifile/v6/intern_test.go
+++ b/pkg/model/khifile/v6/intern_test.go
@@ -15,6 +15,7 @@
 package khifilev6
 
 import (
+	"bytes"
 	"testing"
 
 	khifile "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
@@ -26,7 +27,7 @@ import (
 
 func TestInternPool_Intern(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 
 	testCases := []struct {
 		name   string
@@ -66,7 +67,7 @@ func TestInternPool_Intern(t *testing.T) {
 
 func TestInternPool_Intern_InvalidUTF8(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 
 	testCases := []struct {
 		name        string
@@ -110,7 +111,7 @@ func TestInternPool_Intern_InvalidUTF8(t *testing.T) {
 
 func TestInternPool_ResolveStringFromID(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 	ref1 := pool.InternString("foo")
 	ref2 := pool.InternString("bar")
 
@@ -153,7 +154,7 @@ func TestInternPool_ResolveStringFromID(t *testing.T) {
 
 func TestInternStringRef_ToProto(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 	ref := pool.InternString("foo")
 
 	got := ref.ToProto()
@@ -175,7 +176,7 @@ func TestInternStringRef_ToProto(t *testing.T) {
 
 func TestInternPool_SortedRefs(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 	pool.InternString("c")
 	pool.InternString("a")
 	pool.InternString("b")
@@ -222,7 +223,7 @@ func TestInternPool_SortedRefs(t *testing.T) {
 
 func TestInternPool_InternFieldSet(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 
 	testCases := []struct {
 		name   string
@@ -272,7 +273,7 @@ func TestInternPool_InternFieldSet(t *testing.T) {
 
 func TestInternPool_FieldSetRefs(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 
 	pool.InternFieldSet([]string{"a", "b"})
 	pool.InternFieldSet([]string{"c"})
@@ -320,7 +321,7 @@ func TestInternPool_FieldSetRefs(t *testing.T) {
 
 func TestInternPool_InternStruct(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 
 	fieldSetID1 := pool.InternFieldSet([]string{"foo", "bar"}).id
 	fieldSetID2 := pool.InternFieldSet([]string{"baz"}).id
@@ -437,7 +438,7 @@ func TestInternPool_InternStruct(t *testing.T) {
 
 func TestInternPool_StructRefs(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 
 	fsID := pool.InternFieldSet([]string{"key"}).id
 	ref1 := pool.InternStruct(fsID, []*khifile.InternedValue{{Kind: &khifile.InternedValue_Int64Value{Int64Value: 1}}})
@@ -618,7 +619,7 @@ func TestInternPool_IngestChunk(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pool := NewInternPool(nil)
+			pool := NewTestInternPool(nil)
 			for _, c := range tc.chunks {
 				pool.IngestChunk(c)
 			}
@@ -671,8 +672,8 @@ func TestServerInternPool(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			idGen := id.NewGenerator()
-			clientPool := NewInternPool(idGen)
-			serverPool := NewServerInternPool(clientPool, idGen)
+			clientPool := NewTestInternPool(idGen)
+			serverPool := NewTestServerInternPool(clientPool, idGen)
 
 			for _, s := range tc.clientStrs {
 				clientPool.InternString(s)
@@ -689,5 +690,49 @@ func TestServerInternPool(t *testing.T) {
 				t.Errorf("Resolve() = %q, want %q", resolved, tc.checkStr)
 			}
 		})
+	}
+}
+
+func TestInternPool_StreamingFlush(t *testing.T) {
+	var buf bytes.Buffer
+	writer, err := NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("NewWriter() error = %v", err)
+	}
+
+	idGen := id.NewGenerator()
+	pool := NewInternPool(idGen, writer)
+	pool.SetChunkSizeLimit(50) // Set very small limit to trigger streaming chunk split
+
+	pool.InternString("string_one_with_enough_length_to_reach_limit")
+	pool.InternString("string_two_with_enough_length_to_reach_limit")
+
+	// Flush remaining items
+	if err := pool.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reader, err := NewReader(&buf)
+	if err != nil {
+		t.Fatalf("NewReader() error = %v", err)
+	}
+
+	chunkCount := 0
+	for {
+		chunk, err := reader.NextChunk()
+		if err != nil {
+			break
+		}
+		if chunk.Type == ChunkTypeInternPool {
+			chunkCount++
+		}
+	}
+
+	if chunkCount < 2 {
+		t.Errorf("expected at least 2 intern pool chunks due to streaming split, got %d", chunkCount)
 	}
 }

--- a/pkg/model/khifile/v6/intern_test.go
+++ b/pkg/model/khifile/v6/intern_test.go
@@ -445,9 +445,9 @@ func TestInternPool_StructRefs(t *testing.T) {
 	ref1 := pool.InternStruct(fsID, []*khifile.InternedValue{{Kind: &khifile.InternedValue_Int64Value{Int64Value: 1}}})
 	ref2 := pool.InternStruct(fsID, []*khifile.InternedValue{{Kind: &khifile.InternedValue_Int64Value{Int64Value: 2}}})
 
-	// Simulate an orphaned struct ID in idToStruct (e.g. from concurrent InternStruct collision).
+	// Simulate an orphaned struct ID in FlatStructStore (e.g. from concurrent InternStruct collision).
 	orphanedID := idGen.New(id.Struct)
-	pool.storeStruct(orphanedID, (*khifile.InternedStruct)(nil))
+	pool.FlatStructStore().Store(orphanedID, fsID, nil)
 
 	var refs []*InternStructRef
 	for ref := range pool.StructRefs() {

--- a/pkg/model/khifile/v6/log_accumulator.go
+++ b/pkg/model/khifile/v6/log_accumulator.go
@@ -15,7 +15,9 @@
 package khifilev6
 
 import (
+	"cmp"
 	"fmt"
+	"math"
 	"slices"
 	"sync"
 	"time"
@@ -26,6 +28,9 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// estimatedLogProtoSize is the estimated serialized protobuf byte size for a Log entry plus slice overhead.
+const estimatedLogProtoSize = 48
 
 // StagingLog represents a log entry and its associated metadata to be added to LogAccumulator.
 type StagingLog struct {
@@ -41,15 +46,20 @@ type StagingLog struct {
 // completed chunks directly to the destination Writer.
 // It is safe for concurrent use by multiple goroutines.
 type LogAccumulator struct {
-	clientPool       *InternPool
-	serverPool       *InternPool
-	idGen            *id.Generator
-	writer           *Writer
-	chunkSizeLimit   int
-	currentBatch     []*pb.Log
-	currentBatchSize int
-	parserIDToID     []uint32
-	mu               sync.Mutex
+	clientPool         *InternPool
+	serverPool         *InternPool
+	idGen              *id.Generator
+	writer             *Writer
+	chunkSizeLimit     int
+	batchIDs           []uint32
+	batchTimestamps    []int64 // Unix nanoseconds, or math.MinInt64 if zero
+	batchLogTypeIDs    []uint32
+	batchSeverityIDs   []uint32
+	batchSummaryIDs    []uint32
+	batchBodyStructIDs []uint32
+	currentBatchSize   int
+	parserIDToID       []uint32
+	mu                 sync.Mutex
 }
 
 // NewLogAccumulator creates a new LogAccumulator with the provided client and server InternPools, IDGenerator, and destination Writer.
@@ -58,13 +68,18 @@ func NewLogAccumulator(clientPool *InternPool, serverPool *InternPool, idGen *id
 		serverPool = clientPool
 	}
 	return &LogAccumulator{
-		clientPool:     clientPool,
-		serverPool:     serverPool,
-		idGen:          idGen,
-		writer:         writer,
-		chunkSizeLimit: DefaultChunkSizeLimit,
-		currentBatch:   make([]*pb.Log, 0),
-		parserIDToID:   make([]uint32, 0),
+		clientPool:         clientPool,
+		serverPool:         serverPool,
+		idGen:              idGen,
+		writer:             writer,
+		chunkSizeLimit:     DefaultChunkSizeLimit,
+		batchIDs:           make([]uint32, 0),
+		batchTimestamps:    make([]int64, 0),
+		batchLogTypeIDs:    make([]uint32, 0),
+		batchSeverityIDs:   make([]uint32, 0),
+		batchSummaryIDs:    make([]uint32, 0),
+		batchBodyStructIDs: make([]uint32, 0),
+		parserIDToID:       make([]uint32, 0),
 	}
 }
 
@@ -80,7 +95,7 @@ func (a *LogAccumulator) SetChunkSizeLimit(limit int) {
 	a.chunkSizeLimit = limit
 }
 
-// AddLog converts a StagingLog into a khifilev6.Log proto and adds it to the accumulator.
+// AddLog converts a StagingLog into an interned log entry and adds it to the accumulator.
 // It interns the log body to optimize storage and flushes chunks directly to the Writer when the batch size exceeds the chunk limit.
 func (a *LogAccumulator) AddLog(s *StagingLog) error {
 	if s.Severity == nil || s.Severity.Id == nil {
@@ -96,20 +111,17 @@ func (a *LogAccumulator) AddLog(s *StagingLog) error {
 	}
 
 	logID := a.idGen.New(id.Log)
-	pbLog := &pb.Log{
-		Id:           &logID,
-		BodyStructId: &internedBody.id,
+	summaryStrRef := a.clientPool.InternString(s.Summary)
+
+	var tsNano int64 = math.MinInt64
+	if !s.Timestamp.IsZero() {
+		tsNano = s.Timestamp.UnixNano()
 	}
 
-	pbLog.Ts = timestamppb.New(s.Timestamp)
-	pbLog.SeverityTypeId = s.Severity.Id
-
-	summaryStrRef := a.clientPool.InternString(s.Summary)
-	pbLog.SummaryStringId = &summaryStrRef.id
-
-	pbLog.LogTypeId = s.LogType.Id
-
-	itemSize := proto.Size(pbLog) + 8
+	sevID := s.Severity.GetId()
+	logTypeID := s.LogType.GetId()
+	bodyStructID := internedBody.id
+	summaryID := summaryStrRef.id
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -119,33 +131,57 @@ func (a *LogAccumulator) AddLog(s *StagingLog) error {
 	}
 	a.parserIDToID[s.Log.ID-1] = logID
 
-	if a.currentBatchSize+itemSize > a.chunkSizeLimit && len(a.currentBatch) > 0 {
+	if a.currentBatchSize+estimatedLogProtoSize > a.chunkSizeLimit && len(a.batchIDs) > 0 {
 		if err := a.flushLocked(); err != nil {
 			return err
 		}
 	}
 
-	a.currentBatch = append(a.currentBatch, pbLog)
-	a.currentBatchSize += itemSize
+	a.batchIDs = append(a.batchIDs, logID)
+	a.batchTimestamps = append(a.batchTimestamps, tsNano)
+	a.batchLogTypeIDs = append(a.batchLogTypeIDs, logTypeID)
+	a.batchSeverityIDs = append(a.batchSeverityIDs, sevID)
+	a.batchSummaryIDs = append(a.batchSummaryIDs, summaryID)
+	a.batchBodyStructIDs = append(a.batchBodyStructIDs, bodyStructID)
+	a.currentBatchSize += estimatedLogProtoSize
 
 	return nil
 }
 
+// flushLocked sorts staged logs chronologically and writes them as a compressed LogChunk to the destination Writer.
 func (a *LogAccumulator) flushLocked() error {
-	if len(a.currentBatch) == 0 {
+	n := len(a.batchIDs)
+	if n == 0 {
 		return nil
 	}
 
-	batch := a.currentBatch
-	a.currentBatch = make([]*pb.Log, 0)
-	a.currentBatchSize = 0
+	indices := make([]int, n)
+	for i := range indices {
+		indices[i] = i
+	}
 
-	slices.SortStableFunc(batch, func(x, y *pb.Log) int {
-		return x.GetTs().AsTime().Compare(y.GetTs().AsTime())
+	slices.SortStableFunc(indices, func(i, j int) int {
+		return cmp.Compare(a.batchTimestamps[i], a.batchTimestamps[j])
 	})
 
+	logs := make([]*pb.Log, n)
+	for outIdx, inIdx := range indices {
+		var ts *timestamppb.Timestamp
+		if a.batchTimestamps[inIdx] != math.MinInt64 {
+			ts = timestamppb.New(time.Unix(0, a.batchTimestamps[inIdx]).UTC())
+		}
+		logs[outIdx] = &pb.Log{
+			Id:              proto.Uint32(a.batchIDs[inIdx]),
+			Ts:              ts,
+			SeverityTypeId:  proto.Uint32(a.batchSeverityIDs[inIdx]),
+			LogTypeId:       proto.Uint32(a.batchLogTypeIDs[inIdx]),
+			BodyStructId:    proto.Uint32(a.batchBodyStructIDs[inIdx]),
+			SummaryStringId: proto.Uint32(a.batchSummaryIDs[inIdx]),
+		}
+	}
+
 	chunk := &pb.LogChunk{
-		Logs: batch,
+		Logs: logs,
 	}
 
 	rawChunk, err := CompressChunk(ChunkTypeLog, chunk)
@@ -156,6 +192,14 @@ func (a *LogAccumulator) flushLocked() error {
 	if err := a.writer.WriteRawChunk(rawChunk); err != nil {
 		return fmt.Errorf("failed to write log chunk: %w", err)
 	}
+
+	a.batchIDs = a.batchIDs[:0]
+	a.batchTimestamps = a.batchTimestamps[:0]
+	a.batchLogTypeIDs = a.batchLogTypeIDs[:0]
+	a.batchSeverityIDs = a.batchSeverityIDs[:0]
+	a.batchSummaryIDs = a.batchSummaryIDs[:0]
+	a.batchBodyStructIDs = a.batchBodyStructIDs[:0]
+	a.currentBatchSize = 0
 
 	return nil
 }

--- a/pkg/model/khifile/v6/log_accumulator.go
+++ b/pkg/model/khifile/v6/log_accumulator.go
@@ -23,6 +23,7 @@ import (
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -35,34 +36,52 @@ type StagingLog struct {
 	Severity  *pb.Severity
 }
 
-// LogAccumulator facilitates the construction of a list of Log proto messages
-// by interning their structured data using an InternPool.
+// LogAccumulator facilitates the construction of Log chunks
+// by interning their structured data using an InternPool and streaming
+// completed chunks directly to the destination Writer.
 // It is safe for concurrent use by multiple goroutines.
 type LogAccumulator struct {
-	clientPool   *InternPool
-	serverPool   *InternPool
-	idGen        *id.Generator
-	logs         []*pb.Log
-	parserIDToID []uint32
-	mu           sync.RWMutex
+	clientPool       *InternPool
+	serverPool       *InternPool
+	idGen            *id.Generator
+	writer           *Writer
+	chunkSizeLimit   int
+	currentBatch     []*pb.Log
+	currentBatchSize int
+	parserIDToID     []uint32
+	mu               sync.Mutex
 }
 
-// NewLogAccumulator creates a new LogAccumulator with the provided client and server InternPools and IDGenerator.
-func NewLogAccumulator(clientPool *InternPool, serverPool *InternPool, idGen *id.Generator) *LogAccumulator {
+// NewLogAccumulator creates a new LogAccumulator with the provided client and server InternPools, IDGenerator, and destination Writer.
+func NewLogAccumulator(clientPool *InternPool, serverPool *InternPool, idGen *id.Generator, writer *Writer) *LogAccumulator {
 	if serverPool == nil {
 		serverPool = clientPool
 	}
 	return &LogAccumulator{
-		clientPool:   clientPool,
-		serverPool:   serverPool,
-		idGen:        idGen,
-		logs:         make([]*pb.Log, 0),
-		parserIDToID: make([]uint32, 0),
+		clientPool:     clientPool,
+		serverPool:     serverPool,
+		idGen:          idGen,
+		writer:         writer,
+		chunkSizeLimit: DefaultChunkSizeLimit,
+		currentBatch:   make([]*pb.Log, 0),
+		parserIDToID:   make([]uint32, 0),
 	}
 }
 
+// NewTestLogAccumulator creates a LogAccumulator with MustNewTestWriter for testing purposes.
+func NewTestLogAccumulator(clientPool *InternPool, serverPool *InternPool, idGen *id.Generator) *LogAccumulator {
+	return NewLogAccumulator(clientPool, serverPool, idGen, MustNewTestWriter())
+}
+
+// SetChunkSizeLimit sets the maximum byte size limit for a single LogChunk.
+func (a *LogAccumulator) SetChunkSizeLimit(limit int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.chunkSizeLimit = limit
+}
+
 // AddLog converts a StagingLog into a khifilev6.Log proto and adds it to the accumulator.
-// It interns the log body to optimize storage.
+// It interns the log body to optimize storage and flushes chunks directly to the Writer when the batch size exceeds the chunk limit.
 func (a *LogAccumulator) AddLog(s *StagingLog) error {
 	if s.Severity == nil || s.Severity.Id == nil {
 		return fmt.Errorf("severity or its ID is missing")
@@ -90,25 +109,69 @@ func (a *LogAccumulator) AddLog(s *StagingLog) error {
 
 	pbLog.LogTypeId = s.LogType.Id
 
+	itemSize := proto.Size(pbLog) + 8
+
 	a.mu.Lock()
-	if needed := int(logID) - len(a.logs); needed > 0 {
-		a.logs = slices.Grow(a.logs, needed)[:int(logID)]
-	}
-	a.logs[logID-1] = pbLog
+	defer a.mu.Unlock()
+
 	if needed := int(s.Log.ID) - len(a.parserIDToID); needed > 0 {
 		a.parserIDToID = slices.Grow(a.parserIDToID, needed)[:int(s.Log.ID)]
 	}
 	a.parserIDToID[s.Log.ID-1] = logID
-	a.mu.Unlock()
+
+	if a.currentBatchSize+itemSize > a.chunkSizeLimit && len(a.currentBatch) > 0 {
+		if err := a.flushLocked(); err != nil {
+			return err
+		}
+	}
+
+	a.currentBatch = append(a.currentBatch, pbLog)
+	a.currentBatchSize += itemSize
 
 	return nil
+}
+
+func (a *LogAccumulator) flushLocked() error {
+	if len(a.currentBatch) == 0 {
+		return nil
+	}
+
+	batch := a.currentBatch
+	a.currentBatch = make([]*pb.Log, 0)
+	a.currentBatchSize = 0
+
+	slices.SortStableFunc(batch, func(x, y *pb.Log) int {
+		return x.GetTs().AsTime().Compare(y.GetTs().AsTime())
+	})
+
+	chunk := &pb.LogChunk{
+		Logs: batch,
+	}
+
+	rawChunk, err := CompressChunk(ChunkTypeLog, chunk)
+	if err != nil {
+		return fmt.Errorf("failed to compress log chunk: %w", err)
+	}
+
+	if err := a.writer.WriteRawChunk(rawChunk); err != nil {
+		return fmt.Errorf("failed to write log chunk: %w", err)
+	}
+
+	return nil
+}
+
+// Flush writes any pending buffered logs into a final LogChunk and outputs it to the destination Writer.
+func (a *LogAccumulator) Flush() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.flushLocked()
 }
 
 // ResolveLogID returns the serialized log ID (uint32) for a given parser-side temporary log ID (uint32).
 // It returns false if the log ID is not found.
 func (a *LogAccumulator) ResolveLogID(parserID uint32) (uint32, bool) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if parserID == 0 || int(parserID) > len(a.parserIDToID) {
 		return 0, false
 	}
@@ -117,31 +180,4 @@ func (a *LogAccumulator) ResolveLogID(parserID uint32) (uint32, bool) {
 		return 0, false
 	}
 	return confirmedID, true
-}
-
-// GetLog returns a log by its ID. Returns nil if the log is not found.
-func (a *LogAccumulator) GetLog(id uint32) *pb.Log {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	if id == 0 || int(id) > len(a.logs) {
-		return nil
-	}
-	return a.logs[id-1]
-}
-
-// Accumulate returns the accumulated list of Log proto messages.
-// The returned list is sorted chronologically by their timestamp.
-func (a *LogAccumulator) Accumulate() []*pb.Log {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	result := make([]*pb.Log, 0, len(a.logs))
-	for _, l := range a.logs {
-		if l != nil {
-			result = append(result, l)
-		}
-	}
-	slices.SortStableFunc(result, func(a, b *pb.Log) int {
-		return a.GetTs().AsTime().Compare(b.GetTs().AsTime())
-	})
-	return result
 }

--- a/pkg/model/khifile/v6/log_accumulator_test.go
+++ b/pkg/model/khifile/v6/log_accumulator_test.go
@@ -15,6 +15,7 @@
 package khifilev6
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestLogAccumulator(t *testing.T) {
@@ -56,7 +58,7 @@ func TestLogAccumulator(t *testing.T) {
 		logsToAdd    func(gen *id.Generator) []*StagingLog
 		wantErr      bool
 		wantLogCount int
-		validate     func(t *testing.T, acc *LogAccumulator)
+		validate     func(t *testing.T, logs []*pb.Log, acc *LogAccumulator)
 	}{
 		{
 			name: "empty accumulator",
@@ -65,9 +67,9 @@ func TestLogAccumulator(t *testing.T) {
 			},
 			wantErr:      false,
 			wantLogCount: 0,
-			validate: func(t *testing.T, acc *LogAccumulator) {
-				if gotLog := acc.GetLog(1); gotLog != nil {
-					t.Errorf("GetLog(1) returned a log on empty accumulator instead of nil")
+			validate: func(t *testing.T, logs []*pb.Log, acc *LogAccumulator) {
+				if len(logs) != 0 {
+					t.Errorf("expected 0 logs, got %d", len(logs))
 				}
 			},
 		},
@@ -86,8 +88,7 @@ func TestLogAccumulator(t *testing.T) {
 			},
 			wantErr:      false,
 			wantLogCount: 1,
-			validate: func(t *testing.T, acc *LogAccumulator) {
-				logs := acc.Accumulate()
+			validate: func(t *testing.T, logs []*pb.Log, acc *LogAccumulator) {
 				if logs[0].GetId() != 1 {
 					t.Errorf("expected ID 1, got %d", logs[0].GetId())
 				}
@@ -99,14 +100,6 @@ func TestLogAccumulator(t *testing.T) {
 				}
 				if logs[0].GetLogTypeId() != testLogTypeID {
 					t.Errorf("expected log type %d, got %d", testLogTypeID, logs[0].GetLogTypeId())
-				}
-
-				// Verify GetLog
-				if gotLog := acc.GetLog(1); gotLog == nil || gotLog.GetId() != 1 {
-					t.Errorf("GetLog(1) failed to return the correct log")
-				}
-				if gotLog := acc.GetLog(999); gotLog != nil {
-					t.Errorf("GetLog(999) returned a log instead of nil")
 				}
 			},
 		},
@@ -139,8 +132,7 @@ func TestLogAccumulator(t *testing.T) {
 			},
 			wantErr:      false,
 			wantLogCount: 3,
-			validate: func(t *testing.T, acc *LogAccumulator) {
-				logs := acc.Accumulate()
+			validate: func(t *testing.T, logs []*pb.Log, acc *LogAccumulator) {
 				if logs[0].GetId() != 1 {
 					t.Errorf("expected ID 1, got %d", logs[0].GetId())
 				}
@@ -157,11 +149,6 @@ func TestLogAccumulator(t *testing.T) {
 				}
 				if logs[0].GetBodyStructId() == logs[2].GetBodyStructId() {
 					t.Errorf("log 3 should have different body struct ID from log 0")
-				}
-
-				// Verify GetLog
-				if gotLog := acc.GetLog(2); gotLog == nil || gotLog.GetId() != 2 {
-					t.Errorf("GetLog(2) failed to return the correct log")
 				}
 			},
 		},
@@ -194,8 +181,7 @@ func TestLogAccumulator(t *testing.T) {
 			},
 			wantErr:      false,
 			wantLogCount: 3,
-			validate: func(t *testing.T, acc *LogAccumulator) {
-				logs := acc.Accumulate()
+			validate: func(t *testing.T, logs []*pb.Log, acc *LogAccumulator) {
 				// Expected order should be: summary 2 (8:00), summary 3 (9:00), summary 1 (10:00)
 				if logs[0].GetId() != 2 {
 					t.Errorf("expected first log to have ID 2, got %d", logs[0].GetId())
@@ -253,9 +239,14 @@ func TestLogAccumulator(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			idGen := id.NewGenerator()
-			pool := NewInternPool(idGen)
-			serverPool := NewServerInternPool(pool, idGen)
-			acc := NewLogAccumulator(pool, serverPool, idGen)
+			var buf bytes.Buffer
+			writer, err := NewWriter(&buf)
+			if err != nil {
+				t.Fatalf("NewWriter() error = %v", err)
+			}
+			pool := NewInternPool(idGen, writer)
+			serverPool := NewServerInternPool(pool, idGen, writer)
+			acc := NewLogAccumulator(pool, serverPool, idGen, writer)
 
 			for _, l := range tc.logsToAdd(idGen) {
 				err := acc.AddLog(l)
@@ -264,14 +255,101 @@ func TestLogAccumulator(t *testing.T) {
 				}
 			}
 
-			logs := acc.Accumulate()
+			if err := acc.Flush(); err != nil {
+				t.Fatalf("Flush() error = %v", err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+
+			reader, err := NewReader(&buf)
+			if err != nil {
+				t.Fatalf("NewReader() error = %v", err)
+			}
+
+			var logs []*pb.Log
+			for {
+				chunk, err := reader.NextChunk()
+				if err != nil {
+					break
+				}
+				if chunk.Type == ChunkTypeLog {
+					var logChunk pb.LogChunk
+					if err := proto.Unmarshal(chunk.Data, &logChunk); err != nil {
+						t.Fatalf("failed to unmarshal log chunk: %v", err)
+					}
+					logs = append(logs, logChunk.Logs...)
+				}
+			}
+
 			if len(logs) != tc.wantLogCount {
 				t.Fatalf("expected %d logs, got %d", tc.wantLogCount, len(logs))
 			}
 
 			if tc.validate != nil {
-				tc.validate(t, acc)
+				tc.validate(t, logs, acc)
 			}
 		})
+	}
+}
+
+func TestLogAccumulator_StreamingSplit(t *testing.T) {
+	var buf bytes.Buffer
+	writer, err := NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("NewWriter() error = %v", err)
+	}
+
+	idGen := id.NewGenerator()
+	pool := NewInternPool(idGen, writer)
+	serverPool := NewServerInternPool(pool, idGen, writer)
+	acc := NewLogAccumulator(pool, serverPool, idGen, writer)
+	acc.SetChunkSizeLimit(50) // Small limit to trigger chunk split on AddLog
+
+	node := structured.NewStandardMap(
+		[]string{"msg"},
+		[]structured.Node{structured.NewStandardScalarNode("large message to trigger batch split")},
+	)
+	sevID := uint32(1)
+	logTypeID := uint32(2)
+
+	for i := 0; i < 5; i++ {
+		err := acc.AddLog(&StagingLog{
+			Log:       log.NewLog(idGen, structured.NewNodeReader(node)),
+			Summary:   "summary",
+			Timestamp: time.Now(),
+			Severity:  &pb.Severity{Id: &sevID},
+			LogType:   &pb.LogType{Id: &logTypeID},
+		})
+		if err != nil {
+			t.Fatalf("AddLog() error = %v", err)
+		}
+	}
+
+	if err := acc.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reader, err := NewReader(&buf)
+	if err != nil {
+		t.Fatalf("NewReader() error = %v", err)
+	}
+
+	chunkCount := 0
+	for {
+		chunk, err := reader.NextChunk()
+		if err != nil {
+			break
+		}
+		if chunk.Type == ChunkTypeLog {
+			chunkCount++
+		}
+	}
+
+	if chunkCount < 2 {
+		t.Errorf("expected at least 2 log chunks due to streaming split, got %d", chunkCount)
 	}
 }

--- a/pkg/model/khifile/v6/struct.go
+++ b/pkg/model/khifile/v6/struct.go
@@ -25,26 +25,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile"
-	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
-)
-
-var (
-	nullInternedValue = &pb.InternedValue{
-		Kind: &pb.InternedValue_NullValue{
-			NullValue: structpb.NullValue_NULL_VALUE,
-		},
-	}
-	boolTrueInternedValue = &pb.InternedValue{
-		Kind: &pb.InternedValue_BoolValue{
-			BoolValue: true,
-		},
-	}
-	boolFalseInternedValue = &pb.InternedValue{
-		Kind: &pb.InternedValue_BoolValue{
-			BoolValue: false,
-		},
-	}
+	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 )
 
 // FieldPathSeparator is the separator used for field paths in InternedStruct.
@@ -80,17 +61,19 @@ func ToInternedStruct(node structured.Node, pool *InternPool) (*InternStructRef,
 		return &InternStructRef{pool: pool, id: id.(uint32)}, nil
 	}
 
-	// Slow-path: construct protobuf values only for new unique structs.
-	values := make([]*pb.InternedValue, 0, len(flattenedValues))
-	for _, valNode := range flattenedValues {
-		val, err := ToInternedValue(valNode, pool)
-		if err != nil {
-			return nil, err
-		}
-		values = append(values, val)
+	newID := pool.idGen.New(id.Struct)
+	if err := pool.flatStructs.StoreFromNodes(newID, fieldSetRef.id, flattenedValues, pool); err != nil {
+		return nil, err
 	}
 
-	return pool.internStructWithKey(fieldSetRef.id, values, key), nil
+	actual, loaded := pool.structToID.LoadOrStore(key, newID)
+	if loaded {
+		return &InternStructRef{pool: pool, id: actual.(uint32)}, nil
+	}
+
+	pool.stageStruct(newID)
+
+	return &InternStructRef{pool: pool, id: newID}, nil
 }
 
 // flattenNode is a helper function to recursively flatten map nodes.
@@ -134,64 +117,6 @@ func flattenNodeHelper(node structured.Node, keyBuf []byte, isRoot bool, keys *[
 		keyBuf = keyBuf[:origLen]
 	}
 	return nil
-}
-
-// ToInternedValue converts a structured.Node to an InternedValue.
-func ToInternedValue(node structured.Node, pool *InternPool) (*pb.InternedValue, error) {
-	switch node.Type() {
-	case structured.ScalarNodeType:
-		return scalarToInternedValue(node, pool)
-	case structured.SequenceNodeType:
-		return sequenceToInternedValue(node, pool)
-	case structured.MapNodeType:
-		return mapToInternedValue(node, pool)
-	default:
-		return nil, fmt.Errorf("unknown node type: %v", node.Type())
-	}
-}
-
-func scalarToInternedValue(node structured.Node, pool *InternPool) (*pb.InternedValue, error) {
-	val, err := node.NodeScalarValue()
-	if err != nil {
-		return nil, err
-	}
-	if val == nil {
-		return nullInternedValue, nil
-	}
-	switch v := val.(type) {
-	case bool:
-		if v {
-			return boolTrueInternedValue, nil
-		}
-		return boolFalseInternedValue, nil
-	case string:
-		strRef := pool.InternString(v)
-		return &pb.InternedValue{
-			Kind: &pb.InternedValue_StringValue{
-				StringValue: strRef.id,
-			},
-		}, nil
-	case int:
-		return &pb.InternedValue{
-			Kind: &pb.InternedValue_Int64Value{
-				Int64Value: int64(v),
-			},
-		}, nil
-	case float64:
-		return &pb.InternedValue{
-			Kind: &pb.InternedValue_DoubleValue{
-				DoubleValue: v,
-			},
-		}, nil
-	case time.Time:
-		return &pb.InternedValue{
-			Kind: &pb.InternedValue_TimestampValue{
-				TimestampValue: timestamppb.New(v),
-			},
-		}, nil
-	default:
-		return nil, fmt.Errorf("unsupported scalar type: %T", v)
-	}
 }
 
 func structKeyFromNodes(fieldPathSetID uint32, nodes []structured.Node, pool *InternPool, buf []byte) (string, error) {
@@ -264,36 +189,6 @@ func appendNodeKey(buf []byte, node structured.Node, pool *InternPool) ([]byte, 
 	default:
 		return append(buf, 0xFF), nil
 	}
-}
-
-func sequenceToInternedValue(node structured.Node, pool *InternPool) (*pb.InternedValue, error) {
-	listValues := make([]*pb.InternedValue, 0, node.Len())
-	for _, child := range node.Children() {
-		val, err := ToInternedValue(child, pool)
-		if err != nil {
-			return nil, err
-		}
-		listValues = append(listValues, val)
-	}
-	return &pb.InternedValue{
-		Kind: &pb.InternedValue_ListValue{
-			ListValue: &pb.InternedListValue{
-				Values: listValues,
-			},
-		},
-	}, nil
-}
-
-func mapToInternedValue(node structured.Node, pool *InternPool) (*pb.InternedValue, error) {
-	s, err := ToInternedStruct(node, pool)
-	if err != nil {
-		return nil, err
-	}
-	return &pb.InternedValue{
-		Kind: &pb.InternedValue_StructId{
-			StructId: s.id,
-		},
-	}, nil
 }
 
 // FromInternedStruct converts an InternedStruct back to a structured.Node.

--- a/pkg/model/khifile/v6/struct_test.go
+++ b/pkg/model/khifile/v6/struct_test.go
@@ -194,7 +194,7 @@ time_val: 2026-04-20T03:00:00Z
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			idGenGot := id.NewGenerator()
-			poolGot := NewInternPool(idGenGot)
+			poolGot := NewTestInternPool(idGenGot)
 
 			node, err := structured.FromYAML(tc.yaml)
 			if err != nil {
@@ -210,7 +210,7 @@ time_val: 2026-04-20T03:00:00Z
 			}
 
 			idGenWant := id.NewGenerator()
-			poolWant := NewInternPool(idGenWant)
+			poolWant := NewTestInternPool(idGenWant)
 			want := tc.want(poolWant)
 
 			if diff := cmp.Diff(want, got.ToProto(), protocmp.Transform()); diff != "" {
@@ -242,7 +242,7 @@ time_val: 2026-04-20T03:00:00Z
 
 func TestFromInternedValue(t *testing.T) {
 	idGen := id.NewGenerator()
-	pool := NewInternPool(idGen)
+	pool := NewTestInternPool(idGen)
 	helloStrID := pool.InternString("hello").id
 	timeVal := time.Date(2026, 4, 20, 3, 0, 0, 0, time.UTC)
 

--- a/pkg/model/khifile/v6/timeline_accumulator.go
+++ b/pkg/model/khifile/v6/timeline_accumulator.go
@@ -27,9 +27,9 @@ type TimelineAccumulator struct {
 }
 
 // NewTimelineAccumulator creates a new TimelineAccumulator facade.
-func NewTimelineAccumulator(idGen *id.Generator, clientPool *InternPool, serverPool *InternPool, logAcc *LogAccumulator) *TimelineAccumulator {
+func NewTimelineAccumulator(idGen *id.Generator, clientPool *InternPool, serverPool *InternPool) *TimelineAccumulator {
 	pathPool := NewTimelinePathPool(idGen, clientPool)
-	registry := NewTimelineRegistry(idGen, clientPool, serverPool, logAcc)
+	registry := NewTimelineRegistry(idGen, clientPool, serverPool)
 	return &TimelineAccumulator{
 		pathPool: pathPool,
 		registry: registry,

--- a/pkg/model/khifile/v6/timeline_path_test.go
+++ b/pkg/model/khifile/v6/timeline_path_test.go
@@ -27,7 +27,7 @@ import (
 func TestTimelinePathPool_Get(t *testing.T) {
 	// Set up common dependencies for tests
 	idGen := id.NewGenerator()
-	internPool := NewInternPool(idGen)
+	internPool := NewTestInternPool(idGen)
 
 	id1 := uint32(1)
 	id2 := uint32(2)

--- a/pkg/model/khifile/v6/timeline_registry.go
+++ b/pkg/model/khifile/v6/timeline_registry.go
@@ -19,7 +19,6 @@ import (
 	"iter"
 	"sync"
 
-	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 )
 
@@ -32,8 +31,6 @@ type TimelineRegistry struct {
 	clientPool *InternPool
 	// serverPool is passed to new TimelineBuilder instances for struct interning.
 	serverPool *InternPool
-	// logAcc is the LogAccumulator reference used to resolve log IDs.
-	logAcc *LogAccumulator
 	// builders is a concurrent map caching *TimelinePath to its *TimelineBuilder.
 	builders sync.Map // map[*TimelinePath]*TimelineBuilder
 	// idToBuilder is a concurrent map caching ID to *TimelineBuilder.
@@ -41,7 +38,7 @@ type TimelineRegistry struct {
 }
 
 // NewTimelineRegistry creates a new registry for managing TimelineBuilders.
-func NewTimelineRegistry(idGen *id.Generator, clientPool *InternPool, serverPool *InternPool, logAcc *LogAccumulator) *TimelineRegistry {
+func NewTimelineRegistry(idGen *id.Generator, clientPool *InternPool, serverPool *InternPool) *TimelineRegistry {
 	if serverPool == nil {
 		serverPool = clientPool
 	}
@@ -49,7 +46,6 @@ func NewTimelineRegistry(idGen *id.Generator, clientPool *InternPool, serverPool
 		idGen:      idGen,
 		clientPool: clientPool,
 		serverPool: serverPool,
-		logAcc:     logAcc,
 	}
 }
 
@@ -127,12 +123,4 @@ func (r *TimelineRegistry) ResolveBuilderFromID(id uint32) *TimelineBuilder {
 		return value.(*TimelineBuilder)
 	}
 	return nil
-}
-
-// GetLog retrieves a log entry by its ID from the underlying accumulator.
-func (r *TimelineRegistry) GetLog(id uint32) *pb.Log {
-	if r.logAcc == nil {
-		return nil
-	}
-	return r.logAcc.GetLog(id)
 }

--- a/pkg/model/khifile/v6/timeline_registry_test.go
+++ b/pkg/model/khifile/v6/timeline_registry_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestTimelineRegistry_GetBuilder(t *testing.T) {
 	idGen := id.NewGenerator()
-	internPool := NewInternPool(idGen)
+	internPool := NewTestInternPool(idGen)
 	pool := NewTimelinePathPool(idGen, internPool)
 
 	id := uint32(1)
@@ -123,9 +123,8 @@ func TestTimelineRegistry_GetBuilder(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Use a fresh registry for each test case
-			serverPool := NewServerInternPool(internPool, idGen)
-			logAcc := NewLogAccumulator(internPool, serverPool, idGen)
-			registry := NewTimelineRegistry(idGen, internPool, serverPool, logAcc)
+			serverPool := NewTestServerInternPool(internPool, idGen)
+			registry := NewTimelineRegistry(idGen, internPool, serverPool)
 			tc.test(t, registry)
 		})
 	}

--- a/pkg/model/khifile/v6/timeline_serializer_test.go
+++ b/pkg/model/khifile/v6/timeline_serializer_test.go
@@ -156,11 +156,10 @@ func TestExtractTimelinesAndItemsChunkSource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Isolated Setup for deterministic IDs
 			idGen := id.NewGenerator()
-			internPool := NewInternPool(idGen)
-			serverPool := NewServerInternPool(internPool, idGen)
+			internPool := NewTestInternPool(idGen)
+			serverPool := NewTestServerInternPool(internPool, idGen)
 			pathPool := NewTimelinePathPool(idGen, internPool)
-			logAcc := NewLogAccumulator(internPool, serverPool, idGen)
-			registry := NewTimelineRegistry(idGen, internPool, serverPool, logAcc)
+			registry := NewTimelineRegistry(idGen, internPool, serverPool)
 
 			pathMap := make(map[string]*TimelinePath)
 

--- a/pkg/model/khifile/v6/timeline_sorter_test.go
+++ b/pkg/model/khifile/v6/timeline_sorter_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestCompareAlphabetical(t *testing.T) {
 	idGen := id.NewGenerator()
-	internPool := NewInternPool(idGen)
+	internPool := NewTestInternPool(idGen)
 	pool := NewTimelinePathPool(idGen, internPool)
 	timelineType := &pb.TimelineType{Id: proto.Uint32(1)}
 
@@ -85,7 +85,7 @@ func TestCompareAlphabetical(t *testing.T) {
 
 func TestCompareChronological(t *testing.T) {
 	idGen := id.NewGenerator()
-	internPool := NewInternPool(idGen)
+	internPool := NewTestInternPool(idGen)
 	pool := NewTimelinePathPool(idGen, internPool)
 	timelineType := &pb.TimelineType{Id: proto.Uint32(1)}
 
@@ -161,9 +161,8 @@ func TestCompareChronological(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			serverPool := NewServerInternPool(internPool, idGen)
-			logAcc := NewLogAccumulator(internPool, serverPool, idGen)
-			registry := NewTimelineRegistry(idGen, internPool, serverPool, logAcc)
+			serverPool := NewTestServerInternPool(internPool, idGen)
+			registry := NewTimelineRegistry(idGen, internPool, serverPool)
 
 			tc.setupFunc(registry)
 
@@ -177,7 +176,7 @@ func TestCompareChronological(t *testing.T) {
 
 func TestCompareGroupedChronological(t *testing.T) {
 	idGen := id.NewGenerator()
-	internPool := NewInternPool(idGen)
+	internPool := NewTestInternPool(idGen)
 	pool := NewTimelinePathPool(idGen, internPool)
 	timelineType := &pb.TimelineType{Id: proto.Uint32(1)}
 
@@ -262,9 +261,8 @@ func TestCompareGroupedChronological(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			serverPool := NewServerInternPool(internPool, idGen)
-			logAcc := NewLogAccumulator(internPool, serverPool, idGen)
-			registry := NewTimelineRegistry(idGen, internPool, serverPool, logAcc)
+			serverPool := NewTestServerInternPool(internPool, idGen)
+			registry := NewTimelineRegistry(idGen, internPool, serverPool)
 			tc.setupFunc(registry)
 
 			got := CompareGroupedChronological(tc.a, tc.b, registry, parentToChildren, "-")

--- a/pkg/server/workbench/architecturegraph/builder_test.go
+++ b/pkg/server/workbench/architecturegraph/builder_test.go
@@ -57,7 +57,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "complete topology with node, pod, service, replicaset, deployment and edges",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				nodeStructID := internJSON(t, pool, `{
 					"metadata": {"uid": "node-uid-1", "labels": {"kubernetes.io/hostname": "node-1"}},
@@ -310,7 +310,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "virtual node synthesized when pod references unobserved node",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				podStructID := internJSON(t, pool, `{
 					"metadata": {"uid": "pod-uid-2"},
@@ -376,7 +376,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "node name resolved from binding child timeline",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				podStructID := internJSON(t, pool, `{
 					"metadata": {"uid": "pod-uid-3"},
@@ -455,7 +455,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "deletion threshold filters expired resources and keeps recent deletions",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				pod1StructID := internJSON(t, pool, `{"metadata": {"uid": "pod-1"}}`)
 				pod2StructID := internJSON(t, pool, `{"metadata": {"uid": "pod-2"}}`)
@@ -518,7 +518,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "timeline bitset filtering restricts resources",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				pod1StructID := internJSON(t, pool, `{"metadata": {"uid": "pod-1"}}`)
 				pod2StructID := internJSON(t, pool, `{"metadata": {"uid": "pod-2"}}`)
@@ -580,7 +580,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "empty timeline bitset filters all resources",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 				pod1StructID := internJSON(t, pool, `{"metadata": {"uid": "pod-1"}}`)
 
 				timelines := []*cel.TimelineData{
@@ -618,7 +618,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "node condition positivity and container waiting states",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				nodeStructID := internJSON(t, pool, `{
 					"metadata": {"uid": "node-uid-2"},
@@ -740,7 +740,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "pod node resolved from node child pod phase timeline when manifest lacks node name",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				nodeStructID := internJSON(t, pool, `{
 					"metadata": {"uid": "node-uid-1"},
@@ -832,7 +832,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "pod resolved from pod phase timeline with child container and condition when manifest reader is nil",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				timelines := []*cel.TimelineData{
 					{ID: 1, Name: "test-cluster"},
@@ -948,7 +948,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "pod synthesized from pod phase timeline without primary pod timeline",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				timelines := []*cel.TimelineData{
 					{ID: 1, Name: "test-cluster"},
@@ -1019,7 +1019,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			name: "pod fallback with waiting container and negative condition",
 			setup: func(t *testing.T) (*Builder, *apiv1.GetArchitectureGraphRequest) {
-				pool := khifilev6model.NewInternPool(id.NewGenerator())
+				pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 				timelines := []*cel.TimelineData{
 					{ID: 1, Name: "test-cluster"},

--- a/pkg/server/workbench/cel/env_test.go
+++ b/pkg/server/workbench/cel/env_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestTimelineEvaluator(t *testing.T) {
-	pool := khifilev6model.NewInternPool(id.NewGenerator())
+	pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 	node, err := structured.FromYAML(`kind: Pod
 metadata:
   name: pod-sample
@@ -189,7 +189,7 @@ spec:
 }
 
 func TestLogEvaluator(t *testing.T) {
-	pool := khifilev6model.NewInternPool(id.NewGenerator())
+	pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 	logNode, err := structured.FromYAML(`verb: create
 user:
   username: system:admin
@@ -385,7 +385,7 @@ func TestValidateLogQuery(t *testing.T) {
 }
 
 func TestLogEvaluator_FallbackWithoutTrigramIndex(t *testing.T) {
-	pool := khifilev6model.NewInternPool(id.NewGenerator())
+	pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 	logNode, err := structured.FromYAML(`verb: create
 user:
   username: system:admin
@@ -474,7 +474,7 @@ user:
 }
 
 func TestLogEvaluator_WithTrigramIndex(t *testing.T) {
-	pool := khifilev6model.NewInternPool(id.NewGenerator())
+	pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 	node1, err := structured.FromYAML(`verb: create
 user:

--- a/pkg/server/workbench/cel/trigram_test.go
+++ b/pkg/server/workbench/cel/trigram_test.go
@@ -555,7 +555,7 @@ func TestTrigramIndex_BuildFromStructPool(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pool := khifilev6model.NewInternPool(id.NewGenerator())
+			pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 			structIDs := make([]uint32, 0, len(tc.yamls))
 			for _, yamlStr := range tc.yamls {
 				node, err := structured.FromYAML(yamlStr)
@@ -626,7 +626,7 @@ func TestTrigramIndex_BuildFromLogPool(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pool := khifilev6model.NewInternPool(id.NewGenerator())
+			pool := khifilev6model.NewTestInternPool(id.NewGenerator())
 
 			// Intern strings
 			summaryIDMap := make(map[uint32]uint32)

--- a/pkg/server/workbench/index_manager_test.go
+++ b/pkg/server/workbench/index_manager_test.go
@@ -33,7 +33,20 @@ import (
 func createTestKhiFile(t *testing.T, dir string, inspectionID string) {
 	t.Helper()
 	idGen := id.NewGenerator()
-	b := khifilev6model.NewBuilder(idGen)
+
+	filePath := filepath.Join(dir, inspectionID+".khi")
+	f, err := os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	defer f.Close()
+
+	writer, err := khifilev6model.NewWriter(f)
+	if err != nil {
+		t.Fatalf("failed to create writer: %v", err)
+	}
+
+	b := khifilev6model.NewBuilder(idGen, writer)
 	node := structured.NewStandardMap(
 		[]string{"name", "message"},
 		[]structured.Node{
@@ -53,14 +66,7 @@ func createTestKhiFile(t *testing.T, dir string, inspectionID string) {
 		t.Fatalf("failed to add log: %v", err)
 	}
 
-	filePath := filepath.Join(dir, inspectionID+".khi")
-	f, err := os.Create(filePath)
-	if err != nil {
-		t.Fatalf("failed to create test file: %v", err)
-	}
-	defer f.Close()
-
-	if err := b.Build(f, nil); err != nil {
+	if err := b.Build(nil); err != nil {
 		t.Fatalf("failed to build KHI file: %v", err)
 	}
 }

--- a/pkg/server/workbench/index_test.go
+++ b/pkg/server/workbench/index_test.go
@@ -245,7 +245,7 @@ func TestBuildBaseSearchIndex(t *testing.T) {
 			setupWorkbench: func() *Workbench {
 				wb := NewWorkbench("test-wb", "test-inspection")
 				idGen := id.NewGenerator()
-				pool := khifilev6model.NewInternPool(idGen)
+				pool := khifilev6model.NewTestInternPool(idGen)
 
 				// Style Chunk
 				wb.styleChunk = &khifilev6.TimelineStyleChunk{
@@ -448,7 +448,7 @@ func TestWorkbench_BuildAsyncIndexesWithProgress(t *testing.T) {
 	setupWBAndIndex := func() (*Workbench, *SearchIndex) {
 		wb := NewWorkbench("wb-test", "insp-test")
 		idGen := id.NewGenerator()
-		pool := khifilev6model.NewInternPool(idGen)
+		pool := khifilev6model.NewTestInternPool(idGen)
 		node, err := structured.FromGoValue(map[string]any{"foo": "bar"}, &structured.AlphabeticalGoMapKeyOrderProvider{})
 		if err != nil {
 			t.Fatalf("FromGoValue() error = %v", err)

--- a/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/manifestmapper.go
@@ -249,7 +249,7 @@ func NewManifestLogToTimelineMapper[T any](setting ManifestLogToTimelineMapper[T
 					state = nextState
 
 					if cs != nil {
-						err := cs.Flush(builder.TimelineAccumulator)
+						err := cs.Flush(builder.TimelineAccumulator, builder.LogAccumulator)
 						if err != nil {
 							setErr(err)
 							return

--- a/pkg/task/inspection/commonlogk8saudit/contract/timeline_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/timeline_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestMustK8sClusterTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	testCases := []struct {
@@ -62,7 +62,7 @@ func TestMustK8sClusterTimeline(t *testing.T) {
 }
 
 func TestMustK8sAPIVersionTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	clusterTimeline := MustK8sClusterTimeline(ctx, "test-cluster")
@@ -130,7 +130,7 @@ func TestMustK8sAPIVersionTimeline(t *testing.T) {
 }
 
 func TestMustK8sKindTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	clusterTimeline := MustK8sClusterTimeline(ctx, "test-cluster")
@@ -199,7 +199,7 @@ func TestMustK8sKindTimeline(t *testing.T) {
 }
 
 func TestMustK8sNamespaceTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	clusterTimeline := MustK8sClusterTimeline(ctx, "test-cluster")
@@ -259,7 +259,7 @@ func TestMustK8sNamespaceTimeline(t *testing.T) {
 }
 
 func TestMustK8sNamespacedResourceTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	clusterTimeline := MustK8sClusterTimeline(ctx, "test-cluster")
@@ -320,7 +320,7 @@ func TestMustK8sNamespacedResourceTimeline(t *testing.T) {
 }
 
 func TestMustK8sClusterScopeResourceTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	clusterTimeline := MustK8sClusterTimeline(ctx, "test-cluster")
@@ -380,7 +380,7 @@ func TestMustK8sClusterScopeResourceTimeline(t *testing.T) {
 }
 
 func TestMustK8sSubresourceTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	clusterTimeline := MustK8sClusterTimeline(ctx, "test-cluster")

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestConditionWalker(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 	api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 	kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
@@ -274,7 +274,7 @@ func TestConditionLogToTimelineMapperTask_ProcessLog(t *testing.T) {
 	}
 
 	t.Run("PreProcessLog and ProcessLog standard lifecycle", func(t *testing.T) {
-		builder := khifilev6.NewBuilder(id.NewGenerator())
+		builder := khifilev6.NewTestBuilder(id.NewGenerator())
 		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
@@ -368,7 +368,7 @@ status:
 	})
 
 	t.Run("PreProcessLog and ProcessLog inferred creation", func(t *testing.T) {
-		builder := khifilev6.NewBuilder(id.NewGenerator())
+		builder := khifilev6.NewTestBuilder(id.NewGenerator())
 		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
@@ -449,7 +449,7 @@ status:
 	})
 
 	t.Run("PreProcessLog and ProcessLog inferred creation with UID tracking", func(t *testing.T) {
-		builder := khifilev6.NewBuilder(id.NewGenerator())
+		builder := khifilev6.NewTestBuilder(id.NewGenerator())
 		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
@@ -557,7 +557,7 @@ status:
 	})
 
 	t.Run("PreProcessLog and ProcessLog deletion", func(t *testing.T) {
-		builder := khifilev6.NewBuilder(id.NewGenerator())
+		builder := khifilev6.NewTestBuilder(id.NewGenerator())
 		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
@@ -632,7 +632,7 @@ status:
 	})
 
 	t.Run("DryRun log should be ignored", func(t *testing.T) {
-		builder := khifilev6.NewBuilder(id.NewGenerator())
+		builder := khifilev6.NewTestBuilder(id.NewGenerator())
 		cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 		api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 		kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})

--- a/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task_test.go
@@ -342,7 +342,7 @@ state:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 			containerPath := MustResolveContainerTimelinePath(ctx, "k8s", podNamespace, podName, containerName)
@@ -628,7 +628,7 @@ status:
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 			containerPath := MustResolveContainerTimelinePath(ctx, "k8s", podNamespace, podName, "main-container")

--- a/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/endpointmapper_task_test.go
@@ -587,7 +587,7 @@ endpoints:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 			var reader *structured.NodeReader

--- a/pkg/task/inspection/commonlogk8saudit/impl/errormapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/errormapper_task_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestNonSuccessLogLogToTimelineMapperTaskSetting_ProcessLogByGroup(t *testing.T) {
 	// 1. Set up the mock Builder and construct comparison paths hierarchically.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 	api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 	kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})

--- a/pkg/task/inspection/commonlogk8saudit/impl/namespacerequestmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/namespacerequestmapper_task_test.go
@@ -35,7 +35,7 @@ func TestNamespaceRequestLogToTimelineMapperTaskSetting_ProcessLog(t *testing.T)
 	testTime := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
 
 	// Set up the mock Builder and construct comparison paths hierarchically at the top of the test.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 	api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 	kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})

--- a/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/ownerreferencemapper_task_test.go
@@ -252,7 +252,7 @@ metadata:
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 			nodeReader := parseYAML(tc.yaml)
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/podphasemapper_task_test.go
@@ -481,7 +481,7 @@ status:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 			mapperSetting := &podPhaseLogToTimelineMapperTaskSetting{}
 

--- a/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/resourcemapper_test.go
@@ -36,7 +36,7 @@ func TestResourceRevisionLogToTimelineMapperTaskSetting_ProcessLog(t *testing.T)
 	testTime := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
 
 	// 1. Set up the mock Builder and construct comparison paths hierarchically.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 	api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 	kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
@@ -564,7 +564,7 @@ uid: "test-uid"`,
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Clear comparison path builder states.
-			builder = khifilev6.NewBuilder(id.NewGenerator())
+			builder = khifilev6.NewTestBuilder(id.NewGenerator())
 			cluster = builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 			api = builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 			kind = builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})
@@ -669,7 +669,7 @@ func TestResourceRevisionLogToTimelineMapperTaskSetting_PreProcessAndProcessLog(
 	testTime3 := time.Date(2023, 10, 26, 10, 10, 0, 0, time.UTC)
 	creationTimeUID1 := time.Date(2023, 10, 26, 9, 50, 0, 0, time.UTC)
 
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	cluster := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{Name: "k8s", Type: inspectioncore_contract.TimelineTypeK8sCluster})
 	api := builder.TimelineAccumulator.GetPath(cluster, khifilev6.PathSegment{Name: "core/v1", Type: inspectioncore_contract.TimelineTypeAPIVersion})
 	kind := builder.TimelineAccumulator.GetPath(api, khifilev6.PathSegment{Name: "pod", Type: inspectioncore_contract.TimelineTypeKind})

--- a/pkg/task/inspection/googlecloudclustercomposer/contract/timeline_path_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/contract/timeline_path_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestMustAirflowTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	testCases := []struct {
@@ -66,7 +66,7 @@ func TestMustAirflowTimeline(t *testing.T) {
 }
 
 func TestMustAirflowDAGTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 	envPath := MustAirflowTimeline(ctx, "my-env")
 
@@ -101,7 +101,7 @@ func TestMustAirflowDAGTimeline(t *testing.T) {
 }
 
 func TestMustAirflowDAGRunTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 	envPath := MustAirflowTimeline(ctx, "my-env")
 
@@ -162,7 +162,7 @@ func TestMustAirflowDAGRunTimeline(t *testing.T) {
 }
 
 func TestMustAirflowTaskInstanceTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 	envPath := MustAirflowTimeline(ctx, "my-env")
 	runPath := MustAirflowDAGRunTimeline(ctx, envPath, "my-dag", "my-run")
@@ -198,7 +198,7 @@ func TestMustAirflowTaskInstanceTimeline(t *testing.T) {
 }
 
 func TestMustAirflowComponentTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 	envPath := MustAirflowTimeline(ctx, "my-env")
 
@@ -236,7 +236,7 @@ func TestMustAirflowComponentTimeline(t *testing.T) {
 }
 
 func TestMustAirflowDAGFileTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 	envPath := MustAirflowTimeline(ctx, "my-env")
 
@@ -281,7 +281,7 @@ func TestMustAirflowDAGFileTimeline(t *testing.T) {
 }
 
 func TestMustAirflowDAGProcessorManagerInstanceTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 	envPath := MustAirflowTimeline(ctx, "my-env")
 

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/dag_processor_manager_mapper_test.go
@@ -134,7 +134,7 @@ func TestDagProcessorMapperTask_ProcessLogByGroup(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 			taskDependentValues := typedmap.NewTypedMap()

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/scheduler_test.go
@@ -146,7 +146,7 @@ func TestAirflowSchedulerMapperTask_ProcessLogByGroup(t *testing.T) {
 	mapper := &schedulerLogToTimelineMapper{}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 			taskDependentValues := typedmap.NewTypedMap()

--- a/pkg/task/inspection/googlecloudclustercomposer/impl/worker_test.go
+++ b/pkg/task/inspection/googlecloudclustercomposer/impl/worker_test.go
@@ -129,7 +129,7 @@ func TestAirflowWorkerMapperTask_ProcessLogByGroup(t *testing.T) {
 	mapper := &workerLogToTimelineMapper{}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 			taskDependentValues := typedmap.NewTypedMap()

--- a/pkg/task/inspection/googlecloudcommon/contract/operation_tracker_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/operation_tracker_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestGCPOperationTracker_ProcessOperationLog(t *testing.T) {
 	testTime := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	parentPath := MustGCPProjectTimeline(ctx, "test-project")
@@ -169,7 +169,7 @@ func TestGCPOperationTracker_ProcessOperationLog(t *testing.T) {
 
 func TestProcessGCPClusterNodepoolOperationLog(t *testing.T) {
 	testTime := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	parentPath := MustGCPProjectTimeline(ctx, "test-project")

--- a/pkg/task/inspection/googlecloudcommon/contract/timeline_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/timeline_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestMustComposerEnvironmentTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")
@@ -97,7 +97,7 @@ func TestMustComposerEnvironmentTimeline(t *testing.T) {
 }
 
 func TestMustGKEClusterTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")
@@ -163,7 +163,7 @@ func TestMustGKEClusterTimeline(t *testing.T) {
 }
 
 func TestMustGKENodePoolTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")
@@ -240,7 +240,7 @@ func TestMustGKENodePoolTimeline(t *testing.T) {
 }
 
 func TestMustGCPOperationTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")
@@ -319,7 +319,7 @@ func TestMustGCPOperationTimeline(t *testing.T) {
 }
 
 func TestMustGCPProjectTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	testCases := []struct {
@@ -353,7 +353,7 @@ func TestMustGCPProjectTimeline(t *testing.T) {
 }
 
 func TestMustGCPResourceTypeTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")
@@ -423,7 +423,7 @@ func TestMustGCPResourceTypeTimeline(t *testing.T) {
 }
 
 func TestMustGCPResourceTimeline(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	projectTimeline := MustGCPProjectTimeline(ctx, "test-project")

--- a/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogcomposerapiaudit/impl/parser_tasks_test.go
@@ -299,7 +299,7 @@ config:
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 			projectTimeline := googlecloudcommon_contract.MustGCPProjectTimeline(ctx, tc.inputResource.ProjectID)

--- a/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogcomputeapiaudit/impl/parser_tasks_test.go
@@ -164,7 +164,7 @@ func TestLogIngester_ProcessLog(t *testing.T) {
 }
 
 func TestLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	// Setup context with task result mapping containing ClusterIdentity
 	taskResults := typedmap.NewTypedMap()

--- a/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/parser_task_test.go
@@ -226,7 +226,7 @@ func TestCSMTrafficLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	mapper := &CSMTrafficLogLogToTimelineMapper{}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 			ctx = tasktest.WithTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(), googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
 				ClusterName: "test-cluster",

--- a/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogcsm/impl/traffic_director_parser_task_test.go
@@ -216,7 +216,7 @@ func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	mapper := &CSMTrafficDirectorLogToTimelineMapper{}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			builder := khifilev6.NewBuilder(id.NewGenerator())
+			builder := khifilev6.NewTestBuilder(id.NewGenerator())
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 			ctx = tasktest.WithTaskResult(ctx, googlecloudlogcsm_contract.ClusterIdentityTaskID.Ref(), googlecloudk8scommon_contract.GoogleCloudClusterIdentity{
 				ClusterName: "test-cluster",
@@ -248,7 +248,7 @@ func TestCSMTrafficDirectorLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 					t.Fatalf("log %d: AddLog() failed: %v", i, err)
 				}
 				// Flush verifies that all revisions and their ResourceBody can be interned without error.
-				if err := cs.Flush(builder.TimelineAccumulator); err != nil {
+				if err := cs.Flush(builder.TimelineAccumulator, builder.LogAccumulator); err != nil {
 					t.Fatalf("log %d: Flush() failed: %v", i, err)
 				}
 			}

--- a/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudloggkeapiaudit/impl/parser_tasks_test.go
@@ -60,7 +60,7 @@ var compareNodeOption = cmp.Transformer("StructuredNodeToYAML", func(n structure
 
 func TestLogToTimelineMapperTask(t *testing.T) {
 	// 1. Initialize the Builder.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	// 2. Set up expected path references.
 	wantProjectPath := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{

--- a/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser_test.go
+++ b/pkg/task/inspection/googlecloudloggkeautoscaler/impl/parser_test.go
@@ -224,7 +224,7 @@ func TestAutoscalerTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	testTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	// 1. Initialize the Builder first.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	// 2. Resolve comparative path instances using the Builder's accumulator.
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)

--- a/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontainer/impl/parser_task_test.go
@@ -171,7 +171,7 @@ func TestLogIngester_ProcessLog(t *testing.T) {
 
 // TestLogToTimelineMapper_ProcessLogByGroup tests the containerLogLogToTimelineMapper.ProcessLogByGroup function.
 func TestLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
@@ -242,7 +242,7 @@ func TestLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 
 // TestPodPhaseTimelineMapper_ProcessLogByGroup tests the containerLogPodPhaseTimelineMapper.ProcessLogByGroup function.
 func TestPodPhaseTimelineMapper_ProcessLogByGroup(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/controllermanager_task_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestControllerManagerLogToTimelineMapperTask(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	projectTimeline := googlecloudcommon_contract.MustGCPProjectTimeline(ctx, "test-project")

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/hpacontroller_task_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestHpaControllerTimelineMapper_ProcessLogByGroup(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	projectTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
 		Name: "test-project",

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/other_task_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestOtherLogToTimelineMapperTask(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	projectTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
 		Name: "test-project",

--- a/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8scontrolplane/impl/scheduler_task_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestSchedulerLogToTimelineMapperTask(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	projectTimeline := builder.TimelineAccumulator.GetPath(nil, khifilev6.PathSegment{
 		Name: "test-project",

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestLogToTimelineMapperTask(t *testing.T) {
 	// Initialize the shared Builder reference.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testCases := []struct {
 		desc   string

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/containerd_task_test.go
@@ -298,7 +298,7 @@ func TestContainerdLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	mapper := &containerdNodeLogLogToTimelineMapperSetting{}
 	testTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testCases := []struct {
 		desc                 string

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/kubelet_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/kubelet_task_test.go
@@ -38,7 +38,7 @@ func TestKubeletLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	mapper := &kubeletNodeLogLogToTimelineMapperSetting{}
 	testTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testCases := []struct {
 		desc                 string

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/other_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/other_task_test.go
@@ -45,7 +45,7 @@ func TestOtherLogLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	testTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	// 1. Initialize Builder
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testCases := []struct {
 		desc                 string

--- a/pkg/task/inspection/googlecloudlogk8snode/impl/parser_utility_test.go
+++ b/pkg/task/inspection/googlecloudlogk8snode/impl/parser_utility_test.go
@@ -182,7 +182,7 @@ func TestToReadableResourceName(t *testing.T) {
 func TestCheckStartingAndTerminationLog(t *testing.T) {
 	testTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testCases := []struct {
 		desc           string

--- a/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogmulticloudapiaudit/impl/parser_tasks_test.go
@@ -43,7 +43,7 @@ func testReaderFromYAML(t *testing.T, yaml string) *structured.NodeReader {
 
 func TestLogToTimelineMapperTask(t *testing.T) {
 	// 1. Initialize the Builder first.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testTime := time.Date(2025, time.January, 1, 1, 1, 1, 1, time.UTC)
 

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
@@ -125,7 +125,7 @@ func TestNetworkAPILogIngester_ProcessLog(t *testing.T) {
 
 func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 	testTime := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	// Define expected timeline paths.
 	wantNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGTimeline(khictx.WithValue(context.Background(), inspectioncore_contract.Builder, builder), "cluster", "test-ns", "test-neg")

--- a/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogonpremapiaudit/impl/parser_tasks_test.go
@@ -93,7 +93,7 @@ func TestOnPremAPIAuditTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	testTime := time.Date(2025, time.January, 1, 1, 1, 1, 1, time.UTC)
 
 	// 1. Initialize the Builder.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	cmpNode := cmp.Comparer(func(x, y structured.Node) bool {
 		if x == nil && y == nil {

--- a/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks_test.go
+++ b/pkg/task/inspection/googlecloudlogserialport/impl/parser_tasks_test.go
@@ -76,7 +76,7 @@ func TestSerialPortLogIngester_ProcessLog(t *testing.T) {
 }
 
 func TestSerialPortLogToTimelineMapper_ProcessLogByGroup(t *testing.T) {
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 	wantSerialPortPath := googlecloudlogserialport_contract.MustSerialPortTimeline(ctx, "test-cluster", "node-name-bar", "serial_port_output_qux")
 

--- a/pkg/task/inspection/inspectioncore/impl/serializer.go
+++ b/pkg/task/inspection/inspectioncore/impl/serializer.go
@@ -63,20 +63,11 @@ var SerializeTask = inspectiontaskbase.NewProgressReportableInspectionTask(inspe
 		}
 	}
 
-	// 2. Prepare Output File Store
+	// 2. Prepare Output File Store for size reporting
 	store := inspectioncore_contract.NewFileSystemInspectionResultRepository(filepath.Join(ioConfig.DataDestination, inspectionID+".khi"))
-	writer, err := store.GetWriter()
-	if err != nil {
-		return nil, err
-	}
 
-	// 3. Build KHI v6 format and write
-	if err := builder.Build(writer, &taskProgressReporter{progress: progress}); err != nil {
-		writer.Close()
-		return nil, err
-	}
-
-	if err := writer.Close(); err != nil {
+	// 3. Build KHI v6 format and flush remaining chunks
+	if err := builder.Build(&taskProgressReporter{progress: progress}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/task/inspection/inspectioncore/impl/serializer_test.go
+++ b/pkg/task/inspection/inspectioncore/impl/serializer_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
@@ -126,6 +127,24 @@ func TestSerializeTask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			taskCtx := inspectiontest.WithDefaultTestInspectionTaskContext(ctx)
+
+			if tc.taskMode == inspectioncore_contract.TaskModeRun {
+				ioConfig := khictx.MustGetValue(taskCtx, inspectioncore_contract.CurrentIOConfig)
+				inspectionID := khictx.MustGetValue(taskCtx, inspectioncore_contract.InspectionTaskInspectionID)
+				store := inspectioncore_contract.NewFileSystemInspectionResultRepository(filepath.Join(ioConfig.DataDestination, inspectionID+".khi"))
+				fw, err := store.GetWriter()
+				if err != nil {
+					t.Fatalf("failed to create file writer: %v", err)
+				}
+				w, err := khifilev6.NewWriter(fw)
+				if err != nil {
+					_ = fw.Close()
+					t.Fatalf("failed to create writer: %v", err)
+				}
+				idGen := khictx.MustGetValue(taskCtx, inspectioncore_contract.IDGenerator)
+				b := khifilev6.NewBuilder(idGen, w)
+				taskCtx = khictx.WithValue(taskCtx, inspectioncore_contract.Builder, b)
+			}
 
 			// Obtain the builder from task context.
 			builder := khictx.MustGetValue(taskCtx, inspectioncore_contract.Builder)

--- a/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task_test.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task_test.go
@@ -72,7 +72,7 @@ func TestOSSK8sEventLogIngester_ProcessLog(t *testing.T) {
 
 func TestOSSK8sEventTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	// Initialize the shared Builder reference.
-	builder := khifilev6.NewBuilder(id.NewGenerator())
+	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testCases := []struct {
 		desc   string

--- a/web/src/app/store/domain/log-store.spec.ts
+++ b/web/src/app/store/domain/log-store.spec.ts
@@ -113,7 +113,7 @@ describe('LogStore', () => {
     }).not.toThrow();
   });
 
-  it('should throw error if logs are out of timestamp order', () => {
+  it('should accept logs with out of order timestamps', () => {
     const logs: LogDTO[] = [
       { id: 1, ts: 1000n, logTypeId: 1, severityTypeId: 1, summaryStringId: 1 },
       { id: 2, ts: 999n, logTypeId: 2, severityTypeId: 2, summaryStringId: 2 },
@@ -122,7 +122,7 @@ describe('LogStore', () => {
     expect(() => {
       const s = LogStore.create(internPool, styleStore, 2);
       s.addLogs(logs);
-    }).toThrowError(/Logs are not sorted by timestamp/);
+    }).not.toThrow();
   });
 
   it('should fetch log entries and handle incorrect id lookups', () => {
@@ -288,7 +288,7 @@ describe('LogStore', () => {
       expect(() => emptyStore.getLog(1)).toThrowError(/Log ID 1 not found/);
     });
 
-    it('should throw error when adding unsorted logs', () => {
+    it('should accept adding unsorted logs', () => {
       const dynamicStore = LogStore.create(internPool, styleStore);
       dynamicStore.addLog({
         id: 1,
@@ -306,7 +306,8 @@ describe('LogStore', () => {
           severityTypeId: 1,
           summaryStringId: 1,
         }),
-      ).toThrowError(/Logs are not sorted by timestamp/);
+      ).not.toThrow();
+      expect(dynamicStore.count).toBe(2);
     });
 
     it('should retrieve log ID by chronological index', () => {

--- a/web/src/app/store/domain/log-store.ts
+++ b/web/src/app/store/domain/log-store.ts
@@ -65,7 +65,6 @@ export class LogStore {
   private idToIndex: (number | undefined)[] = [];
 
   private logCount = 0;
-  private previousTimestamp = 0n;
 
   private constructor(
     private readonly internPool: InternPoolStore,
@@ -94,7 +93,6 @@ export class LogStore {
 
   /**
    * Appends multiple logs to the store.
-   * Logs must be in non-decreasing timestamp order.
    *
    * @param logs An iterable of LogDTO objects.
    */
@@ -192,18 +190,10 @@ export class LogStore {
 
   /**
    * Appends a single log to the store.
-   * Logs must be added in non-decreasing timestamp order.
    *
    * @param log The raw LogDTO to add.
    */
   public addLog(log: LogDTO): void {
-    if (this.logCount > 0 && log.ts < this.previousTimestamp) {
-      throw new Error(
-        `Logs are not sorted by timestamp at index ${this.logCount}: timestamp ${log.ts} < ${this.previousTimestamp}`,
-      );
-    }
-    this.previousTimestamp = log.ts;
-
     this.ensureCapacity(this.logCount + 1);
 
     const index = this.logCount;


### PR DESCRIPTION
## Overview
Analysis of heap profiles during the log inspection (collection & generation) phase showed that ~88% of live heap allocations were concentrated in `ToInternedStruct` (individual `*pb.InternedValue` allocations) and `LogAccumulator` (pointer graph of staged logs).

This PR transitions the in-memory staging models to flat, pointer-free Structure-of-Arrays (SoA) representations while preserving on-disk `.khi` format and streaming chunk compatibility.

---

## Key Changes

### 1. Direct Node Encoding into `FlatStructStore`
- Added `StoreFromNodes` to `FlatStructStore`, encoding `structured.Node` scalars and sequences directly into contiguous primitive value slices (`kinds`, `scalarInts`, `scalarFloats`, `scalarStrings`, `listOffsets`).
- Implemented `ensureNestedMapsInterned` to pre-intern nested maps into `InternPool` before acquiring store lock, preventing lock contention and deadlocks.

### 2. Integrate `FlatStructStore` into `InternPool` and `ToInternedStruct`
- Replaced `idToStruct []*pb.InternedStruct` and `unflushedStructs []*pb.InternedStruct` in `InternPool` with `flatStructs *FlatStructStore` and `unflushedStructIDs []uint32`.
- `ToInternedStruct` now directly calls `StoreFromNodes` on cache miss, eliminating temporary `*pb.InternedValue` allocations.
- Removed obsolete legacy conversion helpers (`ToInternedValue`, `scalarToInternedValue`, etc.) adhering to the zero-backward-compatibility policy.
- Transient `*pb.InternedStruct` messages are only constructed during chunk protobuf serialization and compressed immediately.

### 3. Store Staged Logs in Flat Primitive Slices in `LogAccumulator`
- Replaced `currentBatch []*pb.Log` in `LogAccumulator` with flat SoA slices (`batchIDs`, `batchTimestamps`, `batchLogTypeIDs`, `batchSeverityIDs`, `batchSummaryIDs`, `batchBodyStructIDs`).
- `AddLog` converts metadata and appends scalar values directly into primitive arrays without allocating heap `*pb.Log` or `*timestamppb.Timestamp` objects.
- `flushLocked` stably sorts permutation indices based on timestamps, writes the chunk, and resets slice lengths (`[:0]`) to reuse allocated backing capacity across batches.

---

## E2E Benchmark: Memory Consumption Results

Measured via `/usr/bin/time -v` and Go pprof memory profiles (`--memprofile`) on a 4-hour production cluster log query (`p0-gke-basic-1`, 10 features, 42,478+ logs):

| Metric | Baseline | Optimized | Delta | % Change |
| :--- | :--- | :--- | :--- | :--- |
| **Max Resident Set Size (Peak RSS)** | **2,512,676 KB (~2.40 GB)** | **1,933,472 KB (~1.84 GB)** | **-579,204 KB (-565.6 MB)** | **-23.0%** |
| **Minor Page Faults** | 321,992 | 58,013 | -263,979 | **-82.0%** |
| **Live Heap In-Use Space** | 737.09 MB | 409.33 MB | -327.76 MB | **-44.5%** |
| **Live Heap In-Use Objects** | 16,802,357 objects | 9,064,750 objects | **-7,737,607 objects** | **-46.1%** |
| **Output `.khi` Size** | 20.46 MB | 20.42 MB | -0.04 MB | (identical) |

### Top Allocations Breakdown (pprof diff)
- `scalarToInternedValue`: **-320.52 MB (-5,988,669 objects)** (100% eliminated from live heap)
- `ToInternedValue`: **-384.02 MB cum (-7,658,528 objects cum)** (100% eliminated)
- `LogAccumulator.AddLog`: **-315.67 MB cum (-7,431,052 objects cum)** (-48.4% live memory)
- `FlatStructStore`: Only **+104.61 MB** of primitive array capacity was needed to hold all structured data, yielding a net reduction of **~545 MB** in struct storage.

---

## Verification
- `make pre-commit`: PASS
- `make lint-go && make lint-web`: PASS (0 issues)
- `make test-go && make test-web`: PASS (all Go tests and 1088 web tests pass)
- E2E inspection job completed with exit code 0 and verified output file integrity.