### PR TITLE
chore(github): reorganize issue and PR label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: "Bug report \U0001F41E"
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'type:bug, status:needs-triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,7 @@
 name: "Feature request \U0001F680"
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'type:feature, status:needs-triage'
 assignees: ''
 
 ---

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -16,29 +16,40 @@ changelog:
   categories:
     - title: New features 🎉
       labels:
-        - features
+        - type:feature
     - title: Bug Fixes 🐛
       labels:
-        - bug
+        - type:bug
+    - title: Performance Improvements ⚡
+      labels:
+        - type:perf
+    - title: Refactoring ♻️
+      labels:
+        - type:refactor
     - title: CI/CD ⚙️
       labels:
-        - cicd
+        - area:cicd
     - title: Development Environment 💻
       labels:
-        - devenv
+        - area:devenv
     - title: Documentation 📝
       labels:
-        - documentation
+        - type:docs
     - title: Other Changes 🛠
       labels:
         - "*"
       exclude:
         labels:
-          - features
-          - bug
-          - cicd
-          - devenv
-          - documentation
+          - type:feature
+          - type:bug
+          - type:perf
+          - type:refactor
+          - area:cicd
+          - area:devenv
+          - type:docs
+          - dependencies
+          - type:chore
     - title: Dependencies ⏫
       labels:
         - dependencies
+        - type:chore

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -49,7 +49,9 @@ changelog:
           - type:docs
           - dependencies
           - type:chore
+    - title: Maintenance 🧹
+      labels:
+        - type:chore
     - title: Dependencies ⏫
       labels:
         - dependencies
-        - type:chore


### PR DESCRIPTION
## Description

Reorganizes the GitHub issue and PR label system to improve discoverability, triage ergonomics, and alignment with release automation:

- **Release Notes Configuration (`.github/release.yml`)**:
  - Updates changelog categories to use the new taxonomy (`type:feature`, `type:bug`, `type:perf`, `type:refactor`, `area:cicd`, `area:devenv`, `type:docs`, `type:chore`).
  - Fixes category matching for features (previously pointed to non-existent `features` label).
  - Excludes categorized labels from the "Other Changes" section.
- **Issue Templates (`.github/ISSUE_TEMPLATE/`)**:
  - Sets default labels `'type:bug, status:needs-triage'` for `bug-report.md`.
  - Sets default labels `'type:feature, status:needs-triage'` for `feature-request.md`.

*(Note: The corresponding GitHub repository labels on `GoogleCloudPlatform/khi` have already been updated/created/deleted in tandem.)*

## Type of change

- [x] Maintenance / Chore