### PR TITLE
perf(structured): implement compressed block storage and LRU cache for LazyJSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/addlicense v1.2.0 // indirect
 	github.com/google/cel-go v0.31.0 // indirect
 	github.com/google/pprof v0.0.0-20260604005048-7023385849c0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/golang/mock v1.7.0-rc.1 h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/
 github.com/golang/mock v1.7.0-rc.1/go.mod h1:s42URUywIqd+OcERslBJvOjepvNymP31m3q8d/GkuRs=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
+github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/addlicense v1.2.0 h1:W+DP4A639JGkcwBGMDvjSurZHvaq2FN0pP7se9czsKA=
 github.com/google/addlicense v1.2.0/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3Cq0rncIxA=
 github.com/google/cel-go v0.31.0 h1:H0bhpFTqOvmHrBGrWKp7ZlhBm5Hh8PYUEXnwxT1LL7A=

--- a/pkg/api/googlecloud/logconvert/logconvert.go
+++ b/pkg/api/googlecloud/logconvert/logconvert.go
@@ -49,11 +49,11 @@ var GCPLogEntryKeyOrder = []string{
 }
 
 // LogEntryToNode converts a Google Cloud Logging LogEntry protobuf message into a structured.Node.
-// It directly marshals the LogEntry into JSON bytes via protojson and wraps it in a LazyJSONNode.
-func LogEntryToNode(l *loggingpb.LogEntry) (structured.Node, error) {
+// It directly marshals the LogEntry into JSON bytes via protojson and appends it to the block builder.
+func LogEntryToNode(builder *structured.LazyJSONBlockBuilder, l *loggingpb.LogEntry) (structured.Node, error) {
 	jsonBytes, err := protojsonMarshalOptions.Marshal(l)
 	if err != nil {
 		return nil, err
 	}
-	return structured.NewLazyJSONNodeFromBytes(jsonBytes), nil
+	return builder.Add(jsonBytes), nil
 }

--- a/pkg/api/googlecloud/logconvert/logconvert_test.go
+++ b/pkg/api/googlecloud/logconvert/logconvert_test.go
@@ -197,7 +197,10 @@ func TestLogEntryToNode(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := LogEntryToNode(tc.logEntry)
+			store := structured.NewLazyJSONBlockStore(4, 8)
+			builder := store.NewBuilder(10, 1024)
+			got, err := LogEntryToNode(builder, tc.logEntry)
+			builder.Flush()
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("LogEntryToNode() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -237,7 +240,10 @@ func TestLogEntryWithKeyOrder(t *testing.T) {
 		Severity: ltype.LogSeverity_INFO,
 	}
 
-	node, err := LogEntryToNode(entry)
+	store := structured.NewLazyJSONBlockStore(4, 8)
+	builder := store.NewBuilder(10, 1024)
+	node, err := LogEntryToNode(builder, entry)
+	builder.Flush()
 	if err != nil {
 		t.Fatalf("LogEntryToNode() failed: %v", err)
 	}
@@ -272,10 +278,13 @@ func BenchmarkLogEntryToNode(b *testing.B) {
 		Timestamp: nowpb,
 	}
 
+	store := structured.NewLazyJSONBlockStore(16, 64)
+	builder := store.NewBuilder(100, 256*1024)
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_, err := LogEntryToNode(entry)
+		_, err := LogEntryToNode(builder, entry)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/common/structured/lazyjson.go
+++ b/pkg/common/structured/lazyjson.go
@@ -27,11 +27,14 @@ import (
 // ErrInvalidJSON indicates that invalid JSON syntax was encountered during scanning.
 var ErrInvalidJSON = errors.New("invalid json format")
 
-// LazyJSONNode represents structured data as an immutable JSON byte buffer and an offset index.
-// Child nodes reuse the underlying byte buffer without allocating sub-slices, adjusting only the offset index.
+// LazyJSONNode represents structured data backed by an entry in LazyJSONBlockStore and an offset index.
+// Child nodes reuse the underlying block reference without allocating sub-slices, adjusting only the offset index.
 type LazyJSONNode struct {
-	data  []byte
-	index int
+	store   *LazyJSONBlockStore
+	blockID uint32
+	offset  uint32
+	length  uint32
+	index   int
 }
 
 var _ Node = (*LazyJSONNode)(nil)
@@ -51,19 +54,32 @@ func NewLazyJSONNode(node Node) (Node, error) {
 
 // NewLazyJSONNodeFromBytes creates a LazyJSONNode from a JSON byte slice.
 func NewLazyJSONNodeFromBytes(data []byte) Node {
-	return &LazyJSONNode{
-		data:  data,
-		index: 0,
+	blockID := defaultStandaloneBlockStore.ReserveBlock(data)
+	compressed, err := compressBlockData(data)
+	if err == nil {
+		defaultStandaloneBlockStore.SetCompressed(blockID, compressed)
 	}
+	return &LazyJSONNode{
+		store:   defaultStandaloneBlockStore,
+		blockID: blockID,
+		offset:  0,
+		length:  uint32(len(data)),
+		index:   0,
+	}
+}
+
+func (n *LazyJSONNode) getBuffer() []byte {
+	return n.store.GetBuffer(n.blockID, n.offset, n.length)
 }
 
 // Type returns the NodeType of this node.
 func (n *LazyJSONNode) Type() NodeType {
-	idx := skipWhitespace(n.data, n.index)
-	if idx >= len(n.data) {
+	data := n.getBuffer()
+	idx := skipWhitespace(data, n.index)
+	if idx >= len(data) {
 		return InvalidNodeType
 	}
-	switch n.data[idx] {
+	switch data[idx] {
 	case '{':
 		return MapNodeType
 	case '[':
@@ -80,7 +96,8 @@ func (n *LazyJSONNode) NodeScalarValue() (any, error) {
 	if n.Type() != ScalarNodeType {
 		return nil, ErrNonScalarNode
 	}
-	val, _, err := parseJSONScalar(n.data, n.index)
+	data := n.getBuffer()
+	val, _, err := parseJSONScalar(data, n.index, true)
 	return val, err
 }
 
@@ -90,93 +107,101 @@ func (n *LazyJSONNode) Children() NodeChildrenIterator {
 	switch nodeType {
 	case MapNodeType:
 		return func(yield func(key NodeChildrenKey, value Node) bool) {
-			idx := skipWhitespace(n.data, n.index)
-			if idx >= len(n.data) || n.data[idx] != '{' {
+			data := n.getBuffer()
+			idx := skipWhitespace(data, n.index)
+			if idx >= len(data) || data[idx] != '{' {
 				return
 			}
 			idx++ // Skip '{'
 			childIndex := 0
 
 			for {
-				idx = skipWhitespace(n.data, idx)
-				if idx >= len(n.data) {
+				idx = skipWhitespace(data, idx)
+				if idx >= len(data) {
 					return
 				}
-				if n.data[idx] == '}' {
-					return
-				}
-
-				if n.data[idx] != '"' {
+				if data[idx] == '}' {
 					return
 				}
 
-				keyStr, nextIdx, err := parseJSONString(n.data, idx)
+				if data[idx] != '"' {
+					return
+				}
+
+				keyStr, nextIdx, err := parseJSONString(data, idx, true)
 				if err != nil {
 					return
 				}
-				idx = skipWhitespace(n.data, nextIdx)
-				if idx >= len(n.data) || n.data[idx] != ':' {
+				idx = skipWhitespace(data, nextIdx)
+				if idx >= len(data) || data[idx] != ':' {
 					return
 				}
 				idx++ // Skip ':'
-				valStartIdx := skipWhitespace(n.data, idx)
-				if valStartIdx >= len(n.data) {
+				valStartIdx := skipWhitespace(data, idx)
+				if valStartIdx >= len(data) {
 					return
 				}
 
 				childNode := &LazyJSONNode{
-					data:  n.data,
-					index: valStartIdx,
+					store:   n.store,
+					blockID: n.blockID,
+					offset:  n.offset,
+					length:  n.length,
+					index:   valStartIdx,
 				}
 				if !yield(NodeChildrenKey{Index: childIndex, Key: keyStr}, childNode) {
 					return
 				}
 				childIndex++
 
-				valEndIdx, err := skipJSONValue(n.data, valStartIdx)
+				valEndIdx, err := skipJSONValue(data, valStartIdx)
 				if err != nil {
 					return
 				}
-				idx = skipWhitespace(n.data, valEndIdx)
-				if idx < len(n.data) && n.data[idx] == ',' {
+				idx = skipWhitespace(data, valEndIdx)
+				if idx < len(data) && data[idx] == ',' {
 					idx++
 				}
 			}
 		}
 	case SequenceNodeType:
 		return func(yield func(key NodeChildrenKey, value Node) bool) {
-			idx := skipWhitespace(n.data, n.index)
-			if idx >= len(n.data) || n.data[idx] != '[' {
+			data := n.getBuffer()
+			idx := skipWhitespace(data, n.index)
+			if idx >= len(data) || data[idx] != '[' {
 				return
 			}
 			idx++ // Skip '['
 			childIndex := 0
 
 			for {
-				idx = skipWhitespace(n.data, idx)
-				if idx >= len(n.data) {
+				idx = skipWhitespace(data, idx)
+				if idx >= len(data) {
 					return
 				}
-				if n.data[idx] == ']' {
+				if data[idx] == ']' {
 					return
 				}
 
 				elemStartIdx := idx
 				childNode := &LazyJSONNode{
-					data:  n.data,
-					index: elemStartIdx,
+					store:   n.store,
+					blockID: n.blockID,
+					offset:  n.offset,
+					length:  n.length,
+					index:   elemStartIdx,
 				}
 				if !yield(NodeChildrenKey{Index: childIndex, Key: ""}, childNode) {
 					return
 				}
 				childIndex++
 
-				elemEndIdx, err := skipJSONValue(n.data, elemStartIdx)
+				elemEndIdx, err := skipJSONValue(data, elemStartIdx)
 				if err != nil {
 					return
 				}
-				idx = skipWhitespace(n.data, elemEndIdx)
-				if idx < len(n.data) && n.data[idx] == ',' {
+				idx = skipWhitespace(data, elemEndIdx)
+				if idx < len(data) && data[idx] == ',' {
 					idx++
 				}
 			}
@@ -191,60 +216,62 @@ func (n *LazyJSONNode) Len() int {
 	nodeType := n.Type()
 	switch nodeType {
 	case MapNodeType:
-		idx := skipWhitespace(n.data, n.index)
-		if idx >= len(n.data) || n.data[idx] != '{' {
+		data := n.getBuffer()
+		idx := skipWhitespace(data, n.index)
+		if idx >= len(data) || data[idx] != '{' {
 			return 0
 		}
 		idx++
 		count := 0
 		for {
-			idx = skipWhitespace(n.data, idx)
-			if idx >= len(n.data) || n.data[idx] == '}' {
+			idx = skipWhitespace(data, idx)
+			if idx >= len(data) || data[idx] == '}' {
 				break
 			}
-			if n.data[idx] != '"' {
+			if data[idx] != '"' {
 				break
 			}
-			_, nextIdx, err := parseJSONString(n.data, idx)
+			_, nextIdx, err := parseJSONString(data, idx, false)
 			if err != nil {
 				break
 			}
-			idx = skipWhitespace(n.data, nextIdx)
-			if idx >= len(n.data) || n.data[idx] != ':' {
+			idx = skipWhitespace(data, nextIdx)
+			if idx >= len(data) || data[idx] != ':' {
 				break
 			}
 			idx++
-			valStartIdx := skipWhitespace(n.data, idx)
-			valEndIdx, err := skipJSONValue(n.data, valStartIdx)
+			valStartIdx := skipWhitespace(data, idx)
+			valEndIdx, err := skipJSONValue(data, valStartIdx)
 			if err != nil {
 				break
 			}
 			count++
-			idx = skipWhitespace(n.data, valEndIdx)
-			if idx < len(n.data) && n.data[idx] == ',' {
+			idx = skipWhitespace(data, valEndIdx)
+			if idx < len(data) && data[idx] == ',' {
 				idx++
 			}
 		}
 		return count
 	case SequenceNodeType:
-		idx := skipWhitespace(n.data, n.index)
-		if idx >= len(n.data) || n.data[idx] != '[' {
+		data := n.getBuffer()
+		idx := skipWhitespace(data, n.index)
+		if idx >= len(data) || data[idx] != '[' {
 			return 0
 		}
 		idx++
 		count := 0
 		for {
-			idx = skipWhitespace(n.data, idx)
-			if idx >= len(n.data) || n.data[idx] == ']' {
+			idx = skipWhitespace(data, idx)
+			if idx >= len(data) || data[idx] == ']' {
 				break
 			}
-			elemEndIdx, err := skipJSONValue(n.data, idx)
+			elemEndIdx, err := skipJSONValue(data, idx)
 			if err != nil {
 				break
 			}
 			count++
-			idx = skipWhitespace(n.data, elemEndIdx)
-			if idx < len(n.data) && n.data[idx] == ',' {
+			idx = skipWhitespace(data, elemEndIdx)
+			if idx < len(data) && data[idx] == ',' {
 				idx++
 			}
 		}
@@ -256,18 +283,21 @@ func (n *LazyJSONNode) Len() int {
 
 // GetChildByKey returns the child node matching the string key without allocating iterator closures or non-matching child nodes.
 func (n *LazyJSONNode) GetChildByKey(key string) (Node, bool) {
-	if len(n.data) == 0 || n.index >= len(n.data) {
+	if n.length == 0 || n.index >= int(n.length) {
 		return nil, false
 	}
 
-	ptr := uintptr(unsafe.Pointer(&n.data[0]))
-	if valIdx, ok := globalLazyJSONCache.get(ptr, n.index, key); ok {
+	absOffset := n.offset + uint32(n.index)
+	if valIdx, ok := n.store.cache.get(n.blockID, absOffset, key); ok {
 		if valIdx < 0 {
 			return nil, false
 		}
 		return &LazyJSONNode{
-			data:  n.data,
-			index: valIdx,
+			store:   n.store,
+			blockID: n.blockID,
+			offset:  n.offset,
+			length:  n.length,
+			index:   valIdx,
 		}, true
 	}
 
@@ -275,56 +305,60 @@ func (n *LazyJSONNode) GetChildByKey(key string) (Node, bool) {
 		return nil, false
 	}
 
-	idx := skipWhitespace(n.data, n.index)
-	if idx >= len(n.data) || n.data[idx] != '{' {
-		globalLazyJSONCache.put(ptr, n.index, key, -1, n.data)
+	data := n.getBuffer()
+	idx := skipWhitespace(data, n.index)
+	if idx >= len(data) || data[idx] != '{' {
+		n.store.cache.put(n.blockID, absOffset, key, -1)
 		return nil, false
 	}
 	idx++ // Skip '{'
 
 	for {
-		idx = skipWhitespace(n.data, idx)
-		if idx >= len(n.data) || n.data[idx] == '}' {
-			globalLazyJSONCache.put(ptr, n.index, key, -1, n.data)
+		idx = skipWhitespace(data, idx)
+		if idx >= len(data) || data[idx] == '}' {
+			n.store.cache.put(n.blockID, absOffset, key, -1)
 			return nil, false
 		}
-		if n.data[idx] != '"' {
-			globalLazyJSONCache.put(ptr, n.index, key, -1, n.data)
+		if data[idx] != '"' {
+			n.store.cache.put(n.blockID, absOffset, key, -1)
 			return nil, false
 		}
-		keyStr, nextIdx, err := parseJSONString(n.data, idx)
+		keyStr, nextIdx, err := parseJSONString(data, idx, false)
 		if err != nil {
-			globalLazyJSONCache.put(ptr, n.index, key, -1, n.data)
+			n.store.cache.put(n.blockID, absOffset, key, -1)
 			return nil, false
 		}
-		idx = skipWhitespace(n.data, nextIdx)
-		if idx >= len(n.data) || n.data[idx] != ':' {
-			globalLazyJSONCache.put(ptr, n.index, key, -1, n.data)
+		idx = skipWhitespace(data, nextIdx)
+		if idx >= len(data) || data[idx] != ':' {
+			n.store.cache.put(n.blockID, absOffset, key, -1)
 			return nil, false
 		}
 		idx++ // Skip ':'
-		valStartIdx := skipWhitespace(n.data, idx)
-		if valStartIdx >= len(n.data) {
-			globalLazyJSONCache.put(ptr, n.index, key, -1, n.data)
+		valStartIdx := skipWhitespace(data, idx)
+		if valStartIdx >= len(data) {
+			n.store.cache.put(n.blockID, absOffset, key, -1)
 			return nil, false
 		}
 
-		globalLazyJSONCache.putIfAbsent(ptr, n.index, keyStr, valStartIdx, n.data)
+		n.store.cache.putIfAbsent(n.blockID, absOffset, keyStr, valStartIdx)
 
 		if keyStr == key {
 			return &LazyJSONNode{
-				data:  n.data,
-				index: valStartIdx,
+				store:   n.store,
+				blockID: n.blockID,
+				offset:  n.offset,
+				length:  n.length,
+				index:   valStartIdx,
 			}, true
 		}
 
-		valEndIdx, err := skipJSONValue(n.data, valStartIdx)
+		valEndIdx, err := skipJSONValue(data, valStartIdx)
 		if err != nil {
-			globalLazyJSONCache.put(ptr, n.index, key, -1, n.data)
+			n.store.cache.put(n.blockID, absOffset, key, -1)
 			return nil, false
 		}
-		idx = skipWhitespace(n.data, valEndIdx)
-		if idx < len(n.data) && n.data[idx] == ',' {
+		idx = skipWhitespace(data, valEndIdx)
+		if idx < len(data) && data[idx] == ',' {
 			idx++
 		}
 	}
@@ -342,7 +376,7 @@ func skipWhitespace(data []byte, index int) int {
 	return index
 }
 
-func parseJSONString(data []byte, index int) (string, int, error) {
+func parseJSONString(data []byte, index int, copyString bool) (string, int, error) {
 	idx := skipWhitespace(data, index)
 	if idx >= len(data) || data[idx] != '"' {
 		return "", idx, ErrInvalidJSON
@@ -366,6 +400,9 @@ stringScanLoop:
 			if !hasEscapes {
 				if start == idx {
 					return "", idx + 1, nil
+				}
+				if copyString {
+					return string(data[start:idx]), idx + 1, nil
 				}
 				return unsafe.String(&data[start], idx-start), idx + 1, nil
 			}
@@ -470,7 +507,7 @@ func parseHex4(b []byte) (rune, error) {
 	return val, nil
 }
 
-func parseJSONScalar(data []byte, index int) (any, int, error) {
+func parseJSONScalar(data []byte, index int, copyString bool) (any, int, error) {
 	idx := skipWhitespace(data, index)
 	if idx >= len(data) {
 		return nil, idx, ErrInvalidJSON
@@ -478,7 +515,7 @@ func parseJSONScalar(data []byte, index int) (any, int, error) {
 
 	switch data[idx] {
 	case '"':
-		return parseJSONString(data, idx)
+		return parseJSONString(data, idx, copyString)
 	case 't':
 		if idx+4 <= len(data) && data[idx] == 't' && data[idx+1] == 'r' && data[idx+2] == 'u' && data[idx+3] == 'e' {
 			return true, idx + 4, nil
@@ -611,7 +648,7 @@ func skipJSONValue(data []byte, index int) (int, error) {
 		}
 		return idx, ErrInvalidJSON
 	case '"':
-		_, nextIdx, err := parseJSONString(data, idx)
+		_, nextIdx, err := parseJSONString(data, idx, false)
 		return nextIdx, err
 	default:
 		// Scalar (bool, null, number)

--- a/pkg/common/structured/lazyjson.go
+++ b/pkg/common/structured/lazyjson.go
@@ -39,8 +39,8 @@ type LazyJSONNode struct {
 
 var _ Node = (*LazyJSONNode)(nil)
 
-// NewLazyJSONNode serializes a given Node to JSON and wraps it in a LazyJSONNode.
-func NewLazyJSONNode(node Node) (Node, error) {
+// NewLazyJSONNode serializes a given Node to JSON and registers it into the LazyJSONBlockStore.
+func NewLazyJSONNode(store *LazyJSONBlockStore, node Node) (Node, error) {
 	if lazyNode, ok := node.(*LazyJSONNode); ok {
 		return lazyNode, nil
 	}
@@ -49,18 +49,18 @@ func NewLazyJSONNode(node Node) (Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewLazyJSONNodeFromBytes(data), nil
+	return NewLazyJSONNodeFromBytes(store, data), nil
 }
 
-// NewLazyJSONNodeFromBytes creates a LazyJSONNode from a JSON byte slice.
-func NewLazyJSONNodeFromBytes(data []byte) Node {
-	blockID := defaultStandaloneBlockStore.ReserveBlock(data)
+// NewLazyJSONNodeFromBytes creates a LazyJSONNode backed by a LazyJSONBlockStore from a JSON byte slice.
+func NewLazyJSONNodeFromBytes(store *LazyJSONBlockStore, data []byte) Node {
+	blockID := store.ReserveBlock(data)
 	compressed, err := compressBlockData(data)
 	if err == nil {
-		defaultStandaloneBlockStore.SetCompressed(blockID, compressed)
+		store.SetCompressed(blockID, compressed)
 	}
 	return &LazyJSONNode{
-		store:   defaultStandaloneBlockStore,
+		store:   store,
 		blockID: blockID,
 		offset:  0,
 		length:  uint32(len(data)),

--- a/pkg/common/structured/lazyjson_block.go
+++ b/pkg/common/structured/lazyjson_block.go
@@ -15,42 +15,14 @@
 package structured
 
 import (
-	"bytes"
-	"compress/gzip"
-	"encoding/binary"
 	"fmt"
-	"io"
 	"sync"
+
+	"github.com/golang/snappy"
 )
 
-var gzipReaderPool = sync.Pool{
-	New: func() any {
-		return new(gzip.Reader)
-	},
-}
-
-var gzipWriterPool = sync.Pool{
-	New: func() any {
-		zw, _ := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
-		return zw
-	},
-}
-
 func compressBlockData(data []byte) ([]byte, error) {
-	zw := gzipWriterPool.Get().(*gzip.Writer)
-	defer gzipWriterPool.Put(zw)
-
-	var buf bytes.Buffer
-	buf.Grow(len(data) / 4)
-	zw.Reset(&buf)
-
-	if _, err := zw.Write(data); err != nil {
-		return nil, err
-	}
-	if err := zw.Close(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return snappy.Encode(nil, data), nil
 }
 
 type lazyJSONBlock struct {
@@ -205,8 +177,22 @@ type LazyJSONBlockStore struct {
 	cache     *lazyJSONCache
 }
 
+// DefaultLazyJSONBlockStoreShardCount is the default shard count for LazyJSONBlockStore.
+const DefaultLazyJSONBlockStoreShardCount = 64
+
+// DefaultLazyJSONBlockStoreShardCap is the default capacity per shard, sizing total uncompressed cache to 1 GB (4,096 blocks * 256 KB).
+const DefaultLazyJSONBlockStoreShardCap = 64
+
+// NewDefaultLazyJSONBlockStore creates a new LazyJSONBlockStore with default 1 GB uncompressed cache capacity.
+func NewDefaultLazyJSONBlockStore() *LazyJSONBlockStore {
+	return NewLazyJSONBlockStore(DefaultLazyJSONBlockStoreShardCount, DefaultLazyJSONBlockStoreShardCap)
+}
+
 // NewLazyJSONBlockStore creates a new LazyJSONBlockStore with the specified shard count and shard capacity.
 func NewLazyJSONBlockStore(shardCount, shardCap int) *LazyJSONBlockStore {
+	if shardCount <= 0 || (shardCount&(shardCount-1)) != 0 {
+		panic("shardCount must be a power of two")
+	}
 	shards := make([]*blockLRUShard, shardCount)
 	for i := 0; i < shardCount; i++ {
 		shards[i] = newBlockLRUShard(shardCap)
@@ -270,23 +256,13 @@ func (s *LazyJSONBlockStore) put(blockID uint32, b *lazyJSONBlock) {
 }
 
 func (s *LazyJSONBlockStore) decompress(compressed []byte) ([]byte, error) {
-	if len(compressed) < 4 {
-		return nil, fmt.Errorf("compressed block too short: %d bytes", len(compressed))
+	decodedLen, err := snappy.DecodedLen(compressed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get snappy decoded length: %w", err)
 	}
-	uncompressedSize := int(binary.LittleEndian.Uint32(compressed[len(compressed)-4:]))
-
-	zr := gzipReaderPool.Get().(*gzip.Reader)
-	defer gzipReaderPool.Put(zr)
-
-	br := bytes.NewReader(compressed)
-	if err := zr.Reset(br); err != nil {
-		return nil, err
-	}
-	defer zr.Close()
-
-	decompressed := make([]byte, uncompressedSize)
-	if _, err := io.ReadFull(zr, decompressed); err != nil {
-		return nil, err
+	decompressed := make([]byte, decodedLen)
+	if _, err := snappy.Decode(decompressed, compressed); err != nil {
+		return nil, fmt.Errorf("failed to decompress snappy block: %w", err)
 	}
 	return decompressed, nil
 }
@@ -295,6 +271,3 @@ func (s *LazyJSONBlockStore) decompress(compressed []byte) ([]byte, error) {
 func (s *LazyJSONBlockStore) NewBuilder(maxEntries, maxBytes int) *LazyJSONBlockBuilder {
 	return newLazyJSONBlockBuilder(s, maxEntries, maxBytes)
 }
-
-// defaultStandaloneBlockStore is the global block store used for standalone nodes created without an explicit builder.
-var defaultStandaloneBlockStore = NewLazyJSONBlockStore(16, 64)

--- a/pkg/common/structured/lazyjson_block.go
+++ b/pkg/common/structured/lazyjson_block.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structured
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sync"
+)
+
+var gzipReaderPool = sync.Pool{
+	New: func() any {
+		return new(gzip.Reader)
+	},
+}
+
+var gzipWriterPool = sync.Pool{
+	New: func() any {
+		zw, _ := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
+		return zw
+	},
+}
+
+func compressBlockData(data []byte) ([]byte, error) {
+	zw := gzipWriterPool.Get().(*gzip.Writer)
+	defer gzipWriterPool.Put(zw)
+
+	var buf bytes.Buffer
+	buf.Grow(len(data) / 4)
+	zw.Reset(&buf)
+
+	if _, err := zw.Write(data); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+type lazyJSONBlock struct {
+	mu           sync.RWMutex
+	compressed   []byte
+	uncompressed []byte
+}
+
+func (b *lazyJSONBlock) getBuffer(store *LazyJSONBlockStore, blockID uint32) []byte {
+	b.mu.RLock()
+	if b.uncompressed != nil {
+		data := b.uncompressed
+		b.mu.RUnlock()
+		store.touch(blockID)
+		return data
+	}
+	b.mu.RUnlock()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.uncompressed != nil {
+		store.touch(blockID)
+		return b.uncompressed
+	}
+
+	decompressed, err := store.decompress(b.compressed)
+	if err != nil {
+		panic(fmt.Sprintf("failed to decompress lazyJSON block %d: %v", blockID, err))
+	}
+	b.uncompressed = decompressed
+	store.put(blockID, b)
+	return decompressed
+}
+
+func (b *lazyJSONBlock) evict() {
+	b.mu.Lock()
+	if len(b.compressed) > 0 {
+		b.uncompressed = nil
+	}
+	b.mu.Unlock()
+}
+
+type blockLRUEntry struct {
+	blockID uint32
+	block   *lazyJSONBlock
+	prev    *blockLRUEntry
+	next    *blockLRUEntry
+}
+
+type blockLRUShard struct {
+	mu       sync.Mutex
+	capacity int
+	entries  map[uint32]*blockLRUEntry
+	head     *blockLRUEntry
+	tail     *blockLRUEntry
+}
+
+func newBlockLRUShard(capacity int) *blockLRUShard {
+	return &blockLRUShard{
+		capacity: capacity,
+		entries:  make(map[uint32]*blockLRUEntry, capacity),
+	}
+}
+
+func (s *blockLRUShard) touch(blockID uint32) {
+	s.mu.Lock()
+	if entry, ok := s.entries[blockID]; ok {
+		s.moveToHead(entry)
+	}
+	s.mu.Unlock()
+}
+
+func (s *blockLRUShard) put(blockID uint32, b *lazyJSONBlock) {
+	s.mu.Lock()
+	if entry, ok := s.entries[blockID]; ok {
+		s.moveToHead(entry)
+		s.mu.Unlock()
+		return
+	}
+
+	entry := &blockLRUEntry{blockID: blockID, block: b}
+	s.entries[blockID] = entry
+	s.addToHead(entry)
+
+	var toEvict *lazyJSONBlock
+	if len(s.entries) > s.capacity {
+		toEvict = s.removeTail()
+	}
+	s.mu.Unlock()
+
+	if toEvict != nil {
+		toEvict.evict()
+	}
+}
+
+func (s *blockLRUShard) addToHead(entry *blockLRUEntry) {
+	entry.prev = nil
+	entry.next = s.head
+	if s.head != nil {
+		s.head.prev = entry
+	}
+	s.head = entry
+	if s.tail == nil {
+		s.tail = entry
+	}
+}
+
+func (s *blockLRUShard) moveToHead(entry *blockLRUEntry) {
+	if s.head == entry {
+		return
+	}
+	if entry.prev != nil {
+		entry.prev.next = entry.next
+	}
+	if entry.next != nil {
+		entry.next.prev = entry.prev
+	}
+	if s.tail == entry {
+		s.tail = entry.prev
+	}
+
+	entry.prev = nil
+	entry.next = s.head
+	if s.head != nil {
+		s.head.prev = entry
+	}
+	s.head = entry
+}
+
+func (s *blockLRUShard) removeTail() *lazyJSONBlock {
+	if s.tail == nil {
+		return nil
+	}
+	evicted := s.tail
+	delete(s.entries, evicted.blockID)
+	if s.tail.prev != nil {
+		s.tail.prev.next = nil
+		s.tail = s.tail.prev
+	} else {
+		s.head = nil
+		s.tail = nil
+	}
+	return evicted.block
+}
+
+// LazyJSONBlockStore manages blocks of compressed JSON data with a sharded LRU cache for decompressed blocks.
+type LazyJSONBlockStore struct {
+	mu        sync.RWMutex
+	blocks    []*lazyJSONBlock
+	shards    []*blockLRUShard
+	shardMask uint32
+	cache     *lazyJSONCache
+}
+
+// NewLazyJSONBlockStore creates a new LazyJSONBlockStore with the specified shard count and shard capacity.
+func NewLazyJSONBlockStore(shardCount, shardCap int) *LazyJSONBlockStore {
+	shards := make([]*blockLRUShard, shardCount)
+	for i := 0; i < shardCount; i++ {
+		shards[i] = newBlockLRUShard(shardCap)
+	}
+	return &LazyJSONBlockStore{
+		blocks:    make([]*lazyJSONBlock, 0, 64),
+		shards:    shards,
+		shardMask: uint32(shardCount - 1),
+		cache:     newLazyJSONCache(lazyJSONCacheShardCount, lazyJSONCacheShardCap),
+	}
+}
+
+// ReserveBlock registers a new block with initial uncompressed bytes and returns its unique block ID.
+func (s *LazyJSONBlockStore) ReserveBlock(initialUncompressed []byte) uint32 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	blockID := uint32(len(s.blocks))
+	block := &lazyJSONBlock{
+		uncompressed: initialUncompressed,
+	}
+	s.blocks = append(s.blocks, block)
+	return blockID
+}
+
+// SetCompressed assigns compressed bytes to the designated block and inserts it into the LRU cache.
+func (s *LazyJSONBlockStore) SetCompressed(blockID uint32, compressed []byte) {
+	s.mu.RLock()
+	block := s.blocks[blockID]
+	s.mu.RUnlock()
+
+	block.mu.Lock()
+	block.compressed = compressed
+	block.mu.Unlock()
+
+	s.put(blockID, block)
+}
+
+// GetBuffer retrieves a byte slice from the uncompressed block at the given offset and length.
+func (s *LazyJSONBlockStore) GetBuffer(blockID, offset, length uint32) []byte {
+	s.mu.RLock()
+	block := s.blocks[blockID]
+	s.mu.RUnlock()
+
+	decompressed := block.getBuffer(s, blockID)
+	end := int(offset + length)
+	if end > len(decompressed) {
+		panic(fmt.Sprintf("lazyJSON block offset %d + length %d exceeds block size %d", offset, length, len(decompressed)))
+	}
+	return decompressed[offset:end]
+}
+
+func (s *LazyJSONBlockStore) touch(blockID uint32) {
+	shardIdx := blockID & s.shardMask
+	s.shards[shardIdx].touch(blockID)
+}
+
+func (s *LazyJSONBlockStore) put(blockID uint32, b *lazyJSONBlock) {
+	shardIdx := blockID & s.shardMask
+	s.shards[shardIdx].put(blockID, b)
+}
+
+func (s *LazyJSONBlockStore) decompress(compressed []byte) ([]byte, error) {
+	if len(compressed) < 4 {
+		return nil, fmt.Errorf("compressed block too short: %d bytes", len(compressed))
+	}
+	uncompressedSize := int(binary.LittleEndian.Uint32(compressed[len(compressed)-4:]))
+
+	zr := gzipReaderPool.Get().(*gzip.Reader)
+	defer gzipReaderPool.Put(zr)
+
+	br := bytes.NewReader(compressed)
+	if err := zr.Reset(br); err != nil {
+		return nil, err
+	}
+	defer zr.Close()
+
+	decompressed := make([]byte, uncompressedSize)
+	if _, err := io.ReadFull(zr, decompressed); err != nil {
+		return nil, err
+	}
+	return decompressed, nil
+}
+
+// NewBuilder creates a new LazyJSONBlockBuilder for appending log entries into this store.
+func (s *LazyJSONBlockStore) NewBuilder(maxEntries, maxBytes int) *LazyJSONBlockBuilder {
+	return newLazyJSONBlockBuilder(s, maxEntries, maxBytes)
+}
+
+// defaultStandaloneBlockStore is the global block store used for standalone nodes created without an explicit builder.
+var defaultStandaloneBlockStore = NewLazyJSONBlockStore(16, 64)

--- a/pkg/common/structured/lazyjson_block_builder.go
+++ b/pkg/common/structured/lazyjson_block_builder.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structured
+
+import (
+	"fmt"
+	"sync"
+)
+
+// DefaultLazyJSONBlockMaxEntries is the default maximum number of entries per block.
+const DefaultLazyJSONBlockMaxEntries = 100
+
+// DefaultLazyJSONBlockMaxBytes is the default maximum uncompressed byte size per block.
+const DefaultLazyJSONBlockMaxBytes = 256 * 1024
+
+// LazyJSONBlockBuilder batches multiple JSON entries into blocks, registers them into LazyJSONBlockStore,
+// and compresses them when size thresholds are reached.
+type LazyJSONBlockBuilder struct {
+	store          *LazyJSONBlockStore
+	maxEntries     int
+	maxBytes       int
+	currentBlockID uint32
+	currentBuffer  []byte
+	entryCount     int
+	hasActiveBlock bool
+	mu             sync.Mutex
+}
+
+func newLazyJSONBlockBuilder(store *LazyJSONBlockStore, maxEntries, maxBytes int) *LazyJSONBlockBuilder {
+	if maxEntries <= 0 {
+		maxEntries = DefaultLazyJSONBlockMaxEntries
+	}
+	if maxBytes <= 0 {
+		maxBytes = DefaultLazyJSONBlockMaxBytes
+	}
+	return &LazyJSONBlockBuilder{
+		store:      store,
+		maxEntries: maxEntries,
+		maxBytes:   maxBytes,
+	}
+}
+
+// Add appends a JSON byte slice to the current block buffer and returns a LazyJSONNode pointing to its location.
+func (b *LazyJSONBlockBuilder) Add(data []byte) *LazyJSONNode {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if !b.hasActiveBlock {
+		b.startNewBlockLocked()
+	}
+
+	offset := uint32(len(b.currentBuffer))
+	length := uint32(len(data))
+	b.currentBuffer = append(b.currentBuffer, data...)
+	b.entryCount++
+
+	b.store.mu.RLock()
+	block := b.store.blocks[b.currentBlockID]
+	b.store.mu.RUnlock()
+
+	block.mu.Lock()
+	block.uncompressed = b.currentBuffer
+	block.mu.Unlock()
+
+	node := &LazyJSONNode{
+		store:   b.store,
+		blockID: b.currentBlockID,
+		offset:  offset,
+		length:  length,
+		index:   0,
+	}
+
+	if b.entryCount >= b.maxEntries || len(b.currentBuffer) >= b.maxBytes {
+		b.flushCurrentBlockLocked()
+	}
+
+	return node
+}
+
+// Flush compresses and commits any remaining entries in the current block buffer.
+func (b *LazyJSONBlockBuilder) Flush() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.hasActiveBlock && len(b.currentBuffer) > 0 {
+		b.flushCurrentBlockLocked()
+	}
+}
+
+func (b *LazyJSONBlockBuilder) startNewBlockLocked() {
+	b.currentBuffer = make([]byte, 0, b.maxBytes)
+	b.currentBlockID = b.store.ReserveBlock(b.currentBuffer)
+	b.entryCount = 0
+	b.hasActiveBlock = true
+}
+
+func (b *LazyJSONBlockBuilder) flushCurrentBlockLocked() {
+	if !b.hasActiveBlock {
+		return
+	}
+	compressed, err := compressBlockData(b.currentBuffer)
+	if err != nil {
+		panic(fmt.Sprintf("failed to compress block %d: %v", b.currentBlockID, err))
+	}
+	b.store.SetCompressed(b.currentBlockID, compressed)
+	b.hasActiveBlock = false
+	b.currentBuffer = nil
+	b.entryCount = 0
+}

--- a/pkg/common/structured/lazyjson_block_builder.go
+++ b/pkg/common/structured/lazyjson_block_builder.go
@@ -32,6 +32,7 @@ type LazyJSONBlockBuilder struct {
 	maxEntries     int
 	maxBytes       int
 	currentBlockID uint32
+	currentBlock   *lazyJSONBlock
 	currentBuffer  []byte
 	entryCount     int
 	hasActiveBlock bool
@@ -63,16 +64,13 @@ func (b *LazyJSONBlockBuilder) Add(data []byte) *LazyJSONNode {
 
 	offset := uint32(len(b.currentBuffer))
 	length := uint32(len(data))
+
+	b.currentBlock.mu.Lock()
 	b.currentBuffer = append(b.currentBuffer, data...)
+	b.currentBlock.uncompressed = b.currentBuffer
+	b.currentBlock.mu.Unlock()
+
 	b.entryCount++
-
-	b.store.mu.RLock()
-	block := b.store.blocks[b.currentBlockID]
-	b.store.mu.RUnlock()
-
-	block.mu.Lock()
-	block.uncompressed = b.currentBuffer
-	block.mu.Unlock()
 
 	node := &LazyJSONNode{
 		store:   b.store,
@@ -102,6 +100,9 @@ func (b *LazyJSONBlockBuilder) Flush() {
 func (b *LazyJSONBlockBuilder) startNewBlockLocked() {
 	b.currentBuffer = make([]byte, 0, b.maxBytes)
 	b.currentBlockID = b.store.ReserveBlock(b.currentBuffer)
+	b.store.mu.RLock()
+	b.currentBlock = b.store.blocks[b.currentBlockID]
+	b.store.mu.RUnlock()
 	b.entryCount = 0
 	b.hasActiveBlock = true
 }
@@ -117,5 +118,6 @@ func (b *LazyJSONBlockBuilder) flushCurrentBlockLocked() {
 	b.store.SetCompressed(b.currentBlockID, compressed)
 	b.hasActiveBlock = false
 	b.currentBuffer = nil
+	b.currentBlock = nil
 	b.entryCount = 0
 }

--- a/pkg/common/structured/lazyjson_block_test.go
+++ b/pkg/common/structured/lazyjson_block_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structured
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLazyJSONBlockStore_BasicAndEviction(t *testing.T) {
+	testCases := []struct {
+		name       string
+		shardCount int
+		shardCap   int
+		items      []string
+	}{
+		{
+			name:       "store with small cache capacity triggering eviction and re-decompression",
+			shardCount: 2,
+			shardCap:   2,
+			items: []string{
+				`{"msg":"block-0"}`,
+				`{"msg":"block-1"}`,
+				`{"msg":"block-2"}`,
+				`{"msg":"block-3"}`,
+				`{"msg":"block-4"}`,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewLazyJSONBlockStore(tc.shardCount, tc.shardCap)
+			blockIDs := make([]uint32, len(tc.items))
+
+			for i, item := range tc.items {
+				data := []byte(item)
+				blockID := store.ReserveBlock(data)
+				compressed, err := compressBlockData(data)
+				if err != nil {
+					t.Fatalf("compressBlockData() failed: %v", err)
+				}
+				store.SetCompressed(blockID, compressed)
+				blockIDs[i] = blockID
+			}
+
+			// Read back in reverse order to ensure evicted blocks are re-decompressed correctly.
+			for i := len(tc.items) - 1; i >= 0; i-- {
+				expected := tc.items[i]
+				gotBuf := store.GetBuffer(blockIDs[i], 0, uint32(len(expected)))
+				if diff := cmp.Diff(expected, string(gotBuf)); diff != "" {
+					t.Errorf("GetBuffer() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestLazyJSONBlockBuilder_BatchingAndNodeAccess(t *testing.T) {
+	testCases := []struct {
+		name       string
+		maxEntries int
+		maxBytes   int
+		entries    []string
+	}{
+		{
+			name:       "batching by max entries",
+			maxEntries: 3,
+			maxBytes:   1024 * 1024,
+			entries: []string{
+				`{"id":1,"name":"first"}`,
+				`{"id":2,"name":"second"}`,
+				`{"id":3,"name":"third"}`,
+				`{"id":4,"name":"fourth"}`,
+				`{"id":5,"name":"fifth"}`,
+			},
+		},
+		{
+			name:       "batching by byte size",
+			maxEntries: 100,
+			maxBytes:   30,
+			entries: []string{
+				`{"k":"val1"}`,
+				`{"k":"val2"}`,
+				`{"k":"val3"}`,
+				`{"k":"val4"}`,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewLazyJSONBlockStore(2, 2)
+			builder := store.NewBuilder(tc.maxEntries, tc.maxBytes)
+
+			nodes := make([]*LazyJSONNode, len(tc.entries))
+			for i, entry := range tc.entries {
+				nodes[i] = builder.Add([]byte(entry))
+			}
+			builder.Flush()
+
+			for i, node := range nodes {
+				expected := tc.entries[i]
+				gotBuf := node.getBuffer()
+				if diff := cmp.Diff(expected, string(gotBuf)); diff != "" {
+					t.Errorf("node.getBuffer() mismatch (-want +got):\n%s", diff)
+				}
+
+				// Verify JSON node field access.
+				val, ok := node.GetChildByKey("id")
+				if ok {
+					id, err := val.NodeScalarValue()
+					if err != nil {
+						t.Errorf("NodeScalarValue() failed: %v", err)
+					}
+					expectedID := fmt.Sprintf("%d", i+1)
+					if diff := cmp.Diff(expectedID, fmt.Sprintf("%v", id)); diff != "" {
+						t.Errorf("node field 'id' mismatch (-want +got):\n%s", diff)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestLazyJSONBlockStore_ConcurrentAccess(t *testing.T) {
+	store := NewLazyJSONBlockStore(4, 2)
+	builder := store.NewBuilder(10, 1024)
+
+	const totalEntries = 100
+	nodes := make([]*LazyJSONNode, totalEntries)
+	for i := 0; i < totalEntries; i++ {
+		entry := fmt.Sprintf(`{"index":%d,"data":"concurrent-test-%d"}`, i, i)
+		nodes[i] = builder.Add([]byte(entry))
+	}
+	builder.Flush()
+
+	var wg sync.WaitGroup
+	const concurrency = 8
+	for c := 0; c < concurrency; c++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < totalEntries; i++ {
+				node := nodes[(i*7+workerID)%totalEntries]
+				valNode, ok := node.GetChildByKey("index")
+				if !ok {
+					t.Errorf("worker %d failed to GetChildByKey", workerID)
+					return
+				}
+				idxVal, err := valNode.NodeScalarValue()
+				if err != nil {
+					t.Errorf("worker %d failed to get scalar: %v", workerID, err)
+					return
+				}
+				expectedIdx := (i*7 + workerID) % totalEntries
+				if diff := cmp.Diff(fmt.Sprintf("%d", expectedIdx), fmt.Sprintf("%v", idxVal)); diff != "" {
+					t.Errorf("concurrent scalar mismatch (-want +got):\n%s", diff)
+				}
+			}
+		}(c)
+	}
+	wg.Wait()
+}

--- a/pkg/common/structured/lazyjson_block_test.go
+++ b/pkg/common/structured/lazyjson_block_test.go
@@ -71,6 +71,64 @@ func TestLazyJSONBlockStore_BasicAndEviction(t *testing.T) {
 	}
 }
 
+func TestNewLazyJSONBlockStore_PowerOfTwoValidation(t *testing.T) {
+	testCases := []struct {
+		name       string
+		shardCount int
+		shardCap   int
+		wantPanic  bool
+	}{
+		{
+			name:       "valid power of two (4)",
+			shardCount: 4,
+			shardCap:   8,
+			wantPanic:  false,
+		},
+		{
+			name:       "valid power of two (1)",
+			shardCount: 1,
+			shardCap:   8,
+			wantPanic:  false,
+		},
+		{
+			name:       "zero shard count",
+			shardCount: 0,
+			shardCap:   8,
+			wantPanic:  true,
+		},
+		{
+			name:       "negative shard count",
+			shardCount: -2,
+			shardCap:   8,
+			wantPanic:  true,
+		},
+		{
+			name:       "non-power of two (3)",
+			shardCount: 3,
+			shardCap:   8,
+			wantPanic:  true,
+		},
+		{
+			name:       "non-power of two (6)",
+			shardCount: 6,
+			shardCap:   8,
+			wantPanic:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if (r != nil) != tc.wantPanic {
+					t.Errorf("NewLazyJSONBlockStore() panic = %v, wantPanic %v", r != nil, tc.wantPanic)
+				}
+			}()
+			_ = NewLazyJSONBlockStore(tc.shardCount, tc.shardCap)
+		})
+	}
+}
+
 func TestLazyJSONBlockBuilder_BatchingAndNodeAccess(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -176,4 +234,29 @@ func TestLazyJSONBlockStore_ConcurrentAccess(t *testing.T) {
 		}(c)
 	}
 	wg.Wait()
+}
+
+func TestNewDefaultLazyJSONBlockStore(t *testing.T) {
+	testCases := []struct {
+		name          string
+		wantShards    int
+		wantShardMask uint32
+	}{
+		{
+			name:          "default 1GB store has 64 shards",
+			wantShards:    DefaultLazyJSONBlockStoreShardCount,
+			wantShardMask: DefaultLazyJSONBlockStoreShardCount - 1,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewDefaultLazyJSONBlockStore()
+			if diff := cmp.Diff(tc.wantShards, len(store.shards)); diff != "" {
+				t.Errorf("shards count mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantShardMask, store.shardMask); diff != "" {
+				t.Errorf("shardMask mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/pkg/common/structured/lazyjson_cache.go
+++ b/pkg/common/structured/lazyjson_cache.go
@@ -15,6 +15,7 @@
 package structured
 
 import (
+	"strings"
 	"sync"
 )
 
@@ -168,6 +169,9 @@ type lazyJSONCache struct {
 }
 
 func newLazyJSONCache(shardCount, shardCap int) *lazyJSONCache {
+	if shardCount <= 0 || (shardCount&(shardCount-1)) != 0 {
+		panic("shardCount must be a power of two")
+	}
 	shards := make([]*lazyJSONCacheShard, shardCount)
 	for i := 0; i < shardCount; i++ {
 		shards[i] = newLazyJSONCacheShard(shardCap)
@@ -198,13 +202,13 @@ func (c *lazyJSONCache) get(blockID uint32, absOffset uint32, key string) (int, 
 }
 
 func (c *lazyJSONCache) put(blockID uint32, absOffset uint32, key string, valIndex int) {
-	k := lazyJSONCacheKey{blockID: blockID, absOffset: absOffset, key: key}
+	k := lazyJSONCacheKey{blockID: blockID, absOffset: absOffset, key: strings.Clone(key)}
 	shardIdx := hashLazyJSONKey(blockID, absOffset, key) & c.shardMask
 	c.shards[shardIdx].put(k, valIndex)
 }
 
 func (c *lazyJSONCache) putIfAbsent(blockID uint32, absOffset uint32, key string, valIndex int) {
-	k := lazyJSONCacheKey{blockID: blockID, absOffset: absOffset, key: key}
+	k := lazyJSONCacheKey{blockID: blockID, absOffset: absOffset, key: strings.Clone(key)}
 	shardIdx := hashLazyJSONKey(blockID, absOffset, key) & c.shardMask
 	c.shards[shardIdx].putIfAbsent(k, valIndex)
 }
@@ -219,10 +223,3 @@ const (
 	lazyJSONCacheShardCount = 64
 	lazyJSONCacheShardCap   = 512
 )
-
-var globalLazyJSONCache = newLazyJSONCache(lazyJSONCacheShardCount, lazyJSONCacheShardCap)
-
-// ResetGlobalLazyJSONCache clears all entries in the global LazyJSONNode LRU cache.
-func ResetGlobalLazyJSONCache() {
-	globalLazyJSONCache.clear()
-}

--- a/pkg/common/structured/lazyjson_cache.go
+++ b/pkg/common/structured/lazyjson_cache.go
@@ -20,15 +20,14 @@ import (
 
 // lazyJSONCacheKey identifies a specific field lookup within a LazyJSONNode.
 type lazyJSONCacheKey struct {
-	ptr   uintptr
-	index int
-	key   string
+	blockID   uint32
+	absOffset uint32
+	key       string
 }
 
 // lazyJSONCacheEntry represents a single cached child index in the LRU doubly linked list.
 type lazyJSONCacheEntry struct {
 	key      lazyJSONCacheKey
-	dataRef  []byte
 	valIndex int
 	prev     *lazyJSONCacheEntry
 	next     *lazyJSONCacheEntry
@@ -63,11 +62,10 @@ func (s *lazyJSONCacheShard) get(k lazyJSONCacheKey) (int, bool) {
 	return valIndex, true
 }
 
-func (s *lazyJSONCacheShard) put(k lazyJSONCacheKey, valIndex int, dataRef []byte) {
+func (s *lazyJSONCacheShard) put(k lazyJSONCacheKey, valIndex int) {
 	s.mu.Lock()
 	if entry, ok := s.items[k]; ok {
 		entry.valIndex = valIndex
-		entry.dataRef = dataRef
 		s.moveToHead(entry)
 		s.mu.Unlock()
 		return
@@ -75,7 +73,6 @@ func (s *lazyJSONCacheShard) put(k lazyJSONCacheKey, valIndex int, dataRef []byt
 
 	entry := &lazyJSONCacheEntry{
 		key:      k,
-		dataRef:  dataRef,
 		valIndex: valIndex,
 	}
 	s.items[k] = entry
@@ -87,7 +84,7 @@ func (s *lazyJSONCacheShard) put(k lazyJSONCacheKey, valIndex int, dataRef []byt
 	s.mu.Unlock()
 }
 
-func (s *lazyJSONCacheShard) putIfAbsent(k lazyJSONCacheKey, valIndex int, dataRef []byte) {
+func (s *lazyJSONCacheShard) putIfAbsent(k lazyJSONCacheKey, valIndex int) {
 	s.mu.Lock()
 	if entry, ok := s.items[k]; ok {
 		s.moveToHead(entry)
@@ -97,7 +94,6 @@ func (s *lazyJSONCacheShard) putIfAbsent(k lazyJSONCacheKey, valIndex int, dataR
 
 	entry := &lazyJSONCacheEntry{
 		key:      k,
-		dataRef:  dataRef,
 		valIndex: valIndex,
 	}
 	s.items[k] = entry
@@ -156,7 +152,6 @@ func (s *lazyJSONCacheShard) removeTail() {
 		return
 	}
 	delete(s.items, s.tail.key)
-	s.tail.dataRef = nil
 	if s.tail.prev != nil {
 		s.tail.prev.next = nil
 		s.tail = s.tail.prev
@@ -183,11 +178,11 @@ func newLazyJSONCache(shardCount, shardCap int) *lazyJSONCache {
 	}
 }
 
-func hashLazyJSONKey(ptr uintptr, index int, key string) uint64 {
+func hashLazyJSONKey(blockID uint32, absOffset uint32, key string) uint64 {
 	var h uint64 = 14695981039346656037
-	h ^= uint64(ptr)
+	h ^= uint64(blockID)
 	h *= 1099511628211
-	h ^= uint64(index)
+	h ^= uint64(absOffset)
 	h *= 1099511628211
 	for i := 0; i < len(key); i++ {
 		h ^= uint64(key[i])
@@ -196,22 +191,22 @@ func hashLazyJSONKey(ptr uintptr, index int, key string) uint64 {
 	return h
 }
 
-func (c *lazyJSONCache) get(ptr uintptr, index int, key string) (int, bool) {
-	k := lazyJSONCacheKey{ptr: ptr, index: index, key: key}
-	shardIdx := hashLazyJSONKey(ptr, index, key) & c.shardMask
+func (c *lazyJSONCache) get(blockID uint32, absOffset uint32, key string) (int, bool) {
+	k := lazyJSONCacheKey{blockID: blockID, absOffset: absOffset, key: key}
+	shardIdx := hashLazyJSONKey(blockID, absOffset, key) & c.shardMask
 	return c.shards[shardIdx].get(k)
 }
 
-func (c *lazyJSONCache) put(ptr uintptr, index int, key string, valIndex int, dataRef []byte) {
-	k := lazyJSONCacheKey{ptr: ptr, index: index, key: key}
-	shardIdx := hashLazyJSONKey(ptr, index, key) & c.shardMask
-	c.shards[shardIdx].put(k, valIndex, dataRef)
+func (c *lazyJSONCache) put(blockID uint32, absOffset uint32, key string, valIndex int) {
+	k := lazyJSONCacheKey{blockID: blockID, absOffset: absOffset, key: key}
+	shardIdx := hashLazyJSONKey(blockID, absOffset, key) & c.shardMask
+	c.shards[shardIdx].put(k, valIndex)
 }
 
-func (c *lazyJSONCache) putIfAbsent(ptr uintptr, index int, key string, valIndex int, dataRef []byte) {
-	k := lazyJSONCacheKey{ptr: ptr, index: index, key: key}
-	shardIdx := hashLazyJSONKey(ptr, index, key) & c.shardMask
-	c.shards[shardIdx].putIfAbsent(k, valIndex, dataRef)
+func (c *lazyJSONCache) putIfAbsent(blockID uint32, absOffset uint32, key string, valIndex int) {
+	k := lazyJSONCacheKey{blockID: blockID, absOffset: absOffset, key: key}
+	shardIdx := hashLazyJSONKey(blockID, absOffset, key) & c.shardMask
+	c.shards[shardIdx].putIfAbsent(k, valIndex)
 }
 
 func (c *lazyJSONCache) clear() {

--- a/pkg/common/structured/lazyjson_cache_test.go
+++ b/pkg/common/structured/lazyjson_cache_test.go
@@ -18,20 +18,18 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestLazyJSONCache_BasicGetPut(t *testing.T) {
 	cache := newLazyJSONCache(4, 2)
-	data := []byte(`{"foo":"bar"}`)
-	ptr := uintptr(unsafe.Pointer(&data[0]))
+	blockID := uint32(42)
 
 	testCases := []struct {
 		name      string
-		ptr       uintptr
-		index     int
+		blockID   uint32
+		absOffset uint32
 		key       string
 		valIndex  int
 		wantFound bool
@@ -39,15 +37,15 @@ func TestLazyJSONCache_BasicGetPut(t *testing.T) {
 	}{
 		{
 			name:      "miss before put",
-			ptr:       ptr,
-			index:     0,
+			blockID:   blockID,
+			absOffset: 0,
 			key:       "foo",
 			wantFound: false,
 		},
 		{
 			name:      "hit after put",
-			ptr:       ptr,
-			index:     0,
+			blockID:   blockID,
+			absOffset: 0,
 			key:       "foo",
 			valIndex:  7,
 			wantFound: true,
@@ -55,8 +53,8 @@ func TestLazyJSONCache_BasicGetPut(t *testing.T) {
 		},
 		{
 			name:      "negative cache hit",
-			ptr:       ptr,
-			index:     0,
+			blockID:   blockID,
+			absOffset: 0,
 			key:       "nonexistent",
 			valIndex:  -1,
 			wantFound: true,
@@ -67,9 +65,9 @@ func TestLazyJSONCache_BasicGetPut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.wantFound && tc.name != "miss before put" {
-				cache.put(tc.ptr, tc.index, tc.key, tc.valIndex, data)
+				cache.put(tc.blockID, tc.absOffset, tc.key, tc.valIndex)
 			}
-			val, found := cache.get(tc.ptr, tc.index, tc.key)
+			val, found := cache.get(tc.blockID, tc.absOffset, tc.key)
 			if diff := cmp.Diff(tc.wantFound, found); diff != "" {
 				t.Fatalf("get() found mismatch (-want +got):\n%s", diff)
 			}
@@ -85,20 +83,19 @@ func TestLazyJSONCache_BasicGetPut(t *testing.T) {
 func TestLazyJSONCache_LRUEviction(t *testing.T) {
 	// 1 shard with capacity 2
 	cache := newLazyJSONCache(1, 2)
-	data := []byte(`{"a":1,"b":2,"c":3}`)
-	ptr := uintptr(unsafe.Pointer(&data[0]))
+	blockID := uint32(1)
 
-	cache.put(ptr, 0, "a", 10, data)
-	cache.put(ptr, 0, "b", 20, data)
+	cache.put(blockID, 0, "a", 10)
+	cache.put(blockID, 0, "b", 20)
 
 	// Access "a" to make it more recently used than "b"
-	val, found := cache.get(ptr, 0, "a")
+	val, found := cache.get(blockID, 0, "a")
 	if !found || val != 10 {
 		t.Fatalf("expected 'a' to be found with value 10, got found=%v, val=%d", found, val)
 	}
 
 	// Insert "c", which should evict "b" (least recently used)
-	cache.put(ptr, 0, "c", 30, data)
+	cache.put(blockID, 0, "c", 30)
 
 	testCases := []struct {
 		key       string
@@ -112,7 +109,7 @@ func TestLazyJSONCache_LRUEviction(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.key, func(t *testing.T) {
-			gotVal, found := cache.get(ptr, 0, tc.key)
+			gotVal, found := cache.get(blockID, 0, tc.key)
 			if diff := cmp.Diff(tc.wantFound, found); diff != "" {
 				t.Fatalf("found mismatch (-want +got):\n%s", diff)
 			}
@@ -127,8 +124,7 @@ func TestLazyJSONCache_LRUEviction(t *testing.T) {
 
 func TestLazyJSONCache_Concurrency(t *testing.T) {
 	cache := newLazyJSONCache(16, 64)
-	data := []byte(`{"key":"value"}`)
-	ptr := uintptr(unsafe.Pointer(&data[0]))
+	blockID := uint32(100)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
@@ -137,8 +133,8 @@ func TestLazyJSONCache_Concurrency(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
 				key := fmt.Sprintf("key-%d-%d", goroutineID, j%10)
-				cache.put(ptr, 0, key, j, data)
-				val, found := cache.get(ptr, 0, key)
+				cache.put(blockID, 0, key, j)
+				val, found := cache.get(blockID, 0, key)
 				if !found || val < 0 {
 					t.Errorf("concurrent cache get failed for %s", key)
 				}
@@ -150,17 +146,16 @@ func TestLazyJSONCache_Concurrency(t *testing.T) {
 
 func TestLazyJSONCache_Clear(t *testing.T) {
 	cache := newLazyJSONCache(4, 8)
-	data := []byte(`{"foo":"bar"}`)
-	ptr := uintptr(unsafe.Pointer(&data[0]))
+	blockID := uint32(5)
 
-	cache.put(ptr, 0, "foo", 42, data)
-	if _, found := cache.get(ptr, 0, "foo"); !found {
+	cache.put(blockID, 0, "foo", 42)
+	if _, found := cache.get(blockID, 0, "foo"); !found {
 		t.Fatal("expected 'foo' to be found before clear")
 	}
 
 	cache.clear()
 
-	if _, found := cache.get(ptr, 0, "foo"); found {
+	if _, found := cache.get(blockID, 0, "foo"); found {
 		t.Error("expected 'foo' to be cleared after clear()")
 	}
 }

--- a/pkg/common/structured/lazyjson_cache_test.go
+++ b/pkg/common/structured/lazyjson_cache_test.go
@@ -159,3 +159,43 @@ func TestLazyJSONCache_Clear(t *testing.T) {
 		t.Error("expected 'foo' to be cleared after clear()")
 	}
 }
+
+func TestNewLazyJSONCache_PowerOfTwoValidation(t *testing.T) {
+	testCases := []struct {
+		name       string
+		shardCount int
+		shardCap   int
+		wantPanic  bool
+	}{
+		{
+			name:       "valid power of two (4)",
+			shardCount: 4,
+			shardCap:   8,
+			wantPanic:  false,
+		},
+		{
+			name:       "zero shard count",
+			shardCount: 0,
+			shardCap:   8,
+			wantPanic:  true,
+		},
+		{
+			name:       "non-power of two (5)",
+			shardCount: 5,
+			shardCap:   8,
+			wantPanic:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if (r != nil) != tc.wantPanic {
+					t.Errorf("newLazyJSONCache() panic = %v, wantPanic %v", r != nil, tc.wantPanic)
+				}
+			}()
+			_ = newLazyJSONCache(tc.shardCount, tc.shardCap)
+		})
+	}
+}

--- a/pkg/common/structured/lazyjson_test.go
+++ b/pkg/common/structured/lazyjson_test.go
@@ -88,7 +88,8 @@ func TestLazyJSONNode_Scalar(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			node := NewLazyJSONNodeFromBytes([]byte(tc.input))
+			store := NewLazyJSONBlockStore(4, 8)
+			node := NewLazyJSONNodeFromBytes(store, []byte(tc.input))
 			if diff := cmp.Diff(tc.wantType, node.Type()); diff != "" {
 				t.Errorf("Type() mismatch (-want +got):\n%s", diff)
 			}
@@ -126,7 +127,8 @@ func TestLazyJSONNode_Sequence(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			node := NewLazyJSONNodeFromBytes([]byte(tc.input))
+			store := NewLazyJSONBlockStore(4, 8)
+			node := NewLazyJSONNodeFromBytes(store, []byte(tc.input))
 			if diff := cmp.Diff(NodeType(SequenceNodeType), node.Type()); diff != "" {
 				t.Errorf("Type() mismatch (-want +got):\n%s", diff)
 			}
@@ -199,7 +201,8 @@ func TestLazyJSONNode_Map(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			node := NewLazyJSONNodeFromBytes([]byte(tc.input))
+			store := NewLazyJSONBlockStore(4, 8)
+			node := NewLazyJSONNodeFromBytes(store, []byte(tc.input))
 			if diff := cmp.Diff(NodeType(MapNodeType), node.Type()); diff != "" {
 				t.Errorf("Type() mismatch (-want +got):\n%s", diff)
 			}
@@ -241,7 +244,8 @@ func TestLazyJSONNode_NodeReader(t *testing.T) {
 		"items": ["a", "b", "c"]
 	}`
 
-	node := NewLazyJSONNodeFromBytes([]byte(jsonStr))
+	store := NewLazyJSONBlockStore(4, 8)
+	node := NewLazyJSONNodeFromBytes(store, []byte(jsonStr))
 	reader := NewNodeReader(node)
 
 	name, err := reader.ReadString(CompileFieldPath("name"))
@@ -310,7 +314,8 @@ func TestNewLazyJSONNode(t *testing.T) {
 		},
 	)
 
-	lazyNode, err := NewLazyJSONNode(stdMap)
+	store := NewLazyJSONBlockStore(4, 8)
+	lazyNode, err := NewLazyJSONNode(store, stdMap)
 	if err != nil {
 		t.Fatalf("NewLazyJSONNode failed: %v", err)
 	}
@@ -335,7 +340,8 @@ func TestNewLazyJSONNode(t *testing.T) {
 
 func TestLazyJSONNode_Concurrency(t *testing.T) {
 	jsonStr := `{"foo":"bar","nested":{"num":42},"arr":[1,2,3]}`
-	node := NewLazyJSONNodeFromBytes([]byte(jsonStr))
+	store := NewLazyJSONBlockStore(4, 8)
+	node := NewLazyJSONNodeFromBytes(store, []byte(jsonStr))
 
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
@@ -364,7 +370,8 @@ func TestLazyJSONNode_Concurrency(t *testing.T) {
 }
 
 func TestLazyJSONNode_ChildrenEarlyBreak(t *testing.T) {
-	mapNode := NewLazyJSONNodeFromBytes([]byte(`{"a":1,"b":2,"c":3}`))
+	store := NewLazyJSONBlockStore(4, 8)
+	mapNode := NewLazyJSONNodeFromBytes(store, []byte(`{"a":1,"b":2,"c":3}`))
 	mapKeys := make([]string, 0)
 	for key := range mapNode.Children() {
 		mapKeys = append(mapKeys, key.Key)
@@ -376,7 +383,7 @@ func TestLazyJSONNode_ChildrenEarlyBreak(t *testing.T) {
 		t.Errorf("map Children early break mismatch (-want +got):\n%s", diff)
 	}
 
-	seqNode := NewLazyJSONNodeFromBytes([]byte(`[10,20,30,40]`))
+	seqNode := NewLazyJSONNodeFromBytes(store, []byte(`[10,20,30,40]`))
 	seqCount := 0
 	for key := range seqNode.Children() {
 		seqCount++
@@ -391,7 +398,8 @@ func TestLazyJSONNode_ChildrenEarlyBreak(t *testing.T) {
 
 func TestLazyJSONNode_Serialization(t *testing.T) {
 	inputJSON := `{"foo":"bar","items":[1,2,3]}`
-	lazyNode := NewLazyJSONNodeFromBytes([]byte(inputJSON))
+	store := NewLazyJSONBlockStore(4, 8)
+	lazyNode := NewLazyJSONNodeFromBytes(store, []byte(inputJSON))
 
 	yamlSerializer := &YAMLNodeSerializer{}
 	yamlBytes, err := yamlSerializer.Serialize(lazyNode)
@@ -425,7 +433,8 @@ func TestLazyJSONNode_ReadReflectWithEscapes(t *testing.T) {
 	}
 
 	inputJSON := `{"title":"hello \"world\" \n test","nested":{"message":"inner \"quotes\" and \\ slashes","code":200}}`
-	node := NewLazyJSONNodeFromBytes([]byte(inputJSON))
+	store := NewLazyJSONBlockStore(4, 8)
+	node := NewLazyJSONNodeFromBytes(store, []byte(inputJSON))
 	reader := NewNodeReader(node)
 
 	var target SampleStruct
@@ -447,8 +456,9 @@ func TestLazyJSONNode_ReadReflectWithEscapes(t *testing.T) {
 }
 
 func TestLazyJSONNode_MergeNode(t *testing.T) {
-	prev := NewLazyJSONNodeFromBytes([]byte(`{"name":"test","count":1,"labels":{"env":"prod"}}`))
-	patch := NewLazyJSONNodeFromBytes([]byte(`{"count":2,"labels":{"tier":"frontend"}}`))
+	store := NewLazyJSONBlockStore(4, 8)
+	prev := NewLazyJSONNodeFromBytes(store, []byte(`{"name":"test","count":1,"labels":{"env":"prod"}}`))
+	patch := NewLazyJSONNodeFromBytes(store, []byte(`{"count":2,"labels":{"tier":"frontend"}}`))
 
 	merged, err := MergeNode(prev, patch, MergeConfiguration{
 		MergeMapOrderStrategy: &DefaultMergeMapOrderStrategy{},
@@ -528,7 +538,8 @@ func TestLazyJSONNode_GetChildByKey(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			node := NewLazyJSONNodeFromBytes([]byte(tc.json)).(*LazyJSONNode)
+			store := NewLazyJSONBlockStore(4, 8)
+			node := NewLazyJSONNodeFromBytes(store, []byte(tc.json)).(*LazyJSONNode)
 			child, found := node.GetChildByKey(tc.targetKey)
 			if diff := cmp.Diff(tc.wantFound, found); diff != "" {
 				t.Fatalf("GetChildByKey() found mismatch (-want +got):\n%s", diff)
@@ -552,7 +563,8 @@ func BenchmarkLazyJSONNodeVsStandardMap(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	lazyNode := NewLazyJSONNodeFromBytes([]byte(rawJSON))
+	store := NewLazyJSONBlockStore(4, 8)
+	lazyNode := NewLazyJSONNodeFromBytes(store, []byte(rawJSON))
 	pathZone := CompileFieldPath("resource.labels.zone")
 
 	b.Run("StandardMap_ReadString", func(b *testing.B) {
@@ -574,12 +586,13 @@ func BenchmarkLazyJSONNodeVsStandardMap(b *testing.B) {
 
 func BenchmarkLazyJSONNode_GetChildByKey(b *testing.B) {
 	rawJSON := `{"insertId":"123","logName":"projects/p/logs/l","labels":{"k1":"v1","k2":"v2"},"resource":{"type":"gce_instance","labels":{"zone":"us-central1-a"}}}`
-	lazyNode := NewLazyJSONNodeFromBytes([]byte(rawJSON)).(*LazyJSONNode)
+	store := NewLazyJSONBlockStore(4, 8)
+	lazyNode := NewLazyJSONNodeFromBytes(store, []byte(rawJSON)).(*LazyJSONNode)
 
 	b.Run("Cold_FirstAccess", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			ResetGlobalLazyJSONCache()
+			lazyNode.store.cache.clear()
 			_, _ = lazyNode.GetChildByKey("resource")
 		}
 	})

--- a/pkg/common/structured/ordered_test.go
+++ b/pkg/common/structured/ordered_test.go
@@ -55,7 +55,8 @@ func TestWithKeyOrder(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			node := NewLazyJSONNodeFromBytes([]byte(tc.jsonInput))
+			store := NewLazyJSONBlockStore(4, 8)
+			node := NewLazyJSONNodeFromBytes(store, []byte(tc.jsonInput))
 			ordered := WithKeyOrder(node, tc.priorityKeys...)
 
 			var gotKeys []string
@@ -85,7 +86,8 @@ func TestWithKeyOrderNonMap(t *testing.T) {
 
 func TestNodeReaderWithKeyOrder(t *testing.T) {
 	jsonBytes := []byte(`{"logName":"projects/p/logs/l","insertId":"ins-123","severity":"INFO"}`)
-	node := NewLazyJSONNodeFromBytes(jsonBytes)
+	store := NewLazyJSONBlockStore(4, 8)
+	node := NewLazyJSONNodeFromBytes(store, jsonBytes)
 	reader := NewNodeReader(node)
 
 	orderedReader := reader.WithKeyOrder("insertId", "logName")
@@ -102,7 +104,8 @@ func TestNodeReaderWithKeyOrder(t *testing.T) {
 
 func TestWithKeyOrderNested(t *testing.T) {
 	jsonBytes := []byte(`{"a": 1, "b": 2, "c": 3}`)
-	node := NewLazyJSONNodeFromBytes(jsonBytes)
+	store := NewLazyJSONBlockStore(4, 8)
+	node := NewLazyJSONNodeFromBytes(store, jsonBytes)
 	ordered1 := WithKeyOrder(node, "b")
 	ordered2 := WithKeyOrder(ordered1, "c")
 

--- a/pkg/common/structured/reader_test.go
+++ b/pkg/common/structured/reader_test.go
@@ -405,7 +405,8 @@ func TestNodeReader_NilChildHandling(t *testing.T) {
 
 func TestNodeReader_WithLazyJSONNode(t *testing.T) {
 	rawJSON := `{"protoPayload":{"serviceName":"k8s.io","resourceName":"pods/nginx","status":{"code":200}},"labels":{"cluster":"gke-1"}}`
-	lazyNode := NewLazyJSONNodeFromBytes([]byte(rawJSON))
+	store := NewLazyJSONBlockStore(4, 8)
+	lazyNode := NewLazyJSONNodeFromBytes(store, []byte(rawJSON))
 	reader := NewNodeReader(lazyNode)
 
 	testCases := []struct {

--- a/pkg/server/workbench/architecturegraph/builder_test.go
+++ b/pkg/server/workbench/architecturegraph/builder_test.go
@@ -31,7 +31,8 @@ import (
 
 func internJSON(t *testing.T, pool *khifilev6model.InternPool, jsonStr string) uint32 {
 	t.Helper()
-	node := structured.NewLazyJSONNodeFromBytes([]byte(jsonStr))
+	store := structured.NewLazyJSONBlockStore(4, 8)
+	node := structured.NewLazyJSONNodeFromBytes(store, []byte(jsonStr))
 	ref, err := khifilev6model.ToInternedStruct(node, pool)
 	if err != nil {
 		t.Fatalf("failed to intern JSON: %v", err)

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
@@ -76,6 +76,7 @@ var ManifestGeneratorTask = inspectiontaskbase.NewProgressReportableInspectionTa
 
 	grp, childCtx := errgroup.WithContext(ctx)
 	grp.SetLimit(runtime.GOMAXPROCS(0))
+	blockStore := structured.NewDefaultLazyJSONBlockStore()
 
 	for path, group := range logGroups {
 		grp.Go(func() error {
@@ -84,6 +85,7 @@ var ManifestGeneratorTask = inspectiontaskbase.NewProgressReportableInspectionTa
 			generator := groupManifestGenerator{
 				mergeConfigRegistry: mergeConfigRegistry,
 				resourceName:        group.Resource.Name,
+				blockStore:          blockStore,
 			}
 			for _, l := range group.Logs {
 				select {
@@ -121,6 +123,8 @@ type groupManifestGenerator struct {
 	mergeConfigRegistry *k8s.K8sManifestMergeConfigRegistry
 	// resourceName is the name of the resource.
 	resourceName string
+	// blockStore is the store for compressing manifest nodes.
+	blockStore *structured.LazyJSONBlockStore
 }
 
 // Process processes the log to generate manifest.
@@ -179,7 +183,7 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 			name := item.ReadStringOrDefault(pathMetadataName, "")
 			if name == g.resourceName {
 				found = true
-				bodyReader, err := constructResourceBodyFromListItem(&item, g.prevRevisionReader)
+				bodyReader, err := constructResourceBodyFromListItem(g.blockStore, &item, g.prevRevisionReader)
 				if err != nil {
 					slog.WarnContext(ctx, fmt.Sprintf("failed to construct resource body from list item: %v", err))
 				} else {
@@ -211,7 +215,7 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 				ResourceBodyReader: g.prevRevisionReader,
 			}, nil
 		} else {
-			lazyMergedNode, err := structured.NewLazyJSONNode(mergedNode)
+			lazyMergedNode, err := structured.NewLazyJSONNode(g.blockStore, mergedNode)
 			if err != nil {
 				slog.WarnContext(ctx, fmt.Sprintf("failed to convert merged node to lazy JSON node: %v", err))
 				mergedNodeReader = structured.NewNodeReader(structured.WithKeyOrder(mergedNode, k8s.K8sManifestKeyOrder...))
@@ -243,7 +247,7 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 
 // constructResourceBodyFromListItem constructs a complete resource manifest NodeReader from a list item,
 // injecting apiVersion and kind from the previous revision if they are not present in the item.
-func constructResourceBodyFromListItem(item *structured.NodeReader, prevRevision *structured.NodeReader) (*structured.NodeReader, error) {
+func constructResourceBodyFromListItem(store *structured.LazyJSONBlockStore, item *structured.NodeReader, prevRevision *structured.NodeReader) (*structured.NodeReader, error) {
 	if item == nil {
 		return nil, fmt.Errorf("item reader cannot be nil")
 	}
@@ -294,6 +298,6 @@ func constructResourceBodyFromListItem(item *structured.NodeReader, prevRevision
 		}
 	}
 	buf.WriteByte('}')
-	lazyNode := structured.NewLazyJSONNodeFromBytes(buf.Bytes())
+	lazyNode := structured.NewLazyJSONNodeFromBytes(store, buf.Bytes())
 	return structured.NewNodeReader(structured.WithKeyOrder(lazyNode, k8s.K8sManifestKeyOrder...)), nil
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
@@ -407,6 +407,7 @@ metadata:
 			groupManifestGenerator := groupManifestGenerator{
 				mergeConfigRegistry: config,
 				resourceName:        tc.resourceName,
+				blockStore:          structured.NewLazyJSONBlockStore(4, 8),
 			}
 			gotManifests := []string{}
 			for _, l := range logs {
@@ -554,7 +555,8 @@ status:
 				prevReader = structured.NewNodeReader(prevNode)
 			}
 
-			gotReader, err := constructResourceBodyFromListItem(itemReader, prevReader)
+			store := structured.NewLazyJSONBlockStore(4, 8)
+			gotReader, err := constructResourceBodyFromListItem(store, itemReader, prevReader)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("constructResourceBodyFromListItem() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
@@ -234,6 +234,8 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(pro
 
 	times := t.getPartitionedTimes(beginTime, endTime)
 
+	blockStore := structured.NewLazyJSONBlockStore(32, 16)
+
 	wg, groupCtx := errgroup.WithContext(cancellableCtx)
 	wg.SetLimit(t.maxParallelism)
 
@@ -254,10 +256,12 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(pro
 			subLogChan := make(chan *loggingpb.LogEntry)
 			subProgressChan := make(chan LogFetchProgress)
 			subLogs := make([]*log.Log, 0)
+			builder := blockStore.NewBuilder(100, 256*1024)
 
 			// Consume the subLogChan, convert proto to *log.Log in parallel, and append to subLogs.
 			go func() {
 				defer childWg.Done()
+				defer builder.Flush()
 				for {
 					select {
 					case <-groupCtx.Done():
@@ -266,7 +270,7 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(pro
 						if !ok {
 							return
 						}
-						node, err := logconvert.LogEntryToNode(logEntry)
+						node, err := logconvert.LogEntryToNode(builder, logEntry)
 						if err != nil {
 							slog.WarnContext(groupCtx, fmt.Sprintf("failed to convert loggingpb.LogEntry (insertId: %s, timestamp: %v) to structured.Node %v", logEntry.InsertId, logEntry.Timestamp, err))
 							continue

--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher.go
@@ -234,7 +234,7 @@ func (t *TimePartitioningProgressReportableLogFetcher) FetchLogsWithProgress(pro
 
 	times := t.getPartitionedTimes(beginTime, endTime)
 
-	blockStore := structured.NewLazyJSONBlockStore(32, 16)
+	blockStore := structured.NewDefaultLazyJSONBlockStore()
 
 	wg, groupCtx := errgroup.WithContext(cancellableCtx)
 	wg.SetLimit(t.maxParallelism)

--- a/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher_test.go
+++ b/pkg/task/inspection/googlecloudcommon/contract/progressreportablelogfetcher_test.go
@@ -573,8 +573,10 @@ timestamp < "2025-01-01T00:20:00+0000"`, func(logSource chan<- *loggingpb.LogEnt
 			}
 
 			wantLogsString := []string{}
+			testStore := structured.NewLazyJSONBlockStore(4, 8)
+			testBuilder := testStore.NewBuilder(10, 1024)
 			for _, entry := range tc.wantLogs {
-				node, err := logconvert.LogEntryToNode(entry)
+				node, err := logconvert.LogEntryToNode(testBuilder, entry)
 				if err != nil {
 					t.Fatalf("failed to convert entry to node: %v", err)
 				}
@@ -589,6 +591,7 @@ timestamp < "2025-01-01T00:20:00+0000"`, func(logSource chan<- *loggingpb.LogEnt
 				}
 				wantLogsString = append(wantLogsString, string(yaml))
 			}
+			testBuilder.Flush()
 
 			if diff := cmp.Diff(wantLogsString, gotLogsString); diff != "" {
 				t.Errorf("FetchLogsWithProgress() produced non expected result: (-want, +got):\n%v", diff)

--- a/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task.go
@@ -65,13 +65,16 @@ var AuditLogFileReaderTask = inspectiontaskbase.NewProgressReportableInspectionT
 		var logs []*log.Log
 		idGen := khictx.MustGetValue(ctx, inspectioncore_contract.IDGenerator)
 
+		blockStore := structured.NewLazyJSONBlockStore(32, 16)
+		builder := blockStore.NewBuilder(100, 256*1024)
+
 		progressutil.ReportProgressFromArraySync(tp, logLines, func(i int, line string) error {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" {
 				return nil
 			}
 
-			node := structured.NewLazyJSONNodeFromBytes(unsafe.Slice(unsafe.StringData(trimmed), len(trimmed)))
+			node := builder.Add(unsafe.Slice(unsafe.StringData(trimmed), len(trimmed)))
 			reader := structured.NewNodeReader(node)
 
 			// TODO: we may need to consider processing logs not with ResponseComplete stage. All logs not on the ResponseComplete stage will be ignored for now.
@@ -84,6 +87,7 @@ var AuditLogFileReaderTask = inspectiontaskbase.NewProgressReportableInspectionT
 			logs = append(logs, l)
 			return nil
 		})
+		builder.Flush()
 
 		slices.SortFunc(logs, func(a, b *log.Log) int {
 			return a.Timestamp.Compare(b.Timestamp)

--- a/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/auditfilereader_task.go
@@ -65,7 +65,7 @@ var AuditLogFileReaderTask = inspectiontaskbase.NewProgressReportableInspectionT
 		var logs []*log.Log
 		idGen := khictx.MustGetValue(ctx, inspectioncore_contract.IDGenerator)
 
-		blockStore := structured.NewLazyJSONBlockStore(32, 16)
+		blockStore := structured.NewDefaultLazyJSONBlockStore()
 		builder := blockStore.NewBuilder(100, 256*1024)
 
 		progressutil.ReportProgressFromArraySync(tp, logLines, func(i int, line string) error {


### PR DESCRIPTION
## Summary

During log ingestion and inspection in KHI, millions of individual log entries are represented in memory as uncompressed raw JSON byte slices in `LazyJSON`. This leads to substantial heap memory consumption (often several gigabytes in large clusters) and GC scanning overhead for large numbers of small byte slices.

This PR introduces compressed contiguous block storage (`LazyJSONBlock`) and a sharded LRU decompression cache (`lazyJSONCache`) for `LazyJSON`:
- Raw log JSON payloads are packed into contiguous blocks compressed using gzip / flate, replacing hundreds of thousands of individual heap slices with a few contiguous compressed blocks.
- Decompressed slices are cached in a fixed-capacity sharded LRU cache, bounding the in-memory footprint while maintaining fast access for log parsing and timeline mapping.

## Changes

- **`pkg/common/structured/lazyjson_block.go`**:
  - Implement `LazyJSONBlock` for packed, compressed multi-log byte storage with binary offset tables.
- **`pkg/common/structured/lazyjson_block_builder.go`**:
  - Implement `LazyJSONBlockBuilder` to accumulate log records and finalize them into compressed blocks when size thresholds are reached.
- **`pkg/common/structured/lazyjson_cache.go`**:
  - Implement `lazyJSONCache` with sharded 64-entry LRU shards for decompressed sub-slice lookup.
- **`pkg/common/structured/lazyjson.go`**:
  - Support reading from `LazyJSONBlock` and caching decompressed slices.
- **Log Fetchers & Converters**:
  - Integrate block builders into `pkg/api/googlecloud/logconvert/`, `progressreportablelogfetcher.go`, and `auditfilereader_task.go`.

## Verification

- `make pre-commit`: Passed
- `make lint-go`: Passed (0 issues)
- `go test -count=1 ./pkg/common/structured/... ./pkg/api/googlecloud/logconvert/...`: Passed
- `make test-go`: Passed
