### PR TITLE
feat(networkapiaudit): track NEG endpoint lifecycle and support GCE_VM_IP

### DIFF
--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/contract/revision_state.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/contract/revision_state.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlecloudlognetworkapiaudit_contract
+
+import (
+	pb "github.com/GoogleCloudPlatform/khi/pkg/generated/khifile/v6"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6/style"
+)
+
+var (
+	// RevisionStateNEGEndpointAttaching indicates that the network endpoint is currently being attached to the NEG.
+	RevisionStateNEGEndpointAttaching = style.MustRegisterRevisionState(
+		"Endpoint is being attached",
+		"deployed_code_history",
+		"The network endpoint is currently being attached to the NEG.",
+		style.MustForceConvertSRGBHex("#6666ff"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+
+	// RevisionStateNEGEndpointAttached indicates that the network endpoint is attached and active in the NEG.
+	RevisionStateNEGEndpointAttached = style.MustRegisterRevisionState(
+		"Endpoint is attached",
+		"deployed_code",
+		"The network endpoint is attached to the NEG and ready to receive traffic.",
+		style.MustForceConvertSRGBHex("#007700"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+
+	// RevisionStateNEGEndpointDetaching indicates that the network endpoint is currently being detached from the NEG.
+	RevisionStateNEGEndpointDetaching = style.MustRegisterRevisionState(
+		"Endpoint is being detached",
+		"auto_delete",
+		"The network endpoint is currently being detached from the NEG (e.g. connection draining).",
+		style.MustForceConvertSRGBHex("#CC5500"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_NORMAL,
+	)
+
+	// RevisionStateNEGEndpointDetached indicates that the network endpoint has been detached from the NEG.
+	RevisionStateNEGEndpointDetached = style.MustRegisterRevisionState(
+		"Endpoint is detached",
+		"delete_forever",
+		"The network endpoint has been detached from the NEG.",
+		style.MustForceConvertSRGBHex("#CC0000"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_DELETED,
+	)
+
+	// RevisionStateNEGEndpointExistingLogNotFound indicates that the network endpoint existed in the NEG prior to detach, but its attach log was not found in the selected time range.
+	RevisionStateNEGEndpointExistingLogNotFound = style.MustRegisterRevisionState(
+		"Endpoint exists, but attach log not found",
+		"deployed_code",
+		"The network endpoint existed in the NEG prior to detach, but the attach log was not found in the selected time range. Its readiness or health prior to this event cannot be determined.",
+		style.MustForceConvertSRGBHex("#cea700"),
+		pb.RevisionStateStyle_REVISION_STATE_STYLE_PARTIAL_INFO,
+	)
+)

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
@@ -226,7 +226,8 @@ func (m *networkAPITimelineMapper) processEndpointRevisions(
 		var bsSubresourceName string
 		var endpointKey string
 
-		if endpoint.IpAddress != "" && endpoint.Port != "" {
+		switch {
+		case endpoint.IpAddress != "" && endpoint.Port != "":
 			lease, err := ipLeases.GetResourceLeaseHolderAt(endpoint.IpAddress, l.Timestamp)
 			if err != nil {
 				slog.WarnContext(ctx, fmt.Sprintf("Failed to identify the holder of the IP %s.\n This might be because the IP holder resource wasn't updated during the log period ", endpoint.IpAddress))
@@ -245,7 +246,7 @@ func (m *networkAPITimelineMapper) processEndpointRevisions(
 			resourceTimelinePath = commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, holder.Name)
 			bsSubresourceName = holder.Name
 			endpointKey = getPodEndpointKey(endpoint.IpAddress, endpoint.Port)
-		} else if endpoint.Instance != "" {
+		case endpoint.Instance != "":
 			nodeName := getInstanceNameFromResourceName(endpoint.Instance)
 			clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
 			apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
@@ -253,7 +254,7 @@ func (m *networkAPITimelineMapper) processEndpointRevisions(
 			resourceTimelinePath = commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, nodeName)
 			bsSubresourceName = nodeName
 			endpointKey = getNodeEndpointKey(nodeName)
-		} else {
+		default:
 			continue
 		}
 

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
@@ -62,9 +63,15 @@ type negAttachOrDetachRequest struct {
 	NetworkEndpoints []*negAttachOrDetachRequestEndpoint `yaml:"networkEndpoints"`
 }
 
+type pendingNEGOperation struct {
+	Method  string
+	Request *negAttachOrDetachRequest
+}
+
 type perNEGHistoryModificationStatus struct {
-	LastNegAttachRequest *negAttachOrDetachRequest
-	OperationTracker     *googlecloudcommon_contract.GCPOperationTracker
+	PendingOperations map[string]*pendingNEGOperation
+	OperationTracker  *googlecloudcommon_contract.GCPOperationTracker
+	KnownEndpoints    map[string]bool
 }
 
 type networkAPITimelineMapper struct {
@@ -99,8 +106,16 @@ func (m *networkAPITimelineMapper) ProcessLogByGroup(ctx context.Context, l *log
 	}
 	if prevGroupData == nil {
 		prevGroupData = &perNEGHistoryModificationStatus{
-			OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+			PendingOperations: make(map[string]*pendingNEGOperation),
+			OperationTracker:  googlecloudcommon_contract.NewGCPOperationTracker(),
+			KnownEndpoints:    make(map[string]bool),
 		}
+	}
+	if prevGroupData.PendingOperations == nil {
+		prevGroupData.PendingOperations = make(map[string]*pendingNEGOperation)
+	}
+	if prevGroupData.KnownEndpoints == nil {
+		prevGroupData.KnownEndpoints = make(map[string]bool)
 	}
 
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref())
@@ -133,74 +148,114 @@ func (m *networkAPITimelineMapper) ProcessLogByGroup(ctx context.Context, l *log
 	ipLeases := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref())
 	// Add neg subresource under resources with the same IP of the endpoint.
 	shortMethodName := getShortMethodNameFromMethodName(auditFieldSet.MethodName)
+	var startVerb, endVerb *pb.Verb
+	var startState, endState *pb.RevisionState
+
+	switch shortMethodName {
+	case "attachNetworkEndpoints":
+		startVerb = commonlogk8saudit_contract.VerbCreate
+		startState = googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttaching
+		endVerb = commonlogk8saudit_contract.VerbReady
+		endState = googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttached
+	case "detachNetworkEndpoints":
+		startVerb = commonlogk8saudit_contract.VerbNonReady
+		startState = googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetaching
+		endVerb = commonlogk8saudit_contract.VerbDelete
+		endState = googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetached
+	default:
+		return cs, prevGroupData, nil
+	}
+
 	var negRequest *negAttachOrDetachRequest
 	var verb *pb.Verb
 	var state *pb.RevisionState
-	switch shortMethodName {
-	case "attachNetworkEndpoints":
-		if auditFieldSet.Starting() {
-			// Operation starting log only contain its request(IP data), but it should be marked as ready when the last log coming.
-			var err error
-			request, err := parseNEGAttachOrDetachRequest(&auditFieldSet)
-			if err != nil {
-				return nil, prevGroupData, err
-			}
-			prevGroupData.LastNegAttachRequest = request // Save the neg attach request in the per group status, and it will be consumed in the next ending operation log.
-			break
-		}
-		negRequest = prevGroupData.LastNegAttachRequest
-		prevGroupData.LastNegAttachRequest = nil
-		verb = commonlogk8saudit_contract.VerbReady
-		state = commonlogk8saudit_contract.RevisionStateConditionTrue
-	case "detachNetworkEndpoints":
-		if auditFieldSet.Ending() {
-			break
-		}
+
+	switch {
+	case auditFieldSet.Starting():
 		var err error
 		negRequest, err = parseNEGAttachOrDetachRequest(&auditFieldSet)
 		if err != nil {
 			return nil, prevGroupData, err
 		}
-		verb = commonlogk8saudit_contract.VerbNonReady
-		state = commonlogk8saudit_contract.RevisionStateConditionFalse
+		if auditFieldSet.OperationID != "" {
+			prevGroupData.PendingOperations[auditFieldSet.OperationID] = &pendingNEGOperation{
+				Method:  shortMethodName,
+				Request: negRequest,
+			}
+		}
+		verb = startVerb
+		state = startState
+	case auditFieldSet.Ending():
+		if op, found := prevGroupData.PendingOperations[auditFieldSet.OperationID]; found {
+			delete(prevGroupData.PendingOperations, auditFieldSet.OperationID)
+			if auditFieldSet.Status <= 0 {
+				negRequest = op.Request
+				verb = endVerb
+				state = endState
+			}
+		}
+	case auditFieldSet.ImmediateOperation():
+		var err error
+		negRequest, err = parseNEGAttachOrDetachRequest(&auditFieldSet)
+		if err != nil {
+			return nil, prevGroupData, err
+		}
+		verb = endVerb
+		state = endState
 	}
 
 	if negRequest != nil {
 		negToBS := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref())
 		for _, endpoint := range negRequest.NetworkEndpoints {
-			lease, err := ipLeases.GetResourceLeaseHolderAt(endpoint.IpAddress, l.Timestamp)
-			if err != nil {
-				slog.WarnContext(ctx, fmt.Sprintf("Failed to identify the holder of the IP %s.\n This might be because the IP holder resource wasn't updated during the log period ", endpoint.IpAddress))
-				continue
-			}
-			holder := lease.Holder
-			if holder.Kind == "pod" {
+			var resourceTimelinePath *khifilev6.TimelinePath
+			var bsSubresourceName string
+			var endpointKey string
+
+			if endpoint.IpAddress != "" && endpoint.Port != "" {
+				lease, err := ipLeases.GetResourceLeaseHolderAt(endpoint.IpAddress, l.Timestamp)
+				if err != nil {
+					slog.WarnContext(ctx, fmt.Sprintf("Failed to identify the holder of the IP %s.\n This might be because the IP holder resource wasn't updated during the log period ", endpoint.IpAddress))
+					continue
+				}
+				holder := lease.Holder
+				if holder.Kind != "pod" {
+					slog.DebugContext(ctx, fmt.Sprintf("IP %s is held by non-pod resource %s/%s, skipping NEG mapping", endpoint.IpAddress, holder.Kind, holder.Name))
+					continue
+				}
+
 				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
 				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
 				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "pod")
 				nsPath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, holder.Namespace)
-				podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, holder.Name)
-
-				negSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, podPath, negName)
-				cs.AddRevision(negSubresourcePath, &khifilev6.StagingRevision{
-					ChangedTime: l.Timestamp,
-					VerbType:    verb,
-					StateType:   state,
-					Principal:   auditFieldSet.PrincipalEmail,
-				})
-
-				if bsName, found := negToBS[negName]; found {
-					// BackendService is usually global in the context of gsmrsvd backends.
-					bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, clusterIdentity.ProjectID, "backendServices", bsName)
-					negSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, holder.Name)
-					cs.AddRevision(negSubresourcePath, &khifilev6.StagingRevision{
-						ChangedTime: l.Timestamp,
-						VerbType:    verb,
-						StateType:   state,
-						Principal:   auditFieldSet.PrincipalEmail,
-					})
-				}
+				resourceTimelinePath = commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, holder.Name)
+				bsSubresourceName = holder.Name
+				endpointKey = getPodEndpointKey(endpoint.IpAddress, endpoint.Port)
+			} else if endpoint.Instance != "" {
+				nodeName := getInstanceNameFromResourceName(endpoint.Instance)
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+				resourceTimelinePath = commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, nodeName)
+				bsSubresourceName = nodeName
+				endpointKey = getNodeEndpointKey(nodeName)
+			} else {
+				continue
 			}
+
+			// Add revisions to the resource-level NEG subresource timeline.
+			negSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, resourceTimelinePath, negName)
+			isKnown := prevGroupData.KnownEndpoints[endpointKey]
+			addEndpointRevisions(cs, negSubresourcePath, shortMethodName, isKnown, l.Timestamp, verb, state, auditFieldSet.PrincipalEmail)
+
+			// Add revisions to the BackendService-level NEG subresource timeline if associated.
+			if bsName, found := negToBS[negName]; found {
+				// BackendService is usually global in the context of gsmrsvd backends.
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, clusterIdentity.ProjectID, "backendServices", bsName)
+				bsNegSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, bsSubresourceName)
+				addEndpointRevisions(cs, bsNegSubresourcePath, shortMethodName, isKnown, l.Timestamp, verb, state, auditFieldSet.PrincipalEmail)
+			}
+
+			prevGroupData.KnownEndpoints[endpointKey] = true
 		}
 	}
 
@@ -226,6 +281,14 @@ func getNegNameFromResourceName(resourceName string) string {
 	return resourceName[lastSlashIndex+1:]
 }
 
+func getInstanceNameFromResourceName(instance string) string {
+	lastSlashIndex := strings.LastIndex(instance, "/")
+	if lastSlashIndex == -1 {
+		return instance
+	}
+	return instance[lastSlashIndex+1:]
+}
+
 func getShortMethodNameFromMethodName(methodName string) string {
 	lastDotIndex := strings.LastIndex(methodName, ".")
 	if lastDotIndex == -1 {
@@ -245,4 +308,39 @@ func parseNEGAttachOrDetachRequest(auditFieldSet *googlecloudcommon_contract.GCP
 		return nil, err
 	}
 	return &negRequest, nil
+}
+
+func getPodEndpointKey(ip, port string) string {
+	return fmt.Sprintf("pod:%s:%s", ip, port)
+}
+
+func getNodeEndpointKey(nodeName string) string {
+	return fmt.Sprintf("node:%s", nodeName)
+}
+
+// addEndpointRevisions stages revisions for a NEG endpoint on the specified timeline path.
+func addEndpointRevisions(
+	cs *khifilev6.TimelineChangeSet,
+	targetPath *khifilev6.TimelinePath,
+	shortMethodName string,
+	isKnown bool,
+	changedTime time.Time,
+	verb *pb.Verb,
+	state *pb.RevisionState,
+	principal string,
+) {
+	if shortMethodName == "detachNetworkEndpoints" && !isKnown {
+		cs.AddRevision(targetPath, &khifilev6.StagingRevision{
+			ChangedTime: time.Unix(0, 0),
+			VerbType:    commonlogk8saudit_contract.VerbUnknown,
+			StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointExistingLogNotFound,
+			Principal:   "N/A",
+		})
+	}
+	cs.AddRevision(targetPath, &khifilev6.StagingRevision{
+		ChangedTime: changedTime,
+		VerbType:    verb,
+		StateType:   state,
+		Principal:   principal,
+	})
 }

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task.go
@@ -111,12 +111,6 @@ func (m *networkAPITimelineMapper) ProcessLogByGroup(ctx context.Context, l *log
 			KnownEndpoints:    make(map[string]bool),
 		}
 	}
-	if prevGroupData.PendingOperations == nil {
-		prevGroupData.PendingOperations = make(map[string]*pendingNEGOperation)
-	}
-	if prevGroupData.KnownEndpoints == nil {
-		prevGroupData.KnownEndpoints = make(map[string]bool)
-	}
 
 	clusterIdentity := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.ClusterIdentityTaskID.Ref())
 	negs := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref())
@@ -145,7 +139,6 @@ func (m *networkAPITimelineMapper) ProcessLogByGroup(ctx context.Context, l *log
 		prevGroupData.OperationTracker.ProcessOperationLog(ctx, cs, negOperationPath, &auditFieldSet, l.Timestamp)
 	}
 
-	ipLeases := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref())
 	// Add neg subresource under resources with the same IP of the endpoint.
 	shortMethodName := getShortMethodNameFromMethodName(auditFieldSet.MethodName)
 	var startVerb, endVerb *pb.Verb
@@ -205,61 +198,80 @@ func (m *networkAPITimelineMapper) ProcessLogByGroup(ctx context.Context, l *log
 	}
 
 	if negRequest != nil {
-		negToBS := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref())
-		for _, endpoint := range negRequest.NetworkEndpoints {
-			var resourceTimelinePath *khifilev6.TimelinePath
-			var bsSubresourceName string
-			var endpointKey string
-
-			if endpoint.IpAddress != "" && endpoint.Port != "" {
-				lease, err := ipLeases.GetResourceLeaseHolderAt(endpoint.IpAddress, l.Timestamp)
-				if err != nil {
-					slog.WarnContext(ctx, fmt.Sprintf("Failed to identify the holder of the IP %s.\n This might be because the IP holder resource wasn't updated during the log period ", endpoint.IpAddress))
-					continue
-				}
-				holder := lease.Holder
-				if holder.Kind != "pod" {
-					slog.DebugContext(ctx, fmt.Sprintf("IP %s is held by non-pod resource %s/%s, skipping NEG mapping", endpoint.IpAddress, holder.Kind, holder.Name))
-					continue
-				}
-
-				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
-				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
-				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "pod")
-				nsPath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, holder.Namespace)
-				resourceTimelinePath = commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, holder.Name)
-				bsSubresourceName = holder.Name
-				endpointKey = getPodEndpointKey(endpoint.IpAddress, endpoint.Port)
-			} else if endpoint.Instance != "" {
-				nodeName := getInstanceNameFromResourceName(endpoint.Instance)
-				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
-				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
-				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
-				resourceTimelinePath = commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, nodeName)
-				bsSubresourceName = nodeName
-				endpointKey = getNodeEndpointKey(nodeName)
-			} else {
-				continue
-			}
-
-			// Add revisions to the resource-level NEG subresource timeline.
-			negSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, resourceTimelinePath, negName)
-			isKnown := prevGroupData.KnownEndpoints[endpointKey]
-			addEndpointRevisions(cs, negSubresourcePath, shortMethodName, isKnown, l.Timestamp, verb, state, auditFieldSet.PrincipalEmail)
-
-			// Add revisions to the BackendService-level NEG subresource timeline if associated.
-			if bsName, found := negToBS[negName]; found {
-				// BackendService is usually global in the context of gsmrsvd backends.
-				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, clusterIdentity.ProjectID, "backendServices", bsName)
-				bsNegSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, bsSubresourceName)
-				addEndpointRevisions(cs, bsNegSubresourcePath, shortMethodName, isKnown, l.Timestamp, verb, state, auditFieldSet.PrincipalEmail)
-			}
-
-			prevGroupData.KnownEndpoints[endpointKey] = true
-		}
+		m.processEndpointRevisions(ctx, cs, l, &auditFieldSet, prevGroupData, clusterIdentity, negName, shortMethodName, negRequest, verb, state)
 	}
 
 	return cs, prevGroupData, nil
+}
+
+// processEndpointRevisions resolves resource endpoints (Pod or Node) and records the corresponding NEG subresource revisions.
+func (m *networkAPITimelineMapper) processEndpointRevisions(
+	ctx context.Context,
+	cs *khifilev6.TimelineChangeSet,
+	l *log.Log,
+	auditFieldSet *googlecloudcommon_contract.GCPAuditLogFieldSet,
+	prevGroupData *perNEGHistoryModificationStatus,
+	clusterIdentity googlecloudk8scommon_contract.GoogleCloudClusterIdentity,
+	negName string,
+	shortMethodName string,
+	negRequest *negAttachOrDetachRequest,
+	verb *pb.Verb,
+	state *pb.RevisionState,
+) {
+	negToBS := coretask.GetTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref())
+	ipLeases := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref())
+
+	for _, endpoint := range negRequest.NetworkEndpoints {
+		var resourceTimelinePath *khifilev6.TimelinePath
+		var bsSubresourceName string
+		var endpointKey string
+
+		if endpoint.IpAddress != "" && endpoint.Port != "" {
+			lease, err := ipLeases.GetResourceLeaseHolderAt(endpoint.IpAddress, l.Timestamp)
+			if err != nil {
+				slog.WarnContext(ctx, fmt.Sprintf("Failed to identify the holder of the IP %s.\n This might be because the IP holder resource wasn't updated during the log period ", endpoint.IpAddress))
+				continue
+			}
+			holder := lease.Holder
+			if holder.Kind != "pod" {
+				slog.DebugContext(ctx, fmt.Sprintf("IP %s is held by non-pod resource %s/%s, skipping NEG mapping", endpoint.IpAddress, holder.Kind, holder.Name))
+				continue
+			}
+
+			clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
+			apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+			kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "pod")
+			nsPath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, holder.Namespace)
+			resourceTimelinePath = commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, holder.Name)
+			bsSubresourceName = holder.Name
+			endpointKey = getPodEndpointKey(endpoint.IpAddress, endpoint.Port)
+		} else if endpoint.Instance != "" {
+			nodeName := getInstanceNameFromResourceName(endpoint.Instance)
+			clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, clusterIdentity.ClusterName)
+			apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+			kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+			resourceTimelinePath = commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, nodeName)
+			bsSubresourceName = nodeName
+			endpointKey = getNodeEndpointKey(nodeName)
+		} else {
+			continue
+		}
+
+		// Add revisions to the resource-level NEG subresource timeline.
+		negSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, resourceTimelinePath, negName)
+		isKnown := prevGroupData.KnownEndpoints[endpointKey]
+		addEndpointRevisions(cs, negSubresourcePath, shortMethodName, isKnown, l.Timestamp, verb, state, auditFieldSet.PrincipalEmail)
+
+		// Add revisions to the BackendService-level NEG subresource timeline if associated.
+		if bsName, found := negToBS[negName]; found {
+			// BackendService is usually global in the context of gsmrsvd backends.
+			bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, clusterIdentity.ProjectID, "backendServices", bsName)
+			bsNegSubresourcePath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, bsSubresourceName)
+			addEndpointRevisions(cs, bsNegSubresourcePath, shortMethodName, isKnown, l.Timestamp, verb, state, auditFieldSet.PrincipalEmail)
+		}
+
+		prevGroupData.KnownEndpoints[endpointKey] = true
+	}
 }
 
 var _ inspectiontaskbase.LogToTimelineMapper[*perNEGHistoryModificationStatus] = (*networkAPITimelineMapper)(nil)

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
@@ -259,6 +259,7 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 						},
 					},
 				},
+				KnownEndpoints: make(map[string]bool),
 			},
 			wantGroupData: &perNEGHistoryModificationStatus{
 				PendingOperations: map[string]*pendingNEGOperation{},
@@ -433,6 +434,7 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 						},
 					},
 				},
+				KnownEndpoints: make(map[string]bool),
 			},
 			wantGroupData: &perNEGHistoryModificationStatus{
 				PendingOperations: map[string]*pendingNEGOperation{},
@@ -611,6 +613,7 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 						},
 					},
 				},
+				KnownEndpoints: make(map[string]bool),
 			},
 			wantGroupData: &perNEGHistoryModificationStatus{
 				PendingOperations: map[string]*pendingNEGOperation{},
@@ -785,6 +788,7 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 			),
 			prevGroupData: &perNEGHistoryModificationStatus{
 				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+				KnownEndpoints:   make(map[string]bool),
 				PendingOperations: map[string]*pendingNEGOperation{
 					"op-4": {
 						Method: "detachNetworkEndpoints",
@@ -876,6 +880,7 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 			),
 			prevGroupData: &perNEGHistoryModificationStatus{
 				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+				KnownEndpoints:   make(map[string]bool),
 				PendingOperations: map[string]*pendingNEGOperation{
 					"op-attach": {
 						Method: "attachNetworkEndpoints",
@@ -1005,6 +1010,7 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 			),
 			prevGroupData: &perNEGHistoryModificationStatus{
 				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+				KnownEndpoints:   make(map[string]bool),
 				PendingOperations: map[string]*pendingNEGOperation{
 					"op-fail": {
 						Method: "attachNetworkEndpoints",

--- a/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlognetworkapiaudit/impl/parser_task_test.go
@@ -19,13 +19,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
-
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
 	"github.com/GoogleCloudPlatform/khi/pkg/common/structured"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/history/resourceinfo/resourcelease"
+	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	core_contract "github.com/GoogleCloudPlatform/khi/pkg/task/core/contract"
@@ -139,7 +138,7 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 		assert        func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
-			name: "operation started revision is correctly created",
+			name: "attachNetworkEndpoints for Pod endpoint (GCE_VM_IP_PORT) start log",
 			inputLog: testlog.NewMockLog(
 				testTime,
 				googlecloudcommon_contract.GCPAuditLogFieldSet{
@@ -154,14 +153,22 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 			),
 			prevGroupData: nil,
 			wantGroupData: &perNEGHistoryModificationStatus{
-				LastNegAttachRequest: &negAttachOrDetachRequest{
-					NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
-						{
-							Instance:  "test-node",
-							IpAddress: "10.0.0.1",
-							Port:      "80",
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-1": {
+						Method: "attachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "test-node",
+									IpAddress: "10.0.0.1",
+									Port:      "80",
+								},
+							},
 						},
 					},
+				},
+				KnownEndpoints: map[string]bool{
+					"pod:10.0.0.1:80": true,
 				},
 			},
 			setupContext: func(ctx context.Context) context.Context {
@@ -171,7 +178,19 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 						Name:      "test-neg",
 					},
 				}
-				return tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ipLeases := resourcelease.NewResourceLeaseHistory[*commonlogk8saudit_contract.ResourceIdentity]()
+				ipLeases.TouchResourceLease("10.0.0.1", testTime, &commonlogk8saudit_contract.ResourceIdentity{
+					Kind:      "pod",
+					Namespace: "test-ns",
+					Name:      "test-pod",
+				})
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref(), ipLeases)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
 			},
 			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
 				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints", "op-1")
@@ -183,10 +202,36 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 						StateType:    googlecloudcommon_contract.RevisionStateOperationStarted,
 						ResourceBody: testReaderFromYAML(t, "networkEndpoints:\n- instance: test-node\n  ipAddress: 10.0.0.1\n  port: \"80\"").Node,
 					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "pod")
+				nsPath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, "test-ns")
+				podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, "test-pod")
+				wantPodNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, podPath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantPodNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbCreate,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttaching,
+					}, nodeTransformer)
+
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
+				wantBSNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, "test-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbCreate,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttaching,
+					}, nodeTransformer)
 			},
 		},
 		{
-			name: "operation finished revision is correctly created",
+			name: "attachNetworkEndpoints for Pod endpoint (GCE_VM_IP_PORT) finish log",
 			inputLog: testlog.NewMockLog(
 				testTime,
 				googlecloudcommon_contract.GCPAuditLogFieldSet{
@@ -200,18 +245,23 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 			),
 			prevGroupData: &perNEGHistoryModificationStatus{
 				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
-				LastNegAttachRequest: &negAttachOrDetachRequest{
-					NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
-						{
-							Instance:  "test-node",
-							IpAddress: "10.0.0.1",
-							Port:      "80",
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-1": {
+						Method: "attachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "test-node",
+									IpAddress: "10.0.0.1",
+									Port:      "80",
+								},
+							},
 						},
 					},
 				},
 			},
 			wantGroupData: &perNEGHistoryModificationStatus{
-				LastNegAttachRequest: nil,
+				PendingOperations: map[string]*pendingNEGOperation{},
 			},
 			setupContext: func(ctx context.Context) context.Context {
 				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
@@ -256,7 +306,7 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 						ChangedTime: testTime,
 						Principal:   "test-user@google.com",
 						VerbType:    commonlogk8saudit_contract.VerbReady,
-						StateType:   commonlogk8saudit_contract.RevisionStateConditionTrue,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttached,
 					}, nodeTransformer)
 
 				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
@@ -267,8 +317,817 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 						ChangedTime: testTime,
 						Principal:   "test-user@google.com",
 						VerbType:    commonlogk8saudit_contract.VerbReady,
-						StateType:   commonlogk8saudit_contract.RevisionStateConditionTrue,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttached,
 					}, nodeTransformer)
+			},
+		},
+		{
+			name: "attachNetworkEndpoints for Node endpoint (GCE_VM_IP) start log",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-2",
+					OperationFirst: true,
+					OperationLast:  false,
+					PrincipalEmail: "test-user@google.com",
+					Request:        testReaderFromYAML(t, "networkEndpoints:\n- instance: zones/us-central1-a/instances/test-node\n  ipAddress: 10.0.0.13"),
+				},
+			),
+			prevGroupData: nil,
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-2": {
+						Method: "attachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node",
+									IpAddress: "10.0.0.13",
+								},
+							},
+						},
+					},
+				},
+				KnownEndpoints: map[string]bool{
+					"node:test-node": true,
+				},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints", "op-2")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						Principal:    "test-user@google.com",
+						VerbType:     googlecloudcommon_contract.VerbOperationStart,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationStarted,
+						ResourceBody: testReaderFromYAML(t, "networkEndpoints:\n- instance: zones/us-central1-a/instances/test-node\n  ipAddress: 10.0.0.13").Node,
+					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+				nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, "test-node")
+				wantNodeNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, nodePath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodeNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbCreate,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttaching,
+					}, nodeTransformer)
+
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
+				wantBSNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, "test-node")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbCreate,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttaching,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "attachNetworkEndpoints for Node endpoint (GCE_VM_IP) finish log",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-2",
+					OperationFirst: false,
+					OperationLast:  true,
+					PrincipalEmail: "test-user@google.com",
+				},
+			),
+			prevGroupData: &perNEGHistoryModificationStatus{
+				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-2": {
+						Method: "attachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node",
+									IpAddress: "10.0.0.13",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints", "op-2")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationSucceed,
+					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+				nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, "test-node")
+				wantNodeNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, nodePath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodeNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbReady,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttached,
+					}, nodeTransformer)
+
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
+				wantBSNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, "test-node")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbReady,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointAttached,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "detachNetworkEndpoints for Node endpoint (GCE_VM_IP) start log",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-3",
+					OperationFirst: true,
+					OperationLast:  false,
+					PrincipalEmail: "test-user@google.com",
+					Request:        testReaderFromYAML(t, "networkEndpoints:\n- instance: zones/us-central1-a/instances/test-node\n  ipAddress: 10.0.0.13"),
+				},
+			),
+			prevGroupData: nil,
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-3": {
+						Method: "detachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node",
+									IpAddress: "10.0.0.13",
+								},
+							},
+						},
+					},
+				},
+				KnownEndpoints: map[string]bool{
+					"node:test-node": true,
+				},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints", "op-3")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						Principal:    "test-user@google.com",
+						VerbType:     googlecloudcommon_contract.VerbOperationStart,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationStarted,
+						ResourceBody: testReaderFromYAML(t, "networkEndpoints:\n- instance: zones/us-central1-a/instances/test-node\n  ipAddress: 10.0.0.13").Node,
+					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+				nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, "test-node")
+				wantNodeNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, nodePath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodeNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: time.Unix(0, 0),
+						Principal:   "N/A",
+						VerbType:    commonlogk8saudit_contract.VerbUnknown,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointExistingLogNotFound,
+					}).
+					HasRevision(wantNodeNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbNonReady,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetaching,
+					}, nodeTransformer)
+
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
+				wantBSNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, "test-node")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: time.Unix(0, 0),
+						Principal:   "N/A",
+						VerbType:    commonlogk8saudit_contract.VerbUnknown,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointExistingLogNotFound,
+					}).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbNonReady,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetaching,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "detachNetworkEndpoints for Node endpoint (GCE_VM_IP) finish log",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-3",
+					OperationFirst: false,
+					OperationLast:  true,
+					PrincipalEmail: "test-user@google.com",
+				},
+			),
+			prevGroupData: &perNEGHistoryModificationStatus{
+				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-3": {
+						Method: "detachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node",
+									IpAddress: "10.0.0.13",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints", "op-3")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationSucceed,
+					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+				nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, "test-node")
+				wantNodeNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, nodePath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodeNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbDelete,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetached,
+					}, nodeTransformer)
+
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
+				wantBSNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, "test-node")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbDelete,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetached,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "detachNetworkEndpoints for Pod endpoint (GCE_VM_IP_PORT) start log",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-4",
+					OperationFirst: true,
+					OperationLast:  false,
+					PrincipalEmail: "test-user@google.com",
+					Request:        testReaderFromYAML(t, "networkEndpoints:\n- instance: test-node\n  ipAddress: 10.0.0.1\n  port: \"80\""),
+				},
+			),
+			prevGroupData: nil,
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-4": {
+						Method: "detachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "test-node",
+									IpAddress: "10.0.0.1",
+									Port:      "80",
+								},
+							},
+						},
+					},
+				},
+				KnownEndpoints: map[string]bool{
+					"pod:10.0.0.1:80": true,
+				},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				ipLeases := resourcelease.NewResourceLeaseHistory[*commonlogk8saudit_contract.ResourceIdentity]()
+				ipLeases.TouchResourceLease("10.0.0.1", testTime, &commonlogk8saudit_contract.ResourceIdentity{
+					Kind:      "pod",
+					Namespace: "test-ns",
+					Name:      "test-pod",
+				})
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref(), ipLeases)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints", "op-4")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime:  testTime,
+						Principal:    "test-user@google.com",
+						VerbType:     googlecloudcommon_contract.VerbOperationStart,
+						StateType:    googlecloudcommon_contract.RevisionStateOperationStarted,
+						ResourceBody: testReaderFromYAML(t, "networkEndpoints:\n- instance: test-node\n  ipAddress: 10.0.0.1\n  port: \"80\"").Node,
+					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "pod")
+				nsPath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, "test-ns")
+				podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, "test-pod")
+				wantPodNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, podPath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantPodNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: time.Unix(0, 0),
+						Principal:   "N/A",
+						VerbType:    commonlogk8saudit_contract.VerbUnknown,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointExistingLogNotFound,
+					}).
+					HasRevision(wantPodNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbNonReady,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetaching,
+					}, nodeTransformer)
+
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
+				wantBSNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, "test-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: time.Unix(0, 0),
+						Principal:   "N/A",
+						VerbType:    commonlogk8saudit_contract.VerbUnknown,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointExistingLogNotFound,
+					}).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbNonReady,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetaching,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "detachNetworkEndpoints for Pod endpoint (GCE_VM_IP_PORT) finish log",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-4",
+					OperationFirst: false,
+					OperationLast:  true,
+					PrincipalEmail: "test-user@google.com",
+				},
+			),
+			prevGroupData: &perNEGHistoryModificationStatus{
+				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-4": {
+						Method: "detachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "test-node",
+									IpAddress: "10.0.0.1",
+									Port:      "80",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				ipLeases := resourcelease.NewResourceLeaseHistory[*commonlogk8saudit_contract.ResourceIdentity]()
+				ipLeases.TouchResourceLease("10.0.0.1", testTime, &commonlogk8saudit_contract.ResourceIdentity{
+					Kind:      "pod",
+					Namespace: "test-ns",
+					Name:      "test-pod",
+				})
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.IPLeaseHistoryInventoryTaskID.Ref(), ipLeases)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints", "op-4")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationSucceed,
+					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "pod")
+				nsPath := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindPath, "test-ns")
+				podPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, nsPath, "test-pod")
+				wantPodNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, podPath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantPodNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbDelete,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetached,
+					}, nodeTransformer)
+
+				bsPath := googlecloudlognetworkapiaudit_contract.MustGCPResourceTimeline(ctx, "test-project", "backendServices", "test-bs")
+				wantBSNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, bsPath, "test-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantBSNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbDelete,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetached,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "concurrent operations on same NEG are tracked independently",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-detach",
+					OperationFirst: false,
+					OperationLast:  true,
+					PrincipalEmail: "test-user@google.com",
+				},
+			),
+			prevGroupData: &perNEGHistoryModificationStatus{
+				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-attach": {
+						Method: "attachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node-1",
+									IpAddress: "10.0.0.1",
+								},
+							},
+						},
+					},
+					"op-detach": {
+						Method: "detachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node-2",
+									IpAddress: "10.0.0.2",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-attach": {
+						Method: "attachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node-1",
+									IpAddress: "10.0.0.1",
+								},
+							},
+						},
+					},
+				},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+				nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, "test-node-2")
+				wantNodeNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, nodePath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodeNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbDelete,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetached,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "missing start log for detach only creates operation log not found and succeed revisions",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-missing",
+					OperationFirst: false,
+					OperationLast:  true,
+					PrincipalEmail: "test-user@google.com",
+				},
+			),
+			prevGroupData: nil,
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				return tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints", "op-missing")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime: time.Unix(0, 0),
+						Principal:   "test-user@google.com",
+						VerbType:    googlecloudcommon_contract.VerbOperationStart,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationStartedLogNotFound,
+					}, nodeTransformer).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationSucceed,
+					}, nodeTransformer)
+			},
+		},
+		{
+			name: "operation failure does not emit success revision on endpoint",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-fail",
+					OperationFirst: false,
+					OperationLast:  true,
+					PrincipalEmail: "test-user@google.com",
+					Status:         1,
+				},
+			),
+			prevGroupData: &perNEGHistoryModificationStatus{
+				OperationTracker: googlecloudcommon_contract.NewGCPOperationTracker(),
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-fail": {
+						Method: "attachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node",
+									IpAddress: "10.0.0.13",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				wantOpPath := googlecloudlognetworkapiaudit_contract.MustNEGOperationTimeline(ctx, wantNEGPath, "v1.Compute.NetworkEndpointGroups.attachNetworkEndpoints", "op-fail")
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantOpPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    googlecloudcommon_contract.VerbOperationFinish,
+						StateType:   googlecloudcommon_contract.RevisionStateOperationFailed,
+					}, nodeTransformer)
+
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+				nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, "test-node")
+				wantNodeNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, nodePath, "test-neg")
+
+				// Node NEG subresource should NOT have any revision added
+				testchangeset.AssertTimeline(t, cs).
+					HasNoRevision(wantNodeNEGPath)
+			},
+		},
+		{
+			name: "detachNetworkEndpoints when endpoint was already known does not emit ExistingLogNotFound",
+			inputLog: testlog.NewMockLog(
+				testTime,
+				googlecloudcommon_contract.GCPAuditLogFieldSet{
+					MethodName:     "v1.Compute.NetworkEndpointGroups.detachNetworkEndpoints",
+					ResourceName:   "projects/test-project/zones/us-central1-a/networkEndpointGroups/test-neg",
+					OperationID:    "op-detach-known",
+					OperationFirst: true,
+					OperationLast:  false,
+					PrincipalEmail: "test-user@google.com",
+					Request:        testReaderFromYAML(t, "networkEndpoints:\n- instance: zones/us-central1-a/instances/test-node\n  ipAddress: 10.0.0.13"),
+				},
+			),
+			prevGroupData: &perNEGHistoryModificationStatus{
+				OperationTracker:  googlecloudcommon_contract.NewGCPOperationTracker(),
+				PendingOperations: map[string]*pendingNEGOperation{},
+				KnownEndpoints: map[string]bool{
+					"node:test-node": true,
+				},
+			},
+			wantGroupData: &perNEGHistoryModificationStatus{
+				PendingOperations: map[string]*pendingNEGOperation{
+					"op-detach-known": {
+						Method: "detachNetworkEndpoints",
+						Request: &negAttachOrDetachRequest{
+							NetworkEndpoints: []*negAttachOrDetachRequestEndpoint{
+								{
+									Instance:  "zones/us-central1-a/instances/test-node",
+									IpAddress: "10.0.0.13",
+								},
+							},
+						},
+					},
+				},
+				KnownEndpoints: map[string]bool{
+					"node:test-node": true,
+				},
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				negs := googlecloudk8scommon_contract.NEGNameToResourceIdentityMap{
+					"test-neg": {
+						Namespace: "test-ns",
+						Name:      "test-neg",
+					},
+				}
+				negToBS := googlecloudk8scommon_contract.NEGToBackendServiceMap{
+					"test-neg": "test-bs",
+				}
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGNamesInventoryTaskID.Ref(), negs)
+				ctx = tasktest.WithTaskResult(ctx, googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(), negToBS)
+				return ctx
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterPath := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiPath := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterPath, "core/v1")
+				kindPath := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiPath, "node")
+				nodePath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindPath, "test-node")
+				wantNodeNEGPath := googlecloudlognetworkapiaudit_contract.MustNEGUnderResourceTimeline(ctx, nodePath, "test-neg")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasRevision(wantNodeNEGPath, &khifilev6.StagingRevision{
+						ChangedTime: testTime,
+						Principal:   "test-user@google.com",
+						VerbType:    commonlogk8saudit_contract.VerbNonReady,
+						StateType:   googlecloudlognetworkapiaudit_contract.RevisionStateNEGEndpointDetaching,
+					}, nodeTransformer)
+
+				if revisions := cs.Revisions[wantNodeNEGPath]; len(revisions) != 1 {
+					t.Errorf("expected exactly 1 revision on %v, got %d", wantNodeNEGPath, len(revisions))
+				}
 			},
 		},
 	}
@@ -305,26 +1164,13 @@ func TestNetworkAPITimelineMapper_ProcessLogByGroup(t *testing.T) {
 				tc.assert(t, ctx, cs)
 			}
 
-			// Wait, assert the returned group data.
 			if tc.wantGroupData != nil {
-				if tc.wantGroupData.LastNegAttachRequest == nil {
-					if gotGroupData.LastNegAttachRequest != nil {
-						t.Errorf("want LastNegAttachRequest to be nil, but got %v", gotGroupData.LastNegAttachRequest)
-					}
-				} else {
-					if gotGroupData.LastNegAttachRequest == nil {
-						t.Errorf("want LastNegAttachRequest to be %v, but got nil", tc.wantGroupData.LastNegAttachRequest)
-					} else {
-						// check network endpoints
-						if len(gotGroupData.LastNegAttachRequest.NetworkEndpoints) != len(tc.wantGroupData.LastNegAttachRequest.NetworkEndpoints) {
-							t.Fatalf("network endpoints length mismatch: want %d, got %d", len(tc.wantGroupData.LastNegAttachRequest.NetworkEndpoints), len(gotGroupData.LastNegAttachRequest.NetworkEndpoints))
-						}
-						for i, wantEndpoint := range tc.wantGroupData.LastNegAttachRequest.NetworkEndpoints {
-							gotEndpoint := gotGroupData.LastNegAttachRequest.NetworkEndpoints[i]
-							if gotEndpoint.Instance != wantEndpoint.Instance || gotEndpoint.IpAddress != wantEndpoint.IpAddress || gotEndpoint.Port != wantEndpoint.Port {
-								t.Errorf("endpoint mismatch: want %+v, got %+v", wantEndpoint, gotEndpoint)
-							}
-						}
+				if diff := cmp.Diff(tc.wantGroupData.PendingOperations, gotGroupData.PendingOperations); diff != "" {
+					t.Errorf("PendingOperations mismatch (-want +got):\n%s", diff)
+				}
+				if tc.wantGroupData.KnownEndpoints != nil {
+					if diff := cmp.Diff(tc.wantGroupData.KnownEndpoints, gotGroupData.KnownEndpoints); diff != "" {
+						t.Errorf("KnownEndpoints mismatch (-want +got):\n%s", diff)
 					}
 				}
 			}


### PR DESCRIPTION
- Support tracking GCE_VM_IP (Node-level) NEG endpoints under Node and BackendService timelines.
- Visualize full lifecycle states for NEG endpoints (Attaching, Attached, Detaching, Detached) across operation start and finish logs (both GCE_VM_IP and GCE_VM_IP).
- Visualize inferred prior existence before detachment with yellow diagonal stripes (ExistingLogNotFound) when the initial attachment log falls outside the inspection window (both GCE_VM_IP and GCE_VM_IP).