### PR TITLE
fix(workbench): preserve single session on lease timeout and verify open state

### DIFF
--- a/pkg/server/workbench/manager.go
+++ b/pkg/server/workbench/manager.go
@@ -94,7 +94,7 @@ func (m *WorkbenchManager) GetOrOpen(ctx context.Context, workbenchID string, in
 	m.mu.Lock()
 	wb, ok := m.workbenches[workbenchID]
 	lease, hasLease := m.leases[workbenchID]
-	if ok && hasLease && lease.After(time.Now()) && !wb.IsClosed() && wb.InspectionID() == inspectionID {
+	if ok && hasLease && (lease.After(time.Now()) || len(m.workbenches) <= 1) && !wb.IsClosed() && wb.InspectionID() == inspectionID {
 		m.leases[workbenchID] = time.Now().Add(m.ttl)
 		m.mu.Unlock()
 		if err := onProgress(apiv1.OpenWorkbenchResponse_STAGE_READY, 100, "Workbench attached."); err != nil {
@@ -194,7 +194,7 @@ func (m *WorkbenchManager) Heartbeat(workbenchID string) (*Workbench, time.Time,
 
 	wb, ok := m.workbenches[workbenchID]
 	lease, hasLease := m.leases[workbenchID]
-	if !ok || !hasLease || time.Now().After(lease) {
+	if !ok || !hasLease || (len(m.workbenches) > 1 && time.Now().After(lease)) {
 		return nil, time.Time{}, ErrWorkbenchNotFound
 	}
 	if wb.IsClosed() {
@@ -234,7 +234,7 @@ func (m *WorkbenchManager) Get(workbenchID string) (*Workbench, error) {
 
 	wb, ok := m.workbenches[workbenchID]
 	lease, hasLease := m.leases[workbenchID]
-	if !ok || !hasLease || time.Now().After(lease) {
+	if !ok || !hasLease || (len(m.workbenches) > 1 && time.Now().After(lease)) {
 		return nil, ErrWorkbenchNotFound
 	}
 	if wb.IsClosed() {

--- a/pkg/server/workbench/manager_test.go
+++ b/pkg/server/workbench/manager_test.go
@@ -430,3 +430,99 @@ func TestNewWorkbenchManager_PanicsOnNilIndexManager(t *testing.T) {
 	}()
 	NewWorkbenchManager(inspectionServer, nil, time.Minute, 0)
 }
+
+func TestWorkbenchManager_SingleWorkbenchRetention(t *testing.T) {
+	inspectionServer, validInspectionID := createTestInspectionServer(t)
+
+	// Short TTL of 20ms
+	mgr := NewWorkbenchManager(inspectionServer, NewInspectionIndexManager(inspectionServer, t.TempDir()), 20*time.Millisecond, 0)
+	defer mgr.Stop()
+
+	wb, err := mgr.GetOrOpen(context.Background(), "single-session-1", validInspectionID, nil)
+	if err != nil {
+		t.Fatalf("GetOrOpen() unexpected error: %v", err)
+	}
+
+	// Wait for TTL to elapse
+	time.Sleep(40 * time.Millisecond)
+
+	// 1. Get() should still succeed because only 1 workbench exists
+	gotWb, err := mgr.Get(wb.ID())
+	if err != nil {
+		t.Errorf("Get() on expired single workbench unexpected error: %v", err)
+	}
+	if gotWb != wb {
+		t.Errorf("Get() workbench = %p, want %p", gotWb, wb)
+	}
+
+	// 2. Heartbeat() should refresh lease and succeed
+	heartbeatWb, newExpiresAt, err := mgr.Heartbeat(wb.ID())
+	if err != nil {
+		t.Errorf("Heartbeat() on expired single workbench unexpected error: %v", err)
+	}
+	if heartbeatWb != wb {
+		t.Errorf("Heartbeat() workbench = %p, want %p", heartbeatWb, wb)
+	}
+	if !newExpiresAt.After(time.Now()) {
+		t.Errorf("Heartbeat() newExpiresAt = %v, want future time", newExpiresAt)
+	}
+
+	// 3. GetOrOpen() with same ID should reattach without error
+	reattachWb, err := mgr.GetOrOpen(context.Background(), wb.ID(), validInspectionID, nil)
+	if err != nil {
+		t.Errorf("GetOrOpen() reattach unexpected error: %v", err)
+	}
+	if reattachWb != wb {
+		t.Errorf("GetOrOpen() reattach workbench = %p, want %p", reattachWb, wb)
+	}
+}
+
+func TestWorkbenchManager_MultipleWorkbenchesExpiration(t *testing.T) {
+	inspectionServer, validInspectionID := createTestInspectionServer(t)
+
+	mgr := NewWorkbenchManager(inspectionServer, NewInspectionIndexManager(inspectionServer, t.TempDir()), 20*time.Millisecond, 0)
+	defer mgr.Stop()
+
+	// Open session 1
+	wb1, err := mgr.GetOrOpen(context.Background(), "multi-session-1", validInspectionID, nil)
+	if err != nil {
+		t.Fatalf("GetOrOpen(session-1) unexpected error: %v", err)
+	}
+
+	// Stagger session 2 slightly so session 1 has an older expiration time
+	time.Sleep(10 * time.Millisecond)
+	wb2, err := mgr.GetOrOpen(context.Background(), "multi-session-2", validInspectionID, nil)
+	if err != nil {
+		t.Fatalf("GetOrOpen(session-2) unexpected error: %v", err)
+	}
+
+	// Wait until both leases have expired
+	time.Sleep(30 * time.Millisecond)
+
+	sweeper := NewSweeper(10 * time.Millisecond)
+
+	// First sweep: should evict oldest expired session (session 1) and leave session 2
+	evicted := sweeper.Sweep(mgr, time.Now())
+	if evicted != 1 {
+		t.Errorf("first Sweep() evicted = %d, want 1", evicted)
+	}
+
+	if _, err := mgr.Get(wb1.ID()); !errors.Is(err, ErrWorkbenchNotFound) {
+		t.Errorf("Get(wb1.ID()) error = %v, want ErrWorkbenchNotFound", err)
+	}
+
+	// wb2 is now the single remaining workbench, so Get() must succeed despite expired lease
+	gotWb2, err := mgr.Get(wb2.ID())
+	if err != nil {
+		t.Errorf("Get(wb2.ID()) unexpected error: %v", err)
+	}
+	if gotWb2 != wb2 {
+		t.Errorf("Get(wb2.ID()) workbench = %p, want %p", gotWb2, wb2)
+	}
+
+	// Second sweep: should NOT evict wb2 because len(leases) <= 1
+	evictedSecond := sweeper.Sweep(mgr, time.Now())
+	if evictedSecond != 0 {
+		t.Errorf("second Sweep() evicted = %d, want 0", evictedSecond)
+	}
+}

--- a/pkg/server/workbench/sweeper.go
+++ b/pkg/server/workbench/sweeper.go
@@ -69,17 +69,31 @@ func (s *Sweeper) Run(target SweeperTarget) {
 	}()
 }
 
-// Sweep inspects target leases and requests removal of sessions that expired before now.
+// Sweep inspects target leases and evicts the oldest expired session when multiple sessions exist.
+// If only one session exists, it is preserved without eviction.
 func (s *Sweeper) Sweep(target SweeperTarget, now time.Time) int {
 	leases := target.Leases()
-	evictedCount := 0
+	if len(leases) <= 1 {
+		return 0
+	}
+
+	var oldestExpiredID string
+	var oldestExpiredTime time.Time
+
 	for id, expiresAt := range leases {
 		if now.After(expiresAt) {
-			target.Remove(id)
-			evictedCount++
+			if oldestExpiredID == "" || expiresAt.Before(oldestExpiredTime) {
+				oldestExpiredID = id
+				oldestExpiredTime = expiresAt
+			}
 		}
 	}
-	return evictedCount
+
+	if oldestExpiredID != "" {
+		target.Remove(oldestExpiredID)
+		return 1
+	}
+	return 0
 }
 
 // Stop terminates the sweeper goroutine and waits for completion.

--- a/pkg/server/workbench/sweeper_test.go
+++ b/pkg/server/workbench/sweeper_test.go
@@ -58,20 +58,52 @@ func TestSweeper_Sweep(t *testing.T) {
 		wantRemoved []string
 	}{
 		{
-			name: "evicts expired leases only",
+			name: "preserves single expired lease without eviction",
+			leases: map[string]time.Time{
+				"wb-expired-single": baseTime.Add(-10 * time.Second),
+			},
+			now:         baseTime,
+			wantRemoved: nil,
+		},
+		{
+			name: "evicts oldest expired lease when multiple expired exist",
+			leases: map[string]time.Time{
+				"wb-expired-1": baseTime.Add(-10 * time.Second),
+				"wb-expired-2": baseTime.Add(-1 * time.Second),
+			},
+			now:         baseTime,
+			wantRemoved: []string{"wb-expired-1"},
+		},
+		{
+			name: "evicts oldest expired lease when mixed with active leases",
 			leases: map[string]time.Time{
 				"wb-expired-1": baseTime.Add(-10 * time.Second),
 				"wb-expired-2": baseTime.Add(-1 * time.Second),
 				"wb-active-1":  baseTime.Add(10 * time.Second),
 			},
 			now:         baseTime,
-			wantRemoved: []string{"wb-expired-1", "wb-expired-2"},
+			wantRemoved: []string{"wb-expired-1"},
 		},
 		{
 			name: "does nothing when all active",
 			leases: map[string]time.Time{
 				"wb-active-1": baseTime.Add(10 * time.Second),
+				"wb-active-2": baseTime.Add(20 * time.Second),
 			},
+			now:         baseTime,
+			wantRemoved: nil,
+		},
+		{
+			name: "does nothing when single active lease exists",
+			leases: map[string]time.Time{
+				"wb-active-1": baseTime.Add(10 * time.Second),
+			},
+			now:         baseTime,
+			wantRemoved: nil,
+		},
+		{
+			name:        "does nothing when leases is empty",
+			leases:      map[string]time.Time{},
 			now:         baseTime,
 			wantRemoved: nil,
 		},
@@ -108,7 +140,8 @@ func TestSweeper_RunAndStop(t *testing.T) {
 	sweeper := NewSweeper(10 * time.Millisecond)
 	target := &mockSweeperTarget{
 		leases: map[string]time.Time{
-			"session-auto-1": time.Now().Add(-1 * time.Minute),
+			"session-auto-1": time.Now().Add(-2 * time.Minute),
+			"session-auto-2": time.Now().Add(-1 * time.Minute),
 		},
 	}
 

--- a/web/src/app/services/data-loader.service.spec.ts
+++ b/web/src/app/services/data-loader.service.spec.ts
@@ -195,6 +195,28 @@ describe('InspectionDataLoaderService', () => {
       ).not.toHaveBeenCalled();
     });
 
+    it('should dismiss progress and alert when openWorkbench returns undefined', async () => {
+      const alertSpy = spyOn(window, 'alert').and.stub();
+      spyOn(console, 'error').and.stub();
+
+      mockBackendService.getInspectionData.and.returnValue(
+        of({
+          fileName: 'test.khi',
+          content: new Blob(['fake-data']),
+        }),
+      );
+
+      mockWorkbenchClient.openWorkbench.and.resolveTo(undefined);
+
+      await service.loadInspectionDataFromBackend('insp-1');
+
+      expect(mockProgress.dismiss).toHaveBeenCalled();
+      expect(alertSpy).toHaveBeenCalled();
+      expect(
+        mockInspectionDataStore.setNewInspectionData,
+      ).not.toHaveBeenCalled();
+    });
+
     it('should dismiss progress and alert on getInspectionData failure', async () => {
       const alertSpy = spyOn(window, 'alert').and.stub();
       spyOn(console, 'error').and.stub();

--- a/web/src/app/services/data-loader.service.ts
+++ b/web/src/app/services/data-loader.service.ts
@@ -204,10 +204,13 @@ export class InspectionDataLoaderService {
     })();
 
     try {
-      const [{ parsedData, rawInspectionData }] = await Promise.all([
-        localTask,
-        serverTask,
-      ]);
+      const [{ parsedData, rawInspectionData }, workbenchId] =
+        await Promise.all([localTask, serverTask]);
+      if (!workbenchId) {
+        throw new Error(
+          'Failed to initialize or attach to the workbench session on the backend.',
+        );
+      }
       this.inspectionDataStore.setNewInspectionData(parsedData);
       this.extension.notifyLifecycleOnInspectionDataOpen(
         parsedData,


### PR DESCRIPTION
### Summary
This PR fixes an issue where inspecting a large file or switching tabs could cause the Workbench session to expire unexpectedly, treating the Workbench as closed and losing the session.

- **Backend Sweeper**: Skips session eviction when `len(leases) <= 1`. When multiple sessions exist, evicts the single oldest expired session per sweep cycle, naturally converging to retain the most recent session.
- **Backend WorkbenchManager**: In `Heartbeat` and `Get`, preserves the session and allows refreshing the lease even after TTL expiration when `len(workbenches) <= 1`. In `GetOrOpen`, allows reattaching to the existing session without re-reading when `len(workbenches) <= 1`.
- **Frontend DataLoaderService**: Verifies `workbenchId` returned from `openWorkbench` and throws an error if missing, preventing an inconsistent half-loaded state.
- **Unit Tests**: Added tests covering single session retention, oldest-expired session eviction, and frontend failure handling.