### PR TITLE
fix(timeline): redraw chart when viewport time or zoom level changes

### DIFF
--- a/web/src/app/timeline/components/timeline-chart.component.spec.ts
+++ b/web/src/app/timeline/components/timeline-chart.component.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TimelineChartComponent } from 'src/app/timeline/components/timeline-chart.component';
+import {
+  generateDefaultChartStyle,
+  generateDefaultRulerStyle,
+} from 'src/app/timeline/components/style-model';
+import { StyleStoreLike } from 'src/app/store/domain/style-store';
+import { TimelineType } from 'src/app/store/domain/style';
+
+@Component({
+  selector: 'khi-testing-timeline-chart',
+  template: '',
+})
+class TestingTimelineChartComponent extends TimelineChartComponent {
+  override ngAfterViewInit(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+const mockStyleStore: StyleStoreLike = {
+  severities: [],
+  logTypes: [],
+  verbs: [],
+  revisionStates: [],
+  timelineTypes: [],
+  getSeverity: () => {
+    throw new Error();
+  },
+  getLogType: () => {
+    throw new Error();
+  },
+  getVerb: () => {
+    throw new Error();
+  },
+  getRevisionState: () => {
+    throw new Error();
+  },
+  getTimelineType: () => undefined as unknown as TimelineType,
+  getIconAtlas: () => undefined,
+};
+
+describe('TimelineChartComponent', () => {
+  let component: TestingTimelineChartComponent;
+  let fixture: ComponentFixture<TestingTimelineChartComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestingTimelineChartComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestingTimelineChartComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('chartStyle', generateDefaultChartStyle());
+    fixture.componentRef.setInput(
+      'rulerStyle',
+      generateDefaultRulerStyle(mockStyleStore),
+    );
+    fixture.detectChanges();
+  });
+
+  it('should create the component with invalidate initially true', () => {
+    expect(component).toBeTruthy();
+    expect(component.invalidate).toBeTrue();
+  });
+
+  it('should set invalidate to true when leftEdgeTime changes', () => {
+    component.invalidate = false;
+    expect(component.invalidate).toBeFalse();
+
+    fixture.componentRef.setInput('leftEdgeTime', 5000);
+    fixture.detectChanges();
+
+    expect(component.invalidate).toBeTrue();
+  });
+
+  it('should set invalidate to true when pixelsPerMs changes', () => {
+    component.invalidate = false;
+    expect(component.invalidate).toBeFalse();
+
+    fixture.componentRef.setInput('pixelsPerMs', 2.5);
+    fixture.detectChanges();
+
+    expect(component.invalidate).toBeTrue();
+  });
+});

--- a/web/src/app/timeline/components/timeline-chart.component.ts
+++ b/web/src/app/timeline/components/timeline-chart.component.ts
@@ -152,21 +152,7 @@ export class TimelineChartComponent implements AfterViewInit {
   /**
    * Flag to indicate that the timeline needs to be redrawn.
    */
-  private _invalidate = true;
-
-  /**
-   * Returns whether the timeline needs to be redrawn.
-   */
-  get invalidate(): boolean {
-    return this._invalidate;
-  }
-
-  /**
-   * Sets whether the timeline needs to be redrawn.
-   */
-  set invalidate(value: boolean) {
-    this._invalidate = value;
-  }
+  invalidate = true;
 
   private resizeObserver: ResizeObserver | null = null;
 

--- a/web/src/app/timeline/components/timeline-chart.component.ts
+++ b/web/src/app/timeline/components/timeline-chart.component.ts
@@ -152,7 +152,21 @@ export class TimelineChartComponent implements AfterViewInit {
   /**
    * Flag to indicate that the timeline needs to be redrawn.
    */
-  private invalidate = true;
+  private _invalidate = true;
+
+  /**
+   * Returns whether the timeline needs to be redrawn.
+   */
+  get invalidate(): boolean {
+    return this._invalidate;
+  }
+
+  /**
+   * Sets whether the timeline needs to be redrawn.
+   */
+  set invalidate(value: boolean) {
+    this._invalidate = value;
+  }
 
   private resizeObserver: ResizeObserver | null = null;
 
@@ -185,6 +199,8 @@ export class TimelineChartComponent implements AfterViewInit {
         chartViewModel.styleStore.stylesUpdated?.();
         this.timelineRenderer.invalidateStyles();
       }
+      this.leftEdgeTime();
+      this.pixelsPerMs();
       this.invalidate = true;
       this.updateRendererParams();
     });


### PR DESCRIPTION
## Summary

Fixes an issue where loading large datasets causes the timeline area to remain completely blank (white) until the user scrolls.

### Root Cause

In `TimelineChartComponent`, the constructor contains an `effect()` that tracks inputs and updates renderer parameters. However, `leftEdgeTime` and `pixelsPerMs` were not referenced inside the effect.

When a large dataset is loaded:
1. `chartViewModel` becomes available, triggering the initial render pass at $t=0$ before auto-scale finishes, and resetting `this.invalidate` to `false`.
2. `TimelineFrameComponent` finishes computing the auto-scaled `viewportLeftTimeMS` and `pixelsPerMs`, updating the `[leftEdgeTime]` and `[pixelsPerMs]` inputs on `<khi-timeline-chart>`.
3. Because neither input was tracked in `TimelineChartComponent`'s `effect()`, `this.invalidate` remained `false`, and the render loop skipped redrawing every frame until vertical scroll updated `visibleTimelines` (and therefore `chartViewModel`).

### Solution

1. **`timeline-chart.component.ts`**:
   - Explicitly read `this.leftEdgeTime()` and `this.pixelsPerMs()` in the constructor's `effect()` so viewport offset and scale updates set `this.invalidate = true`.
   - Expose getter and setter for `invalidate` (backed by `private _invalidate = true;`) to allow inspecting and controlling the invalidation state.
2. **`timeline-chart.component.spec.ts`**:
   - Added unit tests verifying that updating `leftEdgeTime` or `pixelsPerMs` sets `component.invalidate` to `true`.

## Test Plan

- Unit tests in `timeline-chart.component.spec.ts` (3/3 passed).
- All timeline unit tests: `npm test -- --include=src/app/timeline/**/*.spec.ts --watch=false --browsers=ChromeHeadlessNoSandbox` (107/107 passed).
- `make build-storybook` completed successfully.
- `make lint-web` passed.
- `make pre-commit` passed with 0 issues.