### PR TITLE
perf(timeline): stream chunked timeline items and merge in reader

### DIFF
--- a/pkg/model/khifile/v6/builder.go
+++ b/pkg/model/khifile/v6/builder.go
@@ -50,7 +50,7 @@ func NewBuilder(gen *id.Generator, writer *Writer) *Builder {
 		writer:              writer,
 		internPool:          internPool,
 		serverInternPool:    serverPool,
-		TimelineAccumulator: NewTimelineAccumulator(gen, internPool, serverPool),
+		TimelineAccumulator: NewTimelineAccumulator(gen, internPool, serverPool, writer),
 		LogAccumulator:      logAcc,
 		MetadataAccumulator: NewMetadataAccumulator(),
 	}
@@ -110,23 +110,9 @@ func (b *Builder) Build(reporter BuilderProgressReporter) (err error) {
 	}
 
 	report(0.6, "Writing timeline chunks")
-	// 4. Write TimelineChunks
-	timelines, timelineItems := b.TimelineAccumulator.Accumulate()
-
-	if len(timelines) > 0 {
-		timelineGen := NewTimelineGenerator(slices.Values(timelines))
-		defer timelineGen.Close()
-		if err := b.writer.WriteGenerator(timelineGen); err != nil {
-			return fmt.Errorf("failed to write timeline chunks: %w", err)
-		}
-	}
-
-	if len(timelineItems) > 0 {
-		timelineItemsGen := NewTimelineItemsGenerator(slices.Values(timelineItems))
-		defer timelineItemsGen.Close()
-		if err := b.writer.WriteGenerator(timelineItemsGen); err != nil {
-			return fmt.Errorf("failed to write timeline items chunks: %w", err)
-		}
+	// 4. Flush timeline chunks
+	if err := b.TimelineAccumulator.Flush(); err != nil {
+		return fmt.Errorf("failed to flush timeline accumulator: %w", err)
 	}
 
 	report(0.8, "Flushing intern pool chunks")

--- a/pkg/model/khifile/v6/changeset.go
+++ b/pkg/model/khifile/v6/changeset.go
@@ -337,5 +337,15 @@ func (cs *TimelineChangeSet) Flush(accumulator *TimelineAccumulator, logAcc *Log
 	if flushErr != nil {
 		return flushErr
 	}
+
+	totalAdded := len(cs.Events)
+	for _, revs := range cs.Revisions {
+		totalAdded += len(revs)
+	}
+	if totalAdded > 0 {
+		if err := accumulator.NotifyItemsAdded(totalAdded); err != nil {
+			return fmt.Errorf("failed to notify timeline items added: %w", err)
+		}
+	}
 	return nil
 }

--- a/pkg/model/khifile/v6/changeset_test.go
+++ b/pkg/model/khifile/v6/changeset_test.go
@@ -76,7 +76,7 @@ func TestTimelineChangeSet_Flush(t *testing.T) {
 	pool := khifilev6.NewTestInternPool(idGen)
 	serverPool := khifilev6.NewTestServerInternPool(pool, idGen)
 	logAcc := khifilev6.NewTestLogAccumulator(pool, serverPool, idGen)
-	accumulator := khifilev6.NewTimelineAccumulator(idGen, pool, serverPool)
+	accumulator := khifilev6.NewTestTimelineAccumulator(idGen, pool, serverPool)
 
 	node := structured.NewStandardMap(nil, nil)
 	l := log.NewLog(idGen, structured.NewNodeReader(node))

--- a/pkg/model/khifile/v6/timeline_accumulator.go
+++ b/pkg/model/khifile/v6/timeline_accumulator.go
@@ -15,25 +15,52 @@
 package khifilev6
 
 import (
+	"fmt"
+	"slices"
+	"sync"
+	"sync/atomic"
+
 	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 )
 
+// DefaultTimelineItemsFlushThreshold is the default number of accumulated items before streaming a TimelineChunk.
+const DefaultTimelineItemsFlushThreshold = 10000
+
 // TimelineAccumulator acts as a facade, internally orchestrating a TimelineRegistry
-// and TimelinePathPool to properly manage aliasing and deep hierarchical paths.
+// and TimelinePathPool to properly manage aliasing and deep hierarchical paths,
+// while streaming completed TimelineItems chunks directly to the destination Writer.
 type TimelineAccumulator struct {
-	pathPool *TimelinePathPool
-	registry *TimelineRegistry
+	pathPool       *TimelinePathPool
+	registry       *TimelineRegistry
+	writer         *Writer
+	pendingCount   atomic.Int64
+	flushThreshold int64
+	flushMu        sync.Mutex
 }
 
-// NewTimelineAccumulator creates a new TimelineAccumulator facade.
-func NewTimelineAccumulator(idGen *id.Generator, clientPool *InternPool, serverPool *InternPool) *TimelineAccumulator {
+// NewTimelineAccumulator creates a new TimelineAccumulator facade with destination Writer.
+func NewTimelineAccumulator(idGen *id.Generator, clientPool *InternPool, serverPool *InternPool, writer *Writer) *TimelineAccumulator {
 	pathPool := NewTimelinePathPool(idGen, clientPool)
 	registry := NewTimelineRegistry(idGen, clientPool, serverPool)
 	return &TimelineAccumulator{
-		pathPool: pathPool,
-		registry: registry,
+		pathPool:       pathPool,
+		registry:       registry,
+		writer:         writer,
+		flushThreshold: DefaultTimelineItemsFlushThreshold,
 	}
+}
+
+// NewTestTimelineAccumulator creates a new TimelineAccumulator writing to an in-memory test writer.
+func NewTestTimelineAccumulator(idGen *id.Generator, clientPool *InternPool, serverPool *InternPool) *TimelineAccumulator {
+	return NewTimelineAccumulator(idGen, clientPool, serverPool, MustNewTestWriter())
+}
+
+// SetFlushThreshold sets the item count threshold for streaming TimelineItems chunks.
+func (a *TimelineAccumulator) SetFlushThreshold(threshold int64) {
+	a.flushMu.Lock()
+	defer a.flushMu.Unlock()
+	a.flushThreshold = threshold
 }
 
 // GetPath resolves or creates a TimelinePath in the underlying pool.
@@ -68,9 +95,62 @@ func (a *TimelineAccumulator) HasEvent(path *TimelinePath) bool {
 	return false
 }
 
-// Accumulate extracts the arrays of Timeline and TimelineItems protobuf messages.
-func (a *TimelineAccumulator) Accumulate() ([]*pb.Timeline, []*pb.TimelineItems) {
-	return ExtractTimelinesAndItemsChunkSource(a.pathPool, a.registry)
+// NotifyItemsAdded increments the count of accumulated items and triggers a flush if the threshold is met.
+func (a *TimelineAccumulator) NotifyItemsAdded(count int) error {
+	if count <= 0 {
+		return nil
+	}
+	if a.pendingCount.Add(int64(count)) >= a.flushThreshold {
+		return a.FlushPendingItems()
+	}
+	return nil
+}
+
+// FlushPendingItems drains accumulated items from all builders and streams them as TimelineChunk(s).
+func (a *TimelineAccumulator) FlushPendingItems() error {
+	a.flushMu.Lock()
+	defer a.flushMu.Unlock()
+
+	a.pendingCount.Store(0)
+
+	var items []*pb.TimelineItems
+	for builder := range a.registry.Builders() {
+		if proto := builder.ExtractPendingProto(); proto != nil {
+			items = append(items, proto)
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Sort items by ID to ensure deterministic output within each chunk
+	slices.SortFunc(items, func(a, b *pb.TimelineItems) int {
+		return int(a.GetId()) - int(b.GetId())
+	})
+
+	gen := NewTimelineItemsGenerator(slices.Values(items))
+	defer gen.Close()
+	return a.writer.WriteGenerator(gen)
+}
+
+// Flush streams any remaining TimelineItems chunks, followed by the Timeline hierarchy chunks.
+func (a *TimelineAccumulator) Flush() error {
+	if err := a.FlushPendingItems(); err != nil {
+		return err
+	}
+
+	a.flushMu.Lock()
+	defer a.flushMu.Unlock()
+
+	timelines := extractTimelines(a.pathPool, a.registry)
+	if len(timelines) > 0 {
+		gen := NewTimelineGenerator(slices.Values(timelines))
+		defer gen.Close()
+		if err := a.writer.WriteGenerator(gen); err != nil {
+			return fmt.Errorf("failed to write timeline hierarchy chunks: %w", err)
+		}
+	}
+	return nil
 }
 
 // AddTestRevision adds a dummy revision to the timeline builder at path for testing purposes.

--- a/pkg/model/khifile/v6/timeline_accumulator.go
+++ b/pkg/model/khifile/v6/timeline_accumulator.go
@@ -15,6 +15,7 @@
 package khifilev6
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 	"sync"
@@ -125,7 +126,7 @@ func (a *TimelineAccumulator) FlushPendingItems() error {
 
 	// Sort items by ID to ensure deterministic output within each chunk
 	slices.SortFunc(items, func(a, b *pb.TimelineItems) int {
-		return int(a.GetId()) - int(b.GetId())
+		return cmp.Compare(a.GetId(), b.GetId())
 	})
 
 	gen := NewTimelineItemsGenerator(slices.Values(items))

--- a/pkg/model/khifile/v6/timeline_accumulator_test.go
+++ b/pkg/model/khifile/v6/timeline_accumulator_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package khifilev6
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestTimelineAccumulator_Streaming(t *testing.T) {
+	testCases := []struct {
+		name          string
+		threshold     int64
+		eventsCount   int
+		wantChunksMin int
+	}{
+		{
+			name:          "streams chunks when threshold is exceeded",
+			threshold:     5,
+			eventsCount:   12,
+			wantChunksMin: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			writer, err := NewWriter(&buf)
+			if err != nil {
+				t.Fatalf("failed to create writer: %v", err)
+			}
+
+			idGen := id.NewGenerator()
+			clientPool := NewInternPool(idGen, writer)
+			serverPool := NewServerInternPool(clientPool, idGen, writer)
+			acc := NewTimelineAccumulator(idGen, clientPool, serverPool, writer)
+			acc.SetFlushThreshold(tc.threshold)
+
+			timelineTypeID := uint32(1)
+			path := acc.GetPath(nil, PathSegment{
+				Name: "test-timeline",
+				Type: &pb.TimelineType{Id: &timelineTypeID},
+			})
+			builder := acc.GetBuilder(path)
+
+			for i := 1; i <= tc.eventsCount; i++ {
+				builder.AddEvent(pendingEvent{
+					LogID:     uint32(i),
+					Timestamp: time.Now(),
+				})
+				if err := acc.NotifyItemsAdded(1); err != nil {
+					t.Fatalf("NotifyItemsAdded failed: %v", err)
+				}
+			}
+
+			// Final flush for remaining items and hierarchy
+			if err := acc.Flush(); err != nil {
+				t.Fatalf("Flush failed: %v", err)
+			}
+
+			// Read back all chunks from the stream
+			reader, err := NewReader(&buf)
+			if err != nil {
+				t.Fatalf("failed to create reader: %v", err)
+			}
+
+			timelineChunkCount := 0
+			totalEventsRead := 0
+			hasHierarchy := false
+
+			for {
+				chunk, err := reader.NextChunk()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					t.Fatalf("failed to read next chunk: %v", err)
+				}
+
+				if chunk.Type == ChunkTypeTimeline {
+					timelineChunkCount++
+					var protoChunk pb.TimelineChunk
+					if err := proto.Unmarshal(chunk.Data, &protoChunk); err != nil {
+						t.Fatalf("failed to unmarshal timeline chunk: %v", err)
+					}
+					if len(protoChunk.Timelines) > 0 {
+						hasHierarchy = true
+					}
+					for _, items := range protoChunk.TimelineItems {
+						totalEventsRead += len(items.Events)
+					}
+				}
+			}
+
+			if timelineChunkCount < tc.wantChunksMin {
+				t.Errorf("got %d timeline chunks, want at least %d", timelineChunkCount, tc.wantChunksMin)
+			}
+			if totalEventsRead != tc.eventsCount {
+				t.Errorf("got %d total events, want %d", totalEventsRead, tc.eventsCount)
+			}
+			if !hasHierarchy {
+				t.Errorf("expected timeline hierarchy chunk to be written")
+			}
+		})
+	}
+}

--- a/pkg/model/khifile/v6/timeline_builder.go
+++ b/pkg/model/khifile/v6/timeline_builder.go
@@ -87,6 +87,13 @@ type TimelineBuilder struct {
 	revisions []pendingRevision
 	// events accumulates the logs or events associated with the timeline.
 	events []pendingEvent
+	// hasEverHadItems tracks whether this builder has ever received events or revisions,
+	// even after in-memory slices have been flushed and cleared.
+	hasEverHadItems bool
+	// oldestTime caches the earliest timestamp observed among all events and revisions.
+	oldestTime time.Time
+	// hasOldestTime indicates if oldestTime has been recorded.
+	hasOldestTime bool
 }
 
 // AddEvent adds a parsed event to the builder in a thread-safe manner.
@@ -94,6 +101,13 @@ func (b *TimelineBuilder) AddEvent(e pendingEvent) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.events = append(b.events, e)
+	b.hasEverHadItems = true
+	if !e.Timestamp.IsZero() {
+		if !b.hasOldestTime || e.Timestamp.Before(b.oldestTime) {
+			b.oldestTime = e.Timestamp
+			b.hasOldestTime = true
+		}
+	}
 }
 
 // AddRevision adds a parsed revision to the builder in a thread-safe manner.
@@ -101,9 +115,16 @@ func (b *TimelineBuilder) AddRevision(r pendingRevision) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.revisions = append(b.revisions, r)
+	b.hasEverHadItems = true
+	if !r.ChangedTime.IsZero() {
+		if !b.hasOldestTime || r.ChangedTime.Before(b.oldestTime) {
+			b.oldestTime = r.ChangedTime
+			b.hasOldestTime = true
+		}
+	}
 }
 
-// HasItems returns true if the builder has accumulated any events or revisions.
+// HasItems returns true if the builder currently has accumulated events or revisions in memory.
 func (b *TimelineBuilder) HasItems() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -124,33 +145,40 @@ func (b *TimelineBuilder) HasEvent() bool {
 	return len(b.events) > 0
 }
 
+// HasEverHadItems returns true if the builder has ever accumulated events or revisions,
+// even if they have already been flushed from memory.
+func (b *TimelineBuilder) HasEverHadItems() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.hasEverHadItems
+}
+
 // FindOldestTime returns the oldest timestamp among all accumulated events and revisions in this builder.
 func (b *TimelineBuilder) FindOldestTime() (time.Time, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return b.oldestTime, b.hasOldestTime
+}
 
-	var oldest time.Time
-	found := false
+// ExtractPendingProto converts currently accumulated events and revisions into a TimelineItems protobuf message
+// and clears the in-memory slices to release memory. It returns nil if no events or revisions are staged.
+func (b *TimelineBuilder) ExtractPendingProto() *pb.TimelineItems {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-	for _, rev := range b.revisions {
-		if rev.ChangedTime.IsZero() {
-			continue
-		}
-		if !found || rev.ChangedTime.Before(oldest) {
-			oldest = rev.ChangedTime
-			found = true
-		}
+	if len(b.events) == 0 && len(b.revisions) == 0 {
+		return nil
 	}
-	for _, ev := range b.events {
-		if ev.Timestamp.IsZero() {
-			continue
-		}
-		if !found || ev.Timestamp.Before(oldest) {
-			oldest = ev.Timestamp
-			found = true
-		}
+
+	itemsID := b.TimelineItemsID
+	items := &pb.TimelineItems{
+		Id:        &itemsID,
+		Events:    b.convertEventsToProtoLocked(),
+		Revisions: b.convertRevisionsToProtoLocked(),
 	}
-	return oldest, found
+	b.events = nil
+	b.revisions = nil
+	return items
 }
 
 // ToProto converts the accumulated data into a TimelineItems protobuf message.

--- a/pkg/model/khifile/v6/timeline_builder_test.go
+++ b/pkg/model/khifile/v6/timeline_builder_test.go
@@ -165,3 +165,45 @@ func TestTimelineBuilder_FindOldestTime(t *testing.T) {
 		})
 	}
 }
+
+func TestTimelineBuilder_ExtractPendingProto(t *testing.T) {
+	builder := &TimelineBuilder{TimelineItemsID: 42}
+
+	if got := builder.ExtractPendingProto(); got != nil {
+		t.Fatalf("expected nil from empty builder, got %v", got)
+	}
+
+	builder.AddEvent(pendingEvent{LogID: 10})
+	builder.AddRevision(pendingRevision{LogID: 20})
+
+	firstProto := builder.ExtractPendingProto()
+	if firstProto == nil {
+		t.Fatalf("expected non-nil proto, got nil")
+	}
+	if len(firstProto.Events) != 1 || firstProto.Events[0].GetLogId() != 10 {
+		t.Errorf("unexpected events: %v", firstProto.Events)
+	}
+	if len(firstProto.Revisions) != 1 || firstProto.Revisions[0].GetLogId() != 20 {
+		t.Errorf("unexpected revisions: %v", firstProto.Revisions)
+	}
+
+	// After extraction, internal slices should be cleared
+	if builder.HasItems() {
+		t.Errorf("expected HasItems to be false after ExtractPendingProto")
+	}
+	if !builder.HasEverHadItems() {
+		t.Errorf("expected HasEverHadItems to remain true")
+	}
+
+	secondProto := builder.ExtractPendingProto()
+	if secondProto != nil {
+		t.Errorf("expected nil on second extraction with no new items, got %v", secondProto)
+	}
+
+	// Add more items and verify second extraction works
+	builder.AddEvent(pendingEvent{LogID: 30})
+	thirdProto := builder.ExtractPendingProto()
+	if thirdProto == nil || len(thirdProto.Events) != 1 || thirdProto.Events[0].GetLogId() != 30 {
+		t.Errorf("unexpected third proto: %v", thirdProto)
+	}
+}

--- a/pkg/model/khifile/v6/timeline_serializer.go
+++ b/pkg/model/khifile/v6/timeline_serializer.go
@@ -35,7 +35,7 @@ func extractTimelineItems(registry *TimelineRegistry) []*pb.TimelineItems {
 	var items []*pb.TimelineItems
 
 	for builder := range registry.Builders() {
-		if proto := builder.ToProto(); proto != nil {
+		if proto := builder.ExtractPendingProto(); proto != nil {
 			items = append(items, proto)
 		}
 	}
@@ -59,7 +59,7 @@ func extractTimelines(pool *TimelinePathPool, registry *TimelineRegistry) []*pb.
 	var timelines []*pb.Timeline
 	for _, path := range sortedPaths {
 		var itemsID *uint32
-		if b, ok := registry.GetBuilderIfExists(path); ok && b.HasItems() {
+		if b, ok := registry.GetBuilderIfExists(path); ok && b.HasEverHadItems() {
 			id := b.TimelineItemsID
 			itemsID = &id
 		}

--- a/pkg/server/workbench/index.go
+++ b/pkg/server/workbench/index.go
@@ -15,8 +15,10 @@
 package workbench
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/worker"
 	apiv1 "github.com/GoogleCloudPlatform/khi/pkg/generated/api/v1"
@@ -130,6 +132,7 @@ func (w *Workbench) BuildBaseSearchIndex() (*SearchIndex, error) {
 	}
 	w.rawTimelines = nil
 	w.rawTimelineItems = nil
+	w.seenTimelineIDs = nil
 
 	w.linkTimelineHierarchy(timelines, timelineMap)
 
@@ -360,6 +363,9 @@ func (w *Workbench) indexTimelinesParallel(
 								Severity: sev,
 							})
 						}
+						slices.SortStableFunc(events, func(a, b cel.EventInfo) int {
+							return cmp.Compare(a.LogID, b.LogID)
+						})
 					}
 
 					if len(item.revisions) > 0 {
@@ -386,6 +392,9 @@ func (w *Workbench) indexTimelinesParallel(
 								Severity:             sev,
 							})
 						}
+						slices.SortStableFunc(revisions, func(a, b cel.RevisionInfo) int {
+							return cmp.Compare(a.ChangedTime, b.ChangedTime)
+						})
 					}
 				}
 

--- a/pkg/server/workbench/reader.go
+++ b/pkg/server/workbench/reader.go
@@ -362,28 +362,18 @@ func (w *Workbench) ingestParsedChunk(res *parsedChunkResult) error {
 			}
 		}
 	case khifilev6model.ChunkTypeTimeline:
-		if len(res.rawTimelines) > 0 {
-			if w.seenTimelineIDs == nil {
-				w.seenTimelineIDs = make(map[uint32]bool)
-			}
-			for _, tl := range res.rawTimelines {
-				if !w.seenTimelineIDs[tl.id] {
-					w.seenTimelineIDs[tl.id] = true
-					w.rawTimelines = append(w.rawTimelines, tl)
-				}
+		for _, tl := range res.rawTimelines {
+			if !w.seenTimelineIDs[tl.id] {
+				w.seenTimelineIDs[tl.id] = true
+				w.rawTimelines = append(w.rawTimelines, tl)
 			}
 		}
-		if len(res.rawTimelineItems) > 0 {
-			if w.rawTimelineItems == nil {
-				w.rawTimelineItems = make(map[uint32]*rawTimelineItems)
-			}
-			for _, item := range res.rawTimelineItems {
-				if existing, ok := w.rawTimelineItems[item.id]; ok {
-					existing.events = append(existing.events, item.events...)
-					existing.revisions = append(existing.revisions, item.revisions...)
-				} else {
-					w.rawTimelineItems[item.id] = item
-				}
+		for _, item := range res.rawTimelineItems {
+			if existing, ok := w.rawTimelineItems[item.id]; ok {
+				existing.events = append(existing.events, item.events...)
+				existing.revisions = append(existing.revisions, item.revisions...)
+			} else {
+				w.rawTimelineItems[item.id] = item
 			}
 		}
 	}
@@ -393,62 +383,52 @@ func (w *Workbench) ingestParsedChunk(res *parsedChunkResult) error {
 // ingestTimelineChunk extracts intermediate flat timeline data and items from TimelineChunk,
 // immediately decoupling them from heavy Protobuf messages so they can be garbage collected.
 func (w *Workbench) ingestTimelineChunk(chunk *khifilev6.TimelineChunk) {
-	if len(chunk.Timelines) > 0 {
-		if w.seenTimelineIDs == nil {
-			w.seenTimelineIDs = make(map[uint32]bool)
-		}
-		for _, tl := range chunk.Timelines {
-			if !w.seenTimelineIDs[tl.GetId()] {
-				w.seenTimelineIDs[tl.GetId()] = true
-				w.rawTimelines = append(w.rawTimelines, rawTimeline{
-					id:              tl.GetId(),
-					parentID:        tl.GetParentTimelineId(),
-					nameStringID:    tl.GetNameStringId(),
-					timelineType:    tl.GetTimelineType(),
-					timelineItemsID: tl.GetTimelineItemsId(),
-				})
-			}
+	for _, tl := range chunk.Timelines {
+		if !w.seenTimelineIDs[tl.GetId()] {
+			w.seenTimelineIDs[tl.GetId()] = true
+			w.rawTimelines = append(w.rawTimelines, rawTimeline{
+				id:              tl.GetId(),
+				parentID:        tl.GetParentTimelineId(),
+				nameStringID:    tl.GetNameStringId(),
+				timelineType:    tl.GetTimelineType(),
+				timelineItemsID: tl.GetTimelineItemsId(),
+			})
 		}
 	}
-	if len(chunk.TimelineItems) > 0 {
-		if w.rawTimelineItems == nil {
-			w.rawTimelineItems = make(map[uint32]*rawTimelineItems)
+	for _, item := range chunk.TimelineItems {
+		rawItem := &rawTimelineItems{
+			id: item.GetId(),
 		}
-		for _, item := range chunk.TimelineItems {
-			rawItem := &rawTimelineItems{
-				id: item.GetId(),
-			}
-			if len(item.Events) > 0 {
-				rawItem.events = make([]rawEvent, len(item.Events))
-				for i, evt := range item.Events {
-					rawItem.events[i] = rawEvent{
-						logID: evt.GetLogId(),
-					}
+		if len(item.Events) > 0 {
+			rawItem.events = make([]rawEvent, len(item.Events))
+			for i, evt := range item.Events {
+				rawItem.events[i] = rawEvent{
+					logID: evt.GetLogId(),
 				}
 			}
-			if len(item.Revisions) > 0 {
-				rawItem.revisions = make([]rawRevision, len(item.Revisions))
-				for i, rev := range item.Revisions {
-					var changedTime int64
-					if rev.ChangedTime != nil {
-						changedTime = rev.ChangedTime.AsTime().UnixNano()
-					}
-					rawItem.revisions[i] = rawRevision{
-						logID:                rev.GetLogId(),
-						verbType:             rev.GetVerbType(),
-						stateType:            rev.GetStateType(),
-						changedTime:          changedTime,
-						principalStringID:    rev.GetPrincipalStringId(),
-						resourceBodyStructID: rev.GetResourceBodyStructId(),
-					}
+		}
+		if len(item.Revisions) > 0 {
+			rawItem.revisions = make([]rawRevision, len(item.Revisions))
+			for i, rev := range item.Revisions {
+				var changedTime int64
+				if rev.ChangedTime != nil {
+					changedTime = rev.ChangedTime.AsTime().UnixNano()
+				}
+				rawItem.revisions[i] = rawRevision{
+					logID:                rev.GetLogId(),
+					verbType:             rev.GetVerbType(),
+					stateType:            rev.GetStateType(),
+					changedTime:          changedTime,
+					principalStringID:    rev.GetPrincipalStringId(),
+					resourceBodyStructID: rev.GetResourceBodyStructId(),
 				}
 			}
-			if existing, ok := w.rawTimelineItems[rawItem.id]; ok {
-				existing.events = append(existing.events, rawItem.events...)
-				existing.revisions = append(existing.revisions, rawItem.revisions...)
-			} else {
-				w.rawTimelineItems[rawItem.id] = rawItem
-			}
+		}
+		if existing, ok := w.rawTimelineItems[rawItem.id]; ok {
+			existing.events = append(existing.events, rawItem.events...)
+			existing.revisions = append(existing.revisions, rawItem.revisions...)
+		} else {
+			w.rawTimelineItems[rawItem.id] = rawItem
 		}
 	}
 }

--- a/pkg/server/workbench/reader.go
+++ b/pkg/server/workbench/reader.go
@@ -363,14 +363,27 @@ func (w *Workbench) ingestParsedChunk(res *parsedChunkResult) error {
 		}
 	case khifilev6model.ChunkTypeTimeline:
 		if len(res.rawTimelines) > 0 {
-			w.rawTimelines = append(w.rawTimelines, res.rawTimelines...)
+			if w.seenTimelineIDs == nil {
+				w.seenTimelineIDs = make(map[uint32]bool)
+			}
+			for _, tl := range res.rawTimelines {
+				if !w.seenTimelineIDs[tl.id] {
+					w.seenTimelineIDs[tl.id] = true
+					w.rawTimelines = append(w.rawTimelines, tl)
+				}
+			}
 		}
 		if len(res.rawTimelineItems) > 0 {
 			if w.rawTimelineItems == nil {
 				w.rawTimelineItems = make(map[uint32]*rawTimelineItems)
 			}
 			for _, item := range res.rawTimelineItems {
-				w.rawTimelineItems[item.id] = item
+				if existing, ok := w.rawTimelineItems[item.id]; ok {
+					existing.events = append(existing.events, item.events...)
+					existing.revisions = append(existing.revisions, item.revisions...)
+				} else {
+					w.rawTimelineItems[item.id] = item
+				}
 			}
 		}
 	}
@@ -381,14 +394,20 @@ func (w *Workbench) ingestParsedChunk(res *parsedChunkResult) error {
 // immediately decoupling them from heavy Protobuf messages so they can be garbage collected.
 func (w *Workbench) ingestTimelineChunk(chunk *khifilev6.TimelineChunk) {
 	if len(chunk.Timelines) > 0 {
+		if w.seenTimelineIDs == nil {
+			w.seenTimelineIDs = make(map[uint32]bool)
+		}
 		for _, tl := range chunk.Timelines {
-			w.rawTimelines = append(w.rawTimelines, rawTimeline{
-				id:              tl.GetId(),
-				parentID:        tl.GetParentTimelineId(),
-				nameStringID:    tl.GetNameStringId(),
-				timelineType:    tl.GetTimelineType(),
-				timelineItemsID: tl.GetTimelineItemsId(),
-			})
+			if !w.seenTimelineIDs[tl.GetId()] {
+				w.seenTimelineIDs[tl.GetId()] = true
+				w.rawTimelines = append(w.rawTimelines, rawTimeline{
+					id:              tl.GetId(),
+					parentID:        tl.GetParentTimelineId(),
+					nameStringID:    tl.GetNameStringId(),
+					timelineType:    tl.GetTimelineType(),
+					timelineItemsID: tl.GetTimelineItemsId(),
+				})
+			}
 		}
 	}
 	if len(chunk.TimelineItems) > 0 {
@@ -424,7 +443,12 @@ func (w *Workbench) ingestTimelineChunk(chunk *khifilev6.TimelineChunk) {
 					}
 				}
 			}
-			w.rawTimelineItems[rawItem.id] = rawItem
+			if existing, ok := w.rawTimelineItems[rawItem.id]; ok {
+				existing.events = append(existing.events, rawItem.events...)
+				existing.revisions = append(existing.revisions, rawItem.revisions...)
+			} else {
+				w.rawTimelineItems[rawItem.id] = rawItem
+			}
 		}
 	}
 }

--- a/pkg/server/workbench/reader_test.go
+++ b/pkg/server/workbench/reader_test.go
@@ -22,7 +22,10 @@ import (
 	apiv1 "github.com/GoogleCloudPlatform/khi/pkg/generated/api/v1"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
 	khifilev6model "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/server/workbench/cel"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func createTestKhiFileData(t *testing.T) []byte {
@@ -215,6 +218,130 @@ func TestFormatByteSize(t *testing.T) {
 			got := formatByteSize(tc.input)
 			if got != tc.want {
 				t.Errorf("formatByteSize(%d) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkbench_NewFromReader_TimelineChunkMerge(t *testing.T) {
+	testCases := []struct {
+		name         string
+		buildChunks  func(t *testing.T) []byte
+		wantTimeline *cel.TimelineData
+	}{
+		{
+			name: "merges multiple timeline chunks with duplicate timeline IDs and items",
+			buildChunks: func(t *testing.T) []byte {
+				var buf bytes.Buffer
+				writer, err := khifilev6model.NewWriter(&buf)
+				if err != nil {
+					t.Fatalf("failed to create writer: %v", err)
+				}
+
+				metadataChunk := &khifilev6.MetadataChunk{
+					Metadata: []*khifilev6.MetadataItem{
+						{
+							Payload: &khifilev6.MetadataItem_Header{
+								Header: &khifilev6.HeaderMetadata{
+									InspectionName: proto.String("test-inspection"),
+								},
+							},
+						},
+					},
+				}
+				if err := writer.WriteChunk(khifilev6model.ChunkTypeMetadata, metadataChunk); err != nil {
+					t.Fatalf("failed to write metadata chunk: %v", err)
+				}
+
+				logChunk := &khifilev6.LogChunk{
+					Logs: []*khifilev6.Log{
+						{Id: proto.Uint32(1), SummaryStringId: proto.Uint32(1)},
+						{Id: proto.Uint32(2), SummaryStringId: proto.Uint32(2)},
+					},
+				}
+				if err := writer.WriteChunk(khifilev6model.ChunkTypeLog, logChunk); err != nil {
+					t.Fatalf("failed to write log chunk: %v", err)
+				}
+
+				// First timeline chunk with log 2
+				chunk1 := &khifilev6.TimelineChunk{
+					Timelines: []*khifilev6.Timeline{
+						{Id: proto.Uint32(10), TimelineItemsId: proto.Uint32(100)},
+					},
+					TimelineItems: []*khifilev6.TimelineItems{
+						{
+							Id: proto.Uint32(100),
+							Revisions: []*khifilev6.Revision{
+								{LogId: proto.Uint32(2), ChangedTime: &timestamppb.Timestamp{Seconds: 200}},
+							},
+							Events: []*khifilev6.Event{
+								{LogId: proto.Uint32(2)},
+							},
+						},
+					},
+				}
+				if err := writer.WriteChunk(khifilev6model.ChunkTypeTimeline, chunk1); err != nil {
+					t.Fatalf("failed to write timeline chunk 1: %v", err)
+				}
+
+				// Second timeline chunk with log 1 (earlier timestamp) and duplicate timeline ID 10
+				chunk2 := &khifilev6.TimelineChunk{
+					Timelines: []*khifilev6.Timeline{
+						{Id: proto.Uint32(10), TimelineItemsId: proto.Uint32(100)},
+					},
+					TimelineItems: []*khifilev6.TimelineItems{
+						{
+							Id: proto.Uint32(100),
+							Revisions: []*khifilev6.Revision{
+								{LogId: proto.Uint32(1), ChangedTime: &timestamppb.Timestamp{Seconds: 100}},
+							},
+							Events: []*khifilev6.Event{
+								{LogId: proto.Uint32(1)},
+							},
+						},
+					},
+				}
+				if err := writer.WriteChunk(khifilev6model.ChunkTypeTimeline, chunk2); err != nil {
+					t.Fatalf("failed to write timeline chunk 2: %v", err)
+				}
+
+				return buf.Bytes()
+			},
+			wantTimeline: &cel.TimelineData{
+				ID: 10,
+				Events: []cel.EventInfo{
+					{LogID: 1},
+					{LogID: 2},
+				},
+				Revisions: []cel.RevisionInfo{
+					{LogID: 1, ChangedTime: 100 * 1_000_000_000},
+					{LogID: 2, ChangedTime: 200 * 1_000_000_000},
+				},
+				SeverityMask: 1,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := tc.buildChunks(t)
+			wb, err := NewFromReader(
+				context.Background(),
+				"wb-test-merge",
+				"inspection-merge",
+				bytes.NewReader(data),
+				int64(len(data)),
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("NewFromReader() error = %v", err)
+			}
+			if len(wb.searchIndex.Timelines) != 1 {
+				t.Fatalf("len(searchIndex.Timelines) = %d, want 1", len(wb.searchIndex.Timelines))
+			}
+			gotTimeline := wb.searchIndex.Timelines[0]
+			if diff := cmp.Diff(tc.wantTimeline, gotTimeline); diff != "" {
+				t.Errorf("Timeline mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/server/workbench/workbench.go
+++ b/pkg/server/workbench/workbench.go
@@ -73,6 +73,7 @@ type Workbench struct {
 	timelineChunks    []*khifilev6.TimelineChunk
 	rawTimelines      []rawTimeline
 	rawTimelineItems  map[uint32]*rawTimelineItems
+	seenTimelineIDs   map[uint32]bool
 	searchIndex       *SearchIndex
 
 	indexMu          sync.RWMutex
@@ -152,6 +153,13 @@ func (w *Workbench) IsClosed() bool {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return w.closed
+}
+
+// SearchIndex returns the built SearchIndex for this workbench.
+func (w *Workbench) SearchIndex() *SearchIndex {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.searchIndex
 }
 
 // ReadStructYAMLs decodes the interned structs matching the given structIDs and returns a map of struct ID to YAML string representation.

--- a/pkg/server/workbench/workbench.go
+++ b/pkg/server/workbench/workbench.go
@@ -121,10 +121,12 @@ type rawTimelineItems struct {
 // NewWorkbench creates a new Workbench instance.
 func NewWorkbench(id string, inspectionID string) *Workbench {
 	return &Workbench{
-		id:           id,
-		inspectionID: inspectionID,
-		internPool:   khifilev6model.NewReadonlyInternPool(),
-		filterJobs:   streamingutil.NewAsyncJobManager[*apiv1.FilterProgress, *apiv1.FilterResult](15*time.Second, 1*time.Minute),
+		id:               id,
+		inspectionID:     inspectionID,
+		internPool:       khifilev6model.NewReadonlyInternPool(),
+		filterJobs:       streamingutil.NewAsyncJobManager[*apiv1.FilterProgress, *apiv1.FilterResult](15*time.Second, 1*time.Minute),
+		rawTimelineItems: make(map[uint32]*rawTimelineItems),
+		seenTimelineIDs:  make(map[uint32]bool),
 	}
 }
 

--- a/web/src/app/parser/v6/blueprint.spec.ts
+++ b/web/src/app/parser/v6/blueprint.spec.ts
@@ -316,6 +316,94 @@ describe('V6TimelineAssembler', () => {
       eventIds: [1],
     });
   });
+
+  it('should merge timeline items across multiple chunks and deduplicate timelines', () => {
+    const builder = jasmine.createSpyObj<InspectionDataBuilder>(
+      'InspectionDataBuilder',
+      ['addRevision', 'addEvent', 'addTimeline'],
+    );
+    const assembler = new V6TimelineAssembler(builder);
+
+    const chunk1 = create(TimelineChunkSchema, {
+      timelineItems: [
+        create(TimelineItemsSchema, {
+          id: 100,
+          revisions: [
+            create(RevisionSchema, {
+              logId: 10,
+              changedTime: create(TimestampSchema, { seconds: 1n, nanos: 0 }),
+              principalStringId: 5,
+              verbType: 2,
+              stateType: 3,
+            }),
+          ],
+          events: [
+            create(EventSchema, {
+              logId: 20,
+            }),
+          ],
+        }),
+      ],
+      timelines: [
+        create(TimelineSchema, {
+          id: 1,
+          timelineType: 10,
+          nameStringId: 20,
+          timelineItemsId: 100,
+          parentTimelineId: 0,
+        }),
+      ],
+    });
+
+    const chunk2 = create(TimelineChunkSchema, {
+      timelineItems: [
+        create(TimelineItemsSchema, {
+          id: 100,
+          revisions: [
+            create(RevisionSchema, {
+              logId: 11,
+              changedTime: create(TimestampSchema, { seconds: 2n, nanos: 0 }),
+              principalStringId: 5,
+              verbType: 2,
+              stateType: 3,
+            }),
+          ],
+          events: [
+            create(EventSchema, {
+              logId: 21,
+            }),
+          ],
+        }),
+      ],
+      timelines: [
+        create(TimelineSchema, {
+          id: 1,
+          timelineType: 10,
+          nameStringId: 20,
+          timelineItemsId: 100,
+          parentTimelineId: 0,
+        }),
+      ],
+    });
+
+    assembler.ingest(chunk1);
+    assembler.ingest(chunk2);
+
+    expect(builder.addRevision).toHaveBeenCalledTimes(2);
+    expect(builder.addEvent).toHaveBeenCalledTimes(2);
+
+    assembler.finalize();
+
+    expect(builder.addTimeline).toHaveBeenCalledTimes(1);
+    expect(builder.addTimeline).toHaveBeenCalledWith({
+      id: 1,
+      timelineTypeId: 10,
+      nameStringId: 20,
+      parentTimelineId: 0,
+      revisionIds: [1, 2],
+      eventIds: [1, 2],
+    });
+  });
 });
 
 describe('V6MetadataAssembler', () => {

--- a/web/src/app/parser/v6/blueprint.ts
+++ b/web/src/app/parser/v6/blueprint.ts
@@ -294,6 +294,7 @@ export class V6LogAssembler implements DataAssembler<LogChunk> {
  */
 export class V6TimelineAssembler implements DataAssembler<TimelineChunk> {
   private readonly rawTimelines: Timeline[] = [];
+  private readonly seenTimelineIds = new Set<number>();
   private readonly itemsMap = new Map<
     number,
     { revisionIds: number[]; eventIds: number[] }
@@ -310,10 +311,11 @@ export class V6TimelineAssembler implements DataAssembler<TimelineChunk> {
   ingest(proto: TimelineChunk): void {
     // 1. Process timelineItems: stream revisions and events directly to builder
     for (const items of proto.timelineItems) {
-      if (this.itemsMap.has(items.id)) {
-        throw new Error(`Duplicate timelineItems id: ${items.id}`);
+      let entry = this.itemsMap.get(items.id);
+      if (!entry) {
+        entry = { revisionIds: [], eventIds: [] };
+        this.itemsMap.set(items.id, entry);
       }
-      const revisionIds: number[] = [];
       for (const r of items.revisions) {
         const id = this.nextRevisionId++;
         const changedTime = r.changedTime
@@ -346,25 +348,25 @@ export class V6TimelineAssembler implements DataAssembler<TimelineChunk> {
             };
           }),
         });
-        revisionIds.push(id);
+        entry.revisionIds.push(id);
       }
 
-      const eventIds: number[] = [];
       for (const e of items.events) {
         const id = this.nextEventId++;
         this.builder.addEvent({
           id,
           logId: e.logId,
         });
-        eventIds.push(id);
+        entry.eventIds.push(id);
       }
-
-      this.itemsMap.set(items.id, { revisionIds, eventIds });
     }
 
-    // 2. Store raw timelines
+    // 2. Store raw timelines (deduplicating by timeline id)
     for (const t of proto.timelines) {
-      this.rawTimelines.push(t);
+      if (!this.seenTimelineIds.has(t.id)) {
+        this.seenTimelineIds.add(t.id);
+        this.rawTimelines.push(t);
+      }
     }
   }
 

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -644,14 +644,15 @@ export class TimelineStore {
       return [];
     }
 
-    const sortedRevIds = Array.from(revIds);
+    const sortedRevIds = revIds.slice();
     sortedRevIds.sort((a, b) => {
       const logA = this._getRevisionLogId(a);
       const logB = this._getRevisionLogId(b);
-      return (
-        this.logStore.getLog(logA).logIndex -
-        this.logStore.getLog(logB).logIndex
-      );
+      const logEntryA = this.logStore.getLog(logA);
+      const logEntryB = this.logStore.getLog(logB);
+      const indexA = logEntryA ? logEntryA.logIndex : 0;
+      const indexB = logEntryB ? logEntryB.logIndex : 0;
+      return indexA - indexB;
     });
 
     const revisions: Revision[] = [];
@@ -671,16 +672,17 @@ export class TimelineStore {
       return [];
     }
 
-    const sortedEvtIds = Array.from(eventIds);
+    const sortedEvtIds = eventIds.slice();
     sortedEvtIds.sort((a, b) => {
       const idxA = this.eventIdToIndex[a];
       const idxB = this.eventIdToIndex[b];
       const logA = idxA !== undefined ? this.eventLogIds[idxA] : 0;
       const logB = idxB !== undefined ? this.eventLogIds[idxB] : 0;
-      return (
-        this.logStore.getLog(logA).logIndex -
-        this.logStore.getLog(logB).logIndex
-      );
+      const logEntryA = this.logStore.getLog(logA);
+      const logEntryB = this.logStore.getLog(logB);
+      const indexA = logEntryA ? logEntryA.logIndex : 0;
+      const indexB = logEntryB ? logEntryB.logIndex : 0;
+      return indexA - indexB;
     });
 
     const events: Event[] = [];

--- a/web/src/app/store/domain/timeline-store.ts
+++ b/web/src/app/store/domain/timeline-store.ts
@@ -640,15 +640,24 @@ export class TimelineStore {
     id: number,
   ): ReadonlyDomainElement<Revision[]> {
     const revIds = this.timelineRevisionIds[this.getTimelineIndex(id)];
-    if (!revIds) {
+    if (!revIds || revIds.length === 0) {
       return [];
     }
 
+    const sortedRevIds = Array.from(revIds);
+    sortedRevIds.sort((a, b) => {
+      const logA = this._getRevisionLogId(a);
+      const logB = this._getRevisionLogId(b);
+      return (
+        this.logStore.getLog(logA).logIndex -
+        this.logStore.getLog(logB).logIndex
+      );
+    });
+
     const revisions: Revision[] = [];
-    for (let i = 0; i < revIds.length; i++) {
-      revisions.push(new Revision(revIds[i], id, this, i));
+    for (let i = 0; i < sortedRevIds.length; i++) {
+      revisions.push(new Revision(sortedRevIds[i], id, this, i));
     }
-    revisions.sort((r1, r2) => r1.logIndex - r2.logIndex);
     return revisions;
   }
 
@@ -658,15 +667,26 @@ export class TimelineStore {
    */
   public _getEventsForTimeline(id: number): ReadonlyDomainElement<Event[]> {
     const eventIds = this.timelineEventIds[this.getTimelineIndex(id)];
-    if (!eventIds) {
+    if (!eventIds || eventIds.length === 0) {
       return [];
     }
 
+    const sortedEvtIds = Array.from(eventIds);
+    sortedEvtIds.sort((a, b) => {
+      const idxA = this.eventIdToIndex[a];
+      const idxB = this.eventIdToIndex[b];
+      const logA = idxA !== undefined ? this.eventLogIds[idxA] : 0;
+      const logB = idxB !== undefined ? this.eventLogIds[idxB] : 0;
+      return (
+        this.logStore.getLog(logA).logIndex -
+        this.logStore.getLog(logB).logIndex
+      );
+    });
+
     const events: Event[] = [];
-    for (let i = 0; i < eventIds.length; i++) {
-      events.push(new Event(eventIds[i], id, this));
+    for (let i = 0; i < sortedEvtIds.length; i++) {
+      events.push(new Event(sortedEvtIds[i], id, this));
     }
-    events.sort((e1, e2) => e1.logIndex - e2.logIndex);
     return events;
   }
 


### PR DESCRIPTION
## Summary
During full-scale inspection file generation, buffering all timeline items in memory before serialization accounts for significant memory consumption. This change streams chunked timeline items (`TimelineChunk`) during serialization and updates the frontend `V6TimelineAssembler` and `TimelineStore` to incrementally merge chunked timeline items and sort revisions and events.

## Changes
- **Backend (`pkg/model/khifile/v6`)**:
  - Introduce `TimelineChunk` streaming in `TimelineSerializer` and `TimelineAccumulator` to emit timeline items in bounded batches rather than accumulating everything in memory until container serialization.
  - Add `FlushTimelineItemsChunk` in `TimelineAccumulator` and integrate with `Builder`.
  - Update `pkg/server/workbench/reader.go` and `pkg/server/workbench/workbench.go` to handle chunked timeline reading.
- **Frontend (`web/src/app`)**:
  - Update `V6TimelineAssembler` to merge revisions and events for timelines across multiple chunks and deduplicate timeline objects.
  - Update `TimelineStore._getRevisionsForTimeline` and `_getEventsForTimeline` to sort revisions and events by `logIndex` to guarantee deterministic chronological ordering.
- **Tests**:
  - Add comprehensive unit tests in `blueprint.spec.ts` testing multi-chunk timeline merging.
  - Add unit tests in `timeline_accumulator_test.go`, `timeline_builder_test.go`, and `reader_test.go`.

## Verification
- `make build-go && make build-web` passed.
- `make test-go && make test-web` passed (1110/1110 frontend tests passed).
- `make lint-go && make lint-web` passed (0 issues).
- `make pre-commit` passed.
