### PR TITLE
feat(k8sevent): replace resource UIDs with readable names in event summaries

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/contract/eventsummary.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/eventsummary.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commonlogk8saudit_contract
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
+)
+
+// EventMessageUIDStarterRunes are delimiters that may precede a Kubernetes resource UID in event messages.
+var EventMessageUIDStarterRunes = []rune{'"', ' ', '=', ':', '/', '(', '[', '\'', '#'}
+
+// FormatEventSummary constructs an event log summary and replaces any detected resource UIDs with their readable tags.
+func FormatEventSummary(reason, message string, uidFinder patternfinder.PatternFinder[*ResourceIdentity]) string {
+	if message == "" {
+		return fmt.Sprintf("【%s】", reason)
+	}
+	matches := patternfinder.FindAllWithStarterRunes(message, uidFinder, true, EventMessageUIDStarterRunes...)
+	if len(matches) == 0 {
+		return fmt.Sprintf("【%s】%s", reason, message)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("【%s】", reason))
+	lastIndex := 0
+	for _, match := range matches {
+		sb.WriteString(message[lastIndex:match.Start])
+		sb.WriteString(match.Value.SummaryTag())
+		lastIndex = match.End
+	}
+	sb.WriteString(message[lastIndex:])
+	return sb.String()
+}

--- a/pkg/task/inspection/commonlogk8saudit/contract/eventsummary_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/eventsummary_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commonlogk8saudit_contract
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFormatEventSummary(t *testing.T) {
+	testCases := []struct {
+		desc                    string
+		reason                  string
+		message                 string
+		resourceIdentitiesByUID map[string]*ResourceIdentity
+		want                    string
+	}{
+		{
+			desc:    "empty message returns bracketed reason",
+			reason:  "Scheduled",
+			message: "",
+			want:    "【Scheduled】",
+		},
+		{
+			desc:    "message without UIDs returns reason and message",
+			reason:  "Scheduled",
+			message: "Successfully assigned default/my-pod to node-1",
+			want:    "【Scheduled】Successfully assigned default/my-pod to node-1",
+		},
+		{
+			desc:    "message with single UID replaces UID with summary tag",
+			reason:  "Scheduled",
+			message: "Assigned pod (UID: 11112222-3333-4444-5555-666677778888) to node",
+			resourceIdentitiesByUID: map[string]*ResourceIdentity{
+				"11112222-3333-4444-5555-666677778888": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-pod",
+				},
+			},
+			want: "【Scheduled】Assigned pod (UID: 【my-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】) to node",
+		},
+		{
+			desc:    "message with multiple distinct UIDs replaces all UIDs",
+			reason:  "SyncLoop",
+			message: "Processing pod: uid-1 and service: uid-2",
+			resourceIdentitiesByUID: map[string]*ResourceIdentity{
+				"uid-1": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-pod",
+				},
+				"uid-2": {
+					APIVersion: "core/v1",
+					Kind:       "service",
+					Namespace:  "default",
+					Name:       "my-service",
+				},
+			},
+			want: "【SyncLoop】Processing pod: 【my-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】 and service: 【my-service (Namespace: default, APIVersion: core/v1, Kind: service)】",
+		},
+		{
+			desc:    "message with duplicate UID occurrences replaces all instances",
+			reason:  "SyncLoop",
+			message: "Processing pod: uid-1 and retry for uid-1",
+			resourceIdentitiesByUID: map[string]*ResourceIdentity{
+				"uid-1": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-pod",
+				},
+			},
+			want: "【SyncLoop】Processing pod: 【my-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】 and retry for 【my-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】",
+		},
+		{
+			desc:    "message with cluster-scoped resource UID formats tag without namespace",
+			reason:  "NodeReady",
+			message: "Node uid-node is ready",
+			resourceIdentitiesByUID: map[string]*ResourceIdentity{
+				"uid-node": {
+					APIVersion: "core/v1",
+					Kind:       "node",
+					Namespace:  "",
+					Name:       "node-1",
+				},
+			},
+			want: "【NodeReady】Node 【node-1 (APIVersion: core/v1, Kind: node)】 is ready",
+		},
+		{
+			desc:    "message with unindexed UID leaves text unchanged",
+			reason:  "FailedScheduling",
+			message: "Pod with unknown UID 00000000-0000-0000-0000-000000000000 cannot be scheduled",
+			resourceIdentitiesByUID: map[string]*ResourceIdentity{
+				"other-uid": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "other-pod",
+				},
+			},
+			want: "【FailedScheduling】Pod with unknown UID 00000000-0000-0000-0000-000000000000 cannot be scheduled",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			finder := patternfinder.NewNaivePatternFinder[*ResourceIdentity]()
+			for k, v := range tc.resourceIdentitiesByUID {
+				_ = finder.AddPattern(k, v)
+			}
+			got := FormatEventSummary(tc.reason, tc.message, finder)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("FormatEventSummary() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/commonlogk8saudit/contract/type.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/type.go
@@ -121,6 +121,14 @@ func (r *ResourceIdentity) ParentIdentity() *ResourceIdentity {
 	}
 }
 
+// SummaryTag formats a resource's name, namespace, API version, and kind into a bracketed log summary tag.
+func (r *ResourceIdentity) SummaryTag() string {
+	if r.Namespace == "" {
+		return fmt.Sprintf("【%s (APIVersion: %s, Kind: %s)】", r.Name, r.APIVersion, r.Kind)
+	}
+	return fmt.Sprintf("【%s (Namespace: %s, APIVersion: %s, Kind: %s)】", r.Name, r.Namespace, r.APIVersion, r.Kind)
+}
+
 var _ resourcelease.LeaseHolder = (*ResourceIdentity)(nil)
 
 type ContainerIdentity struct {

--- a/pkg/task/inspection/commonlogk8saudit/contract/type_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/contract/type_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commonlogk8saudit_contract
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestResourceIdentity_SummaryTag(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		identity *ResourceIdentity
+		want     string
+	}{
+		{
+			desc: "namespaced resource",
+			identity: &ResourceIdentity{
+				APIVersion: "core/v1",
+				Kind:       "pod",
+				Namespace:  "default",
+				Name:       "my-pod",
+			},
+			want: "【my-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】",
+		},
+		{
+			desc: "cluster-scoped resource with empty namespace",
+			identity: &ResourceIdentity{
+				APIVersion: "core/v1",
+				Kind:       "node",
+				Namespace:  "",
+				Name:       "node-1",
+			},
+			want: "【node-1 (APIVersion: core/v1, Kind: node)】",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := tc.identity.SummaryTag()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("SummaryTag() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"strings"
-
 	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
@@ -31,9 +29,6 @@ import (
 	googlecloudlogk8sevent_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8sevent/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
-
-// eventMessageUIDStarterRunes are delimiters that may precede a Kubernetes resource UID in event messages.
-var eventMessageUIDStarterRunes = []rune{'"', ' ', '=', ':', '/', '(', '[', '\'', '#'}
 
 // KubernetesEventLogIngester handles log ingestion into the KHI v6 builder format.
 type KubernetesEventLogIngester struct{}
@@ -48,37 +43,6 @@ func (i *KubernetesEventLogIngester) Dependencies() []taskid.UntypedTaskReferenc
 	return []taskid.UntypedTaskReference{
 		commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(),
 	}
-}
-
-// formatEventSummary constructs the event summary and replaces any detected resource UIDs with their readable strings.
-func formatEventSummary(reason, message string, finder patternfinder.PatternFinder[*commonlogk8saudit_contract.ResourceIdentity]) string {
-	if message == "" {
-		return fmt.Sprintf("【%s】", reason)
-	}
-	if finder == nil {
-		return fmt.Sprintf("【%s】%s", reason, message)
-	}
-	matches := patternfinder.FindAllWithStarterRunes(message, finder, true, eventMessageUIDStarterRunes...)
-	if len(matches) == 0 {
-		return fmt.Sprintf("【%s】%s", reason, message)
-	}
-
-	var sb strings.Builder
-	sb.WriteString("【")
-	sb.WriteString(reason)
-	sb.WriteString("】")
-
-	lastIndex := 0
-	for _, match := range matches {
-		if match.Start < lastIndex {
-			continue
-		}
-		sb.WriteString(message[lastIndex:match.Start])
-		sb.WriteString(match.Value.SummaryTag())
-		lastIndex = match.End
-	}
-	sb.WriteString(message[lastIndex:])
-	return sb.String()
 }
 
 // ProcessLog processes a raw log entry and populates its metadata into LogChangeSet.
@@ -99,7 +63,7 @@ func (i *KubernetesEventLogIngester) ProcessLog(ctx context.Context, l *log.Log)
 		return nil, fmt.Errorf("failed to extract kubernetes event: %w", err)
 	}
 	finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
-	cs.SetSummary(formatEventSummary(event.Reason, event.Message, finder))
+	cs.SetSummary(commonlogk8saudit_contract.FormatEventSummary(event.Reason, event.Message, finder))
 
 	return cs, nil
 }
@@ -161,7 +125,7 @@ func (m *KubernetesEventTimelineMapper) ProcessLogByGroup(ctx context.Context, l
 	if event.Message != "" {
 		finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
 		if finder != nil {
-			matches := patternfinder.FindAllWithStarterRunes(event.Message, finder, true, eventMessageUIDStarterRunes...)
+			matches := patternfinder.FindAllWithStarterRunes(event.Message, finder, true, commonlogk8saudit_contract.EventMessageUIDStarterRunes...)
 			for _, match := range matches {
 				matchedPath := commonlogk8saudit_contract.MustResourceTimeline(ctx, event.ClusterName, match.Value)
 				cs.AddEvent(matchedPath)

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task.go
@@ -18,16 +18,22 @@ import (
 	"context"
 	"fmt"
 
+	"strings"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
 	googlecloudcommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudcommon/contract"
-	googlecloudk8scommon_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudk8scommon/contract"
 	googlecloudlogk8sevent_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/googlecloudlogk8sevent/contract"
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 )
+
+// eventMessageUIDStarterRunes are delimiters that may precede a Kubernetes resource UID in event messages.
+var eventMessageUIDStarterRunes = []rune{'"', ' ', '=', ':', '/', '(', '[', '\'', '#'}
 
 // KubernetesEventLogIngester handles log ingestion into the KHI v6 builder format.
 type KubernetesEventLogIngester struct{}
@@ -39,7 +45,40 @@ func (i *KubernetesEventLogIngester) RawLogTask() taskid.TaskReference[[]*log.Lo
 
 // Dependencies returns additional task dependencies of the ingester.
 func (i *KubernetesEventLogIngester) Dependencies() []taskid.UntypedTaskReference {
-	return []taskid.UntypedTaskReference{}
+	return []taskid.UntypedTaskReference{
+		commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(),
+	}
+}
+
+// formatEventSummary constructs the event summary and replaces any detected resource UIDs with their readable strings.
+func formatEventSummary(reason, message string, finder patternfinder.PatternFinder[*commonlogk8saudit_contract.ResourceIdentity]) string {
+	if message == "" {
+		return fmt.Sprintf("【%s】", reason)
+	}
+	if finder == nil {
+		return fmt.Sprintf("【%s】%s", reason, message)
+	}
+	matches := patternfinder.FindAllWithStarterRunes(message, finder, true, eventMessageUIDStarterRunes...)
+	if len(matches) == 0 {
+		return fmt.Sprintf("【%s】%s", reason, message)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("【")
+	sb.WriteString(reason)
+	sb.WriteString("】")
+
+	lastIndex := 0
+	for _, match := range matches {
+		if match.Start < lastIndex {
+			continue
+		}
+		sb.WriteString(message[lastIndex:match.Start])
+		sb.WriteString(match.Value.SummaryTag())
+		lastIndex = match.End
+	}
+	sb.WriteString(message[lastIndex:])
+	return sb.String()
 }
 
 // ProcessLog processes a raw log entry and populates its metadata into LogChangeSet.
@@ -55,11 +94,12 @@ func (i *KubernetesEventLogIngester) ProcessLog(ctx context.Context, l *log.Log)
 		cs.SetSeverity(severity)
 	}
 
-	eventFS, err := googlecloudlogk8sevent_contract.ExtractKubernetesEvent(l.NodeReader)
+	event, err := googlecloudlogk8sevent_contract.ExtractKubernetesEvent(l.NodeReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract kubernetes event: %w", err)
 	}
-	cs.SetSummary(fmt.Sprintf("【%s】%s", eventFS.Reason, eventFS.Message))
+	finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
+	cs.SetSummary(formatEventSummary(event.Reason, event.Message, finder))
 
 	return cs, nil
 }
@@ -98,7 +138,7 @@ func (m *KubernetesEventTimelineMapper) LogIngesterTask() taskid.TaskReference[s
 // Dependencies returns additional task dependencies.
 func (m *KubernetesEventTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
 	return []taskid.UntypedTaskReference{
-		googlecloudk8scommon_contract.NEGToBackendServiceInventoryTaskID.Ref(),
+		commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(),
 	}
 }
 
@@ -107,17 +147,27 @@ func (m *KubernetesEventTimelineMapper) GroupedLogTask() taskid.TaskReference[in
 	return googlecloudlogk8sevent_contract.LogGrouperTaskID.Ref()
 }
 
-// ProcessLogByGroup maps a single GKE Event Log to its resource timeline path.
+// ProcessLogByGroup maps a single GKE Event Log to its resource timeline path and matches any resource UIDs in the message.
 func (m *KubernetesEventTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	event, err := googlecloudlogk8sevent_contract.ExtractKubernetesEvent(l.NodeReader)
 	if err != nil {
 		return nil, struct{}{}, fmt.Errorf("failed to extract kubernetes event: %w", err)
 	}
 
-	targetPath := MustResolveK8sResourceTimelinePath(ctx, &event)
-
+	primaryResourcePath := MustResolveK8sResourceTimelinePath(ctx, &event)
 	cs := khifilev6.NewTimelineChangeSet(l)
-	cs.AddEvent(targetPath)
+	cs.AddEvent(primaryResourcePath)
+
+	if event.Message != "" {
+		finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
+		if finder != nil {
+			matches := patternfinder.FindAllWithStarterRunes(event.Message, finder, true, eventMessageUIDStarterRunes...)
+			for _, match := range matches {
+				matchedPath := commonlogk8saudit_contract.MustResourceTimeline(ctx, event.ClusterName, match.Value)
+				cs.AddEvent(matchedPath)
+			}
+		}
+	}
 
 	return cs, struct{}{}, nil
 }

--- a/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task_test.go
+++ b/pkg/task/inspection/googlecloudlogk8sevent/impl/parser_task_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
@@ -37,9 +39,10 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testCases := []struct {
-		desc   string
-		input  googlecloudlogk8sevent_contract.KubernetesEventFieldSet
-		assert func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+		desc                    string
+		input                   googlecloudlogk8sevent_contract.KubernetesEventFieldSet
+		resourceIdentitiesByUID map[string]*commonlogk8saudit_contract.ResourceIdentity
+		assert                  func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc: "namespaced resource event",
@@ -60,7 +63,8 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				expectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "test-deployment")
 
 				testchangeset.AssertTimeline(t, cs).
-					HasEvent(expectedPath)
+					HasEvent(expectedPath).
+					HasEventCount(1)
 			},
 		},
 		{
@@ -81,7 +85,8 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				expectedPath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindTimeline, "my-node")
 
 				testchangeset.AssertTimeline(t, cs).
-					HasEvent(expectedPath)
+					HasEvent(expectedPath).
+					HasEventCount(1)
 			},
 		},
 		{
@@ -109,7 +114,147 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 				})
 
 				testchangeset.AssertTimeline(t, cs).
-					HasEvent(expectedPath)
+					HasEvent(expectedPath).
+					HasEventCount(1)
+			},
+		},
+		{
+			desc: "event with UID in message matching another resource",
+			input: googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+				ClusterName:  "test-cluster",
+				APIVersion:   "batch/v1",
+				ResourceKind: "job",
+				Namespace:    "default",
+				Resource:     "my-job",
+				Reason:       "SuccessfulCreate",
+				Message:      `Created pod: my-job-pod (UID: a1b2c3d4-e5f6-7890-abcd-ef0123456789)`,
+			},
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"a1b2c3d4-e5f6-7890-abcd-ef0123456789": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-job-pod",
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+				jobAPIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "batch/v1")
+				jobKindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, jobAPIVersionTimeline, "job")
+				jobNamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, jobKindTimeline, "default")
+				jobExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, jobNamespaceTimeline, "my-job")
+
+				podAPIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				podKindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, podAPIVersionTimeline, "pod")
+				podNamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, podKindTimeline, "default")
+				podExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, podNamespaceTimeline, "my-job-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(jobExpectedPath).
+					HasEvent(podExpectedPath).
+					HasEventCount(2)
+			},
+		},
+		{
+			desc: "event with UID in message matching primary resource does not duplicate event",
+			input: googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+				ClusterName:  "test-cluster",
+				APIVersion:   "core/v1",
+				ResourceKind: "pod",
+				Namespace:    "default",
+				Resource:     "my-pod",
+				Reason:       "Killing",
+				Message:      `Stopping container my-pod with uid 11112222-3333-4444-5555-666677778888`,
+			},
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"11112222-3333-4444-5555-666677778888": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-pod",
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+				namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "default")
+				expectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "my-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath).
+					HasEventCount(1)
+			},
+		},
+		{
+			desc: "event with multiple distinct UIDs and duplicate secondary UID occurrences",
+			input: googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+				ClusterName:  "test-cluster",
+				APIVersion:   "batch/v1",
+				ResourceKind: "job",
+				Namespace:    "default",
+				Resource:     "my-job",
+				Reason:       "SuccessfulCreate",
+				Message:      `Created pod: pod-1 (UID: uid-1) and pod-2 (UID: uid-2). Duplicate ref: uid-1`,
+			},
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"uid-1": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "pod-1",
+				},
+				"uid-2": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "pod-2",
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+				jobAPIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "batch/v1")
+				jobKindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, jobAPIVersionTimeline, "job")
+				jobNamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, jobKindTimeline, "default")
+				jobExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, jobNamespaceTimeline, "my-job")
+
+				pod1APIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				pod1KindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, pod1APIVersionTimeline, "pod")
+				pod1NamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, pod1KindTimeline, "default")
+				pod1ExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, pod1NamespaceTimeline, "pod-1")
+
+				pod2APIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				pod2KindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, pod2APIVersionTimeline, "pod")
+				pod2NamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, pod2KindTimeline, "default")
+				pod2ExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, pod2NamespaceTimeline, "pod-2")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(jobExpectedPath).
+					HasEvent(pod1ExpectedPath).
+					HasEvent(pod2ExpectedPath).
+					HasEventCount(3)
+			},
+		},
+		{
+			desc: "event with empty message stages primary resource only",
+			input: googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+				ClusterName:  "test-cluster",
+				APIVersion:   "core/v1",
+				ResourceKind: "pod",
+				Namespace:    "default",
+				Resource:     "my-pod",
+				Message:      "",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "test-cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+				namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "default")
+				expectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "my-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath).
+					HasEventCount(1)
 			},
 		},
 	}
@@ -119,6 +264,13 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 
 			// Set up context with the same Builder reference.
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			finder := patternfinder.NewNaivePatternFinder[*commonlogk8saudit_contract.ResourceIdentity]()
+			if tc.resourceIdentitiesByUID != nil {
+				for k, v := range tc.resourceIdentitiesByUID {
+					_ = finder.AddPattern(k, v)
+				}
+			}
+			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(), finder)
 			mapper := KubernetesEventTimelineMapper{}
 
 			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})
@@ -133,12 +285,13 @@ func TestLogToTimelineMapperTask(t *testing.T) {
 
 func TestKubernetesEventLogIngester_ProcessLog(t *testing.T) {
 	testCases := []struct {
-		name   string
-		input  *log.Log
-		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
+		desc                    string
+		input                   *log.Log
+		resourceIdentitiesByUID map[string]*commonlogk8saudit_contract.ResourceIdentity
+		assert                  func(t *testing.T, cs *khifilev6.LogChangeSet)
 	}{
 		{
-			name: "successful event log ingestion",
+			desc: "successful event log ingestion without UID",
 			input: testlog.NewMockLog(
 				time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
 				inspectioncore_contract.DefaultSeverityFieldSet{
@@ -157,12 +310,85 @@ func TestKubernetesEventLogIngester_ProcessLog(t *testing.T) {
 					HasSummary("【Scheduled】Successfully assigned default/test-pod to node-1")
 			},
 		},
+		{
+			desc: "replaces resource UID in message with readable name",
+			input: testlog.NewMockLog(
+				time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+				googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+					Reason:  "SuccessfulCreate",
+					Message: "Created pod: my-job-pod (UID: a1b2c3d4-e5f6-7890-abcd-ef0123456789)",
+				},
+			),
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"a1b2c3d4-e5f6-7890-abcd-ef0123456789": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-job-pod",
+				},
+			},
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("【SuccessfulCreate】Created pod: my-job-pod (UID: 【my-job-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】)")
+			},
+		},
+		{
+			desc: "replaces multiple distinct UIDs and duplicate UID occurrences in message",
+			input: testlog.NewMockLog(
+				time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+				googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+					Reason:  "SyncLoop",
+					Message: `Processing pod: a1b2c3d4-e5f6-7890-abcd-ef0123456789 and service: f9e8d7c6-b5a4-3210-fedc-ba9876543210 (retry for a1b2c3d4-e5f6-7890-abcd-ef0123456789)`,
+				},
+			),
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"a1b2c3d4-e5f6-7890-abcd-ef0123456789": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-job-pod",
+				},
+				"f9e8d7c6-b5a4-3210-fedc-ba9876543210": {
+					APIVersion: "core/v1",
+					Kind:       "service",
+					Namespace:  "default",
+					Name:       "my-service",
+				},
+			},
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("【SyncLoop】Processing pod: 【my-job-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】 and service: 【my-service (Namespace: default, APIVersion: core/v1, Kind: service)】 (retry for 【my-job-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】)")
+			},
+		},
+		{
+			desc: "event with empty message",
+			input: testlog.NewMockLog(
+				time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+				googlecloudlogk8sevent_contract.KubernetesEventFieldSet{
+					Reason:  "Scheduled",
+					Message: "",
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)).
+					HasSeverity(inspectioncore_contract.SeverityUnknown).
+					HasLogType(commonlogk8saudit_contract.LogTypeEvent).
+					HasSummary("【Scheduled】")
+			},
+		},
 	}
 
 	ingester := &KubernetesEventLogIngester{}
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := t.Context()
+		t.Run(tc.desc, func(t *testing.T) {
+			finder := patternfinder.NewNaivePatternFinder[*commonlogk8saudit_contract.ResourceIdentity]()
+			if tc.resourceIdentitiesByUID != nil {
+				for k, v := range tc.resourceIdentitiesByUID {
+					_ = finder.AddPattern(k, v)
+				}
+			}
+			ctx := tasktest.WithTaskResult(t.Context(), commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(), finder)
 
 			cs, err := ingester.ProcessLog(ctx, tc.input)
 			if err != nil {

--- a/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task.go
@@ -18,7 +18,11 @@ import (
 	"context"
 	"fmt"
 
+	"strings"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
+	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
 	"github.com/GoogleCloudPlatform/khi/pkg/core/task/taskid"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
@@ -26,6 +30,9 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	ossclusterk8s_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/ossclusterk8s/contract"
 )
+
+// eventMessageUIDStarterRunes are delimiters that may precede a Kubernetes resource UID in event messages.
+var eventMessageUIDStarterRunes = []rune{'"', ' ', '=', ':', '/', '(', '[', '\'', '#'}
 
 // OSSK8sEventLogIngester handles event log metadata ingestion.
 type OSSK8sEventLogIngester struct{}
@@ -37,7 +44,40 @@ func (i *OSSK8sEventLogIngester) RawLogTask() taskid.TaskReference[[]*log.Log] {
 
 // Dependencies returns additional dependencies of the ingester.
 func (i *OSSK8sEventLogIngester) Dependencies() []taskid.UntypedTaskReference {
-	return []taskid.UntypedTaskReference{}
+	return []taskid.UntypedTaskReference{
+		commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(),
+	}
+}
+
+// formatEventSummary constructs the event summary and replaces any detected resource UIDs with their readable strings.
+func formatEventSummary(reason, message string, finder patternfinder.PatternFinder[*commonlogk8saudit_contract.ResourceIdentity]) string {
+	if message == "" {
+		return fmt.Sprintf("【%s】", reason)
+	}
+	if finder == nil {
+		return fmt.Sprintf("【%s】%s", reason, message)
+	}
+	matches := patternfinder.FindAllWithStarterRunes(message, finder, true, eventMessageUIDStarterRunes...)
+	if len(matches) == 0 {
+		return fmt.Sprintf("【%s】%s", reason, message)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("【")
+	sb.WriteString(reason)
+	sb.WriteString("】")
+
+	lastIndex := 0
+	for _, match := range matches {
+		if match.Start < lastIndex {
+			continue
+		}
+		sb.WriteString(message[lastIndex:match.Start])
+		sb.WriteString(match.Value.SummaryTag())
+		lastIndex = match.End
+	}
+	sb.WriteString(message[lastIndex:])
+	return sb.String()
 }
 
 // ProcessLog populates metadata into the LogChangeSet.
@@ -49,11 +89,12 @@ func (i *OSSK8sEventLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*k
 	cs.SetLogType(commonlogk8saudit_contract.LogTypeEvent)
 	cs.SetTimestamp(l.Timestamp)
 
-	eventFS, err := ossclusterk8s_contract.ExtractOSSK8sEvent(l.NodeReader)
+	event, err := ossclusterk8s_contract.ExtractOSSK8sEvent(l.NodeReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OSS k8s event fieldset: %w", err)
 	}
-	cs.SetSummary(fmt.Sprintf("【%s】%s", eventFS.Reason, eventFS.Message))
+	finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
+	cs.SetSummary(formatEventSummary(event.Reason, event.Message, finder))
 	cs.SetSeverity(inspectioncore_contract.SeverityUnknown)
 
 	return cs, nil
@@ -92,7 +133,9 @@ func (m *OSSK8sEventTimelineMapper) LogIngesterTask() taskid.TaskReference[struc
 
 // Dependencies returns additional mapper dependencies.
 func (m *OSSK8sEventTimelineMapper) Dependencies() []taskid.UntypedTaskReference {
-	return []taskid.UntypedTaskReference{}
+	return []taskid.UntypedTaskReference{
+		commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(),
+	}
 }
 
 // GroupedLogTask returns the task providing grouped logs.
@@ -100,17 +143,27 @@ func (m *OSSK8sEventTimelineMapper) GroupedLogTask() taskid.TaskReference[inspec
 	return ossclusterk8s_contract.OSSK8sEventLogGrouperTaskID.Ref()
 }
 
-// ProcessLogByGroup maps a single event log to its resource timeline.
+// ProcessLogByGroup maps a single event log to its resource timeline and matches any resource UIDs in the message.
 func (m *OSSK8sEventTimelineMapper) ProcessLogByGroup(ctx context.Context, l *log.Log, _ struct{}) (*khifilev6.TimelineChangeSet, struct{}, error) {
 	event, err := ossclusterk8s_contract.ExtractOSSK8sEvent(l.NodeReader)
 	if err != nil {
 		return nil, struct{}{}, fmt.Errorf("failed to get OSS k8s event fieldset: %w", err)
 	}
 
-	targetPath := commonlogk8saudit_contract.MustResourceTimeline(ctx, "cluster", event.ResourceIdentity())
-
+	primaryResourcePath := commonlogk8saudit_contract.MustResourceTimeline(ctx, "cluster", event.ResourceIdentity())
 	cs := khifilev6.NewTimelineChangeSet(l)
-	cs.AddEvent(targetPath)
+	cs.AddEvent(primaryResourcePath)
+
+	if event.Message != "" {
+		finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
+		if finder != nil {
+			matches := patternfinder.FindAllWithStarterRunes(event.Message, finder, true, eventMessageUIDStarterRunes...)
+			for _, match := range matches {
+				matchedPath := commonlogk8saudit_contract.MustResourceTimeline(ctx, "cluster", match.Value)
+				cs.AddEvent(matchedPath)
+			}
+		}
+	}
 
 	return cs, struct{}{}, nil
 }

--- a/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"strings"
-
 	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
 	inspectiontaskbase "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/taskbase"
 	coretask "github.com/GoogleCloudPlatform/khi/pkg/core/task"
@@ -30,9 +28,6 @@ import (
 	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
 	ossclusterk8s_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/ossclusterk8s/contract"
 )
-
-// eventMessageUIDStarterRunes are delimiters that may precede a Kubernetes resource UID in event messages.
-var eventMessageUIDStarterRunes = []rune{'"', ' ', '=', ':', '/', '(', '[', '\'', '#'}
 
 // OSSK8sEventLogIngester handles event log metadata ingestion.
 type OSSK8sEventLogIngester struct{}
@@ -49,37 +44,6 @@ func (i *OSSK8sEventLogIngester) Dependencies() []taskid.UntypedTaskReference {
 	}
 }
 
-// formatEventSummary constructs the event summary and replaces any detected resource UIDs with their readable strings.
-func formatEventSummary(reason, message string, finder patternfinder.PatternFinder[*commonlogk8saudit_contract.ResourceIdentity]) string {
-	if message == "" {
-		return fmt.Sprintf("【%s】", reason)
-	}
-	if finder == nil {
-		return fmt.Sprintf("【%s】%s", reason, message)
-	}
-	matches := patternfinder.FindAllWithStarterRunes(message, finder, true, eventMessageUIDStarterRunes...)
-	if len(matches) == 0 {
-		return fmt.Sprintf("【%s】%s", reason, message)
-	}
-
-	var sb strings.Builder
-	sb.WriteString("【")
-	sb.WriteString(reason)
-	sb.WriteString("】")
-
-	lastIndex := 0
-	for _, match := range matches {
-		if match.Start < lastIndex {
-			continue
-		}
-		sb.WriteString(message[lastIndex:match.Start])
-		sb.WriteString(match.Value.SummaryTag())
-		lastIndex = match.End
-	}
-	sb.WriteString(message[lastIndex:])
-	return sb.String()
-}
-
 // ProcessLog populates metadata into the LogChangeSet.
 func (i *OSSK8sEventLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*khifilev6.LogChangeSet, error) {
 	cs, err := khifilev6.NewLogChangeSet(l)
@@ -94,7 +58,7 @@ func (i *OSSK8sEventLogIngester) ProcessLog(ctx context.Context, l *log.Log) (*k
 		return nil, fmt.Errorf("failed to get OSS k8s event fieldset: %w", err)
 	}
 	finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
-	cs.SetSummary(formatEventSummary(event.Reason, event.Message, finder))
+	cs.SetSummary(commonlogk8saudit_contract.FormatEventSummary(event.Reason, event.Message, finder))
 	cs.SetSeverity(inspectioncore_contract.SeverityUnknown)
 
 	return cs, nil
@@ -157,7 +121,7 @@ func (m *OSSK8sEventTimelineMapper) ProcessLogByGroup(ctx context.Context, l *lo
 	if event.Message != "" {
 		finder := coretask.GetTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref())
 		if finder != nil {
-			matches := patternfinder.FindAllWithStarterRunes(event.Message, finder, true, eventMessageUIDStarterRunes...)
+			matches := patternfinder.FindAllWithStarterRunes(event.Message, finder, true, commonlogk8saudit_contract.EventMessageUIDStarterRunes...)
 			for _, match := range matches {
 				matchedPath := commonlogk8saudit_contract.MustResourceTimeline(ctx, "cluster", match.Value)
 				cs.AddEvent(matchedPath)

--- a/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task_test.go
+++ b/pkg/task/inspection/ossclusterk8s/impl/k8seventlogparser_task_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/model/id"
 
 	"github.com/GoogleCloudPlatform/khi/pkg/common/khictx"
+	"github.com/GoogleCloudPlatform/khi/pkg/common/patternfinder"
+	tasktest "github.com/GoogleCloudPlatform/khi/pkg/core/task/test"
 	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
 	"github.com/GoogleCloudPlatform/khi/pkg/model/log"
 	commonlogk8saudit_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/commonlogk8saudit/contract"
@@ -33,12 +35,13 @@ import (
 
 func TestOSSK8sEventLogIngester_ProcessLog(t *testing.T) {
 	testCases := []struct {
-		name   string
-		input  *log.Log
-		assert func(t *testing.T, cs *khifilev6.LogChangeSet)
+		desc                    string
+		input                   *log.Log
+		resourceIdentitiesByUID map[string]*commonlogk8saudit_contract.ResourceIdentity
+		assert                  func(t *testing.T, cs *khifilev6.LogChangeSet)
 	}{
 		{
-			name: "successful event log ingestion",
+			desc: "successful event log ingestion without UID",
 			input: testlog.NewMockLog(
 				time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
 				ossclusterk8s_contract.OSSK8sEventFieldSet{
@@ -49,16 +52,90 @@ func TestOSSK8sEventLogIngester_ProcessLog(t *testing.T) {
 			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
 				testchangeset.AssertLog(t, cs).
 					HasTimestamp(time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)).
+					HasSeverity(inspectioncore_contract.SeverityUnknown).
 					HasLogType(commonlogk8saudit_contract.LogTypeEvent).
 					HasSummary("【Scheduled】Successfully assigned default/test-pod to node-1")
+			},
+		},
+		{
+			desc: "replaces resource UID in message with readable name",
+			input: testlog.NewMockLog(
+				time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+				ossclusterk8s_contract.OSSK8sEventFieldSet{
+					Reason:  "SuccessfulCreate",
+					Message: "Created pod: my-job-pod (UID: a1b2c3d4-e5f6-7890-abcd-ef0123456789)",
+				},
+			),
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"a1b2c3d4-e5f6-7890-abcd-ef0123456789": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-job-pod",
+				},
+			},
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("【SuccessfulCreate】Created pod: my-job-pod (UID: 【my-job-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】)")
+			},
+		},
+		{
+			desc: "replaces multiple distinct UIDs and duplicate UID occurrences in message",
+			input: testlog.NewMockLog(
+				time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+				ossclusterk8s_contract.OSSK8sEventFieldSet{
+					Reason:  "SyncLoop",
+					Message: `Processing pod: a1b2c3d4-e5f6-7890-abcd-ef0123456789 and service: f9e8d7c6-b5a4-3210-fedc-ba9876543210 (retry for a1b2c3d4-e5f6-7890-abcd-ef0123456789)`,
+				},
+			),
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"a1b2c3d4-e5f6-7890-abcd-ef0123456789": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-job-pod",
+				},
+				"f9e8d7c6-b5a4-3210-fedc-ba9876543210": {
+					APIVersion: "core/v1",
+					Kind:       "service",
+					Namespace:  "default",
+					Name:       "my-service",
+				},
+			},
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasSummary("【SyncLoop】Processing pod: 【my-job-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】 and service: 【my-service (Namespace: default, APIVersion: core/v1, Kind: service)】 (retry for 【my-job-pod (Namespace: default, APIVersion: core/v1, Kind: pod)】)")
+			},
+		},
+		{
+			desc: "event with empty message",
+			input: testlog.NewMockLog(
+				time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+				ossclusterk8s_contract.OSSK8sEventFieldSet{
+					Reason:  "Scheduled",
+					Message: "",
+				},
+			),
+			assert: func(t *testing.T, cs *khifilev6.LogChangeSet) {
+				testchangeset.AssertLog(t, cs).
+					HasTimestamp(time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)).
+					HasSeverity(inspectioncore_contract.SeverityUnknown).
+					HasLogType(commonlogk8saudit_contract.LogTypeEvent).
+					HasSummary("【Scheduled】")
 			},
 		},
 	}
 
 	ingester := &OSSK8sEventLogIngester{}
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := t.Context()
+		t.Run(tc.desc, func(t *testing.T) {
+			finder := patternfinder.NewNaivePatternFinder[*commonlogk8saudit_contract.ResourceIdentity]()
+			if tc.resourceIdentitiesByUID != nil {
+				for k, v := range tc.resourceIdentitiesByUID {
+					_ = finder.AddPattern(k, v)
+				}
+			}
+			ctx := tasktest.WithTaskResult(t.Context(), commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(), finder)
 
 			cs, err := ingester.ProcessLog(ctx, tc.input)
 			if err != nil {
@@ -75,9 +152,10 @@ func TestOSSK8sEventTimelineMapper_ProcessLogByGroup(t *testing.T) {
 	builder := khifilev6.NewTestBuilder(id.NewGenerator())
 
 	testCases := []struct {
-		desc   string
-		input  ossclusterk8s_contract.OSSK8sEventFieldSet
-		assert func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
+		desc                    string
+		input                   ossclusterk8s_contract.OSSK8sEventFieldSet
+		resourceIdentitiesByUID map[string]*commonlogk8saudit_contract.ResourceIdentity
+		assert                  func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet)
 	}{
 		{
 			desc: "namespaced resource event",
@@ -98,7 +176,8 @@ func TestOSSK8sEventTimelineMapper_ProcessLogByGroup(t *testing.T) {
 				expectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "test-deployment")
 
 				testchangeset.AssertTimeline(t, cs).
-					HasEvent(expectedPath)
+					HasEvent(expectedPath).
+					HasEventCount(1)
 			},
 		},
 		{
@@ -121,7 +200,8 @@ func TestOSSK8sEventTimelineMapper_ProcessLogByGroup(t *testing.T) {
 				expectedPath := commonlogk8saudit_contract.MustK8sSubresourceTimeline(ctx, resourceTimeline, "status")
 
 				testchangeset.AssertTimeline(t, cs).
-					HasEvent(expectedPath)
+					HasEvent(expectedPath).
+					HasEventCount(1)
 			},
 		},
 		{
@@ -142,7 +222,147 @@ func TestOSSK8sEventTimelineMapper_ProcessLogByGroup(t *testing.T) {
 				expectedPath := commonlogk8saudit_contract.MustK8sClusterScopeResourceTimeline(ctx, kindTimeline, "my-node")
 
 				testchangeset.AssertTimeline(t, cs).
-					HasEvent(expectedPath)
+					HasEvent(expectedPath).
+					HasEventCount(1)
+			},
+		},
+		{
+			desc: "event with UID in message matching another resource",
+			input: ossclusterk8s_contract.OSSK8sEventFieldSet{
+				APIVersion:   "batch/v1",
+				ResourceKind: "job",
+				Namespace:    "default",
+				Resource:     "my-job",
+				Subresource:  "",
+				Reason:       "SuccessfulCreate",
+				Message:      `Created pod: my-job-pod (UID: a1b2c3d4-e5f6-7890-abcd-ef0123456789)`,
+			},
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"a1b2c3d4-e5f6-7890-abcd-ef0123456789": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-job-pod",
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				jobAPIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "batch/v1")
+				jobKindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, jobAPIVersionTimeline, "job")
+				jobNamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, jobKindTimeline, "default")
+				jobExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, jobNamespaceTimeline, "my-job")
+
+				podAPIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				podKindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, podAPIVersionTimeline, "pod")
+				podNamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, podKindTimeline, "default")
+				podExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, podNamespaceTimeline, "my-job-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(jobExpectedPath).
+					HasEvent(podExpectedPath).
+					HasEventCount(2)
+			},
+		},
+		{
+			desc: "event with UID in message matching primary resource does not duplicate event",
+			input: ossclusterk8s_contract.OSSK8sEventFieldSet{
+				APIVersion:   "core/v1",
+				ResourceKind: "pod",
+				Namespace:    "default",
+				Resource:     "my-pod",
+				Subresource:  "",
+				Reason:       "Killing",
+				Message:      `Stopping container my-pod with uid 11112222-3333-4444-5555-666677778888`,
+			},
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"11112222-3333-4444-5555-666677778888": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "my-pod",
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+				namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "default")
+				expectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "my-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath).
+					HasEventCount(1)
+			},
+		},
+		{
+			desc: "event with multiple distinct UIDs and duplicate secondary UID occurrences",
+			input: ossclusterk8s_contract.OSSK8sEventFieldSet{
+				APIVersion:   "batch/v1",
+				ResourceKind: "job",
+				Namespace:    "default",
+				Resource:     "my-job",
+				Subresource:  "",
+				Reason:       "SuccessfulCreate",
+				Message:      `Created pod: pod-1 (UID: uid-1) and pod-2 (UID: uid-2). Duplicate ref: uid-1`,
+			},
+			resourceIdentitiesByUID: map[string]*commonlogk8saudit_contract.ResourceIdentity{
+				"uid-1": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "pod-1",
+				},
+				"uid-2": {
+					APIVersion: "core/v1",
+					Kind:       "pod",
+					Namespace:  "default",
+					Name:       "pod-2",
+				},
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				jobAPIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "batch/v1")
+				jobKindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, jobAPIVersionTimeline, "job")
+				jobNamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, jobKindTimeline, "default")
+				jobExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, jobNamespaceTimeline, "my-job")
+
+				pod1APIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				pod1KindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, pod1APIVersionTimeline, "pod")
+				pod1NamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, pod1KindTimeline, "default")
+				pod1ExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, pod1NamespaceTimeline, "pod-1")
+
+				pod2APIVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				pod2KindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, pod2APIVersionTimeline, "pod")
+				pod2NamespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, pod2KindTimeline, "default")
+				pod2ExpectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, pod2NamespaceTimeline, "pod-2")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(jobExpectedPath).
+					HasEvent(pod1ExpectedPath).
+					HasEvent(pod2ExpectedPath).
+					HasEventCount(3)
+			},
+		},
+		{
+			desc: "event with empty message stages primary resource only",
+			input: ossclusterk8s_contract.OSSK8sEventFieldSet{
+				APIVersion:   "core/v1",
+				ResourceKind: "pod",
+				Namespace:    "default",
+				Resource:     "my-pod",
+				Subresource:  "",
+				Message:      "",
+			},
+			assert: func(t *testing.T, ctx context.Context, cs *khifilev6.TimelineChangeSet) {
+				clusterTimeline := commonlogk8saudit_contract.MustK8sClusterTimeline(ctx, "cluster")
+				apiVersionTimeline := commonlogk8saudit_contract.MustK8sAPIVersionTimeline(ctx, clusterTimeline, "core/v1")
+				kindTimeline := commonlogk8saudit_contract.MustK8sKindTimeline(ctx, apiVersionTimeline, "pod")
+				namespaceTimeline := commonlogk8saudit_contract.MustK8sNamespaceTimeline(ctx, kindTimeline, "default")
+				expectedPath := commonlogk8saudit_contract.MustK8sNamespacedResourceTimeline(ctx, namespaceTimeline, "my-pod")
+
+				testchangeset.AssertTimeline(t, cs).
+					HasEvent(expectedPath).
+					HasEventCount(1)
 			},
 		},
 	}
@@ -153,6 +373,13 @@ func TestOSSK8sEventTimelineMapper_ProcessLogByGroup(t *testing.T) {
 
 			// Set up context with the same Builder reference.
 			ctx := khictx.WithValue(t.Context(), inspectioncore_contract.Builder, builder)
+			finder := patternfinder.NewNaivePatternFinder[*commonlogk8saudit_contract.ResourceIdentity]()
+			if tc.resourceIdentitiesByUID != nil {
+				for k, v := range tc.resourceIdentitiesByUID {
+					_ = finder.AddPattern(k, v)
+				}
+			}
+			ctx = tasktest.WithTaskResult(ctx, commonlogk8saudit_contract.ResourceUIDPatternFinderTaskID.Ref(), finder)
 			mapper := OSSK8sEventTimelineMapper{}
 
 			cs, _, err := mapper.ProcessLogByGroup(ctx, l, struct{}{})

--- a/pkg/testutil/testchangeset/changeset_asserter.go
+++ b/pkg/testutil/testchangeset/changeset_asserter.go
@@ -105,8 +105,8 @@ func (a *TimelineChangeSetAsserter) HasNoEvent(path *khifilev6.TimelinePath) *Ti
 // HasEventCount asserts that the total number of staged events matches the expected count.
 func (a *TimelineChangeSetAsserter) HasEventCount(wantCount int) *TimelineChangeSetAsserter {
 	a.t.Helper()
-	if diff := cmp.Diff(wantCount, len(a.cs.Events)); diff != "" {
-		a.t.Errorf("TimelineChangeSet: event count mismatch (-want +got):\n%s", diff)
+	if gotCount := len(a.cs.Events); gotCount != wantCount {
+		a.t.Errorf("TimelineChangeSet: event count mismatch: want %d, got %d", wantCount, gotCount)
 	}
 	return a
 }

--- a/pkg/testutil/testchangeset/changeset_asserter.go
+++ b/pkg/testutil/testchangeset/changeset_asserter.go
@@ -102,6 +102,15 @@ func (a *TimelineChangeSetAsserter) HasNoEvent(path *khifilev6.TimelinePath) *Ti
 	return a
 }
 
+// HasEventCount asserts that the total number of staged events matches the expected count.
+func (a *TimelineChangeSetAsserter) HasEventCount(wantCount int) *TimelineChangeSetAsserter {
+	a.t.Helper()
+	if diff := cmp.Diff(wantCount, len(a.cs.Events)); diff != "" {
+		a.t.Errorf("TimelineChangeSet: event count mismatch (-want +got):\n%s", diff)
+	}
+	return a
+}
+
 // HasRevision asserts that a matching StagingRevision was staged on the expected path.
 func (a *TimelineChangeSetAsserter) HasRevision(wantPath *khifilev6.TimelinePath, wantRevision *khifilev6.StagingRevision, cmpOpts ...cmp.Option) *TimelineChangeSetAsserter {
 	a.t.Helper()

--- a/pkg/testutil/testchangeset/changeset_asserter_test.go
+++ b/pkg/testutil/testchangeset/changeset_asserter_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testchangeset
+
+import (
+	"testing"
+
+	khifilev6 "github.com/GoogleCloudPlatform/khi/pkg/model/khifile/v6"
+)
+
+func TestTimelineChangeSetAsserter_HasEventCount(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		setupCS   func() *khifilev6.TimelineChangeSet
+		wantCount int
+	}{
+		{
+			desc: "zero events matches expected count of zero",
+			setupCS: func() *khifilev6.TimelineChangeSet {
+				return khifilev6.NewTimelineChangeSet(nil)
+			},
+			wantCount: 0,
+		},
+		{
+			desc: "staged events count matches non-zero count",
+			setupCS: func() *khifilev6.TimelineChangeSet {
+				cs := khifilev6.NewTimelineChangeSet(nil)
+				cs.AddEvent(&khifilev6.TimelinePath{ID: 1})
+				cs.AddEvent(&khifilev6.TimelinePath{ID: 2})
+				return cs
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cs := tc.setupCS()
+			AssertTimeline(t, cs).HasEventCount(tc.wantCount)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Replaces raw resource UIDs in Kubernetes event log messages with human-readable resource names (e.g. `【<Name> (Namespace: <Namespace>, APIVersion: <APIVersion>, Kind: <Kind>)】`), similar to node log processing. Also maps matched UIDs to their corresponding secondary resource timeline paths in `ProcessLogByGroup`.

## Changes
- **`ResourceIdentity.SummaryTag()`**: Added a method on `ResourceIdentity` to generate formatted log summary tags `【<Name> (...)】` (omitting empty `Namespace:` for cluster-scoped resources like `Node`).
- **GKE Event Log Parser & Timeline Mapper** (`googlecloudlogk8sevent`):
  - Added `ResourceUIDPatternFinderTask` dependency.
  - Reconstructs event message summaries using `formatEventSummary` with positional slice bounds and `strings.Builder`.
  - Maps any secondary resource UIDs in the event message to their respective timelines.
- **OSS K8s Event Log Parser & Timeline Mapper** (`ossclusterk8s`):
  - Added identical `formatEventSummary` and UID-to-timeline mapping support for OSS event logs.
- **Test Utilities & Coverage**:
  - Added `HasEventCount` assertion method to `TimelineChangeSetAsserter`.
  - Added comprehensive table-driven tests for single UID, multiple distinct UIDs, duplicate secondary UIDs, cluster-scoped resources, and empty messages.