### PR TITLE
feat(timeline): allow inline editing of search filter chips on click

### DIFF
--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.html
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.html
@@ -22,17 +22,43 @@ limitations under the License.
   <mat-icon class="search-prefix-icon">search</mat-icon>
   <div class="search-tokens-wrapper">
     @for (chip of searchTerms(); track $index) {
-      <div class="search-chip">
-        <span class="chip-text">{{ chip }}</span>
-        <button
-          type="button"
-          class="remove-chip-btn"
-          (mousedown)="$event.preventDefault()"
-          (click)="onRemoveChip($index, $event)"
+      @if (editingIndex() === $index) {
+        <div class="search-chip editing" (click)="$event.stopPropagation()">
+          <input
+            #chipEditInput
+            type="text"
+            class="chip-edit-input"
+            [value]="editingText()"
+            (input)="onChipEditInput(chipEditInput.value)"
+            (blur)="onChipEditBlur()"
+            (keydown)="onChipEditKeyDown($event)"
+          />
+          <button
+            type="button"
+            class="remove-chip-btn"
+            (mousedown)="$event.preventDefault()"
+            (click)="onRemoveChip($index, $event)"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
+      } @else {
+        <div
+          class="search-chip"
+          matTooltip="Click to edit"
+          (click)="onChipClick($index, $event)"
         >
-          <mat-icon>close</mat-icon>
-        </button>
-      </div>
+          <span class="chip-text">{{ chip }}</span>
+          <button
+            type="button"
+            class="remove-chip-btn"
+            (mousedown)="$event.preventDefault()"
+            (click)="onRemoveChip($index, $event)"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
+      }
       <span class="or-separator">OR</span>
     }
     <input

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.html
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.html
@@ -30,7 +30,7 @@ limitations under the License.
             class="chip-edit-input"
             [value]="editingText()"
             (input)="onChipEditInput(chipEditInput.value)"
-            (blur)="onChipEditBlur()"
+            (blur)="onChipEditBlur($index)"
             (keydown)="onChipEditKeyDown($event)"
           />
           <button

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.scss
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.scss
@@ -39,6 +39,19 @@ $input-placeholder-color: mat.m2-get-color-from-palette(
 
 $chip-bg-color: mat.m2-get-color-from-palette(mat.$m2-indigo-palette, 50);
 $chip-border-color: mat.m2-get-color-from-palette(mat.$m2-indigo-palette, 200);
+$chip-hover-bg-color: mat.m2-get-color-from-palette(
+  mat.$m2-indigo-palette,
+  100
+);
+$chip-hover-border-color: mat.m2-get-color-from-palette(
+  mat.$m2-indigo-palette,
+  300
+);
+$chip-editing-bg-color: mat.m2-get-color-from-palette(mat.$m2-gray-palette, 50);
+$chip-editing-border-color: mat.m2-get-color-from-palette(
+  mat.$m2-indigo-palette,
+  500
+);
 $chip-text-color: mat.m2-get-color-from-palette(mat.$m2-indigo-palette, 800);
 $chip-remove-hover-color: mat.m2-get-color-from-palette(
   mat.$m2-red-palette,
@@ -120,11 +133,38 @@ $clear-btn-hover-color: mat.m2-get-color-from-palette(
   font-size: 12px;
   color: $chip-text-color;
   max-width: 200px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    background-color: $chip-hover-bg-color;
+    border-color: $chip-hover-border-color;
+  }
+
+  &.editing {
+    background-color: $chip-editing-bg-color;
+    border-color: $chip-editing-border-color;
+    cursor: text;
+  }
 
   .chip-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .chip-edit-input {
+    border: 0;
+    outline: none;
+    background: transparent;
+    font-size: 12px;
+    color: $chip-text-color;
+    padding: 0;
+    min-width: 24px;
+    max-width: 170px;
+    width: 100%;
   }
 
   .remove-chip-btn {

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.spec.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.spec.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ChipSearchBarComponent } from './chip-search-bar.component';
@@ -385,13 +390,14 @@ describe('ChipSearchBarComponent', () => {
     expect(component.editingIndex()).toBeNull();
   });
 
-  it('should adjust editingIndex when a preceding chip is removed', () => {
+  it('should adjust editingIndex and maintain focus when a preceding chip is removed', fakeAsync(() => {
     fixture.componentRef.setInput('searchTerms', ['chip1', 'chip2', 'chip3']);
     fixture.detectChanges();
 
     const chipEls = fixture.debugElement.queryAll(By.css('.search-chip'));
     chipEls[1].nativeElement.click();
     fixture.detectChanges();
+    tick();
 
     expect(component.editingIndex()).toBe(1);
 
@@ -400,9 +406,29 @@ describe('ChipSearchBarComponent', () => {
     );
     removeBtns[0].nativeElement.click();
     fixture.detectChanges();
+    tick();
 
     expect(component.editingIndex()).toBe(0);
     expect(component.searchTerms()).toEqual(['chip2', 'chip3']);
+    const editInput = fixture.debugElement.query(By.css('.chip-edit-input'))
+      .nativeElement as HTMLInputElement;
+    expect(document.activeElement).toBe(editInput);
+  }));
+
+  it('should ignore blur events if the blur index does not match editingIndex', () => {
+    fixture.componentRef.setInput('searchTerms', ['chip1', 'chip2']);
+    fixture.detectChanges();
+
+    component.startChipEdit(0);
+    component.onChipEditInput('modified');
+
+    component.onChipEditBlur(1);
+    expect(component.editingIndex()).toBe(0);
+    expect(component.searchTerms()).toEqual(['chip1', 'chip2']);
+
+    component.onChipEditBlur(0);
+    expect(component.editingIndex()).toBeNull();
+    expect(component.searchTerms()).toEqual(['modified', 'chip2']);
   });
 
   it('should clear editing state when clear button is clicked during edit', () => {

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.spec.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.spec.ts
@@ -244,4 +244,245 @@ describe('ChipSearchBarComponent', () => {
     expect(component.searchTerms()).toEqual([]);
     expect(component.draft()).toBe('');
   });
+
+  it('should switch chip to editing mode when clicked', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo', 'bar']);
+    fixture.detectChanges();
+
+    const chipEls = fixture.debugElement.queryAll(By.css('.search-chip'));
+    chipEls[0].nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.editingIndex()).toBe(0);
+    expect(component.editingText()).toBe('foo');
+
+    const editInput = fixture.debugElement.query(By.css('.chip-edit-input'));
+    expect(editInput).toBeTruthy();
+    expect((editInput.nativeElement as HTMLInputElement).value).toBe('foo');
+  });
+
+  it('should commit edited chip on Enter key', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo', 'bar']);
+    fixture.detectChanges();
+
+    const chipEls = fixture.debugElement.queryAll(By.css('.search-chip'));
+    chipEls[0].nativeElement.click();
+    fixture.detectChanges();
+
+    const editInput = fixture.debugElement.query(By.css('.chip-edit-input'))
+      .nativeElement as HTMLInputElement;
+    component.onChipEditInput('baz');
+    fixture.detectChanges();
+
+    editInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['baz', 'bar']);
+    expect(component.editingIndex()).toBeNull();
+    expect(fixture.debugElement.query(By.css('.chip-edit-input'))).toBeNull();
+  });
+
+  it('should cancel editing and restore original text on Escape key', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo']);
+    fixture.detectChanges();
+
+    const chipEl = fixture.debugElement.query(By.css('.search-chip'));
+    chipEl.nativeElement.click();
+    fixture.detectChanges();
+
+    const editInput = fixture.debugElement.query(By.css('.chip-edit-input'))
+      .nativeElement as HTMLInputElement;
+    component.onChipEditInput('edited');
+    fixture.detectChanges();
+
+    editInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['foo']);
+    expect(component.editingIndex()).toBeNull();
+  });
+
+  it('should commit edited chip on blur', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo']);
+    fixture.detectChanges();
+
+    const chipEl = fixture.debugElement.query(By.css('.search-chip'));
+    chipEl.nativeElement.click();
+    fixture.detectChanges();
+
+    const editInput = fixture.debugElement.query(By.css('.chip-edit-input'))
+      .nativeElement as HTMLInputElement;
+    component.onChipEditInput('blurred');
+    fixture.detectChanges();
+
+    editInput.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['blurred']);
+    expect(component.editingIndex()).toBeNull();
+  });
+
+  it('should remove chip if committed value is empty or whitespace only', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo', 'bar']);
+    fixture.detectChanges();
+
+    const chipEls = fixture.debugElement.queryAll(By.css('.search-chip'));
+    chipEls[0].nativeElement.click();
+    fixture.detectChanges();
+
+    const editInput = fixture.debugElement.query(By.css('.chip-edit-input'))
+      .nativeElement as HTMLInputElement;
+    component.onChipEditInput('   ');
+    fixture.detectChanges();
+
+    editInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['bar']);
+    expect(component.editingIndex()).toBeNull();
+  });
+
+  it('should split into multiple chips when delimiter is in edited chip text', () => {
+    fixture.componentRef.setInput('searchTerms', ['first', 'second']);
+    fixture.detectChanges();
+
+    const chipEls = fixture.debugElement.queryAll(By.css('.search-chip'));
+    chipEls[0].nativeElement.click();
+    fixture.detectChanges();
+
+    const editInput = fixture.debugElement.query(By.css('.chip-edit-input'))
+      .nativeElement as HTMLInputElement;
+    component.onChipEditInput('alpha | beta\ngamma');
+    fixture.detectChanges();
+
+    editInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual([
+      'alpha',
+      'beta',
+      'gamma',
+      'second',
+    ]);
+    expect(component.editingIndex()).toBeNull();
+  });
+
+  it('should remove chip and exit edit mode when remove button is clicked during edit', () => {
+    fixture.componentRef.setInput('searchTerms', ['chip1', 'chip2']);
+    fixture.detectChanges();
+
+    const chipEls = fixture.debugElement.queryAll(By.css('.search-chip'));
+    chipEls[0].nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.editingIndex()).toBe(0);
+
+    const removeBtn = fixture.debugElement.query(By.css('.remove-chip-btn'));
+    removeBtn.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['chip2']);
+    expect(component.editingIndex()).toBeNull();
+  });
+
+  it('should adjust editingIndex when a preceding chip is removed', () => {
+    fixture.componentRef.setInput('searchTerms', ['chip1', 'chip2', 'chip3']);
+    fixture.detectChanges();
+
+    const chipEls = fixture.debugElement.queryAll(By.css('.search-chip'));
+    chipEls[1].nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.editingIndex()).toBe(1);
+
+    const removeBtns = fixture.debugElement.queryAll(
+      By.css('.remove-chip-btn'),
+    );
+    removeBtns[0].nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.editingIndex()).toBe(0);
+    expect(component.searchTerms()).toEqual(['chip2', 'chip3']);
+  });
+
+  it('should clear editing state when clear button is clicked during edit', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo']);
+    fixture.detectChanges();
+
+    const chipEl = fixture.debugElement.query(By.css('.search-chip'));
+    chipEl.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.editingIndex()).toBe(0);
+
+    const clearBtn = fixture.debugElement.query(By.css('.clear-search-btn'));
+    clearBtn.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual([]);
+    expect(component.editingIndex()).toBeNull();
+    expect(component.editingText()).toBe('');
+  });
+
+  it('should commit main draft before starting chip edit', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo']);
+    fixture.detectChanges();
+
+    component.onDraftInput('draft_term');
+    fixture.detectChanges();
+
+    const chipEl = fixture.debugElement.query(By.css('.search-chip'));
+    chipEl.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.searchTerms()).toEqual(['foo', 'draft_term']);
+    expect(component.draft()).toBe('');
+    expect(component.editingIndex()).toBe(0);
+  });
+
+  it('should not close edit mode when clicking inside the active chip editor', () => {
+    fixture.componentRef.setInput('searchTerms', ['foo']);
+    fixture.detectChanges();
+
+    const chipEl = fixture.debugElement.query(By.css('.search-chip'));
+    chipEl.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.editingIndex()).toBe(0);
+
+    const editingChipDiv = fixture.debugElement.query(
+      By.css('.search-chip.editing'),
+    );
+    const clickEvent = new MouseEvent('click', { bubbles: true });
+    spyOn(clickEvent, 'stopPropagation');
+    editingChipDiv.nativeElement.dispatchEvent(clickEvent);
+
+    expect(clickEvent.stopPropagation).toHaveBeenCalled();
+    expect(component.editingIndex()).toBe(0);
+  });
+
+  it('should adjust index and handle bounds check in startChipEdit', () => {
+    fixture.componentRef.setInput('searchTerms', ['first', 'second', 'third']);
+    fixture.detectChanges();
+
+    // Start editing 'first'
+    component.startChipEdit(0);
+    expect(component.editingIndex()).toBe(0);
+
+    // Empty 'first' so it gets removed, then start editing 'third' (originally index 2)
+    component.onChipEditInput('   ');
+    component.startChipEdit(2);
+
+    // Since 'first' was removed, previous index 2 is now index 1 ('third')
+    expect(component.searchTerms()).toEqual(['second', 'third']);
+    expect(component.editingIndex()).toBe(1);
+    expect(component.editingText()).toBe('third');
+
+    // Out of bounds startChipEdit should be ignored
+    component.startChipEdit(99);
+    expect(component.editingIndex()).toBe(1);
+
+    component.startChipEdit(-1);
+    expect(component.editingIndex()).toBe(1);
+  });
 });

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.ts
@@ -29,6 +29,17 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { KHIIconRegistrationModule } from 'src/app/shared/module/icon-registration.module';
 
 /**
+ * Splits raw input text by pipe delimiters or newlines into trimmed, non-empty search terms.
+ * @param raw The raw string containing delimiters.
+ */
+function splitSearchTerms(raw: string): string[] {
+  return raw
+    .split(/[|\r\n]+/)
+    .map((seg) => seg.trim())
+    .filter((seg) => seg.length > 0);
+}
+
+/**
  * Dumb component responsible for rendering an inline multi-chip search input with OR logic.
  */
 @Component({
@@ -65,10 +76,29 @@ export class ChipSearchBarComponent {
   public readonly draft = signal<string>('');
 
   /**
+   * The index of the chip currently being edited, or null if no chip is in edit mode.
+   */
+  public readonly editingIndex = signal<number | null>(null);
+
+  /**
+   * The draft text currently being edited inside the active chip.
+   */
+  public readonly editingText = signal<string>('');
+
+  /**
+   * Reference to the inline chip edit input element.
+   */
+  public readonly chipEditInput =
+    viewChild<ElementRef<HTMLInputElement>>('chipEditInput');
+
+  /**
    * Indicates whether any chips or draft text exist.
    */
   public readonly hasQuery = computed(
-    () => this.searchTerms().length > 0 || this.draft().trim().length > 0,
+    () =>
+      this.searchTerms().length > 0 ||
+      this.draft().trim().length > 0 ||
+      this.editingIndex() !== null,
   );
 
   /**
@@ -111,12 +141,120 @@ export class ChipSearchBarComponent {
   }
 
   /**
+   * Handles clicking on a chip to switch it into edit mode.
+   * @param index Index of the clicked chip.
+   * @param event The associated mouse click event.
+   */
+  onChipClick(index: number, event: MouseEvent) {
+    event.stopPropagation();
+    this.commitDraft();
+    this.startChipEdit(index);
+  }
+
+  /**
+   * Starts editing the chip at the specified index.
+   * @param index Index of the chip to edit.
+   */
+  public startChipEdit(index: number) {
+    if (index < 0 || index >= this.searchTerms().length) {
+      return;
+    }
+    if (this.editingIndex() !== null && this.editingIndex() !== index) {
+      const prevIndex = this.editingIndex()!;
+      const prevLen = this.searchTerms().length;
+      this.commitChipEdit();
+      if (prevIndex < index) {
+        index += this.searchTerms().length - prevLen;
+      }
+      if (index < 0 || index >= this.searchTerms().length) {
+        return;
+      }
+    }
+    this.editingIndex.set(index);
+    this.editingText.set(this.searchTerms()[index] ?? '');
+    setTimeout(() => {
+      const input = this.chipEditInput()?.nativeElement;
+      if (input) {
+        input.focus();
+        input.select();
+      }
+    }, 0);
+  }
+
+  /**
+   * Handles user typing in the active chip edit input.
+   * @param value The raw string value from the input element.
+   */
+  onChipEditInput(value: string) {
+    this.editingText.set(value);
+  }
+
+  /**
+   * Commits the edited chip text back into searchTerms.
+   */
+  public commitChipEdit() {
+    const index = this.editingIndex();
+    if (index === null) {
+      return;
+    }
+    const segments = splitSearchTerms(this.editingText());
+    if (segments.length === 0) {
+      this.searchTerms.update((terms) => terms.filter((_, i) => i !== index));
+    } else {
+      this.searchTerms.update((terms) => [
+        ...terms.slice(0, index),
+        ...segments,
+        ...terms.slice(index + 1),
+      ]);
+    }
+    this.editingIndex.set(null);
+    this.editingText.set('');
+  }
+
+  /**
+   * Cancels the current chip edit and exits edit mode without modifying searchTerms.
+   */
+  public cancelChipEdit() {
+    this.editingIndex.set(null);
+    this.editingText.set('');
+  }
+
+  /**
+   * Handles keyboard navigation in the active chip edit input.
+   * @param event The keyboard event.
+   */
+  onChipEditKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      this.commitChipEdit();
+      this.focus();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      this.cancelChipEdit();
+      this.focus();
+    }
+  }
+
+  /**
+   * Handles blur on the active chip edit input to commit changes.
+   */
+  onChipEditBlur() {
+    this.commitChipEdit();
+  }
+
+  /**
    * Removes a chip at the specified index.
    * @param index Index of the chip to remove.
    * @param event The associated mouse click event.
    */
   onRemoveChip(index: number, event: MouseEvent) {
     event.stopPropagation();
+    if (this.editingIndex() === index) {
+      this.editingIndex.set(null);
+      this.editingText.set('');
+    } else if (this.editingIndex() !== null && this.editingIndex()! > index) {
+      this.editingIndex.update((curr) => (curr !== null ? curr - 1 : null));
+    }
     this.searchTerms.update((terms) => terms.filter((_, i) => i !== index));
   }
 
@@ -160,14 +298,7 @@ export class ChipSearchBarComponent {
       const combined =
         currentVal.slice(0, start) + pastedText + currentVal.slice(end);
 
-      const rawSegments = combined.split(/[|\r\n]+/);
-      const validSegments: string[] = [];
-      for (const seg of rawSegments) {
-        const trimmed = seg.trim();
-        if (trimmed) {
-          validSegments.push(trimmed);
-        }
-      }
+      const validSegments = splitSearchTerms(combined);
       if (validSegments.length > 0) {
         this.searchTerms.update((terms) => [...terms, ...validSegments]);
         this.draft.set('');
@@ -188,6 +319,8 @@ export class ChipSearchBarComponent {
    * Clears all chips and draft.
    */
   clearAll() {
+    this.editingIndex.set(null);
+    this.editingText.set('');
     this.searchTerms.set([]);
     this.draft.set('');
   }

--- a/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.ts
+++ b/web/src/app/shared/components/chip-search-bar/chip-search-bar.component.ts
@@ -237,8 +237,12 @@ export class ChipSearchBarComponent {
 
   /**
    * Handles blur on the active chip edit input to commit changes.
+   * @param index Index of the chip reporting the blur event.
    */
-  onChipEditBlur() {
+  onChipEditBlur(index: number) {
+    if (this.editingIndex() !== index) {
+      return;
+    }
     this.commitChipEdit();
   }
 
@@ -254,6 +258,13 @@ export class ChipSearchBarComponent {
       this.editingText.set('');
     } else if (this.editingIndex() !== null && this.editingIndex()! > index) {
       this.editingIndex.update((curr) => (curr !== null ? curr - 1 : null));
+      setTimeout(() => {
+        const input = this.chipEditInput()?.nativeElement;
+        if (input) {
+          input.focus();
+          input.select();
+        }
+      }, 0);
     }
     this.searchTerms.update((terms) => terms.filter((_, i) => i !== index));
   }


### PR DESCRIPTION
## Summary
This PR adds support for in-place editing of search filter chips in `ChipSearchBarComponent`. Users can click an existing chip to edit its text inline rather than deleting and retyping it.

### Key Changes
- **Inline Chip Editing (`ChipSearchBarComponent`)**:
  - Clicking a chip switches it to an editing state displaying an inline `<input>` element with text pre-selected and auto-focused.
  - Changes are committed on Enter or `blur`, and cancelled on Escape (reverting to the previous text).
  - Main input retains focus on Enter/Escape to preserve keyboard navigation.
  - Delimiter splitting (`|` or newlines) via `splitSearchTerms` splits multi-term inputs into separate chips upon commit.
  - Empty or whitespace-only inputs automatically remove the chip.
  - Clicks inside the inline input stop event propagation to prevent container click handlers from immediately triggering a blur.
  - Chip removals (from delete buttons or clear button) safely update or reset the active editing index.
- **Styling**:
  - Added theme-palette-compliant hover and editing states (`mat.m2-get-color-from-palette`) with pointer cursor for clickable chips.
- **Testing**:
  - Added 12 comprehensive unit tests in `chip-search-bar.component.spec.ts` covering click-to-edit, keydown shortcuts, delimiter splitting, blur commit, removal index adjustments, and event bubbling.

### Testing & Verification
- `npx ng test --browsers ChromeHeadlessNoSandbox --watch=false`: All 1,123 tests passed.
- `make lint-web`: Passed (0 lint issues).
- `make build-storybook`: Passed.
- `make pre-commit`: Passed.