### PR TITLE
perf(inspection): release builder and log accumulators after pipeline completion

### DIFF
--- a/pkg/core/inspection/runner.go
+++ b/pkg/core/inspection/runner.go
@@ -415,11 +415,6 @@ func (i *InspectionTaskRunner) Run(ctx context.Context, req *inspectioncore_cont
 		defer close(i.runComplete)
 		defer i.inspectionCancel()
 		defer cancel()
-		defer func() {
-			i.runnerLock.Lock()
-			i.cancel = nil
-			i.runnerLock.Unlock()
-		}()
 		runFunc(cancelableCtx)
 		progress, found := typedmap.Get(i.metadata, inspectionmetadata.ProgressMetadataKey)
 		if !found {
@@ -566,11 +561,10 @@ func (i *InspectionTaskRunner) Cancel() error {
 	if i.runner == nil {
 		return fmt.Errorf("this task is not yet started")
 	}
-	if i.cancel == nil {
+	select {
+	case <-i.runner.Wait():
 		return fmt.Errorf("task %s is already finished", i.ID)
-	}
-	if _, err := i.Result(); err == nil {
-		return fmt.Errorf("task %s is already finished", i.ID)
+	default:
 	}
 	i.cancel()
 	return nil

--- a/pkg/core/inspection/runner.go
+++ b/pkg/core/inspection/runner.go
@@ -415,6 +415,11 @@ func (i *InspectionTaskRunner) Run(ctx context.Context, req *inspectioncore_cont
 		defer close(i.runComplete)
 		defer i.inspectionCancel()
 		defer cancel()
+		defer func() {
+			i.runnerLock.Lock()
+			i.cancel = nil
+			i.runnerLock.Unlock()
+		}()
 		runFunc(cancelableCtx)
 		progress, found := typedmap.Get(i.metadata, inspectionmetadata.ProgressMetadataKey)
 		if !found {
@@ -556,8 +561,13 @@ func (i *InspectionTaskRunner) GetCurrentMetadata() (*typedmap.ReadonlyTypedMap,
 
 // Cancel requests the cancellation of a running inspection.
 func (i *InspectionTaskRunner) Cancel() error {
-	if i.cancel == nil {
+	i.runnerLock.Lock()
+	defer i.runnerLock.Unlock()
+	if i.runner == nil {
 		return fmt.Errorf("this task is not yet started")
+	}
+	if i.cancel == nil {
+		return fmt.Errorf("task %s is already finished", i.ID)
 	}
 	if _, err := i.Result(); err == nil {
 		return fmt.Errorf("task %s is already finished", i.ID)

--- a/pkg/core/inspection/runner_test.go
+++ b/pkg/core/inspection/runner_test.go
@@ -16,6 +16,8 @@ package coreinspection
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/core/inspection/logger"
@@ -417,6 +419,90 @@ func TestSetInspectionType_SelectionPriority(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantEnabledFeatures, gotEnabledFeatures, cmpopts.SortSlices(func(a, b string) bool { return a < b }), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("enabledFeatures mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestInspectionTaskRunner_Cancel(t *testing.T) {
+	logger.InitGlobalKHILogger()
+
+	testCases := []struct {
+		name       string
+		failTask   bool
+		setupRun   func(t *testing.T, runner *InspectionTaskRunner)
+		wantErrSub string
+	}{
+		{
+			name:       "cancel before start returns error",
+			setupRun:   func(t *testing.T, runner *InspectionTaskRunner) {},
+			wantErrSub: "this task is not yet started",
+		},
+		{
+			name: "cancel after successful completion returns already finished error",
+			setupRun: func(t *testing.T, runner *InspectionTaskRunner) {
+				req := &inspectioncore_contract.InspectionRequest{Values: map[string]any{}}
+				if err := runner.Run(context.Background(), req); err != nil {
+					t.Fatalf("Run failed: %v", err)
+				}
+				<-runner.Wait()
+			},
+			wantErrSub: "is already finished",
+		},
+		{
+			name:     "cancel after failed completion returns already finished error",
+			failTask: true,
+			setupRun: func(t *testing.T, runner *InspectionTaskRunner) {
+				req := &inspectioncore_contract.InspectionRequest{Values: map[string]any{}}
+				_ = runner.Run(context.Background(), req)
+				<-runner.Wait()
+			},
+			wantErrSub: "is already finished",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server, err := NewServer(&inspectioncore_contract.IOConfig{TemporaryFolder: t.TempDir()})
+			if err != nil {
+				t.Fatalf("NewServer failed: %v", err)
+			}
+			inspectionType := InspectionType{Id: "test-inspection", Name: "Test Inspection"}
+			if err := server.AddInspectionType(inspectionType); err != nil {
+				t.Fatalf("AddInspectionType failed: %v", err)
+			}
+			dummyTaskID := taskid.NewDefaultImplementationID[any]("dummy-task")
+			dummyTask := coretask.NewTask(
+				dummyTaskID,
+				nil,
+				func(ctx context.Context) (any, error) {
+					if tc.failTask {
+						return nil, fmt.Errorf("simulated failure")
+					}
+					return "success", nil
+				},
+				coretask.WithLabelValue(inspectioncore_contract.LabelKeyInspectionTypes, []string{inspectionType.Id}),
+				coretask.WithLabelValue(inspectioncore_contract.LabelKeyInspectionDefaultFeatureFlag, true),
+				coretask.WithLabelValue(inspectioncore_contract.LabelKeyInspectionFeatureFlag, true),
+				coretask.NewSubsequentTaskRefsTaskLabel(inspectioncore_contract.SerializerTaskID.Ref()),
+			)
+			if err := server.AddTask(dummyTask); err != nil {
+				t.Fatalf("AddTask failed: %v", err)
+			}
+			inspectionID, err := server.CreateInspection(inspectionType.Id)
+			if err != nil {
+				t.Fatalf("CreateInspection failed: %v", err)
+			}
+			runner := server.GetInspection(inspectionID)
+
+			tc.setupRun(t, runner)
+
+			err = runner.Cancel()
+			if err == nil {
+				t.Fatalf("Cancel() expected error containing %q, got nil", tc.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Errorf("Cancel() error %q does not contain %q", err.Error(), tc.wantErrSub)
 			}
 		})
 	}

--- a/pkg/model/khifile/v6/builder.go
+++ b/pkg/model/khifile/v6/builder.go
@@ -61,8 +61,18 @@ func NewTestBuilder(gen *id.Generator) *Builder {
 	return NewBuilder(gen, MustNewTestWriter())
 }
 
+// Dispose releases accumulators and pools held by the Builder to allow GC to reclaim memory.
+func (b *Builder) Dispose() {
+	b.TimelineAccumulator = nil
+	b.LogAccumulator = nil
+	b.internPool = nil
+	b.serverInternPool = nil
+	b.MetadataAccumulator = nil
+}
+
 // Build writes the accumulated metadata, timeline chunks, and flushes remaining log and intern pool chunks.
 func (b *Builder) Build(reporter BuilderProgressReporter) (err error) {
+	defer b.Dispose()
 	defer func() {
 		if closeErr := b.writer.Close(); closeErr != nil && err == nil {
 			err = fmt.Errorf("failed to close writer: %w", closeErr)


### PR DESCRIPTION
## Summary

During large inspection runs, the in-memory builder holds references to accumulators and intern pools even after `Build()` has finished serialization. Retaining these structures prevents the Go garbage collector from reclaiming intermediate DAG heap memory while post-processing or final response transmission takes place. Additionally, `InspectionTaskRunner` held references to cancellation functions without clearing them on completion.

This PR adds an explicit `Dispose()` method to `khifilev6.Builder` called via `defer` in `Build()`, and cleans up task runner state upon inspection completion.

## Changes

- **`pkg/model/khifile/v6/builder.go`**:
  - Add `Dispose()` method to nil out references to `TimelineAccumulator`, `LogAccumulator`, `internPool`, `serverInternPool`, and `MetadataAccumulator`.
  - Defer `b.Dispose()` in `Build()`.
- **`pkg/core/inspection/runner.go`**:
  - Clear `cancel` function upon completion of the inspection runner goroutine.
  - Return early with an informative error in `Cancel()` if the task is already finished or not started under runner lock.

## Verification

- `make pre-commit`: Passed
- `make lint-go`: Passed (0 issues)
- `make test-go`: All backend tests passed
