### PR TITLE
perf(inspection): cache parsed audit logs in StructuredDataReader

### DIFF
--- a/pkg/common/structured/mock.go
+++ b/pkg/common/structured/mock.go
@@ -91,16 +91,17 @@ func (m *MockNode) Get(targetType reflect.Type) (any, bool) {
 
 // GetMock retrieves a mocked value of type T from the NodeReader if it wraps a MockNode.
 func GetMock[T any](reader *NodeReader) (T, bool) {
+	var zero T
 	if reader == nil || reader.Node == nil {
-		return *new(T), false
+		return zero, false
 	}
 	mockNode, ok := reader.Node.(*MockNode)
 	if !ok {
-		return *new(T), false
+		return zero, false
 	}
 	val, found := mockNode.Get(reflect.TypeFor[T]())
 	if !found {
-		return *new(T), false
+		return zero, false
 	}
 	typedVal, ok := val.(T)
 	return typedVal, ok

--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -72,31 +72,34 @@ func NewNodeReader(node Node) *NodeReader {
 }
 
 // SetCache stores a cached value of type T for the given key into the reader in a thread-safe, lock-free manner.
-// If a concurrent write conflicts, the cache update is skipped and the value will be re-parsed on subsequent lookups.
 func SetCache[T any](reader *NodeReader, key CacheKey[T], val T) {
 	if reader == nil || reader.cache == nil {
 		return
 	}
-	oldEntries := reader.cache.entries.Load()
-	var newEntries []readerCacheEntry
-	if oldEntries == nil {
-		newEntries = []readerCacheEntry{{keyID: key.id, val: val}}
-	} else {
-		found := false
-		newEntries = make([]readerCacheEntry, len(*oldEntries))
-		copy(newEntries, *oldEntries)
-		for i, entry := range newEntries {
-			if entry.keyID == key.id {
-				newEntries[i].val = val
-				found = true
-				break
+	for {
+		oldEntries := reader.cache.entries.Load()
+		var newEntries []readerCacheEntry
+		if oldEntries == nil {
+			newEntries = []readerCacheEntry{{keyID: key.id, val: val}}
+		} else {
+			found := false
+			newEntries = make([]readerCacheEntry, len(*oldEntries))
+			copy(newEntries, *oldEntries)
+			for i, entry := range newEntries {
+				if entry.keyID == key.id {
+					newEntries[i].val = val
+					found = true
+					break
+				}
+			}
+			if !found {
+				newEntries = append(newEntries, readerCacheEntry{keyID: key.id, val: val})
 			}
 		}
-		if !found {
-			newEntries = append(newEntries, readerCacheEntry{keyID: key.id, val: val})
+		if reader.cache.entries.CompareAndSwap(oldEntries, &newEntries) {
+			return
 		}
 	}
-	reader.cache.entries.CompareAndSwap(oldEntries, &newEntries)
 }
 
 // GetCache retrieves a cached value of type T for the given key from the reader in a thread-safe manner.

--- a/pkg/common/structured/reader.go
+++ b/pkg/common/structured/reader.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common"
@@ -32,22 +33,99 @@ var ErrFieldNotFound = errors.New("field not found")
 // NodeReaderChildrenIterator is a type that represents an iterator function for navigating
 type NodeReaderChildrenIterator = func(func(key NodeChildrenKey, value NodeReader) bool)
 
+var nextCacheKeyID atomic.Uint32
+
+// CacheKey is a type-safe token identifying a cached extraction result of type T associated with a NodeReader.
+type CacheKey[T any] struct {
+	id uint32
+}
+
+// NewCacheKey allocates a globally unique type-safe cache key for values of type T.
+func NewCacheKey[T any]() CacheKey[T] {
+	return CacheKey[T]{
+		id: nextCacheKeyID.Add(1),
+	}
+}
+
+type readerCacheEntry struct {
+	keyID uint32
+	val   any
+}
+
+type readerCache struct {
+	entries atomic.Pointer[[]readerCacheEntry]
+}
+
 // NodeReader provides a convenient way to read values from a node structure.
 // It offers type-safe accessor methods and path navigation capabilities.
 type NodeReader struct {
 	Node
+	cache *readerCache
 }
 
 // NewNodeReader creates a new NodeReader instance from a given Node.
 func NewNodeReader(node Node) *NodeReader {
-	return &NodeReader{node}
+	return &NodeReader{
+		Node:  node,
+		cache: &readerCache{},
+	}
+}
+
+// SetCache stores a cached value of type T for the given key into the reader in a thread-safe, lock-free manner.
+// If a concurrent write conflicts, the cache update is skipped and the value will be re-parsed on subsequent lookups.
+func SetCache[T any](reader *NodeReader, key CacheKey[T], val T) {
+	if reader == nil || reader.cache == nil {
+		return
+	}
+	oldEntries := reader.cache.entries.Load()
+	var newEntries []readerCacheEntry
+	if oldEntries == nil {
+		newEntries = []readerCacheEntry{{keyID: key.id, val: val}}
+	} else {
+		found := false
+		newEntries = make([]readerCacheEntry, len(*oldEntries))
+		copy(newEntries, *oldEntries)
+		for i, entry := range newEntries {
+			if entry.keyID == key.id {
+				newEntries[i].val = val
+				found = true
+				break
+			}
+		}
+		if !found {
+			newEntries = append(newEntries, readerCacheEntry{keyID: key.id, val: val})
+		}
+	}
+	reader.cache.entries.CompareAndSwap(oldEntries, &newEntries)
+}
+
+// GetCache retrieves a cached value of type T for the given key from the reader in a thread-safe manner.
+// Returns the zero value and false if no cached value for the key exists or reader is nil.
+func GetCache[T any](reader *NodeReader, key CacheKey[T]) (T, bool) {
+	var zero T
+	if reader == nil || reader.cache == nil {
+		return zero, false
+	}
+	entriesPtr := reader.cache.entries.Load()
+	if entriesPtr == nil {
+		return zero, false
+	}
+	for _, entry := range *entriesPtr {
+		if entry.keyID == key.id {
+			if typed, ok := entry.val.(T); ok {
+				return typed, true
+			}
+			return zero, false
+		}
+	}
+	return zero, false
 }
 
 // Children returns an iterator for navigating through readers of the children of this node.
 func (n *NodeReader) Children() NodeReaderChildrenIterator {
 	return func(callback func(key NodeChildrenKey, value NodeReader) bool) {
 		for key, value := range n.Node.Children() {
-			if !callback(key, NodeReader{value}) {
+			if !callback(key, NodeReader{Node: value}) {
 				return
 			}
 		}
@@ -57,7 +135,8 @@ func (n *NodeReader) Children() NodeReaderChildrenIterator {
 // WithKeyOrder returns a new NodeReader wrapping the node with the specified key order.
 func (n *NodeReader) WithKeyOrder(priorityKeys ...string) *NodeReader {
 	return &NodeReader{
-		Node: WithKeyOrder(n.Node, priorityKeys...),
+		Node:  WithKeyOrder(n.Node, priorityKeys...),
+		cache: n.cache,
 	}
 }
 
@@ -95,7 +174,7 @@ func (n *NodeReader) GetReader(path FieldPath) (*NodeReader, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &NodeReader{node}, nil
+	return NewNodeReader(node), nil
 }
 
 // Serialize serializes the structured data at the given pre-compiled FieldPath with the given NodeSerializer.

--- a/pkg/common/structured/reader_test.go
+++ b/pkg/common/structured/reader_test.go
@@ -15,8 +15,11 @@
 package structured
 
 import (
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestNodeReader(t *testing.T) {
@@ -443,4 +446,196 @@ func TestNodeReader_WithLazyJSONNode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodeReader_Cache(t *testing.T) {
+	type testCacheData struct {
+		name  string
+		value int
+	}
+
+	testKey := NewCacheKey[*testCacheData]()
+	otherKey := NewCacheKey[*testCacheData]()
+
+	testCases := []struct {
+		name      string
+		setup     func() *NodeReader
+		storeVal  *testCacheData
+		queryKey  CacheKey[*testCacheData]
+		wantVal   *testCacheData
+		wantFound bool
+	}{
+		{
+			name: "store and retrieve valid cached data",
+			setup: func() *NodeReader {
+				return NewNodeReader(NewEmptyMapNode())
+			},
+			storeVal:  &testCacheData{name: "foo", value: 42},
+			queryKey:  testKey,
+			wantVal:   &testCacheData{name: "foo", value: 42},
+			wantFound: true,
+		},
+		{
+			name: "uninitialized cache returns false",
+			setup: func() *NodeReader {
+				return NewNodeReader(NewEmptyMapNode())
+			},
+			storeVal:  nil,
+			queryKey:  testKey,
+			wantVal:   nil,
+			wantFound: false,
+		},
+		{
+			name: "nil reader returns false safely",
+			setup: func() *NodeReader {
+				return nil
+			},
+			storeVal:  nil,
+			queryKey:  testKey,
+			wantVal:   nil,
+			wantFound: false,
+		},
+		{
+			name: "different key returns false",
+			setup: func() *NodeReader {
+				return NewNodeReader(NewEmptyMapNode())
+			},
+			storeVal:  &testCacheData{name: "foo", value: 42},
+			queryKey:  otherKey,
+			wantVal:   nil,
+			wantFound: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := tc.setup()
+			if tc.storeVal != nil && reader != nil {
+				SetCache(reader, testKey, tc.storeVal)
+			}
+
+			got, ok := GetCache(reader, tc.queryKey)
+			if ok != tc.wantFound {
+				t.Fatalf("GetCache() found = %v, want %v", ok, tc.wantFound)
+			}
+			if tc.wantFound {
+				if diff := cmp.Diff(tc.wantVal, got, cmp.AllowUnexported(testCacheData{})); diff != "" {
+					t.Errorf("GetCache() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestNodeReader_MultipleCacheKeys(t *testing.T) {
+	type cacheA struct {
+		id   int
+		name string
+	}
+	type cacheB struct {
+		tags []string
+	}
+
+	keyA := NewCacheKey[*cacheA]()
+	keyB := NewCacheKey[*cacheB]()
+
+	testCases := []struct {
+		name       string
+		operations func(r *NodeReader)
+		verify     func(t *testing.T, r *NodeReader)
+	}{
+		{
+			name: "multiple distinct cache keys coexist simultaneously",
+			operations: func(r *NodeReader) {
+				SetCache(r, keyA, &cacheA{id: 1, name: "item-1"})
+				SetCache(r, keyB, &cacheB{tags: []string{"tag-1", "tag-2"}})
+			},
+			verify: func(t *testing.T, r *NodeReader) {
+				gotA, okA := GetCache(r, keyA)
+				if !okA {
+					t.Fatalf("GetCache(keyA) expected ok=true")
+				}
+				wantA := &cacheA{id: 1, name: "item-1"}
+				if diff := cmp.Diff(wantA, gotA, cmp.AllowUnexported(cacheA{})); diff != "" {
+					t.Errorf("cacheA mismatch (-want +got):\n%s", diff)
+				}
+
+				gotB, okB := GetCache(r, keyB)
+				if !okB {
+					t.Fatalf("GetCache(keyB) expected ok=true")
+				}
+				wantB := &cacheB{tags: []string{"tag-1", "tag-2"}}
+				if diff := cmp.Diff(wantB, gotB, cmp.AllowUnexported(cacheB{})); diff != "" {
+					t.Errorf("cacheB mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "overwriting one key does not affect other keys",
+			operations: func(r *NodeReader) {
+				SetCache(r, keyA, &cacheA{id: 1, name: "item-1"})
+				SetCache(r, keyB, &cacheB{tags: []string{"initial"}})
+				// Overwrite keyA
+				SetCache(r, keyA, &cacheA{id: 2, name: "item-updated"})
+			},
+			verify: func(t *testing.T, r *NodeReader) {
+				gotA, okA := GetCache(r, keyA)
+				if !okA {
+					t.Fatalf("GetCache(keyA) expected ok=true")
+				}
+				wantA := &cacheA{id: 2, name: "item-updated"}
+				if diff := cmp.Diff(wantA, gotA, cmp.AllowUnexported(cacheA{})); diff != "" {
+					t.Errorf("cacheA mismatch (-want +got):\n%s", diff)
+				}
+
+				gotB, okB := GetCache(r, keyB)
+				if !okB {
+					t.Fatalf("GetCache(keyB) expected ok=true")
+				}
+				wantB := &cacheB{tags: []string{"initial"}}
+				if diff := cmp.Diff(wantB, gotB, cmp.AllowUnexported(cacheB{})); diff != "" {
+					t.Errorf("cacheB mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewNodeReader(NewEmptyMapNode())
+			tc.operations(r)
+			tc.verify(t, r)
+		})
+	}
+}
+
+func TestNodeReader_CacheConcurrency(t *testing.T) {
+	type concurrentVal struct {
+		idx int
+	}
+	keys := make([]CacheKey[*concurrentVal], 10)
+	for i := range keys {
+		keys[i] = NewCacheKey[*concurrentVal]()
+	}
+
+	r := NewNodeReader(NewEmptyMapNode())
+	var wg sync.WaitGroup
+	const goroutines = 20
+	const iterations = 100
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gID int) {
+			defer wg.Done()
+			for it := 0; it < iterations; it++ {
+				key := keys[(gID+it)%len(keys)]
+				SetCache(r, key, &concurrentVal{idx: gID*iterations + it})
+				val, ok := GetCache(r, key)
+				if ok && val == nil {
+					t.Errorf("GetCache returned ok=true with nil value")
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
 }

--- a/pkg/task/inspection/commonlogk8saudit/contract/extractor.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/extractor.go
@@ -31,9 +31,6 @@ type K8sAuditLogExtractor func(reader *structured.NodeReader) (*K8sAuditLogField
 
 // ExtractK8sAuditLog extracts K8s audit log data from a NodeReader using the extractor in the task context.
 func ExtractK8sAuditLog(ctx context.Context, reader *structured.NodeReader) (*K8sAuditLogFieldSet, error) {
-	if reader == nil {
-		return emptyK8sAuditLogFieldSet, nil
-	}
 	if mock, ok := structured.GetMock[*K8sAuditLogFieldSet](reader); ok {
 		return mock, nil
 	}
@@ -55,9 +52,6 @@ type K8sAuditLogErrorExtractor func(reader *structured.NodeReader) (bool, error)
 
 // ExtractK8sAuditLogError extracts whether the K8s audit log is an error using the error extractor in the task context.
 func ExtractK8sAuditLogError(ctx context.Context, reader *structured.NodeReader) (bool, error) {
-	if reader == nil {
-		return false, nil
-	}
 	if mock, ok := structured.GetMock[*K8sAuditLogFieldSet](reader); ok {
 		return mock.IsError, nil
 	}

--- a/pkg/task/inspection/commonlogk8saudit/contract/extractor.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/extractor.go
@@ -21,18 +21,33 @@ import (
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 )
 
+var emptyK8sAuditLogFieldSet = &K8sAuditLogFieldSet{}
+
+// K8sAuditLogCacheKey identifies the cached K8sAuditLogFieldSet on a NodeReader.
+var K8sAuditLogCacheKey = structured.NewCacheKey[*K8sAuditLogFieldSet]()
+
 // K8sAuditLogExtractor is a function type for extracting K8sAuditLogFieldSet from a NodeReader.
-type K8sAuditLogExtractor func(reader *structured.NodeReader) (K8sAuditLogFieldSet, error)
+type K8sAuditLogExtractor func(reader *structured.NodeReader) (*K8sAuditLogFieldSet, error)
 
 // ExtractK8sAuditLog extracts K8s audit log data from a NodeReader using the extractor in the task context.
-func ExtractK8sAuditLog(ctx context.Context, reader *structured.NodeReader) (K8sAuditLogFieldSet, error) {
-	if mock, ok := structured.GetMock[K8sAuditLogFieldSet](reader); ok {
+func ExtractK8sAuditLog(ctx context.Context, reader *structured.NodeReader) (*K8sAuditLogFieldSet, error) {
+	if reader == nil {
+		return emptyK8sAuditLogFieldSet, nil
+	}
+	if mock, ok := structured.GetMock[*K8sAuditLogFieldSet](reader); ok {
 		return mock, nil
 	}
-	if extractor, found := coretask.GetTaskResultOptional(ctx, K8sAuditLogExtractorRef); found && extractor != nil {
-		return extractor(reader)
+	if cached, ok := structured.GetCache(reader, K8sAuditLogCacheKey); ok {
+		return cached, nil
 	}
-	return K8sAuditLogFieldSet{}, nil
+	if extractor, found := coretask.GetTaskResultOptional(ctx, K8sAuditLogExtractorRef); found && extractor != nil {
+		res, err := extractor(reader)
+		if err == nil && res != nil {
+			structured.SetCache(reader, K8sAuditLogCacheKey, res)
+		}
+		return res, err
+	}
+	return emptyK8sAuditLogFieldSet, nil
 }
 
 // K8sAuditLogErrorExtractor is a function type for extracting whether a log represents an error from a NodeReader.
@@ -40,8 +55,14 @@ type K8sAuditLogErrorExtractor func(reader *structured.NodeReader) (bool, error)
 
 // ExtractK8sAuditLogError extracts whether the K8s audit log is an error using the error extractor in the task context.
 func ExtractK8sAuditLogError(ctx context.Context, reader *structured.NodeReader) (bool, error) {
-	if mock, ok := structured.GetMock[K8sAuditLogFieldSet](reader); ok {
+	if reader == nil {
+		return false, nil
+	}
+	if mock, ok := structured.GetMock[*K8sAuditLogFieldSet](reader); ok {
 		return mock.IsError, nil
+	}
+	if cached, ok := structured.GetCache(reader, K8sAuditLogCacheKey); ok {
+		return cached.IsError, nil
 	}
 	if extractor, found := coretask.GetTaskResultOptional(ctx, K8sAuditLogErrorExtractorRef); found && extractor != nil {
 		return extractor(reader)

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task.go
@@ -360,7 +360,7 @@ func (c *conditionWalker) checkLastTransitionTimes(condition *model.K8sResourceS
 
 // CheckAndRecord compares the current condition with the previous state and records a revision if there is a significant change.
 // It tracks changes in Status, LastTransitionTime, and LastHeartbeatTime (ProbeLikeTime).
-func (c *conditionWalker) CheckAndRecord(ctx context.Context, changedTime time.Time, k8sAuditLog commonlogk8saudit_contract.K8sAuditLogFieldSet, condition *model.K8sResourceStatusCondition, cs *khifilev6.TimelineChangeSet) {
+func (c *conditionWalker) CheckAndRecord(ctx context.Context, changedTime time.Time, k8sAuditLog *commonlogk8saudit_contract.K8sAuditLogFieldSet, condition *model.K8sResourceStatusCondition, cs *khifilev6.TimelineChangeSet) {
 	if condition == nil {
 		refCond := c.getLastCondition(changedTime)
 		if refCond != nil && refCond.Status != "" {

--- a/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/conditionmapper_task_test.go
@@ -43,7 +43,7 @@ func TestConditionWalker(t *testing.T) {
 	ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
 
 	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	k8sFieldSet := commonlogk8saudit_contract.K8sAuditLogFieldSet{
+	k8sFieldSet := &commonlogk8saudit_contract.K8sAuditLogFieldSet{
 		Verb:      commonlogk8saudit_contract.VerbUpdate,
 		Principal: "user-1",
 	}

--- a/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task.go
@@ -231,7 +231,7 @@ type containerStateWalker struct {
 }
 
 // CheckAndRecord compares the current container state with the previous state and records a revision if there is a significant change.
-func (w *containerStateWalker) CheckAndRecord(ctx context.Context, stateReader *structured.NodeReader, cs *khifilev6.TimelineChangeSet, changedTime time.Time, k8sAuditLog commonlogk8saudit_contract.K8sAuditLogFieldSet) {
+func (w *containerStateWalker) CheckAndRecord(ctx context.Context, stateReader *structured.NodeReader, cs *khifilev6.TimelineChangeSet, changedTime time.Time, k8sAuditLog *commonlogk8saudit_contract.K8sAuditLogFieldSet) {
 	containerPath := MustResolveContainerTimelinePath(ctx, k8sAuditLog.ClusterName, w.podNamespace, w.podName, w.containerIdentity.containerName)
 	if stateReader == nil {
 		if w.lastState != "no state" {

--- a/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/containermapper_task_test.go
@@ -360,7 +360,7 @@ state:
 			cs := khifilev6.NewTimelineChangeSet(l)
 
 			for _, step := range tt.steps {
-				k8sFieldSet := commonlogk8saudit_contract.K8sAuditLogFieldSet{
+				k8sFieldSet := &commonlogk8saudit_contract.K8sAuditLogFieldSet{
 					Verb:        step.verb,
 					Principal:   "user-1",
 					ClusterName: "k8s",

--- a/pkg/task/inspection/googlecloudcommon/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/extractor.go
@@ -142,8 +142,20 @@ func (g *GCPAuditLogFieldSet) ResponseString() (string, error) {
 	return "", fmt.Errorf("protoPayload.response field is absent: %w", khierrors.ErrNotFound)
 }
 
+// GCPAuditLogCacheKey identifies the cached GCPAuditLogFieldSet on a NodeReader.
+var GCPAuditLogCacheKey = structured.NewCacheKey[*GCPAuditLogFieldSet]()
+
+// GCPSeverityCacheKey identifies the cached severity on a NodeReader.
+var GCPSeverityCacheKey = structured.NewCacheKey[*pb.Severity]()
+
 // ExtractGCPAuditLog extracts GCP Audit Log fields from a NodeReader.
 func ExtractGCPAuditLog(reader *structured.NodeReader) (GCPAuditLogFieldSet, error) {
+	if reader == nil {
+		return GCPAuditLogFieldSet{}, nil
+	}
+	if cached, ok := structured.GetCache(reader, GCPAuditLogCacheKey); ok {
+		return *cached, nil
+	}
 	if mock, ok := structured.GetMock[GCPAuditLogFieldSet](reader); ok {
 		return mock, nil
 	}
@@ -162,6 +174,8 @@ func ExtractGCPAuditLog(reader *structured.NodeReader) (GCPAuditLogFieldSet, err
 	result.StatusMessage = reader.ReadStringOrDefault(pathStatusMessage, "")
 	result.Request, _ = reader.GetReader(pathRequest)
 	result.Response, _ = reader.GetReader(pathResponse)
+
+	structured.SetCache(reader, GCPAuditLogCacheKey, &result)
 	return result, nil
 }
 
@@ -214,6 +228,12 @@ func ExtractGCPAccessLog(reader *structured.NodeReader) (GCPAccessLogFieldSet, e
 
 // ExtractGCPSeverity extracts severity from a GCP Cloud Logging entry.
 func ExtractGCPSeverity(reader *structured.NodeReader) (*pb.Severity, error) {
+	if reader == nil {
+		return nil, nil
+	}
+	if cached, ok := structured.GetCache(reader, GCPSeverityCacheKey); ok {
+		return cached, nil
+	}
 	if mock, ok := structured.GetMock[inspectioncore_contract.DefaultSeverityFieldSet](reader); ok {
 		return mock.Severity, nil
 	}
@@ -221,7 +241,9 @@ func ExtractGCPSeverity(reader *structured.NodeReader) (*pb.Severity, error) {
 		return mock, nil
 	}
 	severityStr := reader.ReadStringOrDefault(pathSeverity, "")
-	return ParseGCPSeverity(severityStr), nil
+	res := ParseGCPSeverity(severityStr)
+	structured.SetCache(reader, GCPSeverityCacheKey, res)
+	return res, nil
 }
 
 // GCPMainMessageFieldSet represents the main message parsed from a GCP log.

--- a/pkg/task/inspection/googlecloudcommon/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/extractor.go
@@ -150,9 +150,6 @@ var GCPSeverityCacheKey = structured.NewCacheKey[*pb.Severity]()
 
 // ExtractGCPAuditLog extracts GCP Audit Log fields from a NodeReader.
 func ExtractGCPAuditLog(reader *structured.NodeReader) (GCPAuditLogFieldSet, error) {
-	if reader == nil {
-		return GCPAuditLogFieldSet{}, nil
-	}
 	if cached, ok := structured.GetCache(reader, GCPAuditLogCacheKey); ok {
 		return *cached, nil
 	}
@@ -228,9 +225,6 @@ func ExtractGCPAccessLog(reader *structured.NodeReader) (GCPAccessLogFieldSet, e
 
 // ExtractGCPSeverity extracts severity from a GCP Cloud Logging entry.
 func ExtractGCPSeverity(reader *structured.NodeReader) (*pb.Severity, error) {
-	if reader == nil {
-		return nil, nil
-	}
 	if cached, ok := structured.GetCache(reader, GCPSeverityCacheKey); ok {
 		return cached, nil
 	}

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor.go
@@ -43,9 +43,6 @@ var (
 
 // ExtractGCPK8sAuditLogError extracts whether the log represents an error from a GCP Cloud Logging NodeReader.
 func ExtractGCPK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
-	if reader == nil {
-		return false, nil
-	}
 	if cached, ok := structured.GetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey); ok {
 		return cached.IsError, nil
 	}
@@ -57,9 +54,6 @@ func ExtractGCPK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
 
 // ExtractGCPK8sAuditLog extracts Kubernetes audit log data from a GCP Cloud Logging NodeReader.
 func ExtractGCPK8sAuditLog(reader *structured.NodeReader) (*commonlogk8saudit_contract.K8sAuditLogFieldSet, error) {
-	if reader == nil {
-		return nil, nil
-	}
 	if cached, ok := structured.GetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey); ok {
 		return cached, nil
 	}

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor.go
@@ -43,24 +43,30 @@ var (
 
 // ExtractGCPK8sAuditLogError extracts whether the log represents an error from a GCP Cloud Logging NodeReader.
 func ExtractGCPK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
-	if mock, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
-		return mock.IsError, nil
-	}
 	if reader == nil {
 		return false, nil
+	}
+	if cached, ok := structured.GetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey); ok {
+		return cached.IsError, nil
+	}
+	if mock, ok := structured.GetMock[*commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
+		return mock.IsError, nil
 	}
 	return reader.ReadIntOrDefault(pathProtoStatusCode, 0) != 0, nil
 }
 
 // ExtractGCPK8sAuditLog extracts Kubernetes audit log data from a GCP Cloud Logging NodeReader.
-func ExtractGCPK8sAuditLog(reader *structured.NodeReader) (commonlogk8saudit_contract.K8sAuditLogFieldSet, error) {
-	if mock, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
+func ExtractGCPK8sAuditLog(reader *structured.NodeReader) (*commonlogk8saudit_contract.K8sAuditLogFieldSet, error) {
+	if reader == nil {
+		return nil, nil
+	}
+	if cached, ok := structured.GetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey); ok {
+		return cached, nil
+	}
+	if mock, ok := structured.GetMock[*commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
 		return mock, nil
 	}
-	var result commonlogk8saudit_contract.K8sAuditLogFieldSet
-	if reader == nil {
-		return result, nil
-	}
+	result := &commonlogk8saudit_contract.K8sAuditLogFieldSet{}
 
 	result.OperationID = reader.ReadStringOrDefault(pathOperationID, "")
 	result.IsFirst = reader.ReadBoolOrDefault(pathOperationFirst, false)
@@ -89,6 +95,7 @@ func ExtractGCPK8sAuditLog(reader *structured.NodeReader) (commonlogk8saudit_con
 	labelsReader, _ := reader.GetReader(pathLabels)
 	result.MutatingWebhookResults = extractMutatingWebhookResults(labelsReader)
 
+	structured.SetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey, result)
 	return result, nil
 }
 

--- a/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/contract/extractor_test.go
@@ -322,7 +322,7 @@ func TestExtractGCPK8sAuditLog(t *testing.T) {
 			got.Request = nil
 			got.Response = nil
 
-			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(func(a, b *commonlogk8saudit_contract.MutatingWebhookResult) bool {
+			if diff := cmp.Diff(tc.want, *got, cmpopts.SortSlices(func(a, b *commonlogk8saudit_contract.MutatingWebhookResult) bool {
 				if a.Round != b.Round {
 					return a.Round < b.Round
 				}

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor.go
@@ -67,7 +67,7 @@ func ExtractOSSK8sIsEventAuditLog(reader *structured.NodeReader) (bool, error) {
 
 // ExtractOSSK8sIsNonEventAuditLog extracts whether the log is an OSS K8s audit log for a non-event resource.
 func ExtractOSSK8sIsNonEventAuditLog(reader *structured.NodeReader) (bool, error) {
-	if _, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
+	if _, ok := structured.GetMock[*commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
 		return true, nil
 	}
 	if reader == nil {
@@ -85,10 +85,16 @@ func ExtractOSSK8sIsNonEventAuditLog(reader *structured.NodeReader) (bool, error
 
 // ExtractOSSK8sAuditLogError extracts whether an OSS audit log is an error.
 func ExtractOSSK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
-	if mock, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
+	if reader == nil {
+		return false, nil
+	}
+	if mock, ok := structured.GetMock[*commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
 		return mock.IsError, nil
 	}
-	if reader == nil || (!reader.Has(pathAuditID) && !reader.Has(pathObjectRef)) {
+	if cached, ok := structured.GetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey); ok {
+		return cached.IsError, nil
+	}
+	if !reader.Has(pathAuditID) && !reader.Has(pathObjectRef) {
 		return false, nil
 	}
 	statusCode := reader.ReadIntOrDefault(pathResponseStatusCode, 0)
@@ -96,15 +102,21 @@ func ExtractOSSK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
 }
 
 // ExtractOSSK8sAuditLog extracts commonlogk8saudit_contract.K8sAuditLogFieldSet from OSS audit log entries.
-func ExtractOSSK8sAuditLog(reader *structured.NodeReader) (commonlogk8saudit_contract.K8sAuditLogFieldSet, error) {
-	if mock, ok := structured.GetMock[commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
+func ExtractOSSK8sAuditLog(reader *structured.NodeReader) (*commonlogk8saudit_contract.K8sAuditLogFieldSet, error) {
+	if reader == nil {
+		return &commonlogk8saudit_contract.K8sAuditLogFieldSet{}, nil
+	}
+	if cached, ok := structured.GetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey); ok {
+		return cached, nil
+	}
+	if mock, ok := structured.GetMock[*commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
 		return mock, nil
 	}
-	if reader == nil || (!reader.Has(pathAuditID) && !reader.Has(pathObjectRef)) {
-		return commonlogk8saudit_contract.K8sAuditLogFieldSet{}, nil
+	if !reader.Has(pathAuditID) && !reader.Has(pathObjectRef) {
+		return &commonlogk8saudit_contract.K8sAuditLogFieldSet{}, nil
 	}
 
-	var result commonlogk8saudit_contract.K8sAuditLogFieldSet
+	result := &commonlogk8saudit_contract.K8sAuditLogFieldSet{}
 	result.OperationID = reader.ReadStringOrDefault(pathAuditID, "")
 	// Currently this won't support the long running operation. TODO: support long running operation
 	result.IsFirst = true
@@ -141,6 +153,8 @@ func ExtractOSSK8sAuditLog(reader *structured.NodeReader) (commonlogk8saudit_con
 	result.IsError = result.StatusCode < 200 || result.StatusCode >= 300
 	result.Request, _ = reader.GetReader(pathRequestObject)
 	result.Response, _ = reader.GetReader(pathResponseObject)
+
+	structured.SetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey, result)
 	return result, nil
 }
 

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor.go
@@ -85,9 +85,6 @@ func ExtractOSSK8sIsNonEventAuditLog(reader *structured.NodeReader) (bool, error
 
 // ExtractOSSK8sAuditLogError extracts whether an OSS audit log is an error.
 func ExtractOSSK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
-	if reader == nil {
-		return false, nil
-	}
 	if mock, ok := structured.GetMock[*commonlogk8saudit_contract.K8sAuditLogFieldSet](reader); ok {
 		return mock.IsError, nil
 	}
@@ -103,9 +100,6 @@ func ExtractOSSK8sAuditLogError(reader *structured.NodeReader) (bool, error) {
 
 // ExtractOSSK8sAuditLog extracts commonlogk8saudit_contract.K8sAuditLogFieldSet from OSS audit log entries.
 func ExtractOSSK8sAuditLog(reader *structured.NodeReader) (*commonlogk8saudit_contract.K8sAuditLogFieldSet, error) {
-	if reader == nil {
-		return &commonlogk8saudit_contract.K8sAuditLogFieldSet{}, nil
-	}
 	if cached, ok := structured.GetCache(reader, commonlogk8saudit_contract.K8sAuditLogCacheKey); ok {
 		return cached, nil
 	}

--- a/pkg/task/inspection/ossclusterk8s/contract/extractor_test.go
+++ b/pkg/task/inspection/ossclusterk8s/contract/extractor_test.go
@@ -183,7 +183,7 @@ objectRef:
 				protocmp.Transform(),
 			}
 
-			if diff := cmp.Diff(tc.want, got, opts...); diff != "" {
+			if diff := cmp.Diff(tc.want, *got, opts...); diff != "" {
 				t.Errorf("ExtractOSSK8sAuditLog() mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -205,7 +205,7 @@ objectRef:
 			cmpopts.IgnoreFields(commonlogk8saudit_contract.K8sAuditLogFieldSet{}, "Request", "Response"),
 			protocmp.Transform(),
 		}
-		if diff := cmp.Diff(want, got, opts...); diff != "" {
+		if diff := cmp.Diff(want, *got, opts...); diff != "" {
 			t.Errorf("ExtractOSSK8sAuditLog() mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -494,7 +494,7 @@ responseObject:
 	}
 
 	t.Run("from mock", func(t *testing.T) {
-		reader := structured.NewNodeReader(structured.NewMockNode(commonlogk8saudit_contract.K8sAuditLogFieldSet{}))
+		reader := structured.NewNodeReader(structured.NewMockNode(&commonlogk8saudit_contract.K8sAuditLogFieldSet{}))
 		got, err := ExtractOSSK8sIsNonEventAuditLog(reader)
 		if err != nil {
 			t.Fatalf("ExtractOSSK8sIsNonEventAuditLog() unexpected error: %v", err)


### PR DESCRIPTION
## Summary

During inspection runs involving Kubernetes audit logs, multiple timeline mappers (such as container mappers, condition mappers, and manifest mappers) repeatedly extract and parse the same structured audit log objects (e.g., `*auditv1.Event` and operation verb/kind info) from the same log entries.

This PR introduces a type-safe, lock-free caching mechanism (`CacheKey[T]`, `GetCache`, `SetCache`) on `structured.NodeReader` and leverages it in GCP and OSS audit log extractors to reuse parsed audit event field sets and error statuses across mapper tasks without redundant JSON parsing.

## Changes

- **`pkg/common/structured/reader.go`**:
  - Add `CacheKey[T]`, `SetCache[T]`, and `GetCache[T]` for lock-free atomic storage of typed extraction results on `NodeReader`.
- **`pkg/common/structured/reader_test.go`**:
  - Add unit and concurrency tests for `NodeReader` typed caching.
- **Log Extractors (`googlecloudlogk8saudit`, `commonlogk8saudit`, `ossclusterk8s`)**:
  - Cache parsed `K8sAuditLogFieldSet` in `ExtractGCPK8sAuditLog` and `ExtractOSSK8sAuditLog`.
  - Check cache in `ExtractGCPK8sAuditLogError` and `ExtractOSSK8sAuditLogError` before re-evaluating status codes.

## Verification

- `make pre-commit`: Passed
- `make lint-go`: Passed (0 issues)
- `make test-go`: All backend tests passed
- `make lint-web` & `make test-web`: All frontend tests passed (1109 tests passed)
