### PR TITLE
feat(timeline): extract multi-term log search as shared chip-search-bar dumb component

### DIFF
--- a/web/src/app/services/view-state.service.ts
+++ b/web/src/app/services/view-state.service.ts
@@ -68,9 +68,9 @@ export class ViewStateService {
   public readonly standardSelectedSeverity = signal<string>('ANY');
 
   /**
-   * The persistent standard mode log search query.
+   * The persistent standard mode log search terms.
    */
-  public readonly standardLogSearchQuery = signal<string>('');
+  public readonly standardLogSearchTerms = signal<string[]>([]);
 
   /**
    * The persistent advanced mode timeline include CEL query.

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.html
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.html
@@ -27,6 +27,7 @@ limitations under the License.
         <button
           type="button"
           class="remove-chip-btn"
+          (mousedown)="$event.preventDefault()"
           (click)="onRemoveChip($index, $event)"
         >
           <mat-icon>close</mat-icon>
@@ -51,6 +52,7 @@ limitations under the License.
       type="button"
       class="clear-search-btn"
       matTooltip="Clear search"
+      (mousedown)="$event.preventDefault()"
       (click)="onClearClick($event)"
     >
       <mat-icon>close</mat-icon>

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.html
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.html
@@ -1,0 +1,59 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div
+  class="chip-search-container"
+  [class.has-query]="hasQuery()"
+  (click)="onContainerClick()"
+>
+  <mat-icon class="search-prefix-icon">search</mat-icon>
+  <div class="search-tokens-wrapper">
+    @for (chip of searchTerms(); track $index) {
+      <div class="search-chip">
+        <span class="chip-text">{{ chip }}</span>
+        <button
+          type="button"
+          class="remove-chip-btn"
+          (click)="onRemoveChip($index, $event)"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+      <span class="or-separator">OR</span>
+    }
+    <input
+      #inputElement
+      type="text"
+      class="search-text-input"
+      [placeholder]="dynamicPlaceholder()"
+      [value]="draft()"
+      (input)="onDraftInput(inputElement.value)"
+      (blur)="onBlur()"
+      (keydown)="onKeyDown($event)"
+      (paste)="onPaste($event)"
+    />
+  </div>
+  @if (hasQuery()) {
+    <button
+      type="button"
+      class="clear-search-btn"
+      matTooltip="Clear search"
+      (click)="onClearClick($event)"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+  }
+</div>

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.scss
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.scss
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+
+$container-bg-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 50);
+$container-border-color: mat.m2-get-color-from-palette(
+  mat.$m2-gray-palette,
+  400
+);
+$container-border-hover-color: mat.m2-get-color-from-palette(
+  mat.$m2-gray-palette,
+  600
+);
+$container-border-focus-color: mat.m2-get-color-from-palette(
+  mat.$m2-indigo-palette,
+  500
+);
+
+$prefix-icon-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 600);
+$input-text-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 900);
+$input-placeholder-color: mat.m2-get-color-from-palette(
+  mat.$m2-gray-palette,
+  500
+);
+
+$chip-bg-color: mat.m2-get-color-from-palette(mat.$m2-indigo-palette, 50);
+$chip-border-color: mat.m2-get-color-from-palette(mat.$m2-indigo-palette, 200);
+$chip-text-color: mat.m2-get-color-from-palette(mat.$m2-indigo-palette, 800);
+$chip-remove-hover-color: mat.m2-get-color-from-palette(
+  mat.$m2-red-palette,
+  600
+);
+
+$or-badge-bg-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 200);
+$or-badge-text-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 700);
+
+$clear-btn-hover-color: mat.m2-get-color-from-palette(
+  mat.$m2-gray-palette,
+  800
+);
+
+:host {
+  display: contents;
+}
+
+.chip-search-container {
+  display: grid;
+  grid-template:
+    'prefix tokens clear' 1fr
+    / auto 1fr auto;
+  align-items: center;
+  flex: 1 1 220px;
+  min-width: 180px;
+  max-width: 440px;
+  min-height: 36px;
+  border: 1px solid $container-border-color;
+  border-radius: 4px;
+  padding: 2px 8px;
+  background-color: $container-bg-color;
+  cursor: text;
+  box-sizing: border-box;
+  transition:
+    max-width 0.2s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+
+  &:hover {
+    border-color: $container-border-hover-color;
+  }
+
+  &:focus-within {
+    max-width: 580px;
+    border-color: $container-border-focus-color;
+    box-shadow: 0 0 0 1px $container-border-focus-color;
+  }
+}
+
+.search-prefix-icon {
+  grid-area: prefix;
+  color: $prefix-icon-color;
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  margin-right: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.search-tokens-wrapper {
+  grid-area: tokens;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.search-chip {
+  display: flex;
+  align-items: center;
+  background-color: $chip-bg-color;
+  border: 1px solid $chip-border-color;
+  border-radius: 12px;
+  padding: 1px 4px 1px 8px;
+  font-size: 12px;
+  color: $chip-text-color;
+  max-width: 200px;
+
+  .chip-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .remove-chip-btn {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    margin-left: 2px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
+    border-radius: 50%;
+
+    mat-icon {
+      font-size: 14px;
+      width: 14px;
+      height: 14px;
+    }
+
+    &:hover {
+      color: $chip-remove-hover-color;
+    }
+  }
+}
+
+.or-separator {
+  font-size: 10px;
+  font-weight: 700;
+  color: $or-badge-text-color;
+  background-color: $or-badge-bg-color;
+  padding: 1px 4px;
+  border-radius: 4px;
+  letter-spacing: 0.5px;
+  user-select: none;
+}
+
+.search-text-input {
+  flex: 1 1 80px;
+  min-width: 80px;
+  border: 0;
+  outline: none;
+  background: transparent;
+  font-size: 13px;
+  color: $input-text-color;
+  padding: 4px 0;
+
+  &::placeholder {
+    color: $input-placeholder-color;
+  }
+}
+
+.clear-search-btn {
+  grid-area: clear;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: $prefix-icon-color;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 50%;
+  margin-left: 4px;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
+  &:hover {
+    color: $clear-btn-hover-color;
+  }
+}

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.spec.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.spec.ts
@@ -174,6 +174,63 @@ describe('ChipSearchBarComponent', () => {
     ]);
   });
 
+  it('should combine draft at selection when pasting delimited text', () => {
+    const inputEl = fixture.debugElement.query(By.css('.search-text-input'))
+      .nativeElement as HTMLInputElement;
+
+    component.onDraftInput('prefix_suffix');
+    fixture.detectChanges();
+
+    inputEl.setSelectionRange(7, 7); // between 'prefix_' and 'suffix'
+
+    const clipboardData = new DataTransfer();
+    clipboardData.setData('text/plain', 'middle1 | middle2');
+    const pasteEvent = new ClipboardEvent('paste', {
+      clipboardData,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    inputEl.dispatchEvent(pasteEvent);
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual([
+      'prefix_middle1',
+      'middle2suffix',
+    ]);
+    expect(component.draft()).toBe('');
+  });
+
+  it('should prevent default on mousedown for remove button to preserve input focus', () => {
+    fixture.componentRef.setInput('searchTerms', ['chip1']);
+    fixture.detectChanges();
+
+    const removeBtn = fixture.debugElement.query(By.css('.remove-chip-btn'));
+    const mousedownEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    removeBtn.nativeElement.dispatchEvent(mousedownEvent);
+
+    expect(mousedownEvent.defaultPrevented).toBeTrue();
+  });
+
+  it('should prevent default on mousedown for clear button to preserve input focus', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo']);
+    fixture.detectChanges();
+
+    const clearBtn = fixture.debugElement.query(By.css('.clear-search-btn'));
+    const mousedownEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    clearBtn.nativeElement.dispatchEvent(mousedownEvent);
+
+    expect(mousedownEvent.defaultPrevented).toBeTrue();
+  });
+
   it('should clear all chips and draft when clicking clear button', () => {
     fixture.componentRef.setInput('searchTerms', ['foo']);
     fixture.detectChanges();

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.spec.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ChipSearchBarComponent } from './chip-search-bar.component';
+
+describe('ChipSearchBarComponent', () => {
+  let component: ChipSearchBarComponent;
+  let fixture: ComponentFixture<ChipSearchBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChipSearchBarComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipSearchBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render default placeholder when no terms exist', () => {
+    const inputEl = fixture.debugElement.query(By.css('.search-text-input'))
+      .nativeElement as HTMLInputElement;
+    expect(inputEl.placeholder).toBe('Search in log body...');
+  });
+
+  it('should render chips and OR separators when searchTerms has items', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo', 'bar']);
+    fixture.detectChanges();
+
+    const chipEls = fixture.debugElement.queryAll(By.css('.search-chip'));
+    expect(chipEls.length).toBe(2);
+    expect(chipEls[0].nativeElement.textContent).toContain('foo');
+    expect(chipEls[1].nativeElement.textContent).toContain('bar');
+
+    const orSeparators = fixture.debugElement.queryAll(By.css('.or-separator'));
+    expect(orSeparators.length).toBe(2);
+    expect(orSeparators[0].nativeElement.textContent.trim()).toBe('OR');
+  });
+
+  it('should commit draft to chips when Enter key is pressed', () => {
+    const inputEl = fixture.debugElement.query(By.css('.search-text-input'))
+      .nativeElement as HTMLInputElement;
+
+    component.onDraftInput('error');
+    fixture.detectChanges();
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter' });
+    inputEl.dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['error']);
+    expect(component.draft()).toBe('');
+  });
+
+  it('should commit draft to chips when pipe key is pressed', () => {
+    const inputEl = fixture.debugElement.query(By.css('.search-text-input'))
+      .nativeElement as HTMLInputElement;
+
+    component.onDraftInput('warning');
+    fixture.detectChanges();
+
+    const event = new KeyboardEvent('keydown', { key: '|' });
+    inputEl.dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['warning']);
+    expect(component.draft()).toBe('');
+  });
+
+  it('should commit draft to chips on input blur', () => {
+    const inputEl = fixture.debugElement.query(By.css('.search-text-input'))
+      .nativeElement as HTMLInputElement;
+
+    component.onDraftInput('timeout');
+    fixture.detectChanges();
+
+    inputEl.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['timeout']);
+    expect(component.draft()).toBe('');
+  });
+
+  it('should remove a chip when its remove button is clicked', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo', 'bar']);
+    fixture.detectChanges();
+
+    const removeBtns = fixture.debugElement.queryAll(
+      By.css('.remove-chip-btn'),
+    );
+    expect(removeBtns.length).toBe(2);
+
+    removeBtns[0].nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['bar']);
+  });
+
+  it('should pop last chip into draft on Backspace when draft is empty', () => {
+    fixture.componentRef.setInput('searchTerms', ['first', 'second']);
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.query(By.css('.search-text-input'))
+      .nativeElement as HTMLInputElement;
+
+    const event = new KeyboardEvent('keydown', { key: 'Backspace' });
+    inputEl.dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['first']);
+    expect(component.draft()).toBe('second');
+  });
+
+  it('should clear draft on Escape, and clear all if draft is empty', () => {
+    fixture.componentRef.setInput('searchTerms', ['term1']);
+    component.onDraftInput('term2');
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.query(By.css('.search-text-input'))
+      .nativeElement as HTMLInputElement;
+
+    // First Escape clears draft
+    inputEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fixture.detectChanges();
+    expect(component.draft()).toBe('');
+    expect(component.searchTerms()).toEqual(['term1']);
+
+    // Second Escape clears all chips
+    inputEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fixture.detectChanges();
+    expect(component.searchTerms()).toEqual([]);
+  });
+
+  it('should split pasted text with pipe delimiters into multiple chips', () => {
+    const inputEl = fixture.debugElement.query(By.css('.search-text-input'))
+      .nativeElement as HTMLInputElement;
+
+    const clipboardData = new DataTransfer();
+    clipboardData.setData('text/plain', 'alpha | beta|gamma\ndelta');
+    const pasteEvent = new ClipboardEvent('paste', {
+      clipboardData,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    inputEl.dispatchEvent(pasteEvent);
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual([
+      'alpha',
+      'beta',
+      'gamma',
+      'delta',
+    ]);
+  });
+
+  it('should clear all chips and draft when clicking clear button', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo']);
+    fixture.detectChanges();
+
+    const clearBtn = fixture.debugElement.query(By.css('.clear-search-btn'));
+    expect(clearBtn).toBeTruthy();
+
+    clearBtn.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual([]);
+    expect(component.draft()).toBe('');
+  });
+});

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.ts
@@ -153,7 +153,14 @@ export class ChipSearchBarComponent {
     const pastedText = event.clipboardData?.getData('text') ?? '';
     if (pastedText.includes('|') || pastedText.includes('\n')) {
       event.preventDefault();
-      const rawSegments = pastedText.split(/[|\r\n]+/);
+      const input = this.inputElement()?.nativeElement;
+      const start = input?.selectionStart ?? 0;
+      const end = input?.selectionEnd ?? 0;
+      const currentVal = this.draft();
+      const combined =
+        currentVal.slice(0, start) + pastedText + currentVal.slice(end);
+
+      const rawSegments = combined.split(/[|\r\n]+/);
       const validSegments: string[] = [];
       for (const seg of rawSegments) {
         const trimmed = seg.trim();

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.ts
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Component,
+  ElementRef,
+  computed,
+  input,
+  model,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+
+/**
+ * Dumb component responsible for rendering an inline multi-chip search input with OR logic.
+ */
+@Component({
+  selector: 'khi-chip-search-bar',
+  templateUrl: './chip-search-bar.component.html',
+  styleUrls: ['./chip-search-bar.component.scss'],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatTooltipModule,
+    KHIIconRegistrationModule,
+  ],
+})
+export class ChipSearchBarComponent {
+  /**
+   * The list of committed search term chips represented as a two-way model.
+   */
+  public searchTerms = model<string[]>([]);
+
+  /**
+   * Placeholder displayed when no search terms or draft text are entered.
+   */
+  public placeholder = input<string>('Search in log body...');
+
+  /**
+   * Reference to the text input element for direct focus management.
+   */
+  public readonly inputElement =
+    viewChild<ElementRef<HTMLInputElement>>('inputElement');
+
+  /**
+   * The currently uncommitted draft text in the input.
+   */
+  public readonly draft = signal<string>('');
+
+  /**
+   * Indicates whether any chips or draft text exist.
+   */
+  public readonly hasQuery = computed(
+    () => this.searchTerms().length > 0 || this.draft().trim().length > 0,
+  );
+
+  /**
+   * Dynamic placeholder text indicating OR condition when chips are present.
+   */
+  public readonly dynamicPlaceholder = computed(() => {
+    if (this.searchTerms().length > 0) {
+      return 'Add OR condition...';
+    }
+    return this.placeholder();
+  });
+
+  /**
+   * Handles user typing in the input field.
+   * @param value The raw string value from the input field.
+   */
+  onDraftInput(value: string) {
+    this.draft.set(value);
+  }
+
+  /**
+   * Focuses on the text input element.
+   */
+  focus() {
+    this.inputElement()?.nativeElement.focus();
+  }
+
+  /**
+   * Handles container click to focus on the text input.
+   */
+  onContainerClick() {
+    this.focus();
+  }
+
+  /**
+   * Handles input blur to commit any pending draft as a chip.
+   */
+  onBlur() {
+    this.commitDraft();
+  }
+
+  /**
+   * Removes a chip at the specified index.
+   * @param index Index of the chip to remove.
+   * @param event The associated mouse click event.
+   */
+  onRemoveChip(index: number, event: MouseEvent) {
+    event.stopPropagation();
+    this.searchTerms.update((terms) => terms.filter((_, i) => i !== index));
+  }
+
+  /**
+   * Handles keyboard navigation and delimiter triggers (Enter, |, Backspace, Escape).
+   * @param event The keyboard event.
+   */
+  onKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === '|') {
+      event.preventDefault();
+      this.commitDraft();
+    } else if (event.key === 'Backspace') {
+      if (!this.draft() && this.searchTerms().length > 0) {
+        event.preventDefault();
+        const currentTerms = this.searchTerms();
+        const lastTerm = currentTerms[currentTerms.length - 1];
+        this.searchTerms.set(currentTerms.slice(0, -1));
+        this.draft.set(lastTerm);
+      }
+    } else if (event.key === 'Escape') {
+      if (this.draft()) {
+        this.draft.set('');
+      } else if (this.searchTerms().length > 0) {
+        this.clearAll();
+      }
+    }
+  }
+
+  /**
+   * Handles paste events, splitting on pipe delimiters or newlines into distinct chips.
+   * @param event The clipboard paste event.
+   */
+  onPaste(event: ClipboardEvent) {
+    const pastedText = event.clipboardData?.getData('text') ?? '';
+    if (pastedText.includes('|') || pastedText.includes('\n')) {
+      event.preventDefault();
+      const rawSegments = pastedText.split(/[|\r\n]+/);
+      const validSegments: string[] = [];
+      for (const seg of rawSegments) {
+        const trimmed = seg.trim();
+        if (trimmed) {
+          validSegments.push(trimmed);
+        }
+      }
+      if (validSegments.length > 0) {
+        this.searchTerms.update((terms) => [...terms, ...validSegments]);
+        this.draft.set('');
+      }
+    }
+  }
+
+  /**
+   * Clears all chips and uncommitted draft text.
+   * @param event Optional mouse event if triggered by clear button click.
+   */
+  onClearClick(event?: MouseEvent) {
+    event?.stopPropagation();
+    this.clearAll();
+  }
+
+  /**
+   * Clears all chips and draft.
+   */
+  clearAll() {
+    this.searchTerms.set([]);
+    this.draft.set('');
+  }
+
+  /**
+   * Commits the current draft text as a chip.
+   */
+  public commitDraft() {
+    const trimmed = this.draft().trim();
+    if (trimmed) {
+      this.searchTerms.update((terms) => [...terms, trimmed]);
+      this.draft.set('');
+    }
+  }
+}

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.stories.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.stories.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryObj } from '@storybook/angular';
+import { ChipSearchBarComponent } from 'src/app/shared/components/chip-search-bar/chip-search-bar.component';
+
+export default {
+  title: 'Shared/ChipSearchBar',
+  component: ChipSearchBarComponent,
+} as Meta<ChipSearchBarComponent>;
+
+type Story = StoryObj<ChipSearchBarComponent>;
+
+export const Default: Story = {
+  args: {
+    searchTerms: [],
+    placeholder: 'Search in log body...',
+  },
+};
+
+export const WithSingleTerm: Story = {
+  args: {
+    searchTerms: ['error'],
+    placeholder: 'Search in log body...',
+  },
+};
+
+export const WithMultipleTerms: Story = {
+  args: {
+    searchTerms: ['error', 'timeout', 'connection refused'],
+    placeholder: 'Search in log body...',
+  },
+};

--- a/web/src/app/timeline-toolbar/components/toolbar-frame.component.html
+++ b/web/src/app/timeline-toolbar/components/toolbar-frame.component.html
@@ -42,7 +42,7 @@ limitations under the License.
 } @else {
   <khi-timeline-toolbar
     [(selectedSeverity)]="selectedSeverity"
-    [(logSearchQuery)]="logSearchQuery"
+    [(logSearchTerms)]="logSearchTerms"
     [(timelineFilters)]="timelineFilters"
     [(selectedTimelineTypeForBuilder)]="selectedTimelineTypeForBuilder"
     [timelineTypes]="timelineTypes()"

--- a/web/src/app/timeline-toolbar/components/toolbar-frame.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar-frame.component.ts
@@ -62,8 +62,8 @@ export class ToolbarFrameComponent {
   /** Holds the currently selected severity state. */
   readonly selectedSeverity = model.required<string>();
 
-  /** Holds the standard log search input query. */
-  readonly logSearchQuery = model.required<string>();
+  /** Holds the standard log search terms array. */
+  readonly logSearchTerms = model.required<string[]>();
 
   /** Configured standard timeline filters. */
   readonly timelineFilters = model.required<TimelineFilterConfig[]>();

--- a/web/src/app/timeline-toolbar/components/toolbar.component.html
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.html
@@ -96,28 +96,11 @@ limitations under the License.
             </mat-select>
           </mat-form-field>
 
-          <mat-form-field appearance="outline" class="search-input">
-            <mat-icon matPrefix class="search-prefix-icon">search</mat-icon>
-            <mat-label>Search Logs</mat-label>
-            <input
-              #logSearchInput
-              matInput
-              placeholder="Search in log body..."
-              [value]="logSearchQuery()"
-              (input)="logSearchQuery.set($any($event.target).value)"
-            />
-            @if (logSearchQuery()) {
-              <button
-                matSuffix
-                mat-icon-button
-                aria-label="Clear"
-                (click)="logSearchQuery.set('')"
-                class="clear-search-btn"
-              >
-                <mat-icon>close</mat-icon>
-              </button>
-            }
-          </mat-form-field>
+          <khi-chip-search-bar
+            #chipSearchBar
+            [(searchTerms)]="logSearchTerms"
+            placeholder="Search in log body..."
+          ></khi-chip-search-bar>
         </div>
       </div>
       <div class="right-control">

--- a/web/src/app/timeline-toolbar/components/toolbar.component.scss
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.scss
@@ -329,27 +329,3 @@ $delete-icon-hover-color: mat.m2-get-color-from-palette($gray-palette, 800);
 .severity-select {
   width: 150px;
 }
-
-.search-input {
-  width: 200px;
-}
-
-.search-prefix-icon {
-  color: mat.m2-get-color-from-palette($gray-palette, 600);
-  margin-right: 4px;
-}
-
-.clear-search-btn {
-  width: 24px !important;
-  height: 24px !important;
-  padding: 0 !important;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  mat-icon {
-    font-size: 16px !important;
-    width: 16px !important;
-    height: 16px !important;
-  }
-}

--- a/web/src/app/timeline-toolbar/components/toolbar.component.spec.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.spec.ts
@@ -124,4 +124,15 @@ describe('ToolbarComponent', () => {
 
     expect(component.timelineFilters().length).toBe(0);
   });
+
+  it('should bind logSearchTerms to khi-chip-search-bar', () => {
+    fixture.componentRef.setInput('logSearchTerms', ['test-query']);
+    fixture.detectChanges();
+
+    const chipSearchBar = fixture.debugElement.query(
+      By.css('khi-chip-search-bar'),
+    );
+    expect(chipSearchBar).toBeTruthy();
+    expect(component.logSearchTerms()).toEqual(['test-query']);
+  });
 });

--- a/web/src/app/timeline-toolbar/components/toolbar.component.ts
+++ b/web/src/app/timeline-toolbar/components/toolbar.component.ts
@@ -18,7 +18,6 @@ import {
   Component,
   HostListener,
   viewChild,
-  ElementRef,
   input,
   model,
   output,
@@ -35,6 +34,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
+import { ChipSearchBarComponent } from 'src/app/shared/components/chip-search-bar/chip-search-bar.component';
 import { TimelineFilterBuilderComponent } from './timeline-filter-builder.component';
 import { SearchScope } from 'src/app/services/view-state.service';
 import { TimelineFilterConfig } from '../types/filter-config';
@@ -75,14 +75,15 @@ export enum ToolbarPopupStatus {
     MatSelectModule,
     MatInputModule,
     MatFormFieldModule,
+    ChipSearchBarComponent,
   ],
 })
 export class ToolbarComponent {
   /**
-   * Reference to the Log Search input element for search focus management.
+   * Reference to the ChipSearchBarComponent for search focus management.
    */
-  public readonly logSearchInput =
-    viewChild<ElementRef<HTMLInputElement>>('logSearchInput');
+  public readonly chipSearchBar =
+    viewChild<ChipSearchBarComponent>('chipSearchBar');
 
   // Inputs (Signals)
   readonly showButtonLabel = input(false);
@@ -96,7 +97,7 @@ export class ToolbarComponent {
   readonly logOrTimelineNotSelected = input(true);
   readonly nameFilter = model('');
   readonly selectedSeverity = model<string>('ANY');
-  readonly logSearchQuery = model<string>('');
+  readonly logSearchTerms = model<string[]>([]);
 
   /**
    * Holds the current active search scope.
@@ -346,7 +347,7 @@ export class ToolbarComponent {
       }
       if (this.activeSearchScope() === SearchScope.Global) {
         event.preventDefault();
-        this.logSearchInput()?.nativeElement.focus();
+        this.chipSearchBar()?.focus();
       }
     }
   }

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.html
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.html
@@ -19,7 +19,7 @@ limitations under the License.
   [isFiltering]="isFiltering()"
   [progressPercent]="progressPercent()"
   [(selectedSeverity)]="selectedSeverity"
-  [(logSearchQuery)]="logSearchQuery"
+  [(logSearchTerms)]="logSearchTerms"
   [(timelineFilters)]="timelineFilters"
   [(selectedTimelineTypeForBuilder)]="selectedTimelineTypeForBuilder"
   [timelineTypes]="timelineTypes()"

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.spec.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.spec.ts
@@ -32,33 +32,45 @@ import { TimelineFilterConfig } from 'src/app/timeline-toolbar/types/filter-conf
 
 describe('TimelineToolbarSmart compilation helpers', () => {
   describe('compileLogFiltersToCel', () => {
-    it('should return empty string when severity is ANY and searchQuery is empty', () => {
-      expect(compileLogFiltersToCel('ANY', '')).toBe('');
-      expect(compileLogFiltersToCel('ANY', '   ')).toBe('');
+    it('should return empty string when severity is ANY and searchTerms is empty', () => {
+      expect(compileLogFiltersToCel('ANY', [])).toBe('');
+      expect(compileLogFiltersToCel('ANY', ['   '])).toBe('');
     });
 
     it('should compile severity filter when severity is not ANY', () => {
-      expect(compileLogFiltersToCel('INFO', '')).toBe('severity >= INFO');
-      expect(compileLogFiltersToCel('ERROR', '')).toBe('severity >= ERROR');
+      expect(compileLogFiltersToCel('INFO', [])).toBe('severity >= INFO');
+      expect(compileLogFiltersToCel('ERROR', [])).toBe('severity >= ERROR');
     });
 
-    it('should compile search query filter when searchQuery is provided', () => {
-      expect(compileLogFiltersToCel('ANY', 'hello')).toBe('body("hello")');
+    it('should compile search terms filter when single term is provided', () => {
+      expect(compileLogFiltersToCel('ANY', ['hello'])).toBe('body("hello")');
     });
 
-    it('should join severity and search query with &&', () => {
-      expect(compileLogFiltersToCel('WARNING', 'my-query')).toBe(
+    it('should compile search terms filter when multiple terms are provided', () => {
+      expect(compileLogFiltersToCel('ANY', ['foo', 'bar'])).toBe(
+        'body(["foo", "bar"])',
+      );
+    });
+
+    it('should join severity and search terms with &&', () => {
+      expect(compileLogFiltersToCel('WARNING', ['my-query'])).toBe(
         'severity >= WARNING && body("my-query")',
       );
+      expect(compileLogFiltersToCel('WARNING', ['foo', 'bar'])).toBe(
+        'severity >= WARNING && body(["foo", "bar"])',
+      );
     });
 
-    it('should escape double quotes and backslashes in search query', () => {
-      expect(compileLogFiltersToCel('ANY', 'hello "world"')).toBe(
+    it('should escape double quotes and backslashes in search terms', () => {
+      expect(compileLogFiltersToCel('ANY', ['hello "world"'])).toBe(
         'body("hello \\"world\\"")',
       );
-      expect(compileLogFiltersToCel('ANY', 'path\\to\\file')).toBe(
+      expect(compileLogFiltersToCel('ANY', ['path\\to\\file'])).toBe(
         'body("path\\\\to\\\\file")',
       );
+      expect(
+        compileLogFiltersToCel('ANY', ['path\\to\\file', 'hello "world"']),
+      ).toBe('body(["path\\\\to\\\\file", "hello \\"world\\""])');
     });
   });
 
@@ -235,7 +247,7 @@ describe('TimelineToolbarSmartComponent', () => {
   let advancedLogCelSignal: WritableSignal<string>;
   let standardTimelineFiltersSignal: WritableSignal<TimelineFilterConfig[]>;
   let standardSelectedSeveritySignal: WritableSignal<string>;
-  let standardLogSearchQuerySignal: WritableSignal<string>;
+  let standardLogSearchTermsSignal: WritableSignal<string[]>;
 
   beforeEach(async () => {
     mockCelValidationClient = jasmine.createSpyObj(
@@ -255,7 +267,7 @@ describe('TimelineToolbarSmartComponent', () => {
     advancedLogCelSignal = signal('');
     standardTimelineFiltersSignal = signal([]);
     standardSelectedSeveritySignal = signal('ANY');
-    standardLogSearchQuerySignal = signal('');
+    standardLogSearchTermsSignal = signal([]);
 
     mockBackendFilter = {
       updateFilterParams: jasmine.createSpy('updateFilterParams'),
@@ -280,7 +292,7 @@ describe('TimelineToolbarSmartComponent', () => {
         activeSearchScope: signal(0),
         timezoneShift: of(0),
         standardSelectedSeverity: standardSelectedSeveritySignal,
-        standardLogSearchQuery: standardLogSearchQuerySignal,
+        standardLogSearchTerms: standardLogSearchTermsSignal,
         standardTimelineFilters: standardTimelineFiltersSignal,
         advancedTimelineIncludeCel: advancedTimelineIncludeCelSignal,
         advancedTimelineExcludeCel: advancedTimelineExcludeCelSignal,

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.spec.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.spec.ts
@@ -61,12 +61,15 @@ describe('TimelineToolbarSmart compilation helpers', () => {
       );
     });
 
-    it('should escape double quotes and backslashes in search terms', () => {
+    it('should escape double quotes, backslashes, and control characters in search terms', () => {
       expect(compileLogFiltersToCel('ANY', ['hello "world"'])).toBe(
         'body("hello \\"world\\"")',
       );
       expect(compileLogFiltersToCel('ANY', ['path\\to\\file'])).toBe(
         'body("path\\\\to\\\\file")',
+      );
+      expect(compileLogFiltersToCel('ANY', ['line1\nline2'])).toBe(
+        'body("line1\\nline2")',
       );
       expect(
         compileLogFiltersToCel('ANY', ['path\\to\\file', 'hello "world"']),

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
@@ -105,9 +105,9 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
   protected readonly selectedSeverity =
     this.viewStateService.standardSelectedSeverity;
 
-  /** Direct log search filter text query. */
-  protected readonly logSearchQuery =
-    this.viewStateService.standardLogSearchQuery;
+  /** Direct log search terms signal. */
+  protected readonly logSearchTerms =
+    this.viewStateService.standardLogSearchTerms;
 
   /** Configured active standard timeline filters. */
   protected readonly timelineFilters =
@@ -247,11 +247,11 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
       if (!this.isAdvancedMode()) {
         const filters = this.timelineFilters();
         const severity = this.selectedSeverity();
-        const searchQuery = this.logSearchQuery();
+        const searchTerms = this.logSearchTerms();
 
         const timelineQuery = compileFiltersToCel(filters, severity);
         const timelineExclusionQuery = compileExclusionFiltersToCel(filters);
-        const logQuery = compileLogFiltersToCel(severity, searchQuery);
+        const logQuery = compileLogFiltersToCel(severity, searchTerms);
 
         this.viewStateService.advancedTimelineIncludeCel.set(timelineQuery);
         this.viewStateService.advancedTimelineExcludeCel.set(
@@ -425,19 +425,29 @@ export class TimelineToolbarSmartComponent implements OnDestroy {
 }
 
 /**
- * Compiles log search query and severity into a CEL expression.
+ * Compiles log search terms and severity into a CEL expression.
  */
 export function compileLogFiltersToCel(
   severity: string,
-  searchQuery: string,
+  searchTerms: readonly string[] = [],
 ): string {
   const parts: string[] = [];
   if (severity && severity !== 'ANY') {
     parts.push(`severity >= ${severity}`);
   }
-  if (searchQuery && searchQuery.trim() !== '') {
-    const escaped = searchQuery.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const validTerms = searchTerms
+    .map((term) => term.trim())
+    .filter((term) => term !== '');
+
+  if (validTerms.length === 1) {
+    const escaped = validTerms[0].replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     parts.push(`body("${escaped}")`);
+  } else if (validTerms.length > 1) {
+    const jsonEscapedTerms = validTerms.map((term) => {
+      const escaped = term.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      return `"${escaped}"`;
+    });
+    parts.push(`body([${jsonEscapedTerms.join(', ')}])`);
   }
   return parts.join(' && ');
 }

--- a/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
+++ b/web/src/app/timeline-toolbar/timeline-toolbar-smart.component.ts
@@ -440,13 +440,9 @@ export function compileLogFiltersToCel(
     .filter((term) => term !== '');
 
   if (validTerms.length === 1) {
-    const escaped = validTerms[0].replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    parts.push(`body("${escaped}")`);
+    parts.push(`body(${JSON.stringify(validTerms[0])})`);
   } else if (validTerms.length > 1) {
-    const jsonEscapedTerms = validTerms.map((term) => {
-      const escaped = term.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      return `"${escaped}"`;
-    });
+    const jsonEscapedTerms = validTerms.map((term) => JSON.stringify(term));
     parts.push(`body([${jsonEscapedTerms.join(', ')}])`);
   }
   return parts.join(' && ');


### PR DESCRIPTION
## Overview
The standard log search field in the top-right toolbar was previously a narrow fixed-width text input (200px), which could crowd small screens if simply widened and did not intuitively support multiple search matches (OR conditions).

This PR extracts a reusable, pure dumb component `ChipSearchBarComponent` (`khi-chip-search-bar`) into `shared/components/chip-search-bar/` and integrates it into `ToolbarComponent`.

---

## Key Changes

### 1. New Shared Dumb Component `ChipSearchBarComponent` (`web/src/app/shared/components/chip-search-bar/`)
- Renders search terms as distinct chips separated by visual **"OR"** badges.
- Clean Signal-based two-way model `searchTerms = model<string[]>([])` with zero duplicate internal state or `effect()` loops.
- Supports intuitive keyboard navigation:
  - `Enter` or `|` commits the current draft into a chip.
  - `Backspace` on an empty input field pops the last chip back into the input for quick editing.
  - `Escape` clears the current draft or all chips.
  - `blur` (focus out) automatically commits any pending draft.
  - Paste handler splits strings containing `|` or newlines into separate chips automatically.
- Responsive layout: starts compact (`flex: 1 1 220px; min-width: 180px; max-width: 440px;`) and smoothly expands to `max-width: 580px;` on `:focus-within`.
- Implemented corresponding Storybook stories (`chip-search-bar.stories.ts`) and 10 unit test cases (`chip-search-bar.component.spec.ts`).

### 2. Toolbar Integration
- Replaced the old `mat-form-field.search-input` in `ToolbarComponent` with `<khi-chip-search-bar [(searchTerms)]="logSearchTerms">`.
- Global shortcut (Ctrl/Cmd+F) triggers focus on `chipSearchBar`.
- Updated `ToolbarFrameComponent` and `ViewStateService` (`standardLogSearchTerms = signal<string[]>([])`).

### 3. CEL Compilation (`compileLogFiltersToCel`)
- Generates `body("...")` for a single search term and `body(["term1", "term2"])` for multiple search terms, leveraging the Go backend's native regex alternation `(?:term1|term2)` matching.

---

## Verification
- `make test-web`: PASS (all 1,101 tests pass)
- `make lint-web`: PASS (ESLint & Stylelint 0 issues)
- `make build-storybook`: PASS
- `make build-web`: PASS (Angular production build succeeds)
- `make pre-commit`: PASS (all formatting and checks pass)