### PR TITLE
fix(k8saudit): preserve immutable identity metadata after truncated logs

### DIFF
--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
@@ -40,10 +40,11 @@ import (
 )
 
 var (
-	pathAPIVersion   = structured.CompileFieldPath("apiVersion")
-	pathKind         = structured.CompileFieldPath("kind")
-	pathItems        = structured.CompileFieldPath("items")
-	pathMetadataName = structured.CompileFieldPath("metadata.name")
+	pathAPIVersion        = structured.CompileFieldPath("apiVersion")
+	pathKind              = structured.CompileFieldPath("kind")
+	pathItems             = structured.CompileFieldPath("items")
+	pathMetadataName      = structured.CompileFieldPath("metadata.name")
+	pathMetadataNamespace = structured.CompileFieldPath("metadata.namespace")
 )
 
 // ManifestGeneratorTask is the task to generate manifest from k8s audit logs.
@@ -129,9 +130,6 @@ type groupManifestGenerator struct {
 
 // Process processes the log to generate manifest.
 func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*commonlogk8saudit_contract.ResourceManifestLog, error) {
-	if g.prevRevisionReader == nil {
-		g.prevRevisionReader = structured.NewNodeReader(structured.NewEmptyMapNode())
-	}
 	fieldSet, _ := commonlogk8saudit_contract.ExtractK8sAuditLog(ctx, l.NodeReader)
 	if fieldSet.IsDryRun {
 		return &commonlogk8saudit_contract.ResourceManifestLog{
@@ -140,7 +138,9 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 		}, nil
 	}
 	if fieldSet.IsTruncated {
-		g.prevRevisionReader = nil
+		if g.prevRevisionReader != nil {
+			g.prevRevisionReader = extractResourceIdentity(g.blockStore, g.prevRevisionReader)
+		}
 		return &commonlogk8saudit_contract.ResourceManifestLog{
 			Log:                l,
 			ResourceBodyReader: nil,
@@ -202,6 +202,9 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 	}
 
 	if fieldSet.Verb == commonlogk8saudit_contract.VerbPatch && partial {
+		if g.prevRevisionReader == nil {
+			g.prevRevisionReader = structured.NewNodeReader(structured.NewEmptyMapNode())
+		}
 		mergeConfigResolver := g.mergeConfigRegistry.Get(fieldSet.APIVersion, commonlogk8saudit_contract.GetSingularKindName(fieldSet.PluralKind))
 		mergedNode, err := structured.MergeNode(g.prevRevisionReader.Node, currentBodyReader.Node, structured.MergeConfiguration{
 			MergeMapOrderStrategy:    &structured.DefaultMergeMapOrderStrategy{},
@@ -300,4 +303,54 @@ func constructResourceBodyFromListItem(store *structured.LazyJSONBlockStore, ite
 	buf.WriteByte('}')
 	lazyNode := structured.NewLazyJSONNodeFromBytes(store, buf.Bytes())
 	return structured.NewNodeReader(structured.WithKeyOrder(lazyNode, k8s.K8sManifestKeyOrder...)), nil
+}
+
+// extractResourceIdentity extracts immutable resource identity metadata from the previous revision.
+// It preserves apiVersion, kind, metadata.name, metadata.namespace, metadata.uid, and metadata.creationTimestamp,
+// returning a NodeReader containing only those fields. If prevRevision contains no identity fields,
+// it returns an empty map NodeReader.
+func extractResourceIdentity(store *structured.LazyJSONBlockStore, prevRevision *structured.NodeReader) *structured.NodeReader {
+	apiVersion := prevRevision.ReadStringOrDefault(pathAPIVersion, "")
+	kind := prevRevision.ReadStringOrDefault(pathKind, "")
+	name := prevRevision.ReadStringOrDefault(pathMetadataName, "")
+	namespace := prevRevision.ReadStringOrDefault(pathMetadataNamespace, "")
+	uid := prevRevision.ReadStringOrDefault(pathMetadataUID, "")
+	creationTimestamp := prevRevision.ReadStringOrDefault(pathMetadataCreationTimestamp, "")
+
+	if apiVersion == "" && kind == "" && name == "" && namespace == "" && uid == "" && creationTimestamp == "" {
+		return structured.NewNodeReader(structured.NewEmptyMapNode())
+	}
+
+	metadata := make(map[string]any)
+	if name != "" {
+		metadata["name"] = name
+	}
+	if namespace != "" {
+		metadata["namespace"] = namespace
+	}
+	if uid != "" {
+		metadata["uid"] = uid
+	}
+	if creationTimestamp != "" {
+		metadata["creationTimestamp"] = creationTimestamp
+	}
+
+	root := make(map[string]any)
+	if apiVersion != "" {
+		root["apiVersion"] = apiVersion
+	}
+	if kind != "" {
+		root["kind"] = kind
+	}
+	if len(metadata) > 0 {
+		root["metadata"] = metadata
+	}
+
+	jsonBytes, err := json.Marshal(root)
+	if err != nil {
+		return structured.NewNodeReader(structured.NewEmptyMapNode())
+	}
+
+	lazyNode := structured.NewLazyJSONNodeFromBytes(store, jsonBytes)
+	return structured.NewNodeReader(structured.WithKeyOrder(lazyNode, k8s.K8sManifestKeyOrder...))
 }

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task.go
@@ -143,7 +143,7 @@ func (g *groupManifestGenerator) Process(ctx context.Context, l *log.Log) (*comm
 		}
 		return &commonlogk8saudit_contract.ResourceManifestLog{
 			Log:                l,
-			ResourceBodyReader: nil,
+			ResourceBodyReader: g.prevRevisionReader,
 		}, nil
 	}
 	currentBodyReader := fieldSet.Response

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
@@ -105,7 +105,9 @@ metadata:
   labels:
     foo: bar
 `,
-				"",
+				`apiVersion: v1
+kind: Pod
+`,
 				`apiVersion: v1
 kind: Pod
 metadata:
@@ -151,7 +153,14 @@ metadata:
   labels:
     foo: bar
 `,
-				"",
+				`apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+`,
 				`apiVersion: v1
 kind: Pod
 metadata:
@@ -205,8 +214,22 @@ metadata:
   labels:
     foo: bar
 `,
-				"",
-				"",
+				`apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+`,
+				`apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+`,
 				`apiVersion: v1
 kind: Pod
 metadata:
@@ -279,7 +302,14 @@ metadata:
   labels:
     foo: bar
 `,
-				"",
+				`apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+`,
 				`apiVersion: v1
 kind: Pod
 metadata:

--- a/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/manifest_generator_task_test.go
@@ -77,7 +77,7 @@ metadata:
 			},
 		},
 		{
-			desc: "truncated log clears previous revision and does not merge old state in subsequent patch",
+			desc: "truncated log preserves type identity and does not merge old mutable state in subsequent patch",
 			inputs: []*testGroupManifestGeneratorInput{
 				{
 					verb: commonlogk8saudit_contract.VerbCreate,
@@ -106,9 +106,187 @@ metadata:
     foo: bar
 `,
 				"",
-				`metadata:
+				`apiVersion: v1
+kind: Pod
+metadata:
   labels:
     qux: quux
+`,
+			},
+		},
+		{
+			desc: "truncated log preserves immutable identity metadata in subsequent patch",
+			inputs: []*testGroupManifestGeneratorInput{
+				{
+					verb: commonlogk8saudit_contract.VerbCreate,
+					responseYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test-ns
+  uid: "test-uid-1234"
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  labels:
+    foo: bar`,
+				},
+				{
+					verb:        commonlogk8saudit_contract.VerbUpdate,
+					isTruncated: true,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					requestYAML: `metadata:
+  labels:
+    qux: quux`,
+				},
+			},
+			wantBodies: []string{
+				`apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  labels:
+    foo: bar
+`,
+				"",
+				`apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+  labels:
+    qux: quux
+`,
+			},
+		},
+		{
+			desc: "consecutive truncated logs preserve immutable identity metadata in subsequent patch",
+			inputs: []*testGroupManifestGeneratorInput{
+				{
+					verb: commonlogk8saudit_contract.VerbCreate,
+					responseYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test-ns
+  uid: "test-uid-1234"
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  labels:
+    foo: bar`,
+				},
+				{
+					verb:        commonlogk8saudit_contract.VerbUpdate,
+					isTruncated: true,
+				},
+				{
+					verb:        commonlogk8saudit_contract.VerbUpdate,
+					isTruncated: true,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					requestYAML: `metadata:
+  labels:
+    qux: quux`,
+				},
+			},
+			wantBodies: []string{
+				`apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  labels:
+    foo: bar
+`,
+				"",
+				"",
+				`apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+  labels:
+    qux: quux
+`,
+			},
+		},
+		{
+			desc: "initial truncated log followed by patch merges patch into empty body",
+			inputs: []*testGroupManifestGeneratorInput{
+				{
+					verb:        commonlogk8saudit_contract.VerbUpdate,
+					isTruncated: true,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbPatch,
+					requestYAML: `metadata:
+  name: new-pod
+  labels:
+    qux: quux`,
+				},
+			},
+			wantBodies: []string{
+				"",
+				`metadata:
+  name: new-pod
+  labels:
+    qux: quux
+`,
+			},
+		},
+		{
+			desc: "truncated log followed by delete with DeleteOptions returns preserved identity reader",
+			inputs: []*testGroupManifestGeneratorInput{
+				{
+					verb: commonlogk8saudit_contract.VerbCreate,
+					responseYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  labels:
+    foo: bar`,
+				},
+				{
+					verb:        commonlogk8saudit_contract.VerbUpdate,
+					isTruncated: true,
+				},
+				{
+					verb: commonlogk8saudit_contract.VerbDelete,
+					requestYAML: `apiVersion: meta.k8s.io/__internal
+kind: DeleteOptions`,
+				},
+			},
+			wantBodies: []string{
+				`apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  labels:
+    foo: bar
+`,
+				"",
+				`apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: test-pod
+  namespace: test-ns
+  uid: test-uid-1234
 `,
 			},
 		},
@@ -565,15 +743,116 @@ status:
 			}
 
 			if got := gotReader.ReadStringOrDefault(pathAPIVersion, ""); got != tc.wantAPIVer {
-				t.Errorf("apiVersion mismatch (-want +got):\n%s", cmp.Diff(tc.wantAPIVer, got))
+				t.Errorf("apiVersion = %q, want %q", got, tc.wantAPIVer)
 			}
 			if got := gotReader.ReadStringOrDefault(pathKind, ""); got != tc.wantKind {
-				t.Errorf("kind mismatch (-want +got):\n%s", cmp.Diff(tc.wantKind, got))
+				t.Errorf("kind = %q, want %q", got, tc.wantKind)
 			}
 			if got := gotReader.ReadStringOrDefault(pathMetadataName, ""); got != tc.wantMetaName {
-				t.Errorf("metadata.name mismatch (-want +got):\n%s", cmp.Diff(tc.wantMetaName, got))
+				t.Errorf("metadata.name = %q, want %q", got, tc.wantMetaName)
 			}
 
+			yamlBytes, err := gotReader.Serialize(structured.EmptyFieldPath, &structured.YAMLNodeSerializer{})
+			if err != nil {
+				t.Fatalf("Serialize() failed: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantYAML, string(yamlBytes)); diff != "" {
+				t.Errorf("YAML serialization mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExtractResourceIdentity(t *testing.T) {
+	testCases := []struct {
+		name     string
+		prevYAML string
+		wantYAML string
+	}{
+		{
+			name:     "empty map returns empty map",
+			prevYAML: "{}\n",
+			wantYAML: "{}\n",
+		},
+		{
+			name: "prevRevision without identity metadata returns empty map",
+			prevYAML: `spec:
+  replicas: 3
+status:
+  readyReplicas: 3`,
+			wantYAML: "{}\n",
+		},
+		{
+			name: "prevRevision with only type metadata",
+			prevYAML: `apiVersion: v1
+kind: Service
+spec:
+  ports:
+    - port: 80`,
+			wantYAML: `apiVersion: v1
+kind: Service
+`,
+		},
+		{
+			name: "prevRevision with all identity metadata and non-identity fields",
+			prevYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: my-ns
+  uid: uid-abc-123
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  labels:
+    app: test
+spec:
+  containers:
+    - name: c1
+status:
+  phase: Running`,
+			wantYAML: `apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: my-pod
+  namespace: my-ns
+  uid: uid-abc-123
+`,
+		},
+		{
+			name: "cluster-scoped resource without namespace",
+			prevYAML: `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-cluster-role
+  uid: uid-cluster-role-1
+  creationTimestamp: "2026-09-10T00:00:00Z"
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]`,
+			wantYAML: `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: "2026-09-10T00:00:00Z"
+  name: test-cluster-role
+  uid: uid-cluster-role-1
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := structured.NewLazyJSONBlockStore(4, 8)
+			var prevReader *structured.NodeReader
+			if tc.prevYAML != "" {
+				node, err := structured.FromYAML(tc.prevYAML)
+				if err != nil {
+					t.Fatalf("failed to parse prevYAML: %v", err)
+				}
+				prevReader = structured.NewNodeReader(node)
+			}
+
+			gotReader := extractResourceIdentity(store, prevReader)
 			yamlBytes, err := gotReader.Serialize(structured.EmptyFieldPath, &structured.YAMLNodeSerializer{})
 			if err != nil {
 				t.Fatalf("Serialize() failed: %v", err)


### PR DESCRIPTION
### Summary
This PR fixes an issue where Kubernetes audit logs with truncated responses (`audit.k8s.io/truncated: "true"`) caused the manifest generator to lose resource identity metadata, leading subsequent patch logs to be misinterpreted as newly created resources.

- **Manifest Generator**:
  - Preserves immutable identity metadata (`apiVersion`, `kind`, `metadata.name`, `metadata.namespace`, `metadata.uid`, `metadata.creationTimestamp`) from the previous revision when processing truncated logs, rather than resetting to an empty reader.
  - Returns the preserved immutable identity reader as `ResourceBodyReader` on truncated logs (instead of `nil`), ensuring the truncated log itself retains its immutable identity manifest in the timeline revision and does not appear empty in the UI.
- **Nil Revision Handling**:
  - Avoids eager empty map initialization at the start of `Process()`, maintaining `prevRevisionReader` as `nil` until a revision is observed, and only extracting identity metadata when a prior revision actually exists.
  - Safely falls back to an empty map node if `prevRevisionReader` is `nil` prior to a patch merge.
- **Unit & Integration Tests**:
  - Added unit tests in `TestExtractResourceIdentity` verifying field extraction for empty maps, non-identity fields, type-only metadata, full identity metadata, and cluster-scoped resources.
  - Added and updated test cases in `TestGroupManifestGenerator` verifying that immutable identity metadata is preserved on truncated logs and across single/consecutive truncated logs into subsequent patches, that initial truncated logs merge patches cleanly into empty bodies, and that DeleteOptions after truncated logs return preserved identity readers.