### PR TITLE
feat(task): add task description label and WithTaskDescription option

### DIFF
--- a/pkg/core/task/label.go
+++ b/pkg/core/task/label.go
@@ -147,3 +147,21 @@ func NewTaskResultRetentionLabel(retain bool) LabelOpt {
 		retain: retain,
 	}
 }
+
+type taskDescriptionLabelOptImpl struct {
+	description string
+}
+
+// Write implements LabelOpt.
+func (o *taskDescriptionLabelOptImpl) Write(label *typedmap.TypedMap) {
+	typedmap.Set(label, LabelKeyTaskDescription, o.description)
+}
+
+var _ LabelOpt = (*taskDescriptionLabelOptImpl)(nil)
+
+// WithTaskDescription returns a LabelOpt to attach a human-readable description to the task.
+func WithTaskDescription(description string) LabelOpt {
+	return &taskDescriptionLabelOptImpl{
+		description: description,
+	}
+}

--- a/pkg/core/task/label.go
+++ b/pkg/core/task/label.go
@@ -148,20 +148,7 @@ func NewTaskResultRetentionLabel(retain bool) LabelOpt {
 	}
 }
 
-type taskDescriptionLabelOptImpl struct {
-	description string
-}
-
-// Write implements LabelOpt.
-func (o *taskDescriptionLabelOptImpl) Write(label *typedmap.TypedMap) {
-	typedmap.Set(label, LabelKeyTaskDescription, o.description)
-}
-
-var _ LabelOpt = (*taskDescriptionLabelOptImpl)(nil)
-
 // WithTaskDescription returns a LabelOpt to attach a human-readable description to the task.
 func WithTaskDescription(description string) LabelOpt {
-	return &taskDescriptionLabelOptImpl{
-		description: description,
-	}
+	return WithLabelValue(LabelKeyTaskDescription, description)
 }

--- a/pkg/core/task/label_test.go
+++ b/pkg/core/task/label_test.go
@@ -20,34 +20,71 @@ import (
 	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
 )
 
-func TestWithTaskDescription(t *testing.T) {
-	testCases := []struct {
-		name        string
-		description string
-		want        string
-	}{
-		{
-			name:        "sets simple task description",
-			description: "Parses Kubernetes audit log entries.",
-			want:        "Parses Kubernetes audit log entries.",
-		},
-		{
-			name:        "sets empty task description",
-			description: "",
-			want:        "",
-		},
-	}
+func TestWithLabelValue(t *testing.T) {
+	testStringKey := NewTaskLabelKey[string]("test-string-key")
+	testIntKey := NewTaskLabelKey[int]("test-int-key")
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			labels := NewLabelSet(WithTaskDescription(tc.description))
-			got, found := typedmap.Get(labels, LabelKeyTaskDescription)
-			if !found {
-				t.Errorf("LabelKeyTaskDescription not found in label set")
-			}
-			if got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
-			}
-		})
-	}
+	t.Run("string label", func(t *testing.T) {
+		testCases := []struct {
+			name  string
+			value string
+			want  string
+		}{
+			{
+				name:  "sets non-empty string value",
+				value: "hello",
+				want:  "hello",
+			},
+			{
+				name:  "sets empty string value",
+				value: "",
+				want:  "",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				labels := NewLabelSet(WithLabelValue(testStringKey, tc.value))
+				got, found := typedmap.Get(labels, testStringKey)
+				if !found {
+					t.Fatalf("key %q not found in label set", testStringKey)
+				}
+				if got != tc.want {
+					t.Errorf("got %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("int label", func(t *testing.T) {
+		testCases := []struct {
+			name  string
+			value int
+			want  int
+		}{
+			{
+				name:  "sets positive integer",
+				value: 42,
+				want:  42,
+			},
+			{
+				name:  "sets zero",
+				value: 0,
+				want:  0,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				labels := NewLabelSet(WithLabelValue(testIntKey, tc.value))
+				got, found := typedmap.Get(labels, testIntKey)
+				if !found {
+					t.Fatalf("key %q not found in label set", testIntKey)
+				}
+				if got != tc.want {
+					t.Errorf("got %d, want %d", got, tc.want)
+				}
+			})
+		}
+	})
 }

--- a/pkg/core/task/label_test.go
+++ b/pkg/core/task/label_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package coretask
 
 import (

--- a/pkg/core/task/label_test.go
+++ b/pkg/core/task/label_test.go
@@ -1,0 +1,39 @@
+package coretask
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/khi/pkg/common/typedmap"
+)
+
+func TestWithTaskDescription(t *testing.T) {
+	testCases := []struct {
+		name        string
+		description string
+		want        string
+	}{
+		{
+			name:        "sets simple task description",
+			description: "Parses Kubernetes audit log entries.",
+			want:        "Parses Kubernetes audit log entries.",
+		},
+		{
+			name:        "sets empty task description",
+			description: "",
+			want:        "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			labels := NewLabelSet(WithTaskDescription(tc.description))
+			got, found := typedmap.Get(labels, LabelKeyTaskDescription)
+			if !found {
+				t.Errorf("LabelKeyTaskDescription not found in label set")
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/core/task/task.go
+++ b/pkg/core/task/task.go
@@ -45,6 +45,9 @@ var LabelKeySubsequentTaskRefs = NewTaskLabelKey[[]taskid.UntypedTaskReference](
 // LabelKeyTaskResultRetention indicates whether the task result should be retained in the runner after all dependent tasks finish.
 var LabelKeyTaskResultRetention = NewTaskLabelKey[bool](KHISystemPrefix + "task-result-retention")
 
+// LabelKeyTaskDescription is the task label to record a human-readable description of the task.
+var LabelKeyTaskDescription = NewTaskLabelKey[string](KHISystemPrefix + "task-description")
+
 type UntypedTask interface {
 	UntypedID() taskid.UntypedTaskImplementationID
 	// Labels returns KHITaskLabelSet assigned to this task unit.

--- a/pkg/task/inspection/commonlogk8saudit/impl/k8sresourcemergeconfig_task.go
+++ b/pkg/task/inspection/commonlogk8saudit/impl/k8sresourcemergeconfig_task.go
@@ -24,6 +24,11 @@ import (
 )
 
 // DefaultK8sResourceMergeConfigTask is the task that generates the default patch request merge config.
-var DefaultK8sResourceMergeConfigTask = coretask.NewTask(commonlogk8saudit_contract.K8sResourceMergeConfigTaskID, []taskid.UntypedTaskReference{}, func(ctx context.Context) (*k8s.K8sManifestMergeConfigRegistry, error) {
-	return k8s.GenerateDefaultMergeConfig()
-})
+var DefaultK8sResourceMergeConfigTask = coretask.NewTask(
+	commonlogk8saudit_contract.K8sResourceMergeConfigTaskID,
+	[]taskid.UntypedTaskReference{},
+	func(ctx context.Context) (*k8s.K8sManifestMergeConfigRegistry, error) {
+		return k8s.GenerateDefaultMergeConfig()
+	},
+	coretask.WithTaskDescription("Generates the default Kubernetes manifest patch request merge configuration."),
+)

--- a/pkg/task/inspection/inspectioncore/contract/form.go
+++ b/pkg/task/inspection/inspectioncore/contract/form.go
@@ -35,6 +35,7 @@ func (f *FormTaskLabelOpt) Write(label *typedmap.TypedMap) {
 	typedmap.Set(label, TaskLabelKeyIsFormTask, true)
 	typedmap.Set(label, TaskLabelKeyFormFieldLabel, f.label)
 	typedmap.Set(label, TaskLabelKeyFormFieldDescription, f.description)
+	typedmap.Set(label, coretask.LabelKeyTaskDescription, f.description)
 }
 
 // NewFormTaskLabelOpt constructs a new instance of task.LabelOpt for form related tasks.

--- a/pkg/task/inspection/inspectioncore/contract/tasklabel.go
+++ b/pkg/task/inspection/inspectioncore/contract/tasklabel.go
@@ -81,6 +81,7 @@ func (ftl *FeatureTaskLabelImpl) Write(label *typedmap.TypedMap) {
 	typedmap.Set(label, LabelKeyInspectionFeatureFlag, true)
 	typedmap.Set(label, LabelKeyFeatureTaskTitle, ftl.title)
 	typedmap.Set(label, LabelKeyFeatureTaskDescription, ftl.description)
+	typedmap.Set(label, coretask.LabelKeyTaskDescription, ftl.description)
 	typedmap.Set(label, LabelKeyFeatureTaskOrder, ftl.featureOrder)
 	typedmap.Set(label, LabelKeyInspectionDefaultFeatureFlag, ftl.isDefaultFeature)
 }


### PR DESCRIPTION
## Summary
Adds `LabelKeyTaskDescription` to `pkg/core/task` along with `WithTaskDescription` label option to attach human-readable descriptions to inspection tasks.

## Details
- Add `LabelKeyTaskDescription` in `pkg/core/task/task.go`.
- Add `WithTaskDescription` and its implementation in `pkg/core/task/label.go`.
- Add unit test `TestWithTaskDescription` in `pkg/core/task/label_test.go`.
- Attach description to `DefaultK8sResourceMergeConfigTask`.
- Propagate form/feature task descriptions to `LabelKeyTaskDescription` in `pkg/task/inspection/inspectioncore/contract`.