### PR TITLE
fix(inspection): resolve timezone offset fallback to UTC by unifying to timezoneShiftHours

### DIFF
--- a/pkg/server/api/v1/inspection.go
+++ b/pkg/server/api/v1/inspection.go
@@ -668,7 +668,7 @@ func convertParametersToMap(params *apiv1.InspectionParameters) map[string]any {
 		}
 	}
 	if params.GetTimezoneShiftHours() != 0 {
-		values["timezoneShiftHours"] = params.GetTimezoneShiftHours()
+		values[inspectioncore_contract.TaskInputKeyTimezoneShiftHours] = params.GetTimezoneShiftHours()
 	}
 	return values
 }

--- a/pkg/task/inspection/googlecloudlogk8saudit/impl/parser_test.go
+++ b/pkg/task/inspection/googlecloudlogk8saudit/impl/parser_test.go
@@ -65,8 +65,7 @@ func getAuditLogJobTestConfig() *taskrecord.JobTestConfig {
 				"@all_cluster_scoped",
 				"@all_namespaced",
 			},
-			"timezoneShift":      "9",
-			"timezoneShiftHours": 9,
+			"timezoneShiftHours": float64(9),
 		},
 		RecordedTasks: []taskid.UntypedTaskReference{
 			googlecloudlogk8saudit_contract.GCPK8sAuditLogListLogEntriesTaskID.Ref(),

--- a/pkg/task/inspection/inspectioncore/contract/contextkey.go
+++ b/pkg/task/inspection/inspectioncore/contract/contextkey.go
@@ -35,6 +35,9 @@ var InspectionTaskMode = typedmap.NewTypedKey[InspectionTaskModeType]("khi.googl
 // It contains a map of parameter names to their values.
 var InspectionTaskInput = typedmap.NewTypedKey[map[string]any]("khi.google.com/inspection/task-input")
 
+// TaskInputKeyTimezoneShiftHours is the map key for timezone shift hours in InspectionTaskInput.
+const TaskInputKeyTimezoneShiftHours = "timezoneShiftHours"
+
 // InspectionCreationTime is the context key to access the time when user created the inspection.
 var InspectionCreationTime = typedmap.NewTypedKey[time.Time]("khi.google.com/inspection/creation-time")
 

--- a/pkg/task/inspection/inspectioncore/impl/timezoneshiftinput_task.go
+++ b/pkg/task/inspection/inspectioncore/impl/timezoneshiftinput_task.go
@@ -26,13 +26,10 @@ import (
 
 var TimeZoneShiftInputTask = inspectiontaskbase.NewInspectionTask(inspectioncore_contract.TimeZoneShiftInputTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context, taskMode inspectioncore_contract.InspectionTaskModeType) (*time.Location, error) {
 	req := khictx.MustGetValue(ctx, inspectioncore_contract.InspectionTaskInput)
-	if tzShiftAny, found := req["timezoneShift"]; found {
-		if tzShiftFloat, convertible := tzShiftAny.(float64); convertible {
+	if tzShiftAny, found := req[inspectioncore_contract.TaskInputKeyTimezoneShiftHours]; found {
+		if tzShiftFloat, convertible := tzShiftAny.(float64); convertible && tzShiftFloat != 0 {
 			return time.FixedZone("Unknown", int(tzShiftFloat*3600)), nil
-		} else {
-			return time.UTC, nil
 		}
-	} else {
-		return time.UTC, nil
 	}
+	return time.UTC, nil
 })

--- a/pkg/task/inspection/inspectioncore/impl/timezoneshiftinput_task_test.go
+++ b/pkg/task/inspection/inspectioncore/impl/timezoneshiftinput_task_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectioncore_impl
+
+import (
+	"testing"
+	"time"
+
+	inspectiontest "github.com/GoogleCloudPlatform/khi/pkg/core/inspection/test"
+	inspectioncore_contract "github.com/GoogleCloudPlatform/khi/pkg/task/inspection/inspectioncore/contract"
+)
+
+// TestTimeZoneShiftInputTask verifies that TimeZoneShiftInputTask parses the timezone offset
+// parameter and returns the corresponding time.Location or falls back to UTC.
+func TestTimeZoneShiftInputTask(t *testing.T) {
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		name              string
+		input             map[string]any
+		wantZoneName      string
+		wantOffsetSeconds int
+		wantUTC           bool
+	}{
+		{
+			name: "positive offset +9 hours",
+			input: map[string]any{
+				inspectioncore_contract.TaskInputKeyTimezoneShiftHours: float64(9),
+			},
+			wantZoneName:      "Unknown",
+			wantOffsetSeconds: 9 * 3600,
+			wantUTC:           false,
+		},
+		{
+			name: "negative offset -7 hours",
+			input: map[string]any{
+				inspectioncore_contract.TaskInputKeyTimezoneShiftHours: float64(-7),
+			},
+			wantZoneName:      "Unknown",
+			wantOffsetSeconds: -7 * 3600,
+			wantUTC:           false,
+		},
+		{
+			name: "zero offset falls back to UTC",
+			input: map[string]any{
+				inspectioncore_contract.TaskInputKeyTimezoneShiftHours: float64(0),
+			},
+			wantZoneName:      "UTC",
+			wantOffsetSeconds: 0,
+			wantUTC:           true,
+		},
+		{
+			name:              "missing timezone key defaults to UTC",
+			input:             map[string]any{},
+			wantZoneName:      "UTC",
+			wantOffsetSeconds: 0,
+			wantUTC:           true,
+		},
+		{
+			name: "non float64 value defaults to UTC",
+			input: map[string]any{
+				inspectioncore_contract.TaskInputKeyTimezoneShiftHours: "9",
+			},
+			wantZoneName:      "UTC",
+			wantOffsetSeconds: 0,
+			wantUTC:           true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := inspectiontest.WithDefaultTestInspectionTaskContext(t.Context())
+			got, _, err := inspectiontest.RunInspectionTask(ctx, TimeZoneShiftInputTask, inspectioncore_contract.TaskModeRun, tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantUTC && got != time.UTC {
+				t.Errorf("got %v, want time.UTC", got)
+			}
+			gotZoneName, gotOffset := baseTime.In(got).Zone()
+			if gotZoneName != tc.wantZoneName {
+				t.Errorf("zone name = %q, want %q", gotZoneName, tc.wantZoneName)
+			}
+			if gotOffset != tc.wantOffsetSeconds {
+				t.Errorf("offset = %d, want %d", gotOffset, tc.wantOffsetSeconds)
+			}
+		})
+	}
+}

--- a/web/src/app/services/api/backend-api.service.spec.ts
+++ b/web/src/app/services/api/backend-api.service.spec.ts
@@ -555,7 +555,7 @@ describe('InspectionTaskClient testing', () => {
         expect(backendAPISpy.runInspection).toHaveBeenCalledWith('test', {
           test: 'foo',
 
-          timezoneShift: -new Date().getTimezoneOffset() / 60, // This parameter should come from view state
+          timezoneShiftHours: -new Date().getTimezoneOffset() / 60, // This parameter should come from view state
         });
         done();
       });
@@ -579,7 +579,7 @@ describe('InspectionTaskClient testing', () => {
         expect(backendAPISpy.dryRunInspection).toHaveBeenCalledWith('test', {
           test: 'foo',
 
-          timezoneShift: -new Date().getTimezoneOffset() / 60, // This parameter should come from view state
+          timezoneShiftHours: -new Date().getTimezoneOffset() / 60, // This parameter should come from view state
         });
         expect(response).toEqual(testData);
         done();

--- a/web/src/app/services/api/backend-api.service.ts
+++ b/web/src/app/services/api/backend-api.service.ts
@@ -197,8 +197,8 @@ export class BackendAPIImpl implements BackendAPI {
       request as Record<string, unknown>,
     );
     const tzShift =
-      typeof request['timezoneShift'] === 'number'
-        ? (request['timezoneShift'] as number)
+      typeof request['timezoneShiftHours'] === 'number'
+        ? (request['timezoneShiftHours'] as number)
         : 0;
     return from(
       this.connectClient.inspectionClient.runInspection({
@@ -219,8 +219,8 @@ export class BackendAPIImpl implements BackendAPI {
       request as Record<string, unknown>,
     );
     const tzShift =
-      typeof request['timezoneShift'] === 'number'
-        ? (request['timezoneShift'] as number)
+      typeof request['timezoneShiftHours'] === 'number'
+        ? (request['timezoneShiftHours'] as number)
         : 0;
     return from(
       this.connectClient.inspectionClient.dryRunInspection({
@@ -327,7 +327,7 @@ export class InspectionClient {
 
   private nonFormParameters = concat(this.viewState.timezoneShift).pipe(
     map((tzShift) => ({
-      timezoneShift: tzShift,
+      timezoneShiftHours: tzShift,
     })),
     shareReplay(1),
   );


### PR DESCRIPTION
## Background
Following the Connect-RPC migration (#908), the timezone shift parameter was changed to `timezoneShiftHours`. However, references to the legacy `timezoneShift` key remained in `TimeZoneShiftInputTask` and the frontend client, causing timezone offsets to always fall back to UTC.

## What changed
Ensured that browser/request timezone offsets are correctly propagated to `TimeZoneShiftInputTask`, so that inspection form defaults (such as End time) and log queries properly reflect the local timezone instead of defaulting to UTC. Also added unit tests for `TimeZoneShiftInputTask`.